### PR TITLE
Only use ShinyProgressArc when required

### DIFF
--- a/components/CircularMultiGauge.qml
+++ b/components/CircularMultiGauge.qml
@@ -30,21 +30,44 @@ Item {
 		Repeater {
 			id: arcRepeater
 			width: parent.width
-			delegate: ProgressArc {
+			delegate: Loader {
+				id: loader
 				property int status: Gauges.getValueStatus(model.value, model.valueType)
+				property real value: model.value
 				width: parent.width - (index*_stepSize)
 				height: width
 				anchors.centerIn: parent
-				radius: width/2
-				startAngle: 0
-				endAngle: 270
-				value: model.value
-				progressColor: Theme.statusColorValue(status)
-				remainderColor: Theme.statusColorValue(status, true)
-				strokeWidth: gauges.strokeWidth
 				visible: model.index < Theme.geometry.briefPage.centerGauge.maximumGaugeCount
-				animationEnabled: gauges.animationEnabled
-				shineAnimationEnabled: model.tankType === VenusOS.Tank_Type_Battery && Global.battery.mode === VenusOS.Battery_Mode_Charging
+				sourceComponent: model.tankType === VenusOS.Tank_Type_Battery ? shinyProgressArc : progressArc
+
+				Component {
+					id: shinyProgressArc
+					ShinyProgressArc {
+						radius: width/2
+						startAngle: 0
+						endAngle: 270
+						value: loader.value
+						progressColor: Theme.statusColorValue(loader.status)
+						remainderColor: Theme.statusColorValue(loader.status, true)
+						strokeWidth: gauges.strokeWidth
+						animationEnabled: gauges.animationEnabled
+						shineAnimationEnabled: Global.battery.mode === VenusOS.Battery_Mode_Charging
+					}
+				}
+
+				Component {
+					id: progressArc
+					ProgressArc {
+						radius: width/2
+						startAngle: 0
+						endAngle: 270
+						value: loader.value
+						progressColor: Theme.statusColorValue(loader.status)
+						remainderColor: Theme.statusColorValue(loader.status, true)
+						strokeWidth: gauges.strokeWidth
+						animationEnabled: gauges.animationEnabled
+					}
+				}
 			}
 		}
 	}

--- a/components/CircularSingleGauge.qml
+++ b/components/CircularSingleGauge.qml
@@ -26,7 +26,8 @@ Item {
 		layer.enabled: true
 		layer.samples: 4
 
-		ProgressArc {
+		// The single circular gauge is always the battery gauge :. shiny.
+		ShinyProgressArc {
 			id: arc
 
 			width: gauges.width

--- a/components/ProgressArc.qml
+++ b/components/ProgressArc.qml
@@ -5,15 +5,13 @@
 import QtQuick
 import QtQuick.Shapes
 import Victron.VenusOS
-import Qt5Compat.GraphicalEffects as Effects
 
-Item {
+Shape {
 	id: control
 
 	property real value
 	property real radius
 	property bool animationEnabled: true
-	property bool shineAnimationEnabled: false
 	property real strokeWidth: Theme.geometry.progressArc.strokeWidth
 	property alias progressColor: progress.strokeColor
 	property alias remainderColor: remainder.strokeColor
@@ -31,101 +29,25 @@ Item {
 		}
 	}
 
-	Shape {
-		anchors.fill: parent
+	Arc {
+		id: remainder
 
-		Arc {
-			id: remainder
-
-			radius: control.radius
-			startAngle: control.transitionAngle
-			direction: control.direction
-			strokeWidth: control.strokeWidth
-			strokeColor: Theme.color.darkOk
-			fillColor: control.fillColor
-		}
+		radius: control.radius
+		startAngle: control.transitionAngle
+		direction: control.direction
+		strokeWidth: control.strokeWidth
+		strokeColor: Theme.color.darkOk
+		fillColor: control.fillColor
 	}
 
-	// Unfortunately, we need two separate Shape items in the shine animation case,
-	// as we need to use an Item-derived type as the maskSource of the OpacityMask,
-	// and thus a ShapePath cannot be used as the maskSource
-	// (and we only want the shine over the "progress" area, not "remainder").
-	Shape {
-		id: progressShape
-		anchors.fill: parent
+	Arc {
+		id: progress
 
-		Arc {
-			id: progress
-
-			radius: control.radius
-			endAngle: control.transitionAngle
-			direction: control.direction
-			strokeWidth: control.strokeWidth
-			strokeColor: Theme.color.ok
-			fillColor: control.fillColor
-		}
-	}
-
-	Item {
-		id: shineItem
-		anchors.fill: progressShape
-		visible: false
-
-		Rectangle {
-			id: shineRect
-
-			y: parent.height/2 - height*Theme.geometry.briefPage.centerGauge.shine.highlightPosition
-			x: parent.width/2
-			width: parent.width/2 + 3*control.strokeWidth
-			height: Theme.geometry.briefPage.centerGauge.shine.widthRatio * shineItem.height
-
-			gradient: Gradient {
-				GradientStop { position: 0; color: "transparent" }
-				GradientStop { position: Theme.geometry.briefPage.centerGauge.shine.highlightPosition; color: Theme.color.briefPage.circularGauge.shine }
-				GradientStop { position: 1.0; color: "transparent" }
-			}
-
-			opacity: 0.0
-			Behavior on opacity { OpacityAnimator { duration: Theme.animation.page.fade.duration } }
-
-			transform: Rotation {
-				id: rot
-				origin.x: 0
-				origin.y: shineRect.height*Theme.geometry.briefPage.centerGauge.shine.highlightPosition
-				angle: -60
-			}
-
-			SequentialAnimation {
-				running: control.animationEnabled && control.shineAnimationEnabled
-				loops: Animation.Infinite
-				ScriptAction {
-					script: { shineRect.opacity = 1.0; opacityTimer.start() }
-				}
-				NumberAnimation {
-					target: rot
-					property: "angle"
-					easing { type: Easing.InOutQuad }
-					from: -80 // not -90, as we want to avoid overspill from the trailing edge.
-					to:   260 // not 270, as we want to avoid overspill from the leading edge.
-					duration: Theme.animation.briefPage.centerGauge.shine.duration
-				}
-				PauseAnimation {
-					duration: Theme.animation.briefPage.centerGauge.shine.duration * Theme.animation.briefPage.centerGauge.shine.pauseRatio
-				}
-			}
-		}
-
-		Timer {
-			id: opacityTimer
-			interval: Theme.animation.briefPage.centerGauge.shine.duration - Theme.animation.page.fade.duration
-			onTriggered: shineRect.opacity = 0.0
-		}
-	}
-
-	Effects.OpacityMask {
-		visible: control.animationEnabled && control.shineAnimationEnabled
-		anchors.fill: control
-		maskSource: progressShape
-		source: shineItem
+		radius: control.radius
+		endAngle: control.transitionAngle
+		direction: control.direction
+		strokeWidth: control.strokeWidth
+		strokeColor: Theme.color.ok
+		fillColor: control.fillColor
 	}
 }

--- a/components/ShinyProgressArc.qml
+++ b/components/ShinyProgressArc.qml
@@ -1,0 +1,131 @@
+/*
+** Copyright (C) 2021 Victron Energy B.V.
+*/
+
+import QtQuick
+import QtQuick.Shapes
+import Victron.VenusOS
+import Qt5Compat.GraphicalEffects as Effects
+
+Item {
+	id: control
+
+	property real value
+	property real radius
+	property bool animationEnabled: true
+	property bool shineAnimationEnabled: false
+	property real strokeWidth: Theme.geometry.progressArc.strokeWidth
+	property alias progressColor: progress.strokeColor
+	property alias remainderColor: remainder.strokeColor
+	property alias startAngle: progress.startAngle
+	property alias endAngle: remainder.endAngle
+	property int direction: PathArc.Clockwise
+	property color fillColor: "transparent"
+
+	property real transitionAngle: startAngle + ((endAngle - startAngle) * Math.min(Math.max(control.value, 0.0), 100.0) / 100.0)
+	Behavior on transitionAngle {
+		enabled: control.animationEnabled
+		NumberAnimation {
+			duration: Theme.animation.progressArc.duration
+			easing.type: Easing.InOutQuad
+		}
+	}
+
+	Shape {
+		anchors.fill: parent
+
+		Arc {
+			id: remainder
+
+			radius: control.radius
+			startAngle: control.transitionAngle
+			direction: control.direction
+			strokeWidth: control.strokeWidth
+			strokeColor: Theme.color.darkOk
+			fillColor: control.fillColor
+		}
+	}
+
+	// Unfortunately, we need two separate Shape items in the shine animation case,
+	// as we need to use an Item-derived type as the maskSource of the OpacityMask,
+	// and thus a ShapePath cannot be used as the maskSource
+	// (and we only want the shine over the "progress" area, not "remainder").
+	Shape {
+		id: progressShape
+		anchors.fill: parent
+
+		Arc {
+			id: progress
+
+			radius: control.radius
+			endAngle: control.transitionAngle
+			direction: control.direction
+			strokeWidth: control.strokeWidth
+			strokeColor: Theme.color.ok
+			fillColor: control.fillColor
+		}
+	}
+
+	Item {
+		id: shineItem
+		anchors.fill: progressShape
+		visible: false
+
+		Rectangle {
+			id: shineRect
+
+			y: parent.height/2 - height*Theme.geometry.briefPage.centerGauge.shine.highlightPosition
+			x: parent.width/2
+			width: parent.width/2 + 3*control.strokeWidth
+			height: Theme.geometry.briefPage.centerGauge.shine.widthRatio * shineItem.height
+
+			gradient: Gradient {
+				GradientStop { position: 0; color: "transparent" }
+				GradientStop { position: Theme.geometry.briefPage.centerGauge.shine.highlightPosition; color: Theme.color.briefPage.circularGauge.shine }
+				GradientStop { position: 1.0; color: "transparent" }
+			}
+
+			opacity: 0.0
+			Behavior on opacity { OpacityAnimator { duration: Theme.animation.page.fade.duration } }
+
+			transform: Rotation {
+				id: rot
+				origin.x: 0
+				origin.y: shineRect.height*Theme.geometry.briefPage.centerGauge.shine.highlightPosition
+				angle: -60
+			}
+
+			SequentialAnimation {
+				running: control.animationEnabled && control.shineAnimationEnabled
+				loops: Animation.Infinite
+				ScriptAction {
+					script: { shineRect.opacity = 1.0; opacityTimer.start() }
+				}
+				NumberAnimation {
+					target: rot
+					property: "angle"
+					easing { type: Easing.InOutQuad }
+					from: -80 // not -90, as we want to avoid overspill from the trailing edge.
+					to:   260 // not 270, as we want to avoid overspill from the leading edge.
+					duration: Theme.animation.briefPage.centerGauge.shine.duration
+				}
+				PauseAnimation {
+					duration: Theme.animation.briefPage.centerGauge.shine.duration * Theme.animation.briefPage.centerGauge.shine.pauseRatio
+				}
+			}
+		}
+
+		Timer {
+			id: opacityTimer
+			interval: Theme.animation.briefPage.centerGauge.shine.duration - Theme.animation.page.fade.duration
+			onTriggered: shineRect.opacity = 0.0
+		}
+	}
+
+	Effects.OpacityMask {
+		visible: control.animationEnabled && control.shineAnimationEnabled
+		anchors.fill: control
+		maskSource: progressShape
+		source: shineItem
+	}
+}

--- a/qml.qrc
+++ b/qml.qrc
@@ -80,6 +80,7 @@
         <file>components/SideGauge.qml</file>
         <file>components/SegmentedButtonRow.qml</file>
         <file>components/SeparatorBar.qml</file>
+        <file>components/ShinyProgressArc.qml</file>
         <file>components/SolarYieldGraph.qml</file>
         <file>components/SplashView.qml</file>
         <file>components/StatusBar.qml</file>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -187,6 +187,8 @@ int main(int argc, char *argv[])
 		"Victron.VenusOS", 2, 0, "SegmentedButtonRow");
 	qmlRegisterType(QUrl(QStringLiteral("qrc:/components/SeparatorBar.qml")),
 		"Victron.VenusOS", 2, 0, "SeparatorBar");
+	qmlRegisterType(QUrl(QStringLiteral("qrc:/components/ShinyProgressArc.qml")),
+		"Victron.VenusOS", 2, 0, "ShinyProgressArc");
 	qmlRegisterType(QUrl(QStringLiteral("qrc:/components/SideGauge.qml")),
 		"Victron.VenusOS", 2, 0, "SideGauge");
 	qmlRegisterType(QUrl(QStringLiteral("qrc:/components/SolarYieldGauge.qml")),


### PR DESCRIPTION
The shiny progress arc requires multiple Shapes which has a
negative performance impact.  Since we use progress arcs in a
variety of places in the UI (e.g. for arc gauges etc) we should
only use the shiny gauge when required (i.e. battery gauges only).