### PR TITLE
Show 'None' for solar history alarms/errors where applicable #277

### DIFF
--- a/pages/solar/SolarChargerPage.qml
+++ b/pages/solar/SolarChargerPage.qml
@@ -116,11 +116,15 @@ Page {
 			ListNavigationItem {
 				//% "Alarms and Errors"
 				text: qsTrId("charger_alarms_alarms_and_errors")
-				secondaryText: root.solarCharger.errorModel.count > 0
-					  //: Shows number of items found. %1 = number of items
-					  //% "%1 found"
-					? qsTrId("charger_history_found_with_count").arg(root.solarCharger.errorModel.count)
-					: ""
+				secondaryText: enabled
+					? (root.solarCharger.errorModel.count > 0
+						  //: Shows number of items found. %1 = number of items
+						  //% "%1 found"
+						? qsTrId("charger_history_found_with_count").arg(root.solarCharger.errorModel.count)
+						: "")
+					  //: Indicates there are no alarms/errors present
+					  //% "None"
+					: qsTrId("charger_alarms_none")
 				secondaryLabel.color: root.solarCharger.errorModel.count ? Theme.color.critical : Theme.color.font.secondary
 
 				// Only enable if there is content on the alarms/errors page.


### PR DESCRIPTION
It's a bit odd if the alarms/errors link cannot be clicked (if there are none to view), so show 'None' to indicate there is no information viewable there.