### PR TITLE
3.d / 8.v: Avoid layer multisampling for antialiasing support

### DIFF
--- a/components/ArcGauge.qml
+++ b/components/ArcGauge.qml
@@ -24,10 +24,13 @@ Item {
 	property var arcY
 
 	Item {
-		// Antialiasing
+		id: antialiased
 		anchors.fill: parent
+
+		// Antialiasing without requiring multisample framebuffers.
 		layer.enabled: true
-		layer.samples: 4
+		layer.smooth: true
+		layer.textureSize: Qt.size(antialiased.width*2, antialiased.height*2)
 
 		ProgressArc {
 			id: arc

--- a/components/CircularMultiGauge.qml
+++ b/components/CircularMultiGauge.qml
@@ -21,11 +21,13 @@ Item {
 	readonly property real _stepSize: 2 * (strokeWidth + Theme.geometry.circularMultiGauge.spacing)
 
 	Item {
+		id: antialiased
 		anchors.fill: parent
 
-		// Antialiasing
+		// Antialiasing without requiring multisample framebuffers.
 		layer.enabled: true
-		layer.samples: 4
+		layer.smooth: true
+		layer.textureSize: Qt.size(antialiased.width*2, antialiased.height*2)
 
 		Repeater {
 			id: arcRepeater

--- a/components/CircularSingleGauge.qml
+++ b/components/CircularSingleGauge.qml
@@ -20,11 +20,13 @@ Item {
 	property alias shineAnimationEnabled: arc.shineAnimationEnabled
 
 	Item {
+		id: antialiased
 		anchors.fill: parent
 
-		// Antialiasing
+		// Antialiasing without requiring multisample framebuffers.
 		layer.enabled: true
-		layer.samples: 4
+		layer.smooth: true
+		layer.textureSize: Qt.size(antialiased.width*2, antialiased.height*2)
 
 		// The single circular gauge is always the battery gauge :. shiny.
 		ShinyProgressArc {

--- a/components/LoadGraphShapePath.qml
+++ b/components/LoadGraphShapePath.qml
@@ -23,8 +23,12 @@ Shape {
 	function calcY(data) { return (1 - data) * height }
 
 	smooth: true
+
+	// Antialiasing without requiring multisample framebuffers.
 	layer.enabled: true
-	layer.samples: 8
+	layer.smooth: true
+	layer.textureSize: Qt.size(root.width*2, root.height*2)
+
 	NumberAnimation on offset {
 		id: animation
 

--- a/components/ScaledArcGauge.qml
+++ b/components/ScaledArcGauge.qml
@@ -22,10 +22,13 @@ Item {
 	property var arcY
 
 	Item {
-		// Antialiasing
+		id: antialiased
 		anchors.fill: parent
+
+		// Antialiasing without requiring multisample framebuffers.
 		layer.enabled: true
-		layer.samples: 4
+		layer.smooth: true
+		layer.textureSize: Qt.size(antialiased.width*2, antialiased.height*2)
 
 		ScaledArc {
 			id: arc

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -459,6 +459,11 @@ int main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
+#if defined(VENUS_DESKTOP_BUILD)
+	QSurfaceFormat format = window->format();
+	format.setSamples(4); // enable MSAA
+	window->setFormat(format);
+#endif
 	engine.setIncubationController(window->incubationController());
 
 	/* Write to window properties here to perform any additional initialization


### PR DESCRIPTION
Use supersampling rather than multisampling for antialiasing.
The downside is greatly increased memory use for these items.
The upside is that it works on device + webassembly.