### PR TITLE
Show information about loading progress

### DIFF
--- a/components/SplashView.qml
+++ b/components/SplashView.qml
@@ -148,20 +148,19 @@ Rectangle {
 			topMargin: Theme.geometry.progressBar.height
 		}
 		opacity: BackendConnection.state === BackendConnection.Failed ? 1.0 : loadingProgress.opacity
-		font.pixelSize: Theme.font.size.body1
+		font.pixelSize: Theme.font.size.caption
 		color: Theme.color.font.secondary
-		text: "(" + BackendConnection.state + ") " +
-		      //% "Unable to connect to device"
-		     (BackendConnection.state === BackendConnection.Failed ? qsTrId("splash_view_unable_to_connect_to_device")
-		      //% "Disconnected from device, attempting to reconnect"
-		    : BackendConnection.state === BackendConnection.Disconnected ? qsTrId("splash_view_disconnected")
-		      //% "Connecting to device"
-		    : BackendConnection.state === BackendConnection.Connecting ? qsTrId("splash_view_connecting")
-		      //% "Connected to device, awaiting portal ID"
-		    : BackendConnection.state === BackendConnection.Connected ? qsTrId("splash_view_connected")
-		      //% "Connected to device, loading user interface"
-		    : BackendConnection.state === BackendConnection.Ready ? qsTrId("splash_view_ready")
-		      //% "Idle"
-		    : qsTrId("splash_view_idle"))
+		text: //% "Unable to connect"
+			 ((BackendConnection.state === BackendConnection.Failed ? qsTrId("splash_view_unable_to_connect")
+			  //% "Disconnected, attempting to reconnect"
+			: BackendConnection.state === BackendConnection.Disconnected ? qsTrId("splash_view_disconnected")
+			  //% "Connecting"
+			: BackendConnection.state === BackendConnection.Connecting ? qsTrId("splash_view_connecting")
+			  //% "Connected, awaiting broker messages"
+			: BackendConnection.state === BackendConnection.Connected ? qsTrId("splash_view_connected")
+			  //% "Connected, loading user interface"
+			: BackendConnection.state === BackendConnection.Ready ? qsTrId("splash_view_ready")
+			  //% "Idle"
+			: qsTrId("splash_view_idle")) + " [" + BackendConnection.state) + "]"
 	}
 }

--- a/themes/geometry/FiveInch.json
+++ b/themes/geometry/FiveInch.json
@@ -227,7 +227,7 @@
     "geometry.splashView.logo.verticalCenterOffset": -13,
     "geometry.splashView.logo.horizontalCenterOffset": -1,
     "geometry.splashView.gaugeAnimation.verticalCenterOffset": -8,
-    "geometry.splashView.progressBar.bottomMargin": 168,
+    "geometry.splashView.progressBar.bottomMargin": 178,
     "geometry.splashView.progressBar.width": 368,
 
     "geometry.generatorCard.durationButton.height": 40,

--- a/themes/geometry/SevenInch.json
+++ b/themes/geometry/SevenInch.json
@@ -227,7 +227,7 @@
     "geometry.splashView.logo.verticalCenterOffset": -25,
     "geometry.splashView.logo.horizontalCenterOffset": -2,
     "geometry.splashView.gaugeAnimation.verticalCenterOffset": 0,
-    "geometry.splashView.progressBar.bottomMargin": 224,
+    "geometry.splashView.progressBar.bottomMargin": 244,
     "geometry.splashView.progressBar.width": 464,
 
     "geometry.generatorCard.durationButton.height": 40,


### PR DESCRIPTION
Especially, show the backend connection state, in both numeric and text format to simplify communication when testing in non-English script locales.