### PR TITLE
Dm mqtt 2

### DIFF
--- a/data/DataManager.qml
+++ b/data/DataManager.qml
@@ -101,7 +101,13 @@ Item {
 		source: active ? "qrc:/data/mqtt/MqttDataManager.qml" : ""
 
 		onStatusChanged: if (status === Loader.Error) console.warn("Unable to load mqtt data manager:", errorString())
-		onLoaded: Global.dataBackendLoaded = true
+		onLoaded: timer.running = true // delay construction of the ui to give the uid mapper time to receive all topics. This prevents spammy error messages at startup.
+
+		Timer {
+			id: timer
+			interval: 3000
+			onTriggered: Global.dataBackendLoaded = true
+		}
 	}
 
 	Loader {


### PR DESCRIPTION
When using mqtt, delay construction of the ui to give the uid mapper time to receive all topics. This prevents spammy error messages at startup, when running on the desktop against the venus-docker simulator. These error messages don't appear on the device.

Note that this doesn't slow down startup time on the device, which is bogged down preloading pages for a while.