### PR TITLE
Fix DataPoint internal references in mock mode

### DIFF
--- a/components/DataPoint.qml
+++ b/components/DataPoint.qml
@@ -56,8 +56,6 @@ QtObject {
 
 	property Component _mockComponent : Component {
 		QtObject {
-			id: root
-
 			property string source: root.source
 			property var value: Global.mockDataSimulator ? Global.mockDataSimulator.mockDataValues[source] : undefined
 			property real min: 0


### PR DESCRIPTION
References to 'root' were broken due as the internal 'root' id was the same as that in the root document.