### PR TITLE
Add ComboBox component

### DIFF
--- a/components/ComboBox.qml
+++ b/components/ComboBox.qml
@@ -1,0 +1,134 @@
+/*
+** Copyright (C) 2021 Victron Energy B.V.
+*/
+
+import QtQuick
+import QtQuick.Controls as C
+import QtQuick.Controls.impl as CP
+import Victron.VenusOS
+
+C.ComboBox {
+	id: root
+
+	property var _displayIcon
+
+	implicitWidth: 240
+	implicitHeight: 48
+	leftPadding: 22
+	rightPadding: 14
+
+	delegate: C.ItemDelegate {
+		id: itemDelegate
+
+		width: root.width
+		height: root.height - 2
+		leftPadding: 0
+		rightPadding: 0
+		topPadding: -2
+		bottomPadding: 0
+
+		contentItem: Item {
+			CP.ColorImage {
+				id: delegateIcon
+
+				x: root.leftPadding - 2
+				anchors.verticalCenter: parent.verticalCenter
+				source: model.icon
+				color: !!model.enabled ? Theme.primaryFontColor : Theme.secondaryFontColor
+			}
+
+			Label {
+				anchors {
+					left: delegateIcon.right
+					leftMargin: 10
+					right: parent.right
+					verticalCenter: parent.verticalCenter
+				}
+
+				text: model.text
+				font.pixelSize: 22 // TODO add to Theme if size is used elsewhere
+				elide: Text.ElideRight
+				color: delegateIcon.color
+			}
+		}
+
+		background: Rectangle {
+			color: itemDelegate.down || model.index === root.currentIndex
+				   ? Theme.okColor
+				   : Theme.okSecondaryColor
+		}
+
+		highlighted: root.highlightedIndex === model.index
+		enabled: !!model.enabled
+	}
+
+	indicator: CP.ColorImage {
+		x: root.width - width - root.rightPadding
+		y: root.topPadding + (root.availableHeight - height) / 2
+
+		source: 'qrc:/images/dropdown.svg'
+		color: Theme.okColor
+	}
+
+	contentItem: Item {
+		width: root.width
+		height: root.height
+
+		Image {
+			id: mainItemIcon
+
+			source: root._displayIcon
+			anchors.verticalCenter: parent.verticalCenter
+		}
+
+		Label {
+			anchors {
+				left: mainItemIcon.right
+				leftMargin: 10
+				right: parent.right
+				rightMargin: 18
+				verticalCenter: parent.verticalCenter
+			}
+
+			text: root.displayText
+			font.pixelSize: 22 // TODO add to Theme if size is used elsewhere
+			elide: Text.ElideRight
+		}
+	}
+
+	background: Rectangle {
+		width: root.width
+		height: root.height
+		border.color: Theme.okColor
+		border.width: 2
+		radius: 6
+		color: root.pressed ? Theme.okColor : Theme.okSecondaryColor
+	}
+
+	popup: C.Popup {
+		width: root.width
+		implicitHeight: contentItem.implicitHeight
+		padding: 2
+
+		contentItem: ListView {
+			clip: true
+			implicitHeight: contentHeight + 4
+			model: root.popup.visible ? root.delegateModel : null
+			currentIndex: root.highlightedIndex
+			boundsBehavior: Flickable.StopAtBounds
+		}
+
+		background: Rectangle {
+			color: Theme.okSecondaryColor
+			border.color: Theme.okColor
+			border.width: 2
+			radius: 6
+		}
+	}
+
+	onCurrentIndexChanged: {
+		var current = model.get(currentIndex)
+		displayText = current.text
+		_displayIcon = current.icon
+	}
+}

--- a/images/dropdown.svg
+++ b/images/dropdown.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="12" viewBox="0 0 20 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M19.0001 0.999861L10 9.99997L0.999895 0.999861" stroke="#387DC5" stroke-width="2"/>
+</svg>

--- a/main.cpp
+++ b/main.cpp
@@ -40,6 +40,8 @@ int main(int argc, char *argv[])
 		"Victron.VenusOS", 2, 0, "Button");
 	qmlRegisterType(QUrl(QStringLiteral("qrc:/components/CircularMultiGauge.qml")),
 		"Victron.VenusOS", 2, 0, "CircularMultiGauge");
+	qmlRegisterType(QUrl(QStringLiteral("qrc:/components/ComboBox.qml")),
+		"Victron.VenusOS", 2, 0, "ComboBox");
 	qmlRegisterType(QUrl(QStringLiteral("qrc:/components/Label.qml")),
 		"Victron.VenusOS", 2, 0, "Label");
 	qmlRegisterType(QUrl(QStringLiteral("qrc:/components/NavBar.qml")),

--- a/qml.qrc
+++ b/qml.qrc
@@ -1,6 +1,7 @@
 <RCC>
     <qresource prefix="/">
         <file>main.qml</file>
+        <file>components/ComboBox.qml</file>
         <file>components/CircularMultiGauge.qml</file>
         <file>components/NavBar.qml</file>
         <file>components/NavButton.qml</file>
@@ -20,6 +21,7 @@
         <file>components/Slider.qml</file>
         <file>components/SpinBox.qml</file>
         <file>components/Switch.qml</file>
+        <file>images/dropdown.svg</file>
         <file>images/icon_minus.svg</file>
         <file>images/icon_plus.svg</file>
         <file>images/levels.svg</file>


### PR DESCRIPTION
Usage:

```
        ComboBox {
            model: ListModel {
                ListElement { text: 'Battery'; icon: 'qrc:/images/battery.svg'; enabled: true }
                ListElement { text: 'Fresh water'; icon: 'qrc:/images/freshWater.svg'; enabled: true }
                ListElement { text: 'Black water'; icon: 'qrc:/images/blackWater.svg'; enabled: false }
            }
        }
```

Not yet implemented: the 'down' arrow indicator that should be shown when there are too many times than what can fit on the screen.

Also, the corners of the border of the combobox popup are slightly clipped on the inside edge. I think this is due to something with the padding offsets that I haven't figured out.
