### PR TITLE
3.d / 8.v: Avoid layer multisampling for antialiasing support

### DIFF
--- a/components/ArcGauge.qml
+++ b/components/ArcGauge.qml
@@ -14,18 +14,19 @@ Item {
 	property int valueType: Gauges.FallingPercentage
 	property alias startAngle: arc.startAngle
 	property alias endAngle: arc.endAngle
-	property alias radius: arc.radius
-	property alias strokeWidth: arc.strokeWidth
+	property alias radius: arc._radius
+	property alias strokeWidth: arc._strokeWidth
 	property alias direction: arc.direction
 	property int alignment: Qt.AlignLeft
 	property var arcX
 	property var arcY
 
 	Item {
-		// Antialiasing
-		anchors.fill: parent
-		layer.enabled: true
-		layer.samples: 4
+		id: arcGauge
+		readonly property int antialiasingFactor: 2
+		width: parent.width*antialiasingFactor
+		height: parent.height*antialiasingFactor
+		visible: false
 
 		ProgressArc {
 			id: arc
@@ -33,14 +34,24 @@ Item {
 			property int status: Gauges.getValueStatus(gauge.value, gauge.valueType)
 			property real margin: strokeWidth/2
 
+			property real _radius
+			property real _strokeWidth: Theme.geometry.progressArc.strokeWidth
+			radius: _radius * arcGauge.antialiasingFactor
+			strokeWidth: _strokeWidth * arcGauge.antialiasingFactor
+
 			width: radius*2 - strokeWidth
 			height: width
-			x: arcX !== undefined ? arcX : (gauge.alignment === Qt.AlignRight ? (gauge.width - 2*radius) - margin : margin)
-			y: arcY !== undefined ? arcY : ((gauge.height - height) / 2 - margin)
-			radius: gauge.radius
+			x: arcX !== undefined ? arcX*arcGauge.antialiasingFactor : (gauge.alignment === Qt.AlignRight ? (parent.width - 2*radius) - margin : margin)
+			y: arcY !== undefined ? arcY*arcGauge.antialiasingFactor : ((parent.height - height) / 2 - margin)
 			value: gauge.value
 			progressColor: Theme.statusColorValue(status)
 			remainderColor: Theme.statusColorValue(status, true)
 		}
+	}
+	ShaderEffectSource {
+		id: antialiasedArcGauge
+		anchors.fill: parent
+		sourceItem: arcGauge
+		smooth: true
 	}
 }

--- a/components/CircularMultiGauge.qml
+++ b/components/CircularMultiGauge.qml
@@ -17,11 +17,11 @@ Item {
 	readonly property real _stepSize: 2 * (strokeWidth + Theme.geometry.circularMultiGauge.spacing)
 
 	Item {
-		anchors.fill: parent
-
-		// Antialiasing
-		layer.enabled: true
-		layer.samples: 4
+		id: arcGauges
+		readonly property int antialiasingFactor: 2
+		width: parent.width*antialiasingFactor
+		height: parent.height*antialiasingFactor
+		visible: false
 
 		Repeater {
 			id: arcRepeater
@@ -29,7 +29,7 @@ Item {
 			model: gauges.model
 			delegate: ProgressArc {
 				property int status: Gauges.getValueStatus(model.value, model.valueType)
-				width: parent.width - (strokeWidth + index*_stepSize)
+				width: parent.width - (strokeWidth + index*_stepSize*arcGauges.antialiasingFactor)
 				height: width
 				anchors.centerIn: parent
 				radius: width/2
@@ -38,10 +38,16 @@ Item {
 				value: model.value
 				progressColor: Theme.statusColorValue(status)
 				remainderColor: Theme.statusColorValue(status, true)
-				strokeWidth: gauges.strokeWidth
+				strokeWidth: gauges.strokeWidth * arcGauges.antialiasingFactor
 				visible: model.index < Theme.geometry.briefPage.centerGauge.maximumGaugeCount
 			}
 		}
+	}
+	ShaderEffectSource {
+		id: antialiasedArcGauges
+		anchors.fill: parent
+		sourceItem: arcGauges
+		smooth: true
 	}
 
 	Item {

--- a/components/CircularSingleGauge.qml
+++ b/components/CircularSingleGauge.qml
@@ -15,16 +15,16 @@ Item {
 	property alias caption: captionLabel.text
 
 	Item {
-		anchors.fill: parent
-
-		// Antialiasing
-		layer.enabled: true
-		layer.samples: 4
+		id: arcGauge
+		readonly property int antialiasingFactor: 2
+		width: parent.width*antialiasingFactor
+		height: parent.height*antialiasingFactor
+		visible: false
 
 		ProgressArc {
 			property int status: Gauges.getValueStatus(model.value, model.valueType)
 			
-			width: gauges.width - strokeWidth
+			width: parent.width - strokeWidth
 			height: width
 			anchors.centerIn: parent
 			radius: width/2
@@ -33,8 +33,14 @@ Item {
 			value: model.value
 			progressColor: Theme.statusColorValue(status)
 			remainderColor: Theme.statusColorValue(status, true)
-			strokeWidth: gauges.strokeWidth
+			strokeWidth: gauges.strokeWidth * arcGauge.antialiasingFactor
 		}
+	}
+	ShaderEffectSource {
+		id: antialiasedArcGauge
+		anchors.fill: parent
+		sourceItem: arcGauge
+		smooth: true
 	}
 
 	Column {

--- a/components/LoadGraphShapePath.qml
+++ b/components/LoadGraphShapePath.qml
@@ -24,7 +24,6 @@ Shape {
 
 	smooth: true
 	layer.enabled: true
-	layer.samples: 8
 	NumberAnimation on offset {
 		id: animation
 

--- a/components/ScaledArcGauge.qml
+++ b/components/ScaledArcGauge.qml
@@ -13,18 +13,19 @@ Item {
 	property int valueType: Gauges.FallingPercentage
 	property alias startAngle: arc.startAngle
 	property alias endAngle: arc.endAngle
-	property alias radius: arc.radius
-	property alias strokeWidth: arc.strokeWidth
+	property alias radius: arc._radius
+	property alias strokeWidth: arc._strokeWidth
 	property alias direction: arc.direction
 	property int alignment: Qt.AlignLeft
 	property var arcX
 	property var arcY
 
 	Item {
-		// Antialiasing
-		anchors.fill: parent
-		layer.enabled: true
-		layer.samples: 4
+		id: arcGauge
+		readonly property int antialiasingFactor: 2
+		width: parent.width*antialiasingFactor
+		height: parent.height*antialiasingFactor
+		visible: false
 
 		ScaledArc {
 			id: arc
@@ -32,12 +33,23 @@ Item {
 			property int status: Gauges.getValueStatus(gauge.value, gauge.valueType)
 			property real margin: strokeWidth/2
 
+			property real _radius
+			property real _strokeWidth: Theme.geometry.progressArc.strokeWidth
+			radius: _radius * arcGauge.antialiasingFactor
+			strokeWidth: _strokeWidth * arcGauge.antialiasingFactor
+
 			width: radius*2 - strokeWidth
 			height: width
-			x: arcX !== undefined ? arcX : (gauge.alignment === Qt.AlignRight ? (gauge.width - 2*radius) - margin : margin)
-			y: arcY !== undefined ? arcY : ((gauge.height - height) / 2 - margin)
+			x: arcX !== undefined ? arcX*arcGauge.antialiasingFactor : (gauge.alignment === Qt.AlignRight ? (parent.width - 2*radius) - margin : margin)
+			y: arcY !== undefined ? arcY*arcGauge.antialiasingFactor : ((parent.height - height) / 2 - margin)
 			value: gauge.value
 			strokeColor: Theme.statusColorValue(status)
 		}
+	}
+	ShaderEffectSource {
+		id: antialiasedArcGauge
+		anchors.fill: parent
+		sourceItem: arcGauge
+		smooth: true
 	}
 }


### PR DESCRIPTION
QtQuick's layer.samples support relies on an OpenGL ES 3.x feature
called multisample framebuffers, however the CerboGX Mali400 only
supports OpenGL ES 2.0.

Instead of using layer.samples multisampling for antialiasing, this
commit uses a smoothed ShaderEffectSource (FBO) with an oversized
sourceItem, to achieve a similar effect (at the cost of some memory).