### PR TITLE
Add BackendConnection::Reconnecting state

### DIFF
--- a/components/SplashView.qml
+++ b/components/SplashView.qml
@@ -153,6 +153,8 @@ Rectangle {
 		text: //% "Unable to connect"
 			 ((BackendConnection.state === BackendConnection.Failed ? qsTrId("splash_view_unable_to_connect")
 			  //% "Disconnected, attempting to reconnect"
+			: BackendConnection.state === BackendConnection.Reconnecting ? qsTrId("splash_view_reconnecting")
+			   //% "Disconnected"
 			: BackendConnection.state === BackendConnection.Disconnected ? qsTrId("splash_view_disconnected")
 			  //% "Connecting"
 			: BackendConnection.state === BackendConnection.Connecting ? qsTrId("splash_view_connecting")

--- a/src/backendconnection.cpp
+++ b/src/backendconnection.cpp
@@ -93,7 +93,7 @@ void BackendConnection::setState(VeQItemMqttProducer::ConnectionState backendCon
 	}
 	case VeQItemMqttProducer::Reconnecting:
 	{
-		setState(BackendConnection::State::Disconnected);
+		setState(BackendConnection::State::Reconnecting);
 		break;
 	}
 	case VeQItemMqttProducer::Failed:

--- a/src/backendconnection.h
+++ b/src/backendconnection.h
@@ -29,12 +29,14 @@ public:
 	};
 	Q_ENUM(SourceType)
 
+	// Same as VeQItemMqttProducer::ConnectionState
 	enum State {
 		Idle,
 		Connecting,
 		Connected,
 		Ready,
 		Disconnected,
+		Reconnecting,
 		Failed
 	};
 	Q_ENUM(State)


### PR DESCRIPTION
BackendConnection::initMqttConnection() will set the internal state to whatever is returned by VeQItemMqttProducer::ConnectionState, so we should support all VeQItemMqttProducer::ConnectionState values.