### PR TITLE
Use AC input current limit for AC input widget gauge if applicable

### DIFF
--- a/components/widgets/AcInputWidget.qml
+++ b/components/widgets/AcInputWidget.qml
@@ -36,6 +36,9 @@ OverviewWidget {
 			id: valueRange
 
 			value: sideGauge.visible ? root.quantityLabel.value : NaN
+			maximumValue: Global.systemSettings.electricalQuantity.value === VenusOS.Units_Amp
+				? Global.acInputs.currentLimit
+				: NaN
 		}
 	}
 


### PR DESCRIPTION
If units are shown in amps, use the AC input's current limit as the maximum gauge value in the Overview page.

This makes the implementation consistent with what is already done for the AC inputs gauge on the Brief page.