### PR TITLE
Update the default maximum value for VeQuickItem

### DIFF
--- a/pages/settings/PageGeneratorAcLoad.qml
+++ b/pages/settings/PageGeneratorAcLoad.qml
@@ -64,7 +64,6 @@ Page {
 				suffix: "W"
 				stepSize: 5
 				from: stopValue.value + stepSize
-				to: 1602
 			}
 
 			ListSpinBox {


### PR DESCRIPTION
This was causing issues with SpinBoxes when the maximum value was less than the current value.