### PR TITLE
Remove Global property checks in Component.onCompleted handlers

### DIFF
--- a/data/common/EssData.qml
+++ b/data/common/EssData.qml
@@ -99,13 +99,11 @@ QtObject {
 	}
 
 	Component.onCompleted: {
-		if (!!Global.ess) {
-			Global.ess.minimumStateOfCharge = Qt.binding(function() {
-				return veMinimumSocLimit.value || 0
-			})
-			Global.ess.stateOfChargeLimit = Qt.binding(function() {
-				return veSocLimit.value || 0
-			})
-		}
+		Global.ess.minimumStateOfCharge = Qt.binding(function() {
+			return veMinimumSocLimit.value || 0
+		})
+		Global.ess.stateOfChargeLimit = Qt.binding(function() {
+			return veSocLimit.value || 0
+		})
 	}
 }

--- a/data/common/SystemData.qml
+++ b/data/common/SystemData.qml
@@ -13,9 +13,7 @@ QtObject {
 	readonly property DataPoint systemState: DataPoint {
 		source: "com.victronenergy.system/SystemState/State"
 		Component.onCompleted: {
-			if (!!Global.system) {
-				Global.system.state = Qt.binding(function() { return value || VenusOS.System_State_Off })
-			}
+			Global.system.state = Qt.binding(function() { return value || VenusOS.System_State_Off })
 		}
 	}
 
@@ -118,23 +116,14 @@ QtObject {
 	readonly property DataPoint veSystemPower: DataPoint {
 		source: "com.victronenergy.system/Dc/System/Power"
 		Component.onCompleted: {
-			if (!!Global.system) {
-				Global.system.dc.power = Qt.binding(function() { return value === undefined ? NaN : value })
-			}
+			Global.system.dc.power = Qt.binding(function() { return value === undefined ? NaN : value })
 		}
 	}
 
 	readonly property DataPoint veBatteryVoltage: DataPoint {
-		function _update() {
-			if (!!Global.system) {
-				Global.system.dc.voltage = value === undefined ? NaN : value
-			}
-		}
 		source: "com.victronenergy.system/Dc/Battery/Voltage"
 		Component.onCompleted: {
-			if (!!Global.system) {
-				Global.system.dc.voltage = Qt.binding(function() { return value === undefined ? NaN : value })
-			}
+			Global.system.dc.voltage = Qt.binding(function() { return value === undefined ? NaN : value })
 		}
 	}
 
@@ -143,18 +132,14 @@ QtObject {
 	readonly property DataPoint veBusService: DataPoint {
 		source: "com.victronenergy.system/VebusService"
 		Component.onCompleted: {
-			if (!!Global.system) {
-				Global.system.veBus.serviceUid = Qt.binding(function() { return value || "" })
-			}
+			Global.system.veBus.serviceUid = Qt.binding(function() { return value || "" })
 		}
 	}
 
 	readonly property DataPoint veBusDcPower: DataPoint {
 		source: veBusService.value ? veBusService.value + "/Dc/0/Power" : ""
 		Component.onCompleted: {
-			if (!!Global.system) {
-				Global.system.veBus.power = Qt.binding(function() { return value === undefined ? NaN : value })
-			}
+			Global.system.veBus.power = Qt.binding(function() { return value === undefined ? NaN : value })
 		}
 	}
 }


### PR DESCRIPTION
These Global properties must be valid at the time that the Component.onCompleted handlers are called, otherwise the property bindings will not be set, and will not be set at a later point either. So, remove the property checks so that a warning is produced if the property is not available.

The checks were added as part of a575ebab745ef76dbd1512bf049a9648d26477cf but these particular checks are not required as the handlers are only triggered in Component.onCompleted, rather than from property bindings that may still be re-evaulated when the language changes and the UI is rebuilt.