### PR TITLE
Qt For WebAssembly / Emscripten support

### DIFF
--- a/ApplicationContent.qml
+++ b/ApplicationContent.qml
@@ -1,0 +1,109 @@
+/*
+** Copyright (C) 2021 Victron Energy B.V.
+*/
+
+import QtQuick
+import Victron.VenusOS
+import "/components/Utils.js" as Utils
+import "data" as Data
+import "demo" as Demo
+
+Item {
+	property alias dialogManager: dialogManager
+	property alias mainView: mainView
+
+	Data.DataManager {
+		id: dataManager
+	}
+
+	Loader {
+		id: demoManagerLoader
+
+		active: false
+		sourceComponent: Demo.DemoManager {}
+		onStatusChanged: {
+			if (status === Loader.Ready) {
+				if (Global.demoManager != null) {
+					console.warn("Global.demoManager is already set, overwriting")
+				}
+				Global.demoManager = item
+			} else if (status === Loader.Ready) {
+				console.warn("Unable to load DemoManager:", errorString())
+			}
+		}
+	}
+
+	DemoModeDataPoint {
+		forceValidDemoMode: !splashView.enabled
+		onDemoModeChanged: {
+			if (demoMode === VenusOS.SystemSettings_DemoModeActive) {
+				// Ensure Global.demoManager is set before initializing the DataManager.
+				demoManagerLoader.active = true
+				dataManager.dataSourceType = VenusOS.DataPoint_MockSource
+			} else if (demoMode === VenusOS.SystemSettings_DemoModeInactive) {
+				demoManagerLoader.active = false
+				dataManager.dataSourceType = VenusOS.DataPoint_DBusSource
+			}
+		}
+	}
+
+	PageManager {
+		id: pageManager
+		Component.onCompleted: Global.pageManager = pageManager
+	}
+
+	SplashView {
+		id: splashView
+		anchors.fill: parent
+		enabled: true
+		opacity: enabled ? 1 : 0
+
+		Behavior on opacity {
+			NumberAnimation {
+				duration: Theme.animation.page.fade.duration
+				easing.type: Easing.InOutQuad
+			}
+		}
+
+		onHideSplash: {
+			splashView.enabled = false
+			mainView.enabled = true
+		}
+	}
+
+	MainView {
+		id: mainView
+		anchors.fill: parent
+		enabled: false
+		opacity: enabled ? 1 : 0
+		pageManager: pageManager
+
+		Behavior on opacity {
+			NumberAnimation {
+				duration: Theme.animation.page.fade.duration
+				easing.type: Easing.InOutQuad
+			}
+		}
+	}
+
+	MouseArea {
+		id: idleModeMouseArea
+		anchors.fill: parent
+
+		onPressed: function(mouse) {
+			mouse.accepted = false
+			if (pageManager.idleModeTimer.running) {
+				pageManager.idleModeTimer.restart()
+			}
+			if (pageManager.interactivity === VenusOS.PageManager_InteractionMode_Idle) {
+				mouse.accepted = true
+				pageManager.interactivity = VenusOS.PageManager_InteractionMode_EndFullScreen
+			}
+		}
+	}
+
+	DialogManager {
+		// we rely on the implicit Z ordering, so must be declared after the other views.
+		id: dialogManager
+	}
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,6 @@ set(TRANSLATIONS_TS_TARGET venus-gui-v2-translations-ts)
 set(TRANSLATIONS_QM_TARGET venus-gui-v2-translations-qm)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTOMOC ON)
@@ -18,19 +15,30 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 message("Building VenusOS for ${CMAKE_SYSTEM_NAME}")
 
-find_package(Qt6 COMPONENTS Core Qml Quick Svg Xml DBus LinguistTools)
-if (NOT ${Qt6_FOUND})
-    # cmake can't automatically find Qt 6.2 on Ubuntu Linux, give it a hint:
-    if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-        list(APPEND CMAKE_PREFIX_PATH "/opt/Qt/6.2.0/gcc_64/lib/cmake/")
-    endif()
+option(VENUS_DESKTOP_BUILD "enable desktop build via cmake -DVENUS_DESKTOP_BUILD=ON" OFF) # Disabled by default
+option(VENUS_WEBASSEMBLY_BUILD "enable webassembly build via cmake -DVENUS_WEBASSEMBLY_BUILD=ON" OFF) # Disabled by default
 
-    find_package(Qt6 COMPONENTS Core Qml Quick Svg Xml DBus LinguistTools REQUIRED)
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
+    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+    add_compile_definitions(VENUS_WEBASSEMBLY_BUILD)
+    find_package(Qt6 COMPONENTS Core Qml Quick Svg Xml LinguistTools REQUIRED)
+else()
+    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+    find_package(Qt6 COMPONENTS Core Qml Quick Svg Xml DBus LinguistTools)
+    if (NOT ${Qt6_FOUND})
+        # cmake can't automatically find Qt 6.2 on Ubuntu Linux, give it a hint:
+        if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+            list(APPEND CMAKE_PREFIX_PATH "/opt/Qt/6.2.0/gcc_64/lib/cmake/")
+        endif()
+        find_package(Qt6 COMPONENTS Core Qml Quick Svg Xml DBus LinguistTools REQUIRED)
+    endif()
 endif()
 
-option(VENUS_DESKTOP_BUILD "enable desktop build via cmake -DVENUS_DESKTOP_BUILD=ON" OFF) # Disabled by default
-
-qt6_add_resources(QML_RESOURCES
+qt_add_resources(QML_RESOURCES
     qml.qrc)
 
 # translations support.
@@ -94,7 +102,7 @@ set(VELIB_SOURCES
     velib/src/qt/v_busitems.cpp
 )
 
-list(APPEND SOURCES
+set(VENUS_SOURCES
     main.cpp
     theme.h
     theme.cpp
@@ -103,28 +111,43 @@ list(APPEND SOURCES
     logging.h
     enums.h
     enums.cpp
-    ${VELIB_SOURCES}
-    ${QML_RESOURCES}
 )
 
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
+    list(APPEND SOURCES
+        ${VENUS_SOURCES}
+        ${QML_RESOURCES}
+    )
+else()
+    list(APPEND SOURCES
+        ${VELIB_SOURCES}
+        ${VENUS_SOURCES}
+        ${QML_RESOURCES}
+    )
+endif()
+
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
+    qt_add_executable(${PROJECT_NAME}
+        ${SOURCES}
+    )
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
     add_compile_definitions(VENUS_DESKTOP_BUILD)
-    add_executable(${PROJECT_NAME}
+    qt_add_executable(${PROJECT_NAME}
       MACOSX_BUNDLE
       ${SOURCES}
     )
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
     add_compile_definitions(VENUS_DESKTOP_BUILD)
-    add_executable(${PROJECT_NAME}
+    qt_add_executable(${PROJECT_NAME}
         ${SOURCES}
     )
 elseif(VENUS_DESKTOP_BUILD)
     add_compile_definitions(VENUS_DESKTOP_BUILD)
-    add_executable(${PROJECT_NAME}
+    qt_add_executable(${PROJECT_NAME}
         ${SOURCES}
     )
 else()
-    add_executable(${PROJECT_NAME}
+    qt_add_executable(${PROJECT_NAME}
         ${SOURCES}
     )
 endif()
@@ -138,24 +161,29 @@ qt_add_resources(${PROJECT_NAME} "i18n"
 target_compile_definitions(${PROJECT_NAME}
     PRIVATE $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:QT_QML_DEBUG>)
 
-target_link_libraries(${PROJECT_NAME} PRIVATE
-    Qt6::Core
-    Qt6::Qml
-    Qt6::Quick
-    Qt6::Svg
-    Qt6::Xml
-    Qt6::DBus
-)
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
+    target_link_libraries(${PROJECT_NAME} PRIVATE
+        Qt6::Core
+        Qt6::Qml
+        Qt6::Quick
+        Qt6::Svg
+        Qt6::Xml
+    )
+else()
+    target_link_libraries(${PROJECT_NAME} PRIVATE
+        Qt6::Core
+        Qt6::Qml
+        Qt6::Quick
+        Qt6::Svg
+        Qt6::Xml
+        Qt6::DBus
+    )
+endif()
 
-qt6_add_qml_module(${PROJECT_NAME}
+qt_add_qml_module(${PROJECT_NAME}
     URI Victron.VenusOS
     VERSION 2.0
 )
-
-find_package(Qt6QmlImportScanner)
-if (Qt6QmlImportScanner_FOUND)
-    qt6_import_qml_plugins(${PROJECT_NAME})
-endif()
 
 # see if the dependency graph is correct, for translations support...
 add_custom_target(graphviz

--- a/data/DataManager.qml
+++ b/data/DataManager.qml
@@ -5,7 +5,6 @@
 import QtQuick
 import Victron.VenusOS
 
-import "dbus" as DBusData
 import "mock" as MockData
 
 Item {
@@ -75,7 +74,7 @@ Item {
 		id: dbusDataLoader
 
 		active: false
-		sourceComponent: DBusData.DBusDataManager {}
+		source: active ? "qrc:/data/dbus/DBusDataManager.qml" : undefined
 
 		onLoaded: Global.dataBackendLoaded = true
 	}

--- a/main.qml
+++ b/main.qml
@@ -4,120 +4,27 @@
 
 import QtQuick
 import QtQuick.Window
-import QtQuick.Controls
 import Victron.VenusOS
-import "/components/Utils.js" as Utils
-import "data" as Data
-import "demo" as Demo
 
 Window {
 	id: root
 
-	property alias dialogManager: dialogManager
-
-	width: [800, 1024][Theme.screenSize]
-	height: [480, 600][Theme.screenSize]
-	color: mainView.backgroundColor
+	property alias dialogManager: content.dialogManager
 
 	//: Application title
 	//% "Venus OS GUI"
 	//~ Context only shown on desktop systems
 	title: qsTrId("venus_os_gui")
+	color: content.mainView.backgroundColor
 
-	Data.DataManager {
-		id: dataManager
-	}
+	width: [800, 1024][Theme.screenSize]
+	height: [480, 600][Theme.screenSize]
 
-	Loader {
-		id: demoManagerLoader
-
-		active: false
-		sourceComponent: Demo.DemoManager {}
-		onStatusChanged: {
-			if (status === Loader.Ready) {
-				if (Global.demoManager != null) {
-					console.warn("Global.demoManager is already set, overwriting")
-				}
-				Global.demoManager = item
-			} else if (status === Loader.Ready) {
-				console.warn("Unable to load DemoManager:", errorString())
-			}
-		}
-	}
-
-	DemoModeDataPoint {
-		forceValidDemoMode: !splashView.enabled
-		onDemoModeChanged: {
-			if (demoMode === VenusOS.SystemSettings_DemoModeActive) {
-				// Ensure Global.demoManager is set before initializing the DataManager.
-				demoManagerLoader.active = true
-				dataManager.dataSourceType = VenusOS.DataPoint_MockSource
-			} else if (demoMode === VenusOS.SystemSettings_DemoModeInactive) {
-				demoManagerLoader.active = false
-				dataManager.dataSourceType = VenusOS.DataPoint_DBusSource
-			}
-		}
-	}
-
-	PageManager {
-		id: pageManager
-
-		Component.onCompleted: Global.pageManager = pageManager
-	}
-
-	SplashView {
-		id: splashView
-		anchors.fill: parent
-		enabled: true
-		opacity: enabled ? 1 : 0
-
-		Behavior on opacity {
-			NumberAnimation {
-				duration: Theme.animation.page.fade.duration
-				easing.type: Easing.InOutQuad
-			}
-		}
-
-		onHideSplash: {
-			splashView.enabled = false
-			mainView.enabled = true
-		}
-	}
-
-	MainView {
-		id: mainView
-		anchors.fill: parent
-		enabled: false
-		opacity: enabled ? 1 : 0
-		pageManager: pageManager
-
-		Behavior on opacity {
-			NumberAnimation {
-				duration: Theme.animation.page.fade.duration
-				easing.type: Easing.InOutQuad
-			}
-		}
-	}
-
-	MouseArea {
-		id: idleModeMouseArea
-
-		anchors.fill: parent
-		enabled: pageManager.interactivity === VenusOS.PageManager_InteractionMode_Idle
-		onClicked: pageManager.interactivity = VenusOS.PageManager_InteractionMode_EndFullScreen
-	}
-
-	MouseArea {
-		anchors.fill: parent
-		onPressed: function(mouse) {
-			mouse.accepted = false
-			if (pageManager.idleModeTimer.running) {
-				pageManager.idleModeTimer.restart()
-			}
-		}
-	}
-
-	DialogManager {
-		id: dialogManager
+	ApplicationContent {
+		id: content
+		anchors.centerIn: parent
+		width: [800, 1024][Theme.screenSize]
+		height: [480, 600][Theme.screenSize]
+		clip: Qt.platform.os == "wasm"
 	}
 }

--- a/qml.qrc
+++ b/qml.qrc
@@ -1,6 +1,7 @@
 <RCC>
     <qresource prefix="/">
         <file>main.qml</file>
+        <file>ApplicationContent.qml</file>
         <file>Global.qml</file>
         <file>components/controls/Button.qml</file>
         <file>components/controls/ComboBox.qml</file>


### PR DESCRIPTION
- add ifdefs to CMakeLists.txt to support WebAssembly builds
  which don't use DBus
- add ifdefs to main.cpp to remove usages of DBus
- load wasm.qml instead of main.qml on WebAssembly platform
- contain the main window content in a sub-item which on
  WebAssembly platform is sized according to the theme's selected
  size and clips

To build:
- install emscripten SDK as documented in Qt For WebAssembly docs
- install Qt 6.2.4 with Qt For WebAssembly support
  Note: Qt 6.2.2 suffers from QTBUG-98764 Flickable issue
- reboot machine
- run QtCreator, configure for WebAssembly target, release build

To deploy:
- place the following files in a separate directory:
  qtloader.js
  qtlogo.svg
  venus-gui-v2.cbp
  venus-gui-v2.html
  venus-gui-v2.js
  venus-gui-v2.wasm

To run:
- C:\Development\emscripten\emsdk\python\3.9.2-1_64bit\python.exe \
  C:/Development/emscripten/emsdk/upstream/emscripten/emrun.py \
    --browser chrome --port 30000 --no_emrun_detect
    --serve_after_close C:/path/to/deployment/dir/venus-gui-v2.html