### PR TITLE
Quantity displays should use different precisions depending on the unit. Fixes #449

### DIFF
--- a/components/QuantityLabel.qml
+++ b/components/QuantityLabel.qml
@@ -15,10 +15,11 @@ Item {
 	property alias valueColor: valueLabel.color
 	property alias unitColor: unitLabel.color
 	property int alignment: Qt.AlignHCenter
+	property int precision: Units.defaultUnitPrecision(unit)
 
 	readonly property var _quantity: unit === VenusOS.Units_None
 		 ? undefined
-		 : Units.getDisplayText(unit, value, Theme.geometry.quantityLabel.valueLength)
+		 : Units.getDisplayText(unit, value, precision)
 
 	// Restrict the height to the baseline to help align the baseline of labels in different
 	// QuantityLabel items with different font sizes. E.g. Environments tab may have multiple gauges

--- a/components/widgets/BatteryWidget.qml
+++ b/components/widgets/BatteryWidget.qml
@@ -20,18 +20,7 @@ OverviewWidget {
 	icon.source: batteryData.icon
 	type: VenusOS.OverviewWidget_Type_Battery
 
-	quantityLabel.value: {
-		// Show 2 decimal places if available
-		if (isNaN(batteryData.stateOfCharge)) {
-			return NaN
-		}
-		const fixed = batteryData.stateOfCharge.toFixed(2)
-		const floored = Math.floor(batteryData.stateOfCharge)
-		if (fixed === floored) {
-			return floored
-		}
-		return fixed
-	}
+	quantityLabel.value: batteryData.stateOfCharge
 	quantityLabel.unit: VenusOS.Units_Percentage
 
 	color: "transparent"
@@ -254,7 +243,7 @@ OverviewWidget {
 				bottomMargin: Theme.geometry.overviewPage.widget.battery.bottomRow.bottomMargin
 			}
 
-			value: batteryData.voltage.toFixed(1)
+			value: batteryData.voltage
 			unit: VenusOS.Units_Volt
 			font.pixelSize: Theme.font.size.body2
 		},
@@ -267,7 +256,7 @@ OverviewWidget {
 				bottom: parent.bottom
 				bottomMargin: Theme.geometry.overviewPage.widget.battery.bottomRow.bottomMargin
 			}
-			value: batteryData.current.toFixed(1)
+			value: batteryData.current
 			unit: VenusOS.Units_Amp
 			font.pixelSize: Theme.font.size.body2
 		},
@@ -281,7 +270,7 @@ OverviewWidget {
 				bottom: parent.bottom
 				bottomMargin: Theme.geometry.overviewPage.widget.battery.bottomRow.bottomMargin
 			}
-			value: batteryData.power.toFixed(1)
+			value: batteryData.power
 			unit: VenusOS.Units_Watt
 			font.pixelSize: Theme.font.size.body2
 		}

--- a/data/mock/EvChargersImpl.qml
+++ b/data/mock/EvChargersImpl.qml
@@ -44,7 +44,7 @@ QtObject {
 
 			readonly property string serviceUid: "com.victronenergy.evcharger.ttyUSB" + deviceInstance.value
 
-			property int status: Math.random() * VenusOS.Evcs_Status_OverheatingDetected
+			property int status: VenusOS.Evcs_Status_Charging
 			property int mode: Math.random() * VenusOS.Evcs_Mode_Scheduled
 			property bool connected
 			property int chargingTime: 100000

--- a/pages/BriefPage.qml
+++ b/pages/BriefPage.qml
@@ -76,8 +76,8 @@ Page {
 			name: properties.name
 			icon.source: battery.icon
 			value: isNaN(battery.stateOfCharge) ? 0 : Math.round(battery.stateOfCharge)
-			voltage: isNaN(battery.voltage) ? NaN : battery.voltage.toFixed(1)
-			current: isNaN(battery.current) ? NaN : battery.current.toFixed(1)
+			voltage: battery.voltage
+			current: battery.current
 			status: Gauges.getValueStatus(value, properties.valueType)
 			caption: {
 				const timeToGo = Global.batteries.timeToGoText(battery)

--- a/pages/evcs/EvChargerListPage.qml
+++ b/pages/evcs/EvChargerListPage.qml
@@ -4,6 +4,7 @@
 
 import QtQuick
 import Victron.VenusOS
+import "/components/Units.js" as Units
 
 Page {
 	id: root
@@ -58,8 +59,10 @@ Page {
 			secondaryText: {
 				const statusText = Global.evChargers.chargerStatusToText(model.evCharger.status)
 				if (model.evCharger.status === VenusOS.Evcs_Status_Charging) {
-					const energy = isNaN(model.evCharger.energy) ? "--" : model.evCharger.energy.toFixed(1)
-					return energy + "kWh | " + statusText
+					const quantity = Units.getDisplayText(VenusOS.Units_Energy_KiloWattHour,
+							model.evCharger.energy,
+							Units.defaultUnitPrecision(VenusOS.Units_Energy_KiloWattHour))
+					return quantity.number + quantity.unit + " | " + statusText
 				}
 				return statusText
 			}


### PR DESCRIPTION
Instead of calling toFixed() in different places throughout the code base, use a set of default precisions based on the unit type.