### PR TITLE
Improve timezone handling

### DIFF
--- a/data/SystemSettings.qml
+++ b/data/SystemSettings.qml
@@ -118,6 +118,15 @@ QtObject {
 		}
 	}
 
+	property DataPoint timeZone: DataPoint {
+		source: "com.victronenergy.settings/Settings/System/TimeZone"
+		onValueChanged: {
+			if (value !== undefined) {
+				ClockTime.systemTimeZone = value
+			}
+		}
+	}
+
 	function reset() {
 		// no-op
 	}

--- a/pages/settings/PageTzInfo.qml
+++ b/pages/settings/PageTzInfo.qml
@@ -61,7 +61,7 @@ Page {
 			ListTextItem {
 				//% "Date/Time UTC"
 				text: qsTrId("settings_tz_date_time_utc")
-				secondaryText: Qt.formatDateTime(ClockTime.currentDateTimeUtc, "yyyy-MM-dd hh:mm")
+				secondaryText: ClockTime.currentTimeUtcText
 			}
 
 			ListButton {

--- a/src/clocktime.cpp
+++ b/src/clocktime.cpp
@@ -1,5 +1,9 @@
 #include "clocktime.h"
 
+#if !defined(VENUS_WEBASSEMBLY_BUILD)
+#include <QTimeZone>
+#endif
+
 using namespace Victron::VenusOS;
 
 ClockTime::ClockTime(QObject *parent)
@@ -32,13 +36,27 @@ void ClockTime::timerEvent(QTimerEvent *)
 
 void ClockTime::updateTime()
 {
-	m_currentDateTime = QDateTime::currentDateTime();
-	m_currentDateTimeUtc = m_currentDateTime.toUTC();
+	if (m_systemTimeZone.compare(QStringLiteral("/UTC"), Qt::CaseInsensitive) == 0
+			|| m_systemTimeZone.compare(QStringLiteral("UTC"), Qt::CaseInsensitive) == 0) {
+		m_currentDateTime = QDateTime::currentDateTimeUtc();
+	} else {
+#if defined(VENUS_WEBASSEMBLY_BUILD)
+		// Cannot use QTimeZone in Emscripten builds.
+		// We thus cannot convert to the specified timezone offset.
+		// The local time will be the local time of the browser.
+		m_currentDateTime = QDateTime::currentDateTime();
+#else
+		m_currentDateTime = QDateTime::currentDateTime().toTimeZone(QTimeZone(m_systemTimeZone.toUtf8()));
+#endif
+	}
+	m_currentDateTimeUtc = QDateTime::currentDateTimeUtc();
 	m_currentTimeText = m_currentDateTime.toString("hh:mm");
+	m_currentTimeUtcText = m_currentDateTimeUtc.toString("yyyy-MM-dd hh:mm");
 
 	emit currentDateTimeChanged();
 	emit currentDateTimeUtcChanged();
 	emit currentTimeTextChanged();
+	emit currentTimeUtcTextChanged();
 }
 
 void ClockTime::scheduleNextTimeCheck(const QTime &now)
@@ -55,5 +73,19 @@ void ClockTime::scheduleNextTimeCheck(const QTime &now)
 ClockTime* ClockTime::instance(QObject* parent)
 {
 	return new ClockTime(parent);
+}
+
+QString ClockTime::systemTimeZone() const
+{
+	return m_systemTimeZone;
+}
+
+void ClockTime::setSystemTimeZone(const QString &tz)
+{
+	if (m_systemTimeZone != tz) {
+		m_systemTimeZone = tz;
+		updateTime();
+		emit systemTimeZoneChanged();
+	}
 }
 

--- a/src/clocktime.h
+++ b/src/clocktime.h
@@ -15,11 +15,16 @@ class ClockTime : public QObject
 	Q_PROPERTY(QDateTime currentDateTime MEMBER m_currentDateTime NOTIFY currentDateTimeChanged)
 	Q_PROPERTY(QDateTime currentDateTimeUtc MEMBER m_currentDateTimeUtc NOTIFY currentDateTimeUtcChanged)
 	Q_PROPERTY(QString currentTimeText MEMBER m_currentTimeText NOTIFY currentTimeTextChanged)
+	Q_PROPERTY(QString currentTimeUtcText MEMBER m_currentTimeUtcText NOTIFY currentTimeUtcTextChanged)
+	Q_PROPERTY(QString systemTimeZone READ systemTimeZone WRITE setSystemTimeZone NOTIFY systemTimeZoneChanged)
 
 public:
 	ClockTime(QObject *parent);
 
 	static ClockTime* instance(QObject* parent = nullptr);
+
+	QString systemTimeZone() const;
+	void setSystemTimeZone(const QString &tz); // "region/city" format.
 
 public Q_SLOTS:
 	QString formatTime(int hour, int minute) const;
@@ -29,6 +34,8 @@ Q_SIGNALS:
 	void currentDateTimeChanged();
 	void currentDateTimeUtcChanged();
 	void currentTimeTextChanged();
+	void currentTimeUtcTextChanged();
+	void systemTimeZoneChanged();
 
 protected:
 	void timerEvent(QTimerEvent *) override;
@@ -40,6 +47,8 @@ private:
 	QDateTime m_currentDateTime;
 	QDateTime m_currentDateTimeUtc;
 	QString m_currentTimeText;
+	QString m_currentTimeUtcText;
+	QString m_systemTimeZone;
 	int m_timerId = 0;
 };
 


### PR DESCRIPTION
Ensure that changes performed in the Settings UI cause writes to the appropriate backend setting value.

Ensure that backend setting value changes trigger clock updates.

Note that currently Qt for WebAssembly doesn't support proper QTimezone enumeration or tzdb.  Thus, we only support UTC or local timezone (i.e. timezone of the browser, not the device). Future resolution required, see issue #299 for more info.

Contributes to issue #406