### PR TITLE
ESS settings: fix active SOC limit and peak shaving value

### DIFF
--- a/pages/settings/PageSettingsHub4.qml
+++ b/pages/settings/PageSettingsHub4.qml
@@ -122,13 +122,18 @@ Page {
 			visible: defaultVisible
 				&& essMode.value !== VenusOS.Ess_Hub4ModeState_Disabled
 				&& Global.ess.isBatteryLifeActive(batteryLifeState.dataValue)
-			secondaryText: Math.max(Global.ess.minimumStateOfCharge.value || 0, socLimit.value || 0) + "%"
+			secondaryText: Math.max(Global.ess.minimumStateOfCharge || 0, socLimit.value || 0) + "%"
 		}
 
 		ListRadioButtonGroup {
 			//% "Peak shaving"
 			text: qsTrId("settings_ess_peak_shaving")
-			currentIndex: batteryLifeState.dataValue === VenusOS.Ess_BatteryLifeState_KeepCharged ? 1 : peakshaveItem.value
+			currentIndex: {
+				if (batteryLifeState.dataValue === VenusOS.Ess_BatteryLifeState_KeepCharged) {
+					return 1
+				}
+				return peakshaveItem.value === 1 ? 1 : 0
+			}
 			updateOnClick: false
 			visible: defaultVisible && essMode.value !== VenusOS.Ess_Hub4ModeState_Disabled
 			enabled: batteryLifeState.dataValue !== VenusOS.Ess_BatteryLifeState_KeepCharged

--- a/pages/settings/PageSettingsHub4Feedin.qml
+++ b/pages/settings/PageSettingsHub4Feedin.qml
@@ -33,12 +33,8 @@ Page {
 					&& doNotFeedInvOvervoltage.valid
 
 				DataPoint {
-					id: vebusPath
-					source: "com.victronenergy.system/VebusService"
-				}
-				DataPoint {
 					id: doNotFeedInvOvervoltage
-					source: !vebusPath.valid ? "" : (vebusPath.value + "/Hub4/DoNotFeedInOvervoltage")
+					source: Global.system.veBus.serviceUid ? Global.system.veBus.serviceUid + "/Hub4/DoNotFeedInOvervoltage" : ""
 				}
 			}
 


### PR DESCRIPTION
Active SOC Limit should refer to Global.ess.minimumStateOfCharge instead of Global.ess.minimumStateOfCharge.value.

Peak Shaving should use peakshaveItem.value to check which value is selected, instead of using the value directly as the currentIndex.

Also, can use Global.system.veBus.serviceUid, which stores the value of com.victronenergy.system/VebusService.