### PR TITLE
Patch the minified .js to contain the module arguments

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -77,7 +77,8 @@ jobs:
         mkdir build-wasm && cd build-wasm
         ${QTDIR}/bin/qt-cmake -DCMAKE_BUILD_TYPE=MinSizeRel ..
         cmake --build .
-        sed -i "/^var Module/a Module.arguments = [ '--mqtt', 'ws://'+document.location.host+':9001/' ];" venus-gui-v2.js
+        grep -q -E '^var Module=[^;]*;' venus-gui-v2.js
+        sed -i "s%^\(var Module=[^;]*;\)%\1Module.arguments=['--mqtt','ws://'+document.location.host+':9001/'];%" venus-gui-v2.js
         sed -i "s/qtlogo.svg/victronenergy.svg/" venus-gui-v2.html
         sed -i "s/background-color: white;/background-color: #4790d0;/" venus-gui-v2.html
         sed -i "s/\(, body {\)/\1 background-color: #4790d0;/" venus-gui-v2.html


### PR DESCRIPTION
What the regexp does:
- search for the begining of the line that starts with "var Module=", then data containing no-semicolon and then the semicolon.
- copy that part into the copy buffer (the brackets do that)
- replace the matched part with the copy buffer (itself) + the Module arguments part (between the seconds procent signs)

This needs to be done by using sed instead of patch because new builds will contain changed javascript and therefor change the line. Besides, using patch will result in a patch file that is over twice the size as the original file.

Added a grep before the sed instruction to make sure that the text to add to exists.