### PR TITLE
Fix bug in mqtt/SolarChargersImpl

### DIFF
--- a/data/mqtt/SolarChargersImpl.qml
+++ b/data/mqtt/SolarChargersImpl.qml
@@ -91,19 +91,21 @@ QtObject {
 
 			for (let i = 0; i < count; ++i) {
 				const acPv = objectAt(i)
-				for (let j = 0; j < acPv.pvPhases.count; ++j) {
-					const phase = acPv.pvPhases.objectAt(j)
-					if (!isNaN(phase.power)) {
-						if (isNaN(totalPower)) {
-							totalPower = 0
+				if (!!acPv) {
+					for (let j = 0; j < acPv.pvPhases.count; ++j) {
+						const phase = acPv.pvPhases.objectAt(j)
+						if (!isNaN(phase.power)) {
+							if (isNaN(totalPower)) {
+								totalPower = 0
+							}
+							totalPower += phase.power
 						}
-						totalPower += phase.power
-					}
-					if (!isNaN(phase.current)) {
-						if (isNaN(totalCurrent)) {
-							totalCurrent = 0
+						if (!isNaN(phase.current)) {
+							if (isNaN(totalCurrent)) {
+								totalCurrent = 0
+							}
+							totalCurrent += phase.current
 						}
-						totalCurrent += phase.current
 					}
 				}
 			}


### PR DESCRIPTION
The repeater creates the delegate for index 2 first, then 1, then 0. When the delegate for index 2 updates, updateAcTotals() gets called, and we try to read the power from the delegate for index 0, which hasn't been created yet.

For some reason, this doesn't happen when using dbus, so I haven't updated the dbus/SolarChargersImpl.