### PR TITLE
Configure border width/color in OverviewWidget. Fixes #335

### DIFF
--- a/components/widgets/EvcsWidget.qml
+++ b/components/widgets/EvcsWidget.qml
@@ -14,8 +14,7 @@ OverviewWidget {
 	title: qsTrId("overview_widget_evcs_title")
 	icon.source: "qrc:/images/icon_charging_station_24.svg"
 	type: VenusOS.OverviewWidget_Type_Evcs
-	border.width: Theme.geometry.overviewPage.widget.border.width
-	border.color: Theme.color.overviewPage.widget.border
+	enabled: true
 	quantityLabel.dataObject: { "power": Global.evChargers.power, "current": NaN }
 
 	extraContent.children: [

--- a/components/widgets/OverviewWidget.qml
+++ b/components/widgets/OverviewWidget.qml
@@ -51,6 +51,10 @@ Rectangle {
 	radius: Theme.geometry.overviewPage.widget.radius
 	color: Theme.color.overviewPage.widget.background
 
+	border.width: enabled ? Theme.geometry.overviewPage.widget.border.width : 0
+	border.color: Theme.color.overviewPage.widget.border
+	enabled: false
+
 	states: State {
 		name: "expanded"
 		when: root.expanded

--- a/components/widgets/SolarYieldWidget.qml
+++ b/components/widgets/SolarYieldWidget.qml
@@ -12,9 +12,7 @@ OverviewWidget {
 	title: qsTrId("overview_widget_solaryield_title")
 	icon.source: "qrc:/images/solaryield.svg"
 	type: VenusOS.OverviewWidget_Type_Solar
-	border.width: enabled ? Theme.geometry.overviewPage.widget.border.width : 0
-	border.color: Theme.color.overviewPage.widget.border
-
+	enabled: true
 	quantityLabel.dataObject: Global.solarChargers
 
 	extraContent.children: [


### PR DESCRIPTION
This fixes the background rendering issue in mock mode on Mac for BatteryWidget, as the default border values (which are used if the border is not explicitly customized) seem to cause gradient rendering issues in the BatteryWidget.

This partially reverts 9b56b44a75dedb26f21796b4b4fffaefa01dc741, which removed the default border values from OverviewWidget.

The solar/evcs widgets are set to enabled to be given the blue border (i.e. indicate they are clickable).