### PR TITLE
Don't use Loader to load Virtual Keyboard Input Panel

### DIFF
--- a/ApplicationContent.qml
+++ b/ApplicationContent.qml
@@ -9,6 +9,8 @@ import "data" as Data
 import "demo" as Demo
 
 Item {
+	id: root
+
 	property alias dialogManager: dialogManager
 	property alias mainView: mainView
 
@@ -110,42 +112,21 @@ Item {
 		id: dialogManager
 	}
 
-	// Load the VKB separately so that the app still runs if QtQuick.VirtualKeyboard is not
-	// available (e.g. in Qt WASM).
 	// Place this above idleModeMouseArea so that the mouse area can call testCloseOnClick() when
 	// clicking outside of the focused text field, below the VKB layer.
-	Loader {
-		id: inputPanelLoader
+	InputPanel {
+		id: vkb
 
-		x: 0
-		y: root.height
-		source: "qrc:/components/InputPanel.qml"
+		mainViewItem: mainView
+		y: Qt.inputMethod.visible ? root.height - vkb.height : root.height
 
-		onStatusChanged: {
-			if (status === Loader.Ready) {
-				Global.inputPanel = item
-			} else if (status === Loader.Error) {
-				console.warn("Cannot load InputPanel!")
-			}
-		}
-
-		states: State {
-			name: "visible"
-			when: Qt.inputMethod.visible
-
-			PropertyChanges {
-				target: inputPanelLoader
-				y: root.height - inputPanelLoader.item.height
-			}
-		}
-
-		transitions: Transition {
+		Behavior on y {
 			NumberAnimation {
-				property: "y"
 				duration: Theme.animation.inputPanel.slide.duration
 				easing.type: Easing.InOutQuad
 			}
 		}
 
+		Component.onCompleted: Global.inputPanel = vkb
 	}
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
     set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
     add_compile_definitions(VENUS_WEBASSEMBLY_BUILD)
-    find_package(Qt6 COMPONENTS Core Qml Quick Svg Xml LinguistTools REQUIRED)
+    find_package(Qt6 COMPONENTS Core Qml Quick Svg Xml VirtualKeyboard LinguistTools REQUIRED)
 else()
     set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
     set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
@@ -196,6 +196,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
         Qt6::Quick
         Qt6::Svg
         Qt6::Xml
+        Qt6::VirtualKeyboard
     )
 else()
     target_link_libraries(${PROJECT_NAME} PRIVATE

--- a/components/InputPanel.qml
+++ b/components/InputPanel.qml
@@ -9,6 +9,7 @@ import Victron.VenusOS
 QtVirtualKeyboard.InputPanel {
 	id: root
 
+	property var mainViewItem
 	property var focusedItem
 	property var focusedFlickable
 	property real toContentY
@@ -55,8 +56,8 @@ QtVirtualKeyboard.InputPanel {
 				console.warn("onAboutToFocusTextField(): invalid item/flickable:", textField, flickable)
 				return
 			}
-			const inputPanelY = mainView.height - root.height
-			const toWinY = textField.mapToItem(mainView, 0, toTextFieldY).y
+			const inputPanelY = mainViewItem.height - root.height
+			const toWinY = textField.mapToItem(mainViewItem, 0, toTextFieldY).y
 			const delta = toWinY - inputPanelY
 
 			if (delta > 0) {

--- a/macdeployhelper.sh
+++ b/macdeployhelper.sh
@@ -21,6 +21,7 @@ echo import QtQuick >> $DHQML
 echo import QtQuick.Window >> $DHQML
 echo import QtQuick.Controls >> $DHQML
 echo import QtQuick.Layouts >> $DHQML
+echo import QtQuick.VirtualKeyboard >> $DHQML
 echo >> $DHQML
 echo Item { } >> $DHQML
 echo >> $DHQML

--- a/windeployhelper.bat
+++ b/windeployhelper.bat
@@ -20,6 +20,7 @@ echo import QtQuick >> %DHQML%
 echo import QtQuick.Window >> %DHQML%
 echo import QtQuick.Controls >> %DHQML%
 echo import QtQuick.Layouts >> %DHQML%
+echo import QtQuick.VirtualKeyboard >> %DHQML%
 echo= >> %DHQML%
 echo Item { } >> %DHQML%
 echo= >> %DHQML%


### PR DESCRIPTION
On some platforms, the InputPanel doesn't inherit geometry
correctly from the loader.

So, just instantiate the InputPanel directly.

This currently breaks WebAssembly - see QTBUG-104109.