### PR TITLE
Avoid showing opaque navbar area on top of control cards and drilldow…

### DIFF
--- a/components/NavBar.qml
+++ b/components/NavBar.qml
@@ -5,85 +5,91 @@
 import QtQuick
 import Victron.VenusOS
 
-Row {
+Rectangle {  // Use an opaque background so that page disappears behind nav bar when scrolled
 	id: root
 
 	property alias model: buttonRepeater.model
 	property int currentIndex
 	property url currentUrl
 
-	width: parent.width - 2*Theme.geometry.page.content.horizontalMargin
+	width: parent.width
 	height: Theme.geometry.navigationBar.height
-	spacing: Theme.geometry.navigationBar.spacing
 
-	Repeater {
-		id: buttonRepeater
+	Row {
+		x: Theme.geometry.page.content.horizontalMargin
+		width: parent.width - 2*Theme.geometry.page.content.horizontalMargin
+		height: parent.height
+		spacing: Theme.geometry.navigationBar.spacing
 
-		model: ListModel {
-			ListElement {
-				//% "Brief"
-				text: qsTrId("nav_brief")
-				icon: "qrc:/images/brief.svg"
-				url: "qrc:/pages/BriefPage.qml"
-			}
-			ListElement {
-				//% "Overview"
-				text: qsTrId("nav_overview")
-				icon: "qrc:/images/overview.svg"
-				url: "qrc:/pages/OverviewPage.qml"
-			}
-			ListElement {
-				//% "Levels"
-				text: qsTrId("nav_levels")
-				icon: "qrc:/images/levels.svg"
-				url: "qrc:/pages/LevelsPage.qml"
-			}
-			ListElement {
-				//% "Notifications"
-				text: qsTrId("nav_notifications")
-				icon: "qrc:/images/notifications.svg"
-				url: "qrc:/pages/NotificationsPage.qml"
-			}
-			ListElement {
-				//% "Settings"
-				text: qsTrId("nav_settings")
-				icon: "qrc:/images/settings.png"
-				url: "qrc:/pages/SettingsPage.qml"
-			}
-		}
+		Repeater {
+			id: buttonRepeater
 
-		delegate: NavButton {
-			height: root.height
-			width: Theme.geometry.navigationBar.button.width
-			text: model.text
-			icon.source: model.icon
-			checked: root.currentIndex === model.index
-			enabled: root.currentIndex !== model.index
-			backgroundColor: "transparent"
-
-			onClicked: {
-				root.currentIndex = model.index
-				root.currentUrl = model.url
+			model: ListModel {
+				ListElement {
+					//% "Brief"
+					text: qsTrId("nav_brief")
+					icon: "qrc:/images/brief.svg"
+					url: "qrc:/pages/BriefPage.qml"
+				}
+				ListElement {
+					//% "Overview"
+					text: qsTrId("nav_overview")
+					icon: "qrc:/images/overview.svg"
+					url: "qrc:/pages/OverviewPage.qml"
+				}
+				ListElement {
+					//% "Levels"
+					text: qsTrId("nav_levels")
+					icon: "qrc:/images/levels.svg"
+					url: "qrc:/pages/LevelsPage.qml"
+				}
+				ListElement {
+					//% "Notifications"
+					text: qsTrId("nav_notifications")
+					icon: "qrc:/images/notifications.svg"
+					url: "qrc:/pages/NotificationsPage.qml"
+				}
+				ListElement {
+					//% "Settings"
+					text: qsTrId("nav_settings")
+					icon: "qrc:/images/settings.png"
+					url: "qrc:/pages/SettingsPage.qml"
+				}
 			}
 
-			Component.onCompleted: {
-				if (model.index === root.currentIndex) {
+			delegate: NavButton {
+				height: root.height
+				width: Theme.geometry.navigationBar.button.width
+				text: model.text
+				icon.source: model.icon
+				checked: root.currentIndex === model.index
+				enabled: root.currentIndex !== model.index
+				backgroundColor: "transparent"
+
+				onClicked: {
+					root.currentIndex = model.index
 					root.currentUrl = model.url
 				}
-			}
 
-			Rectangle {
-				anchors {
-					top: parent.top
-					topMargin: Theme.geometry.navigationBar.notifications.redDot.topMargin
-					horizontalCenter: parent.horizontalCenter
-					horizontalCenterOffset: Theme.geometry.navigationBar.notifications.redDot.horizontalCenterOffset
+				Component.onCompleted: {
+					if (model.index === root.currentIndex) {
+						root.currentUrl = model.url
+					}
 				}
-				width: Theme.geometry.notificationsPage.delegate.marker.width
-				height: width
-				radius: Theme.geometry.notificationsPage.delegate.marker.radius
-				color: Theme.color.critical
-				visible: model.url === "qrc:/pages/NotificationsPage.qml" && Global.notifications.activeModel.hasNewNotifications
+
+				Rectangle {
+					anchors {
+						top: parent.top
+						topMargin: Theme.geometry.navigationBar.notifications.redDot.topMargin
+						horizontalCenter: parent.horizontalCenter
+						horizontalCenterOffset: Theme.geometry.navigationBar.notifications.redDot.horizontalCenterOffset
+					}
+					width: Theme.geometry.notificationsPage.delegate.marker.width
+					height: width
+					radius: Theme.geometry.notificationsPage.delegate.marker.radius
+					color: Theme.color.critical
+					visible: model.url === "qrc:/pages/NotificationsPage.qml" && Global.notifications.activeModel.hasNewNotifications
+				}
 			}
 		}
 	}

--- a/pages/MainView.qml
+++ b/pages/MainView.qml
@@ -74,19 +74,6 @@ Item {
 		}
 	}
 
-	// Opaque background, so that page contents disappear behind the status bar when scrolled.
-	Rectangle {
-		anchors {
-			bottom: parent.bottom
-			left: parent.left
-			right: parent.right
-			top: navBar.top
-		}
-		color: root.backgroundColor
-		opacity: navBar.opacity
-		visible: navBar.visible
-	}
-
 	StatusBar {
 		id: statusBar
 
@@ -118,20 +105,20 @@ Item {
 
 		x: {
 			if (!pageStack.currentItem || pageStack.depth < 1) {
-				return Theme.geometry.page.content.horizontalMargin
+				return 0
 			}
 			if (currentIndex === model.count - 1
 					&& pageStack.currentItem.topLeftButton !== VenusOS.StatusBar_LeftButton_ControlsActive
 					&& (!pageStack.previousItem || pageStack.previousItem.topLeftButton !== VenusOS.StatusBar_LeftButton_ControlsActive)) {
 				// Stack is showing a settings sub-page, so keep the nav bar visible.
-				return Theme.geometry.page.content.horizontalMargin
+				return 0
 			}
 			// Make the nav bar slide in/out along with the bottom page in the stack.
-			return pageStack.get(0).x + Theme.geometry.page.content.horizontalMargin
+			return pageStack.get(0).x
 		}
 
 		y: root.height + 4  // nudge below the visible area for wasm
-		width: parent.width - (2 * Theme.geometry.page.content.horizontalMargin)
+		color: root.backgroundColor
 		opacity: 0
 
 		onCurrentIndexChanged: {


### PR DESCRIPTION
…n pages

The navbar opaque background cannot span the entire width of the parent MainView, as that causes the background to always be visible, instead of scrolling off the screen together with the navbar, as it should when control cards and drilldown pages are visible.

Move the opaque background to NavBar.qml to fix this and avoid the messiness of syncing the geometry of a separate background item.