### PR TITLE
Improve Inverter/charger state display

### DIFF
--- a/components/widgets/InverterWidget.qml
+++ b/components/widgets/InverterWidget.qml
@@ -8,8 +8,6 @@ import Victron.VenusOS
 OverviewWidget {
 	id: root
 
-	property int systemState
-
 	//% "Inverter / Charger"
 	title: qsTrId("overview_widget_inverter_title")
 	icon.source: "qrc:/images/inverter_charger.svg"
@@ -19,14 +17,15 @@ OverviewWidget {
 
 	extraContent.children: [
 		Label {
-			id: statusLabel
 			anchors {
 				left: parent.left
 				leftMargin: Theme.geometry.overviewPage.widget.content.horizontalMargin
+				right: parent.right
+				rightMargin: Theme.geometry.overviewPage.widget.content.horizontalMargin
 			}
 			font.pixelSize: Theme.font.overviewPage.widget.quantityLabel.maximumSize
-
-			text: Global.inverters.inverterStateToText(root.systemState)
+			text: Global.system.systemStateToText(Global.system.state)
+			wrapMode: Text.Wrap
 		}
 	]
 }

--- a/data/Inverters.qml
+++ b/data/Inverters.qml
@@ -42,59 +42,5 @@ QtObject {
 		}
 	}
 
-	function inverterStateToText(s) {
-		switch (s) {
-		case VenusOS.System_State_Off:
-			//: System state = 'Off'
-			//% "Off"
-			return qsTrId("inverters_state_off")
-		case VenusOS.System_State_LowPower:
-			//: System state = 'Low power'
-			//% "Low power"
-			return qsTrId("inverters_state_lowpower")
-		case VenusOS.System_State_FaultCondition:
-			//: System state = 'Fault condition'
-			//% "Fault"
-			return qsTrId("inverters_state_faultcondition")
-		case VenusOS.System_State_BulkCharging:
-			//: System state = 'Bulk charging'
-			//% "Bulk"
-			return qsTrId("inverters_state_bulkcharging")
-		case VenusOS.System_State_AbsorptionCharging:
-			//: System state = 'Absorption charging'
-			//% "Absorption"
-			return qsTrId("inverters_state_absorptioncharging")
-		case VenusOS.System_State_FloatCharging:
-			//: System state = 'Float charging'
-			//% "Float"
-			return qsTrId("inverters_state_floatcharging")
-		case VenusOS.System_State_StorageMode:
-			//: System state = 'Storage mode'
-			//% "Storage"
-			return qsTrId("inverters_state_storagemode")
-		case VenusOS.System_State_EqualizationCharging:
-			//: System state = 'Equalization charging'
-			//% "Equalize"
-			return qsTrId("inverters_state_equalisationcharging")
-		case VenusOS.System_State_PassThrough:
-			//: System state = 'Pass-thru'
-			//% "Pass-through"
-			return qsTrId("inverters_state_passthrough")
-		case VenusOS.System_State_Inverting:
-			//: System state = 'Inverting'
-			//% "Inverting"
-			return qsTrId("inverters_state_inverting")
-		case VenusOS.System_State_Assisting:
-			//: System state = 'Assisting'
-			//% "Assisting"
-			return qsTrId("inverters_state_assisting")
-		case VenusOS.System_State_Discharging:
-			//: System state = 'Discharging'
-			//% "Discharging"
-			return qsTrId("inverters_state_discharging")
-		}
-		return ""
-	}
-
 	Component.onCompleted: Global.inverters = root
 }

--- a/data/System.qml
+++ b/data/System.qml
@@ -39,5 +39,84 @@ QtObject {
 		dc.reset()
 	}
 
+	function systemStateToText(s) {
+		switch (s) {
+		case VenusOS.System_State_Off:
+			return CommonWords.off
+		case VenusOS.System_State_LowPower:
+			//% "AES mode"
+			return qsTrId("inverters_state_aes_mode")
+		case VenusOS.System_State_FaultCondition:
+			//% "Fault condition"
+			return qsTrId("inverters_state_faultcondition")
+		case VenusOS.System_State_BulkCharging:
+			//% "Bulk charging"
+			return qsTrId("inverters_state_bulkcharging")
+		case VenusOS.System_State_AbsorptionCharging:
+			//% "Absorption charging"
+			return qsTrId("inverters_state_absorptioncharging")
+		case VenusOS.System_State_FloatCharging:
+			//% "Float charging"
+			return qsTrId("inverters_state_floatcharging")
+		case VenusOS.System_State_StorageMode:
+			//% "Storage mode"
+			return qsTrId("inverters_state_storagemode")
+		case VenusOS.System_State_EqualizationCharging:
+			//% "Equalization charging"
+			return qsTrId("inverters_state_equalisationcharging")
+		case VenusOS.System_State_PassThrough:
+			//% "Pass-thru"
+			return qsTrId("inverters_state_passthru")
+		case VenusOS.System_State_Inverting:
+			//% "Inverting"
+			return qsTrId("inverters_state_inverting")
+		case VenusOS.System_State_Assisting:
+			//% "Assisting"
+			return qsTrId("inverters_state_assisting")
+		case VenusOS.System_State_PowerSupplyMode:
+			//% "Power supply mode"
+			return qsTrId("inverters_state_powersupplymode")
+
+		case VenusOS.System_State_Wakeup:
+			//% "Wake up"
+			return qsTrId("inverters_state_wakeup")
+		case VenusOS.System_State_RepeatedAbsorption:
+			//% "Repeated absorption"
+			return qsTrId("inverters_state_repeatedabsorption")
+		case VenusOS.System_State_AutoEqualize:
+			//% "Auto equalize"
+			return qsTrId("inverters_state_autoequalize")
+		case VenusOS.System_State_BatterySafe:
+			//% "Battery safe"
+			return qsTrId("inverters_state_battery_safe")
+		case VenusOS.System_State_LoadDetect:
+			//% "Load detect"
+			return qsTrId("inverters_state_loaddetect")
+		case VenusOS.System_State_Blocked:
+			//% "Blocked"
+			return qsTrId("inverters_state_blocked")
+		case VenusOS.System_State_Test:
+			//% "Test"
+			return qsTrId("inverters_state_test")
+		case VenusOS.System_State_ExternalControl:
+			//% "External control"
+			return qsTrId("inverters_state_externalccontrol")
+
+		case VenusOS.System_State_Discharging:
+			//% "Discharging"
+			return qsTrId("inverters_state_discharging")
+		case VenusOS.System_State_Sustain:
+			//% "Sustain"
+			return qsTrId("inverters_state_sustain")
+		case VenusOS.System_State_Recharge:
+			//% "Recharge"
+			return qsTrId("inverters_state_recharge")
+		case VenusOS.System_State_ScheduledRecharge:
+			//% "Scheduled recharge"
+			return qsTrId("inverters_state_scheduledrecharge")
+		}
+		return ""
+	}
+
 	Component.onCompleted: Global.system = root
 }

--- a/pages/OverviewPage.qml
+++ b/pages/OverviewPage.qml
@@ -595,7 +595,6 @@ Page {
 		expanded: Global.pageManager.expandLayout
 		animateGeometry: root.isCurrentPage && Global.pageManager.animatingIdleResize
 		animationEnabled: root.animationEnabled
-		systemState: Global.system.state
 		connectors: [ inverterToAcLoadsConnector, inverterToBatteryConnector ]
 
 		WidgetConnectorAnchor {

--- a/pages/controlcards/InverterCard.qml
+++ b/pages/controlcards/InverterCard.qml
@@ -15,7 +15,10 @@ ControlCard {
 	title.icon.source: "qrc:/images/inverter_charger.svg"
 	//% "Inverter / Charger"
 	title.text: qsTrId("controlcard_inverter_charger")
-	status.text: Global.inverters.inverterStateToText(inverter.state)
+
+	// VE.Bus state is a subset of the aggregated system state, so use the same systemStateToText()
+	// function to get a text description.
+	status.text: Global.system.systemStateToText(inverter.state)
 
 	Component {
 		id: currentLimitDialogComponent

--- a/src/enums.h
+++ b/src/enums.h
@@ -237,20 +237,34 @@ public:
 	};
 	Q_ENUM(Relays_State)
 
+	// Values are from gui-v1 SystemState.qml
 	enum System_State {
-		System_State_Off = 0,
-		System_State_LowPower,
-		System_State_FaultCondition,
-		System_State_BulkCharging,
-		System_State_AbsorptionCharging,
-		System_State_FloatCharging,
-		System_State_StorageMode,
-		System_State_EqualizationCharging,
-		System_State_PassThrough,
-		System_State_Inverting,
-		System_State_Assisting,
-		System_State_Discharging = 256,
-		System_State_Sustain = 257
+		System_State_Off = 0x00,
+		System_State_LowPower = 0x01,
+		System_State_FaultCondition = 0x02,
+		System_State_BulkCharging = 0x03,
+		System_State_AbsorptionCharging = 0x04,
+		System_State_FloatCharging = 0x05,
+		System_State_StorageMode = 0x06,
+		System_State_EqualizationCharging = 0x07,
+		System_State_PassThrough = 0x08,
+		System_State_Inverting = 0x09,
+		System_State_Assisting = 0x0A,
+		System_State_PowerSupplyMode = 0x0B,
+
+		System_State_Wakeup = 0xF5,
+		System_State_RepeatedAbsorption = 0xF6,
+		System_State_AutoEqualize = 0xF7,
+		System_State_BatterySafe = 0xF8,
+		System_State_LoadDetect = 0xF9,
+		System_State_Blocked = 0xFA,
+		System_State_Test = 0xFB,
+		System_State_ExternalControl = 0xFC,
+
+		System_State_Discharging = 0x100,
+		System_State_Sustain = 0x101,
+		System_State_Recharge = 0x102,
+		SystemState_ScheduledCharge = 0x103
 	};
 	Q_ENUM(System_State)
 


### PR DESCRIPTION
- Move Global.inverters.inverterStateToText() to Global.system.systemStateToText() as the VE.Bus state (as provided for VE.Bus inverters) is a subset of the overall system state, which is shown in the Inverter/Charger widget.
- Add more states to the System_State enum, using the values from gui-v1 SystemState.qml. The text descriptions can be longer than those in gui-v1 as there is more space here for the text.
- Ensure InverterWidget wraps the state text if it is too long, and have it access Global.system.state directly (no need for an intermediate systemState property).