### PR TITLE
Add StatusBar component

### DIFF
--- a/components/ControlCard.qml
+++ b/components/ControlCard.qml
@@ -6,20 +6,14 @@ import QtQuick
 import Victron.VenusOS
 
 Rectangle {
-	property Page page: ListView.view ? ListView.view.parent : null
 	property alias icon: icon
 	property alias title: title
 	property alias status: status
 
 	width: 368 // TODO - handle 7" size if it is different
-	height: 432 // TODO - handle 7" size if it is different
+	height: parent.height
 	color: Theme.controlCardBackgroundColor
 	radius: 8
-
-	MouseArea {
-		anchors.fill: parent
-		onClicked: if (page) page.controlsButtonClicked(page.isControlCardsPage)
-	}
 
 	Row {
 		anchors {

--- a/components/NavBar.qml
+++ b/components/NavBar.qml
@@ -13,14 +13,19 @@ Row {
 	signal buttonClicked(buttonIndex: int)
 
 	anchors.horizontalCenter: parent.horizontalCenter
-	spacing: 32
+	height: 72
+
+	spacing: 8 // TODO: 16 in 7inch mode
 
 	Repeater {
 		id: buttonRepeater
 
+		height: parent.height
 		property int currentIndex: 0
 
 		delegate: NavButton {
+			height: parent.height
+			width: 144 // TODO: 176 in 7inch mode
 			text: model.text
 			icon.source: model.icon
 			icon.width: model.iconWidth

--- a/components/NavButton.qml
+++ b/components/NavButton.qml
@@ -9,8 +9,6 @@ import Victron.VenusOS
 Button {
 	id: root
 
-	width: 112
-	height: 67
 	icon.width: Theme.iconSizeMedium
 	icon.height: Theme.iconSizeMedium
 	spacing: Theme.marginSmall

--- a/components/PageStack.qml
+++ b/components/PageStack.qml
@@ -1,0 +1,42 @@
+import QtQuick
+import QtQuick.Controls as C
+import Victron.VenusOS
+
+C.StackView {
+	id: pageStack
+	initialItem: "qrc:/pages/MainPage.qml"
+
+	// Slide new drill-down pages in from the right
+	pushEnter: Transition {
+		NumberAnimation {
+			property: "x"
+			from: width
+			to: 0
+			duration: 250
+		}
+	}
+	pushExit: Transition {
+		NumberAnimation {
+			property: "x"
+			from: 0
+			to: -width
+			duration: 250
+		}
+	}
+	popEnter: Transition {
+		NumberAnimation {
+			property: "x"
+			from: -width
+			to: 0
+			duration: 250
+		}
+	}
+	popExit: Transition {
+		NumberAnimation {
+			property: "x"
+			from: 0
+			to: width
+			duration: 250
+		}
+	}
+}

--- a/components/StatusBar.qml
+++ b/components/StatusBar.qml
@@ -1,0 +1,80 @@
+/*
+** Copyright (C) 2021 Victron Energy B.V.
+*/
+
+import QtQuick
+import QtQuick.Controls as C
+import Victron.VenusOS
+
+Item {
+	id: root
+
+	property bool controlsActive
+	property bool sidePanelActive
+	property bool sidePanelVisible
+
+	width: parent.width
+	height: 48
+
+	Button {
+		id: controlsButton
+
+		anchors {
+			left: parent.left
+			leftMargin: 26
+			verticalCenter: parent.verticalCenter
+		}
+
+		height: 32
+		width: height
+		display: C.AbstractButton.IconOnly
+		color: Theme.okColor
+		icon.source: root.controlsActive ? "qrc:/images/controls-toggled.svg" : "qrc:/images/controls.svg"
+		icon.width: 28
+		icon.height: 28
+		onClicked: root.controlsActive = !root.controlsActive
+	}
+
+	Label {
+		id: clockLabel
+		anchors.centerIn: parent
+		font.pixelSize: 22
+		text: clockTimer.timeString
+		Timer {
+			id: clockTimer
+			interval: 1000 // 1 second
+			running: root.opacity > 0.0
+			property string timeString: "00:00"
+			onTriggered: {
+				var currDate = new Date()
+				var hours = currDate.getHours()
+				var mins = currDate.getMinutes()
+				if (hours < 10) hours = "0" + hours
+				if (mins < 10)   mins = "0" + mins
+				timeString = hours + ":" + mins
+			}
+		}
+	}
+
+	Button {
+		id: sidePanelButton
+
+		anchors {
+			right: parent.right
+			rightMargin: 26
+			verticalCenter: parent.verticalCenter
+		}
+
+		opacity: sidePanelVisible ? 1.0 : 0.0
+		Behavior on opacity { OpacityAnimator { duration: 250; easing.type: Easing.InOutQuad } }
+
+		height: 32
+		width: height
+		display: C.AbstractButton.IconOnly
+		color: Theme.okColor
+		icon.source: root.state === '' ? "qrc:/images/panel-toggle.svg" : "qrc:/images/panel-toggled.svg"
+		icon.width: 28
+		icon.height: 20
+		onClicked: root.sidePanelActive = !root.sidePanelActive
+	}
+}

--- a/components/Utils.js
+++ b/components/Utils.js
@@ -84,3 +84,12 @@ function formatAsHHMM(seconds) {
 	const duration = decomposeDuration(seconds)
 	return pad(duration.h, 2) + ":" + pad(duration.m, 2)
 }
+
+function reactToSignalOnce(sig, slot) {
+	var f = function() {
+		slot.apply(this, arguments)
+		sig.disconnect(f)
+	}
+	sig.connect(f)
+}
+

--- a/main.cpp
+++ b/main.cpp
@@ -74,6 +74,8 @@ int main(int argc, char *argv[])
 		"Victron.VenusOS", 2, 0, "NavBar");
 	qmlRegisterType(QUrl(QStringLiteral("qrc:/components/NavButton.qml")),
 		"Victron.VenusOS", 2, 0, "NavButton");
+	qmlRegisterType(QUrl(QStringLiteral("qrc:/components/PageStack.qml")),
+		"Victron.VenusOS", 2, 0, "PageStack");
 	qmlRegisterType(QUrl(QStringLiteral("qrc:/components/ProgressArc.qml")),
 		"Victron.VenusOS", 2, 0, "ProgressArc");
 	qmlRegisterType(QUrl(QStringLiteral("qrc:/components/ScaledArc.qml")),
@@ -84,6 +86,8 @@ int main(int argc, char *argv[])
 		"Victron.VenusOS", 2, 0, "SegmentedButtonRow");
 	qmlRegisterType(QUrl(QStringLiteral("qrc:/components/SeparatorBar.qml")),
 		"Victron.VenusOS", 2, 0, "SeparatorBar");
+	qmlRegisterType(QUrl(QStringLiteral("qrc:/components/StatusBar.qml")),
+		"Victron.VenusOS", 2, 0, "StatusBar");
 	qmlRegisterSingletonType(QUrl(QStringLiteral("qrc:/components/SwitchesModel.qml")),
 		"Victron.VenusOS", 2, 0, "SwitchesModel");
 	qmlRegisterSingletonType(QUrl(QStringLiteral("qrc:/components/Units.qml")),
@@ -106,6 +110,8 @@ int main(int argc, char *argv[])
 		"Victron.VenusOS", 2, 0, "SwitchesCard");
 
 	/* dialogs */
+	qmlRegisterType(QUrl(QStringLiteral("qrc:/dialogs/DialogManager.qml")),
+		"Victron.VenusOS", 2, 0, "DialogManager");
 	qmlRegisterType(QUrl(QStringLiteral("qrc:/dialogs/InputCurrentLimitDialog.qml")),
 		"Victron.VenusOS", 2, 0, "InputCurrentLimitDialog");
 	qmlRegisterType(QUrl(QStringLiteral("qrc:/dialogs/InverterChargerModeDialog.qml")),
@@ -114,10 +120,10 @@ int main(int argc, char *argv[])
 		"Victron.VenusOS", 2, 0, "GeneratorDisableAutostartDialog");
 	qmlRegisterType(QUrl(QStringLiteral("qrc:/dialogs/GeneratorDurationSelectorDialog.qml")),
 		"Victron.VenusOS", 2, 0, "GeneratorDurationSelectorDialog");
-	qmlRegisterType(QUrl(QStringLiteral("qrc:/dialogs/DialogManager.qml")),
-		"Victron.VenusOS", 2, 0, "DialogManager");
 
 	/* pages */
+	qmlRegisterSingletonType(QUrl(QStringLiteral("qrc:/pages/PageManager.qml")),
+		"Victron.VenusOS", 2, 0, "PageManager");
 	qmlRegisterType(QUrl(QStringLiteral("qrc:/pages/Page.qml")),
 		"Victron.VenusOS", 2, 0, "Page");
 	qmlRegisterType(QUrl(QStringLiteral("qrc:/pages/MainPage.qml")),

--- a/main.qml
+++ b/main.qml
@@ -7,7 +7,7 @@ import QtQuick.Window
 import QtQuick.Controls
 import Victron.Velib
 import Victron.VenusOS
-import "pages"
+import "/components/Utils.js" as Utils
 import "data"
 
 Window {
@@ -28,53 +28,101 @@ Window {
 	//~ Context only shown on desktop systems
 	title: qsTrId("venus_os_gui")
 
-	StackView {
-		id: pageStack
-		anchors.fill: parent
-		initialItem: "qrc:/pages/MainPage.qml"
+	StatusBar {
+		id: statusBar
 
-		// Slide new drill-down pages in from the right
-		pushEnter: Transition {
-			PropertyAnimation {
-				property: "x"
-				from: width
+		sidePanelVisible: PageManager.sidePanelVisible
+		property bool hidden: statusBar.y === -statusBar.height
+		property bool sidePanelWasVisible
+
+		onControlsActiveChanged: {
+			if (controlsActive) {
+				if (PageManager.sidePanelVisible) {
+					statusBar.sidePanelWasVisible = true
+				}
+				PageManager.sidePanelVisible = false
+				PageManager.pushPage("qrc:/pages/ControlCardsPage.qml")
+			} else {
+				PageManager.popPage()
+				if (statusBar.sidePanelWasVisible) {
+					PageManager.sidePanelVisible = true
+				}
+			}
+		}
+
+		onSidePanelActiveChanged: {
+			PageManager.sidePanelActive = sidePanelActive
+		}
+
+		function show() {
+			if (hidden) {
+				animateStatusBarIn.start()
+			}
+		}
+
+		function hide() {
+			if (!hidden) {
+				animateStatusBarOut.start()
+			}
+		}
+
+		SequentialAnimation {
+			id: animateStatusBarIn
+			NumberAnimation {
+				target: statusBar
+				property: "y"
+				from: -statusBar.height
 				to: 0
 				duration: 250
+				easing.type: Easing.InOutQuad
+			}
+			OpacityAnimator {
+				target: statusBar
+				from: 0.0
+				to: 1.0
+				duration: 250
+				easing.type: Easing.InOutQuad
 			}
 		}
-		pushExit: Transition {
-			PropertyAnimation {
-				property: "x"
+
+		SequentialAnimation {
+			id: animateStatusBarOut
+			OpacityAnimator {
+				target: statusBar
+				from: 1.0
+				to: 0.0
+				duration: 250
+				easing.type: Easing.InOutQuad
+			}
+			NumberAnimation {
+				target: statusBar
+				property: "y"
 				from: 0
-				to: -width
+				to: -statusBar.height
 				duration: 250
-			}
-		}
-		popEnter: Transition {
-			PropertyAnimation {
-				property: "x"
-				from: 0
-				to: width
-				duration: 250
-			}
-		}
-		popExit: Transition {
-			PropertyAnimation {
-				property: "x"
-				from: -width
-				to: 0
-				duration: 250
+				easing.type: Easing.InOutQuad
 			}
 		}
 	}
 
-	Connections {
-		target: pageStack.currentItem
-		function onControlsButtonClicked(wasToggled) {
-			if (wasToggled) {
+	PageStack {
+		id: pageStack
+		anchors {
+			top: statusBar.bottom
+			left: parent.left
+			right: parent.right
+			bottom: parent.bottom
+		}
+
+		Connections {
+			target: PageManager.emitter
+
+			function onPagePushRequested() {
+				pageStack.push(PageManager.pageToPush)
+			}
+
+			function onPagePopRequested() {
 				pageStack.pop()
-			} else {
-				pageStack.push("qrc:/pages/ControlCardsPage.qml")
 			}
 		}
 	}

--- a/pages/BriefPage.qml
+++ b/pages/BriefPage.qml
@@ -40,13 +40,10 @@ Page {
 	CircularMultiGauge {
 		id: gauge
 
+		height: parent.height
+		width: height
 		x: sidePanel.x/2 - width/2
-		anchors {
-			top: parent.top
-			topMargin: 56
-		}
-		width: 315
-		height: 320
+
 		model: gaugeData.model
 	}
 
@@ -56,12 +53,11 @@ Page {
 		id: leftEdge
 		anchors {
 			top: parent.top
-			topMargin: 56
 			left: parent.left
-			leftMargin: 40
+			leftMargin: 40 // TODO: 56 for 7inch
 			right: gauge.left
 		}
-		height: 320
+		height: parent.height
 		opacity: root.sideOpacity
 		active: leftGaugeTypes.length === 1
 		source: {
@@ -76,12 +72,11 @@ Page {
 		id: rightEdge
 		anchors {
 			top: parent.top
-			topMargin: 56
 			right: parent.right
-			rightMargin: 40
+			rightMargin: 40 // TODO: 56 for 7inch
 			left: gauge.right
 		}
-		height: 320
+		height: parent.height
 		opacity: root.sideOpacity
 		active: rightGaugeTypes.length === 1
 		source: {
@@ -134,12 +129,11 @@ Page {
 		id: rightUpper
 		anchors {
 			top: parent.top
-			topMargin: 56
 			right: parent.right
 			rightMargin: 40
 			left: gauge.right
 		}
-		height: 160
+		height: parent.height/2
 		opacity: root.sideOpacity
 		active: rightGaugeTypes.length === 2
 		source: {
@@ -152,13 +146,12 @@ Page {
 	Loader {
 		id: rightLower
 		anchors {
-			top: parent.top
-			topMargin: 216
+			top: rightUpper.bottom
 			right: parent.right
 			rightMargin: 40
 			left: gauge.right
 		}
-		height: 160
+		height: parent.height/2
 		opacity: root.sideOpacity
 		active: rightGaugeTypes.length === 2
 		source: {
@@ -169,34 +162,15 @@ Page {
 		}
 	}
 
-	Button {
-		id: button
-
-		anchors {
-			top: parent.top
-			topMargin: 14
-			right: parent.right
-			rightMargin: 26
-		}
-
-		width: 32
-		height: width
-		display: C.AbstractButton.IconOnly
-		icon.source: root.state === '' ? "qrc:/images/panel-toggle.svg" : "qrc:/images/panel-toggled.svg"
-		icon.width: 28
-		icon.height: 20
-		onClicked: root.state = root.state === '' ? 'panelOpen' : ''
-		color: Theme.okColor
-	}
-
 	BriefMonitorPanel {
 		id: sidePanel
 
-		anchors.top: button.bottom
-		x: root.width
-		opacity: 0
 		width: 240
 		height: 367
+
+		// hidden by default.
+		x: root.width
+		opacity: 0.0
 	}
 
 	property var gaugeConfig: [
@@ -308,6 +282,7 @@ Page {
 		QT_TRID_NOOP('gaugeBlackWaterText')
 	]
 
+	state: PageManager.sidePanelActive ? 'panelOpen' : ''
 	states: State {
 		name: 'panelOpen'
 		PropertyChanges {

--- a/pages/ControlCardsPage.qml
+++ b/pages/ControlCardsPage.qml
@@ -10,22 +10,20 @@ import Victron.VenusOS
 Page {
 	id: root
 
-	isControlCardsPage: true
-
 	ListView {
 		anchors {
 			left: parent.left
 			leftMargin: 24 // TODO - handle 7" size if it is different
 			right: parent.right
 			top: parent.top
-			topMargin: 42 // TODO - handle 7" size if it is different
 			bottom: parent.bottom
-			bottomMargin: 8 // TODO - handle 7" size if it is different
+			bottomMargin: 16 // TODO - handle 7" size if it is different
 		}
 		spacing: 16
 		orientation: ListView.Horizontal
 		model: ControlCardsModel
 		delegate: Loader {
+			height: parent.height
 			source: url
 		}
 	}

--- a/pages/MainPage.qml
+++ b/pages/MainPage.qml
@@ -11,15 +11,6 @@ import Victron.VenusOS
 Page {
 	id: root
 
-	controlsButton.visible: false
-
-	Connections {
-		target: navStack.currentItem
-		function onControlsButtonClicked(wasToggled) {
-			root.controlsButtonClicked(wasToggled)
-		}
-	}
-
 	C.StackView {
 		id: navStack
 		clip: true
@@ -35,18 +26,18 @@ Page {
 
 		// Fade new navigation pages in
 		replaceEnter: Transition {
-			PropertyAnimation {
-				property: "opacity"
+			OpacityAnimator {
 				from: 0.0
 				to: 1.0
+				easing.type: Easing.InOutQuad
 				duration: 250
 			}
 		}
 		replaceExit: Transition {
-			PropertyAnimation {
-				property: "opacity"
+			OpacityAnimator {
 				from: 1.0
 				to: 0.0
+				easing.type: Easing.InOutQuad
 				duration: 250
 			}
 		}
@@ -104,11 +95,64 @@ Page {
 		}
 
 		property var currentUrl: navBar.model.get(0).url
+		onCurrentUrlChanged: PageManager.sidePanelVisible = (currentUrl == navBar.model.get(0).url)
 		onButtonClicked: function (buttonIndex) {
 			var navUrl = model.get(buttonIndex).url
 			if (navUrl != currentUrl) {
 				currentUrl = navUrl
 				navStack.replace(null, navUrl)
+			}
+		}
+
+		property bool hidden: navBar.y === root.height
+
+		function show() {
+			if (hidden) {
+				animateNavBarIn.start()
+			}
+		}
+
+		function hide() {
+			if (!hidden) {
+				animateNavBarOut.start()
+			}
+		}
+
+		SequentialAnimation {
+			id: animateNavBarIn
+			NumberAnimation {
+				target: navBar
+				property: "y"
+				from: root.height
+				to: root.height - navBar.height
+				duration: 250
+				easing.type: Easing.InOutQuad
+			}
+			OpacityAnimator {
+				target: navBar
+				from: 0.0
+				to: 1.0
+				duration: 250
+				easing.type: Easing.InOutQuad
+			}
+		}
+
+		SequentialAnimation {
+			id: animateNavBarOut
+			OpacityAnimator {
+				target: navBar
+				from: 1.0
+				to: 0.0
+				duration: 250
+				easing.type: Easing.InOutQuad
+			}
+			NumberAnimation {
+				target: navBar
+				property: "y"
+				from: root.height - navBar.height
+				to: root.height
+				duration: 250
+				easing.type: Easing.InOutQuad
 			}
 		}
 	}

--- a/pages/Page.qml
+++ b/pages/Page.qml
@@ -10,27 +10,6 @@ import Victron.VenusOS
 Item {
 	id: root
 
-	signal controlsButtonClicked(bool wasToggled)
-	property bool isControlCardsPage
-	property alias controlsButton: controlsButton
-
-	Button {
-		id: controlsButton
-
-		anchors {
-			left: parent.left
-			leftMargin: 26
-			top: parent.top
-			topMargin: 10
-		}
-
-		height: 32
-		width: height
-		display: C.AbstractButton.IconOnly
-		color: Theme.okColor
-		icon.source: isControlCardsPage ? "qrc:/images/controls-toggled.svg" : "qrc:/images/controls.svg"
-		icon.width: 28
-		icon.height: 28
-		onClicked: root.controlsButtonClicked(isControlCardsPage)
-	}
+	width: parent ? parent.width : 0
+	height: parent ? parent.height : 0
 }

--- a/pages/PageManager.qml
+++ b/pages/PageManager.qml
@@ -1,0 +1,28 @@
+/*
+** Copyright (C) 2021 Victron Energy B.V.
+*/
+pragma Singleton
+
+import QtQml
+
+QtObject {
+	property var pageToPush
+
+	function pushPage(page) {
+		pageToPush = page
+		emitter.pagePushRequested()
+	}
+
+	function popPage() {
+		emitter.pagePopRequested()
+	}
+
+	property QtObject emitter: QtObject {
+		signal pagePushRequested()
+		signal pagePopRequested()
+	}
+
+	// Ugly hack, but ...
+	property bool sidePanelVisible
+	property bool sidePanelActive
+}

--- a/qml.qrc
+++ b/qml.qrc
@@ -19,11 +19,13 @@
         <file>components/ModalDialog.qml</file>
         <file>components/NavBar.qml</file>
         <file>components/NavButton.qml</file>
+        <file>components/PageStack.qml</file>
         <file>components/ProgressArc.qml</file>
         <file>components/ScaledArc.qml</file>
         <file>components/ScaledArcGauge.qml</file>
         <file>components/SegmentedButtonRow.qml</file>
         <file>components/SeparatorBar.qml</file>
+        <file>components/StatusBar.qml</file>
         <file>components/SwitchesModel.qml</file>
         <file>components/Units.qml</file>
         <file>components/Utils.js</file>
@@ -35,6 +37,7 @@
         <file>data/Inverters.qml</file>
         <file>data/Relays.qml</file>
         <file>data/Tanks.qml</file>
+        <file>pages/PageManager.qml</file>
         <file>pages/Page.qml</file>
         <file>pages/MainPage.qml</file>
         <file>pages/ControlCardsPage.qml</file>


### PR DESCRIPTION
The StatusBar is now completely separate to pages.
It lives in the main.qml only, and is shown/hidden when appropriate.
The top-level pagestack now fills the space between the bottom of the
StatusBar and the bottom of the window, allowing its size to be
animated smoothly when required.

Also add animations for the navigation bar, and allow animating
it out, to allow the navigation pages to take up the entire space
if necessary (e.g. in non-interactive mode).