### PR TITLE
Correctly save/load volume units and fix m3 unit display

### DIFF
--- a/components/Units.js
+++ b/components/Units.js
@@ -38,8 +38,8 @@ function getDisplayText(unit, value, length, unitMatchValue = undefined) {
 		// \u2113 = l, \u3398 = kl
 		return _scaledQuantity(value, unitMatchValue, length, "\u2113", "\u3398")
 	case V.VenusOS.Units_Volume_CubicMeter:
-		// \u33A5 = m3
-		return _scaledQuantity(value, unitMatchValue, length, "\u33A5")
+		// \u33A5 is not supported by the font, so insert this m3 char directly.
+		return _scaledQuantity(value, unitMatchValue, length, "m³")
 	case V.VenusOS.Units_Volume_GallonUS:
 	case V.VenusOS.Units_Volume_GallonImperial:
 		return _scaledQuantity(value, unitMatchValue, length, "gal")

--- a/data/SystemSettings.qml
+++ b/data/SystemSettings.qml
@@ -58,7 +58,7 @@ QtObject {
 	}
 
 	property DataPoint volumeUnit: DataPoint {
-		source: "com.victronenergy.settings/Settings/Gui/Units/Volume"
+		source: "com.victronenergy.settings/Settings/System/VolumeUnit"
 	}
 
 	property QtObject briefView: QtObject {

--- a/pages/settings/PageSettingsDisplayUnits.qml
+++ b/pages/settings/PageSettingsDisplayUnits.qml
@@ -52,8 +52,8 @@ Page {
 				text: qsTrId("settings_units_volume")
 
 				optionModel: [
-					//% "m3"
-					{ display: qsTrId("settings_units_m3"), value: VenusOS.Units_Volume_CubicMeter },
+					//% "Cubic meters"
+					{ display: qsTrId("settings_units_cubic_meters"), value: VenusOS.Units_Volume_CubicMeter },
 					//% "Liters"
 					{ display: qsTrId("settings_units_liters"), value: VenusOS.Units_Volume_Liter },
 					//% "Gallons (US)"

--- a/src/backendconnection.cpp
+++ b/src/backendconnection.cpp
@@ -17,7 +17,6 @@ void addSettings(VeQItemSettingsInfo *info)
 
 	// see enum.h Units_Type for enum values
 	info->add("Gui/Units/Energy", 2); // watt, amp
-	info->add("Gui/Units/Volume", 6);  // cubic meter, liter, gallon US, gallon imperial
 
 	// Brief settings levels are 0-6 (Fuel - Gasoline) or -1 for Battery.
 	info->add("Gui/BriefView/Level/1", -1, -1, 6);     // Battery

--- a/src/enums.h
+++ b/src/enums.h
@@ -65,16 +65,18 @@ public:
 	Q_ENUM(StatusBar_RightButton)
 
 	enum Units_Type {
+		// Volume unit values are those expected by com.victronenergy.settings/Settings/System/VolumeUnit
+		Units_Volume_CubicMeter = 0,
+		Units_Volume_Liter = 1,
+		Units_Volume_GallonImperial = 2,
+		Units_Volume_GallonUS = 3,
+
 		Units_Percentage,
 		Units_Potential_Volt,
 		Units_Energy_Watt,
 		Units_Energy_Amp,
 		Units_Temperature_Celsius,
 		Units_Temperature_Fahrenheit,
-		Units_Volume_CubicMeter,
-		Units_Volume_Liter,
-		Units_Volume_GallonUS,
-		Units_Volume_GallonImperial
 	};
 	Q_ENUM(Units_Type)
 	


### PR DESCRIPTION
The /Settings/Gui/Units/Volume settings path is not saved/loaded for MQTT backends, so don't use that; use the existing /Settings/System/VolumeUnit settings path instead, and change the enums.h volume enum values to reflect the values expected for that path.

This avoids 'convertVolumeForUnit(): cannot convert m3 to unit undefined' when running with MQTT.

Also remove the unicode char for the m3 unit display as that cannot be rendered by the Museo Sans font.