### PR TITLE
Update clock time regularly and consolidate fetching of current date/…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,8 @@ set(VELIB_SOURCES
 
 set(VENUS_SOURCES
     main.cpp
+    clocktime.h
+    clocktime.cpp
     theme.h
     theme.cpp
     language.h

--- a/Global.qml
+++ b/Global.qml
@@ -18,7 +18,6 @@ QtObject {
 	property var pageManager
 	property var demoManager    // only valid when demo mode is active
 	property var inputPanel
-	property date now: new Date()
 
 	// data sources
 	property var acInputs
@@ -37,13 +36,6 @@ QtObject {
 
 	readonly property bool ready: pageManager != null && dataBackendLoaded
 	property bool dataBackendLoaded
-
-	readonly property Timer _timer: Timer {
-		interval: 60000 // 1 minute
-		running: true
-		repeat: true
-		onTriggered: now = new Date()
-	}
 
 	signal aboutToFocusTextField(var textField, int toTextFieldY, var flickable)
 }

--- a/clocktime.cpp
+++ b/clocktime.cpp
@@ -1,0 +1,44 @@
+#include "clocktime.h"
+
+using namespace Victron::VenusOS;
+
+ClockTime::ClockTime(QObject *parent)
+	: QObject(parent)
+{
+	updateTime();
+	scheduleNextTimeCheck(m_currentDateTime.time());
+}
+
+void ClockTime::timerEvent(QTimerEvent *)
+{
+	const QTime currentTime = QTime::currentTime();
+	if (currentTime.minute() != m_currentDateTime.time().minute()) {
+		updateTime();
+	}
+	scheduleNextTimeCheck(currentTime);
+}
+
+void ClockTime::updateTime()
+{
+	m_currentDateTime = QDateTime::currentDateTime();
+	m_currentTimeText = m_currentDateTime.toString("hh:mm");
+	emit currentDateTimeChanged();
+	emit currentTimeTextChanged();
+}
+
+void ClockTime::scheduleNextTimeCheck(const QTime &now)
+{
+	if (m_timerId > 0) {
+		killTimer(m_timerId);
+	}
+
+	// Wait until just after the next clock minute, then update the time properties.
+	const int secsUntilNextMin = 60 - now.second();
+	m_timerId = startTimer((secsUntilNextMin + 1) * 1000);
+}
+
+ClockTime* ClockTime::instance(QObject* parent)
+{
+	return new ClockTime(parent);
+}
+

--- a/clocktime.h
+++ b/clocktime.h
@@ -1,0 +1,44 @@
+#ifndef VICTRON_VENUSOS_CLOCKTIME_H
+#define VICTRON_VENUSOS_CLOCKTIME_H
+
+#include <QObject>
+#include <QDateTime>
+#include <QTime>
+
+namespace Victron {
+
+namespace VenusOS {
+
+class ClockTime : public QObject
+{
+	Q_OBJECT
+	Q_PROPERTY(QDateTime currentDateTime MEMBER m_currentDateTime NOTIFY currentDateTimeChanged)
+	Q_PROPERTY(QString currentTimeText MEMBER m_currentTimeText NOTIFY currentTimeTextChanged)
+
+public:
+	ClockTime(QObject *parent);
+
+	static ClockTime* instance(QObject* parent = nullptr);
+
+signals:
+	void currentDateTimeChanged();
+	void currentTimeTextChanged();
+
+protected:
+	void timerEvent(QTimerEvent *) override;
+
+private:
+	void updateTime();
+	void scheduleNextTimeCheck(const QTime &now);
+
+	QDateTime m_currentDateTime;
+	QString m_currentTimeText;
+	int m_timerId = 0;
+};
+
+} /* VenusOS */
+
+} /* Victron */
+
+#endif // VICTRON_VENUSOS_CLOCKTIME_H
+

--- a/components/NotificationDelegate.qml
+++ b/components/NotificationDelegate.qml
@@ -13,7 +13,7 @@ Rectangle {
 	property string description
 
 	function _formatTimestamp(date) {
-		let ms = Math.floor(Global.now - date)
+		let ms = Math.floor(ClockTime.currentDateTime - date)
 		let minutes = Math.floor(ms / 60000)
 		if (minutes < 1) {
 			//% "now"

--- a/components/StatusBar.qml
+++ b/components/StatusBar.qml
@@ -55,23 +55,9 @@ Item {
 		id: clockLabel
 		anchors.centerIn: parent
 		font.pixelSize: 22
-		text: root.title.length > 0 ? root.title : clockTimer.timeString
-
-		Timer {
-			id: clockTimer
-			interval: 1000 // 1 second
-			running: root.opacity > 0.0 && root.title.length === 0
-			property string timeString: "00:00"
-			onTriggered: {
-				var currDate = new Date()
-				var hours = currDate.getHours()
-				var mins = currDate.getMinutes()
-				if (hours < 10) hours = "0" + hours
-				if (mins < 10)   mins = "0" + mins
-				timeString = hours + ":" + mins
-			}
-		}
+		text: root.title.length > 0 ? root.title : ClockTime.currentTimeText
 	}
+
 	Button {
 		anchors {
 			top: parent.top

--- a/main.cpp
+++ b/main.cpp
@@ -8,6 +8,7 @@
 #include "enums.h"
 #include "dbus_service.h"
 #include "notificationsmodel.h"
+#include "clocktime.h"
 #include <math.h>
 
 #if !defined(VENUS_WEBASSEMBLY_BUILD)
@@ -82,6 +83,11 @@ int main(int argc, char *argv[])
 		"Victron.VenusOS", 2, 0, "HistoricalNotificationsModel",
 		[](QQmlEngine *, QJSEngine *) -> QObject * {
 		return Victron::VenusOS::HistoricalNotificationsModel::instance();
+	});
+	qmlRegisterSingletonType<Victron::VenusOS::ClockTime>(
+		"Victron.VenusOS", 2, 0, "ClockTime",
+		[](QQmlEngine *, QJSEngine *) -> QObject * {
+		return Victron::VenusOS::ClockTime::instance();
 	});
 
 	/* main content */


### PR DESCRIPTION
…time

Add ClockTime to consolidate fetching of the current date/time from
the clock display and the notification delegates.

This also fixes the bug where the clock time was not updating after
initialization.