### PR TITLE
Allow SuperUser users to access Debug settings

### DIFF
--- a/pages/SettingsPage.qml
+++ b/pages/SettingsPage.qml
@@ -140,7 +140,7 @@ Page {
 			{
 				text: "Debug",
 				page: "/pages/settings/debug/PageDebug.qml",
-				showAccessLevel: VenusOS.User_AccessType_Service
+				showAccessLevel: VenusOS.User_AccessType_SuperUser
 			},
 		]
 

--- a/pages/settings/debug/PageDebug.qml
+++ b/pages/settings/debug/PageDebug.qml
@@ -11,6 +11,24 @@ Page {
 	GradientListView {
 		model: ObjectModel {
 
+			ListItem {
+				id: frameRateSwitch
+				//% "Enable frame-rate visualizer"
+				text: qsTrId("settings_page_debug_enable_fps_visualizer")
+				content.children: [
+					Switch {
+						id: switchItem
+						checked: FrameRateModel.enabled
+						onClicked: FrameRateModel.enabled = !FrameRateModel.enabled
+					}
+				]
+
+				MouseArea {
+					anchors.fill: parent
+					onClicked: FrameRateModel.enabled = !FrameRateModel.enabled
+				}
+			}
+
 			ListNavigationItem {
 				text: "Power"
 				onClicked: Global.pageManager.pushPage("/pages/settings/debug/PagePowerDebug.qml", { title: text })


### PR DESCRIPTION
Previously, only Service users were able to access the Debug settings page.  SuperUser users should also have this capability.

Also add the ability to toggle the frame rate visualizer on or off from the Debug settings page.