### PR TITLE
Load English translations if locale-specific translations aren't found

### DIFF
--- a/language.h
+++ b/language.h
@@ -35,7 +35,8 @@ Q_SIGNALS:
 	void currentLanguageChanged();
 
 private:
-	QLocale::Language m_currentLanguage = QLocale::English;
+	bool installTranslatorForLanguage(QLocale::Language language);
+	QLocale::Language m_currentLanguage = QLocale::AnyLanguage;
 	QQmlEngine* m_qmlEngine = nullptr;
 	QHash<QLocale::Language, QTranslator*> m_loadedTranslators;
 };

--- a/main.cpp
+++ b/main.cpp
@@ -12,7 +12,6 @@
 #include <velib/qt/ve_qitems_dbus.hpp>
 #include <velib/qt/ve_qitem.hpp>
 
-#include <QTranslator>
 #include <QGuiApplication>
 #include <QQmlComponent>
 #include <QQmlContext>
@@ -31,7 +30,7 @@ int main(int argc, char *argv[])
 	qmlRegisterSingletonType<Victron::VenusOS::Theme>(
 		"Victron.VenusOS", 2, 0, "Theme",
 		&Victron::VenusOS::Theme::instance);
-	qmlRegisterSingletonType<Victron::VenusOS::Language>(
+	const int languageSingletonId = qmlRegisterSingletonType<Victron::VenusOS::Language>(
 		"Victron.VenusOS", 2, 0, "Language",
 		[](QQmlEngine *engine, QJSEngine *) -> QObject* {
 			return new Victron::VenusOS::Language(engine);
@@ -304,21 +303,11 @@ int main(int argc, char *argv[])
 		producer->open(VBusItems::getConnection());
 	}
 
-	/* Load appropriate translations, e.g. :/i18n/venus-gui-v2_fr.qm */
-	QTranslator translator;
-	if (translator.load(
-		QLocale(),
-		QLatin1String("venus-gui-v2"),
-		QLatin1String("_"),
-		QLatin1String(":/i18n"))) {
-		QCoreApplication::installTranslator(&translator);
-		qCDebug(venusGui) << "Successfully loaded translations for locale" << QLocale().name();
-	} else {
-		qCWarning(venusGui) << "Unable to load translations for locale" << QLocale().name();
-	}
-
 	QQmlEngine engine;
 	engine.setProperty("colorScheme", Victron::VenusOS::Theme::Dark);
+
+	/* Force construction of translator */
+	(void)engine.singletonInstance<Victron::VenusOS::Language*>(languageSingletonId);
 
 	const QSizeF physicalScreenSize = QGuiApplication::primaryScreen()->physicalSize();
 	const int screenDiagonalMm = sqrt((physicalScreenSize.width() * physicalScreenSize.width())


### PR DESCRIPTION
This commit ensures that all translation handling is done within the
language singleton, rather than loading the current-locale translations
within main.cpp.

It also ensures that if no locale-specific translation catalogue is
found, we fall back to English translations by default.