### PR TITLE
Fix PvInverter phase initialization

### DIFF
--- a/data/common/PvInverter.qml
+++ b/data/common/PvInverter.qml
@@ -57,9 +57,10 @@ Device {
 		}
 
 		readonly property VeQItemSortTableModel _phaseSources: VeQItemSortTableModel {
-			filterRole: VeQItemTableModel.UniqueIdRole
-			filterRegExp: "L[0-9]+"
-			onRowCountChanged: phases.setPhaseCount(rowCount)
+			dynamicSortFilter: true
+			filterRole: VeQItemTableModel.IdRole
+			filterRegExp: "^L[0-9]+"
+			onRowCountChanged: Qt.callLater(phases.setPhaseCount, rowCount)
 
 			model: VeQItemTableModel {
 				uids: [pvInverter.serviceUid + "/Ac"]


### PR DESCRIPTION
Filter on the IdRole instead, to avoid generating a large number of intermediate results that don't match.

Also callLater() to avoid resetting the model multiple times before all phases have been found.