### PR TITLE
Fix UI glitch when fractional scaling is enabled

### DIFF
--- a/components/NavBar.qml
+++ b/components/NavBar.qml
@@ -12,7 +12,7 @@ Row {
 	property int currentIndex
 	property url currentUrl
 
-	width: parent.width
+	width: parent.width - 2*Theme.geometry.page.content.horizontalMargin
 	height: Theme.geometry.navigationBar.height
 	spacing: Theme.geometry.navigationBar.spacing
 

--- a/pages/MainView.qml
+++ b/pages/MainView.qml
@@ -234,7 +234,7 @@ Item {
 		model: null
 
 		Loader {
-			y: root.height
+			y: root.height + 4 // avoid fractional scaling smearing a row of pixels into visible area
 			asynchronous: true
 			source: url
 


### PR DESCRIPTION
Ensure that the preloaded content is a few pixels below the visible area, so that it is properly clipped out, otherwise e.g. fractional scaling on Windows can cause the topmost row of preloaded content pixels to be smeared into the bottommost row of visible pixels, especially on WASM.

Also reduce the width of the NavBar by twice the horizontal page offset (which is the NavBar's usual x offset) so that it doesn't enter the clipped area when it is supposed to be offscreen (e.g. when the ESS controls page is visible).