### PR TITLE
Improve layout of timezone settings delegate items

### DIFF
--- a/components/listitems/ListItem.qml
+++ b/components/listitems/ListItem.qml
@@ -13,6 +13,7 @@ Item {
 	property bool down
 	property alias backgroundRect: backgroundRect
 	property int spacing: Theme.geometry.gradientList.spacing
+	property real textOffset: 0
 
 	property int showAccessLevel: VenusOS.User_AccessType_User
 	property int writeAccessLevel: VenusOS.User_AccessType_Installer
@@ -65,7 +66,7 @@ Item {
 			left: parent.left
 			leftMargin: Theme.geometry.listItem.content.horizontalMargin
 			verticalCenter: parent.verticalCenter
-			verticalCenterOffset: -root.spacing/2
+			verticalCenterOffset: -root.spacing/2 - root.textOffset
 		}
 		font.pixelSize: Theme.font.size.body2
 		wrapMode: Text.Wrap
@@ -78,7 +79,8 @@ Item {
 		anchors {
 			right: parent.right
 			rightMargin: Theme.geometry.listItem.content.horizontalMargin
-			verticalCenter: primaryLabel.verticalCenter
+			verticalCenter: parent.verticalCenter
+			verticalCenterOffset: -root.spacing/2
 		}
 		spacing: Theme.geometry.listItem.content.spacing
 		width: Math.min(implicitWidth, root.maximumContentWidth)

--- a/components/listitems/ListRadioButton.qml
+++ b/components/listitems/ListRadioButton.qml
@@ -15,6 +15,7 @@ ListItem {
 
 	signal clicked()
 
+	textOffset: caption.text.length ? caption.height/2 : 0
 	implicitHeight: visible ? defaultImplicitHeight + (caption.text.length ? caption.implicitHeight : 0)  : 0
 	down: mouseArea.containsPress
 	enabled: userHasWriteAccess
@@ -30,10 +31,7 @@ ListItem {
 	ListLabel {
 		id: caption
 
-		anchors {
-			bottom: parent.bottom
-			bottomMargin: Theme.geometry.listItem.content.verticalMargin
-		}
+		anchors.top: root.primaryLabel.bottom
 		topPadding: 0
 		bottomPadding: 0
 	}


### PR DESCRIPTION
Add a property to allow tweaking the positioning of the primary text label in a ListItem, so that derived delegate types can specify an appropriate value for that property to ensure that their is sufficient space for both the primary and secondary text labels.