### PR TITLE
Avoid creating new gradients unnecessarily in ViewGradient

### DIFF
--- a/ApplicationContent.qml
+++ b/ApplicationContent.qml
@@ -83,4 +83,23 @@ Item {
 			}
 		})
 	}
+
+	Gradient {
+		id: viewGradient
+
+		GradientStop {
+			position: Theme.geometry.viewGradient.position1
+			color: Theme.color.viewGradient.color1
+		}
+		GradientStop {
+			position: Theme.geometry.viewGradient.position2
+			color: Theme.color.viewGradient.color2
+		}
+		GradientStop {
+			position: Theme.geometry.viewGradient.position3
+			color: Theme.color.viewGradient.color3
+		}
+
+		Component.onCompleted: Global.viewGradient = viewGradient
+	}
 }

--- a/Global.qml
+++ b/Global.qml
@@ -22,6 +22,7 @@ QtObject {
 	property var dataServiceModel: null
 	property var firmwareUpdate
 
+	property var viewGradient
 	property var inputPanel
 	property var dialogLayer
 	property var notificationLayer

--- a/components/ViewGradient.qml
+++ b/components/ViewGradient.qml
@@ -12,18 +12,5 @@ Rectangle {
 		right: root.right
 	}
 	height: Theme.geometry.viewGradient.height
-	gradient: Gradient {
-		GradientStop {
-			position: Theme.geometry.viewGradient.position1
-			color: Theme.color.viewGradient.color1
-		}
-		GradientStop {
-			position: Theme.geometry.viewGradient.position2
-			color: Theme.color.viewGradient.color2
-		}
-		GradientStop {
-			position: Theme.geometry.viewGradient.position3
-			color: Theme.color.viewGradient.color3
-		}
-	}
+	gradient: Global.viewGradient
 }


### PR DESCRIPTION
Gradients are not cheap to create, and the gradient in ViewGradient is used often, so store the created version in Global.