### PR TITLE
Fix saving/loading of Brief page 'showPercentages' value

### DIFF
--- a/components/CircularMultiGauge.qml
+++ b/components/CircularMultiGauge.qml
@@ -106,7 +106,7 @@ Item {
 					horizontalAlignment: Text.AlignRight
 					font.pixelSize: Theme.font.size.body2
 					color: Theme.color.font.primary
-					visible: Global.systemSettings.briefView.showPercentages.value === true
+					visible: Global.systemSettings.briefView.showPercentages.value === 1
 					//% "%1%"
 					text: qsTrId("%1%").arg(isNaN(model.value) ? 0 : Math.round(model.value))
 				}

--- a/data/mock/SystemSettingsImpl.qml
+++ b/data/mock/SystemSettingsImpl.qml
@@ -68,7 +68,7 @@ QtObject {
 		Global.systemSettings.temperatureUnit.setValue(VenusOS.Units_Temperature_Celsius)
 		Global.systemSettings.volumeUnit.setValue(VenusOS.Units_Volume_CubicMeter)
 		Global.systemSettings.briefView.centralGauges.setValue([VenusOS.Tank_Type_Battery, VenusOS.Tank_Type_Fuel, VenusOS.Tank_Type_FreshWater, VenusOS.Tank_Type_BlackWater])
-		Global.systemSettings.briefView.showPercentages.setValue(false)
+		Global.systemSettings.briefView.showPercentages.setValue(0)
 
 		// Other system settings
 		setMockSettingValue("System/VncInternet", 1)

--- a/pages/settings/PageSettingsDisplayBrief.qml
+++ b/pages/settings/PageSettingsDisplayBrief.qml
@@ -49,8 +49,8 @@ Page {
 			//: Show percentage values in Brief view
 			//% "Show %"
 			text: qsTrId("settings_briefview_show_percentage")
-			checked: Global.systemSettings.briefView.showPercentages.value === true
-			onClicked: Global.systemSettings.briefView.showPercentages.setValue(checked)
+			checked: Global.systemSettings.briefView.showPercentages.value === 1
+			onClicked: Global.systemSettings.briefView.showPercentages.setValue(checked ? 1 : 0)
 		}
 	}
 }


### PR DESCRIPTION
The value is a number, not a boolean.