### PR TITLE
Rename "inverters" to "veBus"

### DIFF
--- a/Global.qml
+++ b/Global.qml
@@ -36,7 +36,6 @@ QtObject {
 	property var ess
 	property var evChargers
 	property var generators
-	property var inverters
 	property var notifications
 	property var pvInverters
 	property var relays
@@ -44,6 +43,7 @@ QtObject {
 	property var system
 	property var systemSettings
 	property var tanks
+	property var veBusDevices
 	property var venusPlatform
 
 	property bool splashScreenVisible: true
@@ -90,7 +90,6 @@ QtObject {
 		ess = null
 		evChargers = null
 		generators = null
-		inverters = null
 		notifications = null
 		pvInverters = null
 		relays = null
@@ -98,6 +97,7 @@ QtObject {
 		system = null
 		systemSettings = null
 		tanks = null
+		veBusDevices = null
 		venusPlatform = null
 
 		// The last thing we do is set the splash screen visible.

--- a/components/dialogs/InverterChargerModeDialog.qml
+++ b/components/dialogs/InverterChargerModeDialog.qml
@@ -26,10 +26,10 @@ ModalDialog {
 			id: repeater
 			width: parent.width
 			model: [
-				VenusOS.Inverters_Mode_On,
-				VenusOS.Inverters_Mode_ChargerOnly,
-				VenusOS.Inverters_Mode_InverterOnly,
-				VenusOS.Inverters_Mode_Off,
+				VenusOS.VeBusDevice_Mode_On,
+				VenusOS.VeBusDevice_Mode_ChargerOnly,
+				VenusOS.VeBusDevice_Mode_InverterOnly,
+				VenusOS.VeBusDevice_Mode_Off,
 			]
 			delegate: buttonStyling
 		}
@@ -40,7 +40,7 @@ ModalDialog {
 
 		RadioButtonControlValue {
 			button.checked: modelData === root.mode
-			label.text: Global.inverters.inverterModeToText(modelData)
+			label.text: Global.veBusDevices.modeToText(modelData)
 			onClicked: root.mode = modelData
 		}
 	}

--- a/components/widgets/VeBusDeviceWidget.qml
+++ b/components/widgets/VeBusDeviceWidget.qml
@@ -11,7 +11,7 @@ OverviewWidget {
 	//% "Inverter / Charger"
 	title: qsTrId("overview_widget_inverter_title")
 	icon.source: "qrc:/images/inverter_charger.svg"
-	type: VenusOS.OverviewWidget_Type_Inverter
+	type: VenusOS.OverviewWidget_Type_VeBusDevice
 
 	quantityLabel.visible: false
 

--- a/data/DataManager.qml
+++ b/data/DataManager.qml
@@ -18,7 +18,6 @@ Item {
 			&& !!Global.ess
 			&& !!Global.evChargers
 			&& !!Global.generators
-			&& !!Global.inverters
 			&& !!Global.notifications
 			&& !!Global.pvInverters
 			&& !!Global.relays
@@ -26,6 +25,7 @@ Item {
 			&& !!Global.system
 			&& !!Global.systemSettings
 			&& !!Global.tanks
+			&& !!Global.veBusDevices
 			&& !!Global.venusPlatform
 
 	readonly property bool _shouldInitialize: _dataObjectsReady
@@ -79,7 +79,6 @@ Item {
 	Ess {}
 	EvChargers {}
 	Generators {}
-	Inverters {}
 	Notifications {}
 	PvInverters {}
 	Relays {}
@@ -87,6 +86,7 @@ Item {
 	System {}
 	SystemSettings {}
 	Tanks {}
+	VeBusDevices {}
 	VenusPlatform {}
 
 	Loader {

--- a/data/System.qml
+++ b/data/System.qml
@@ -27,8 +27,8 @@ QtObject {
 
 		// Max AC power is calculated using com.victronenergy.vebus/Ac/Out/NominalInverterPower.
 		// Assume NominalInverterPower = 80% of max AC load power.
-		readonly property real maximumAcPower: (!Global.inverters || isNaN(Global.inverters.totalNominalInverterPower))
-				? NaN : Global.inverters.totalNominalInverterPower * (100 / 80)
+		readonly property real maximumAcPower: (!Global.veBusDevices || isNaN(Global.veBusDevices.totalNominalInverterPower))
+				? NaN : Global.veBusDevices.totalNominalInverterPower * (100 / 80)
 	}
 
 	property QtObject solar: QtObject {

--- a/data/VeBusDevices.qml
+++ b/data/VeBusDevices.qml
@@ -10,26 +10,26 @@ QtObject {
 	id: root
 
 	property DeviceModel model: DeviceModel {
-		objectProperty: "inverter"
+		objectProperty: "veBusDevices"
 	}
 
 	property real totalNominalInverterPower: NaN
 
-	function addInverter(inverter) {
-		if (model.addObject(inverter)) {
+	function addVeBusDevice(veBusDevice) {
+		if (model.addObject(veBusDevice)) {
 			refreshNominalInverterPower()
 		}
 	}
 
-	function removeInverter(inverter) {
-		return model.removeObject(inverter.serviceUid)
+	function removeVeBusDevice(veBusDevice) {
+		return model.removeObject(veBusDevice.serviceUid)
 	}
 
 	function refreshNominalInverterPower() {
 		let total = NaN
 		for (let i = 0; i < model.count; ++i) {
-			const inverter = model.objectAt(i)
-			const value = inverter.nominalInverterPower
+			const veBusDevice = model.objectAt(i)
+			const value = veBusDevice.nominalInverterPower
 			if (!isNaN(value)) {
 				total = isNaN(total) ? value : total + value
 			}
@@ -41,22 +41,22 @@ QtObject {
 		model.clear()
 	}
 
-	function inverterModeToText(m) {
+	function modeToText(m) {
 		switch (m) {
-		case VenusOS.Inverters_Mode_On:
+		case VenusOS.VeBusDevice_Mode_On:
 			return CommonWords.onOrOff(1)
-		case VenusOS.Inverters_Mode_ChargerOnly:
+		case VenusOS.VeBusDevice_Mode_ChargerOnly:
 			//% "Charger only"
-			return qsTrId("inverters_mode_charger_only")
-		case VenusOS.Inverters_Mode_InverterOnly:
+			return qsTrId("veBusDevices_mode_charger_only")
+		case VenusOS.VeBusDevice_Mode_InverterOnly:
 			//% "Inverter only"
-			return qsTrId("inverters_mode_inverter_only")
-		case VenusOS.Inverters_Mode_Off:
+			return qsTrId("veBusDevices_mode_inverter_only")
+		case VenusOS.VeBusDevice_Mode_Off:
 			return CommonWords.onOrOff(0)
 		default:
 			return ""
 		}
 	}
 
-	Component.onCompleted: Global.inverters = root
+	Component.onCompleted: Global.veBusDevices = root
 }

--- a/data/common/VeBusDevice.qml
+++ b/data/common/VeBusDevice.qml
@@ -19,11 +19,11 @@ Device {
 
 	readonly property int productId: _productId.value === undefined ? -1 : _productId.value
 	readonly property int productType: _productUpperByte === 0x19 || _productUpperByte === 0x26
-			? VenusOS.Inverters_ProductType_EuProduct
-			: (_productUpperByte === 0x20 || _productUpperByte === 0x27 ? VenusOS.Inverters_ProductType_UsProduct : -1)
-	readonly property var ampOptions: productType === VenusOS.Inverters_ProductType_EuProduct
+			? VenusOS.VeBusDevice_ProductType_EuProduct
+			: (_productUpperByte === 0x20 || _productUpperByte === 0x27 ? VenusOS.VeBusDevice_ProductType_UsProduct : -1)
+	readonly property var ampOptions: productType === VenusOS.VeBusDevice_ProductType_EuProduct
 			? _euAmpOptions
-			: (productType === VenusOS.Inverters_ProductType_UsProduct ? _usAmpOptions : [])
+			: (productType === VenusOS.VeBusDevice_ProductType_UsProduct ? _usAmpOptions : [])
 
 	/* - Mask the Product id with `0xFF00`
 	 * - If the result is `0x1900` or `0x2600` it is an EU model (230VAC)
@@ -43,7 +43,7 @@ Device {
 
 	readonly property VeQuickItem _nominalInverterPower: VeQuickItem {
 		uid: inverter.serviceUid + "/Ac/Out/NominalInverterPower"
-		onValueChanged: if (!!Global.inverters) Global.inverters.refreshNominalInverterPower()
+		onValueChanged: if (!!Global.veBusDevices) Global.veBusDevices.refreshNominalInverterPower()
 	}
 
 	readonly property VeQuickItem _mode: VeQuickItem {
@@ -60,11 +60,11 @@ Device {
 
 	property bool _valid: deviceInstance.value !== undefined
 	on_ValidChanged: {
-		if (!!Global.inverters) {
+		if (!!Global.veBusDevices) {
 			if (_valid) {
-				Global.inverters.addInverter(inverter)
+				Global.veBusDevices.addVeBusDevice(inverter)
 			} else {
-				Global.inverters.removeInverter(inverter)
+				Global.veBusDevices.removeVeBusDevice(inverter)
 			}
 		}
 	}

--- a/data/dbus/DBusDataManager.qml
+++ b/data/dbus/DBusDataManager.qml
@@ -16,7 +16,6 @@ QtObject {
 	property var ess: EssImpl { }
 	property var evChargers: EvChargersImpl { }
 	property var generators: GeneratorsImpl { }
-	property var inverters: InvertersImpl { }
 	property var notifications: NotificationsImpl {}
 	property var pvInverters: PvInvertersImpl { }
 	property var relays: RelaysImpl {}
@@ -24,6 +23,7 @@ QtObject {
 	property var system: SystemImpl { }
 	property var systemSettings: SystemSettingsImpl { }
 	property var tanks: TanksImpl { }
+	property var veBusDevices: VeBusDevicesImpl {}
 
 	property VeQItemTableModel servicesTableModel: VeQItemTableModel {
 		uids: ["dbus"]

--- a/data/dbus/VeBusDevicesImpl.qml
+++ b/data/dbus/VeBusDevicesImpl.qml
@@ -18,7 +18,7 @@ QtObject {
 			model: Global.dataServiceModel
 		}
 
-		delegate: Inverter {
+		delegate: VeBusDevice {
 			serviceUid: model.uid
 		}
 	}
@@ -31,7 +31,7 @@ QtObject {
 			model: Global.dataServiceModel
 		}
 
-		delegate: Inverter {
+		delegate: VeBusDevice {
 			serviceUid: model.uid
 		}
 	}

--- a/data/mock/MockDataManager.qml
+++ b/data/mock/MockDataManager.qml
@@ -27,7 +27,7 @@ QtObject {
 			property var ess: EssImpl {}
 			property var evChargers: EvChargersImpl {}
 			property var generators: GeneratorsImpl {}
-			property var inverters: InvertersImpl {}
+			property var veBusDevices: VeBusDevicesImpl {}
 			property var notifications: NotificationsImpl {}
 			property var pvInverters: PvInvertersImpl {}
 			property var relays: RelaysImpl {}

--- a/data/mock/VeBusDevicesImpl.qml
+++ b/data/mock/VeBusDevicesImpl.qml
@@ -14,11 +14,11 @@ QtObject {
 			productId: 9816,
 			name: "Quattro 48/5000/70-2x100",
 			ampOptions: [ 3.0, 6.0, 10.0, 13.0, 16.0, 25.0, 32.0, 63.0 ].map(function(v) { return { value: v } }),   // EU amp options
-			mode: VenusOS.Inverters_Mode_On,
+			mode: VenusOS.VeBusDevice_Mode_On,
 			modeAdjustable: true,
 		}
-		let inverter = inverterComponent.createObject(root, quattro)
-		Global.inverters.addInverter(inverter)
+		let inverter = veBusDeviceComponent.createObject(root, quattro)
+		Global.veBusDevices.addVeBusDevice(inverter)
 
 		for (let i = 0; i < 2; ++i) {
 			const settingData = {
@@ -46,7 +46,7 @@ QtObject {
 	}
 
 	property int _objectId
-	property Component inverterComponent: Component {
+	property Component veBusDeviceComponent: Component {
 		MockDevice {
 			id: inverter
 
@@ -68,7 +68,7 @@ QtObject {
 				inputSettings.get(inputIndex).inputSettings.setCurrentLimit(currentLimit)
 			}
 
-			name: "Inverter" + deviceInstance.value
+			name: "VeBusDevice" + deviceInstance.value
 			Component.onCompleted: deviceInstance.value = root._objectId++
 		}
 	}

--- a/data/mqtt/MqttDataManager.qml
+++ b/data/mqtt/MqttDataManager.qml
@@ -16,7 +16,6 @@ QtObject {
 	property var ess: EssImpl { }
 	property var evChargers: EvChargersImpl { }
 	property var generators: GeneratorsImpl { }
-	property var inverters: InvertersImpl { }
 	property var notifications: NotificationsImpl {}
 	property var pvInverters: PvInvertersImpl { }
 	property var relays: RelaysImpl {}
@@ -24,4 +23,5 @@ QtObject {
 	property var system: SystemImpl { }
 	property var systemSettings: SystemSettingsImpl { }
 	property var tanks: TanksImpl { }
+	property var veBusDevices: VeBusDevicesImpl {}
 }

--- a/data/mqtt/VeBusDevicesImpl.qml
+++ b/data/mqtt/VeBusDevicesImpl.qml
@@ -16,7 +16,7 @@ QtObject {
 			flags: VeQItemTableModel.AddChildren | VeQItemTableModel.AddNonLeaves | VeQItemTableModel.DontAddItem
 		}
 
-		delegate: Inverter {
+		delegate: VeBusDevice {
 			serviceUid: model.uid
 		}
 	}
@@ -27,7 +27,7 @@ QtObject {
 			flags: VeQItemTableModel.AddChildren | VeQItemTableModel.AddNonLeaves | VeQItemTableModel.DontAddItem
 		}
 
-		delegate: Inverter {
+		delegate: VeBusDevice {
 			serviceUid: model.uid
 		}
 	}

--- a/pages/ControlCardsPage.qml
+++ b/pages/ControlCardsPage.qml
@@ -50,9 +50,9 @@ Page {
 				height: cardsView.height
 
 				Repeater {
-					model: Global.inverters.model
+					model: Global.veBusDevices.model
 
-					InverterCard {
+					VeBusDeviceCard {
 						width: root.cardWidth
 						inverter: model.inverter
 					}

--- a/pages/OverviewPage.qml
+++ b/pages/OverviewPage.qml
@@ -10,7 +10,7 @@ Page {
 	id: root
 
 	property var _leftWidgets: []
-	readonly property var _centerWidgets: [inverterWidget, batteryWidget]
+	readonly property var _centerWidgets: [veBusDeviceWidget, batteryWidget]
 	property var _rightWidgets: []
 
 	// Preferred order for the input widgets on the left hand side
@@ -342,7 +342,7 @@ Page {
 			return VenusOS.WidgetConnector_AnimationMode_NotAnimated
 		}
 
-		if (connectorWidget.endWidget === inverterWidget) {
+		if (connectorWidget.endWidget === veBusDeviceWidget) {
 			// For AC inputs, positive power means energy is flowing towards inverter/charger,
 			// and negative power means energy is flowing towards the input.
 			return power > Theme.geometry.overviewPage.connector.animationPowerThreshold
@@ -386,7 +386,7 @@ Page {
 				parent: root
 				startWidget: gridWidget
 				startLocation: VenusOS.WidgetConnector_Location_Right
-				endWidget: inverterWidget
+				endWidget: veBusDeviceWidget
 				endLocation: VenusOS.WidgetConnector_Location_Left
 				expanded: root._expandLayout
 				animateGeometry: root._animateGeometry
@@ -419,7 +419,7 @@ Page {
 				parent: root
 				startWidget: shoreWidget
 				startLocation: VenusOS.WidgetConnector_Location_Right
-				endWidget: inverterWidget
+				endWidget: veBusDeviceWidget
 				endLocation: VenusOS.WidgetConnector_Location_Left
 				expanded: root._expandLayout
 				animateGeometry: root._animateGeometry
@@ -452,7 +452,7 @@ Page {
 				parent: root
 				startWidget: acGeneratorWidget
 				startLocation: VenusOS.WidgetConnector_Location_Right
-				endWidget: inverterWidget
+				endWidget: veBusDeviceWidget
 				endLocation: VenusOS.WidgetConnector_Location_Left
 				expanded: root._expandLayout
 				animateGeometry: root._animateGeometry
@@ -581,7 +581,7 @@ Page {
 				parent: root
 				startWidget: solarWidget
 				startLocation: VenusOS.WidgetConnector_Location_Right
-				endWidget: inverterWidget
+				endWidget: veBusDeviceWidget
 				endLocation: VenusOS.WidgetConnector_Location_Left
 				visible: defaultVisible && Global.pvInverters.model.count > 0
 				expanded: root._expandLayout
@@ -619,8 +619,8 @@ Page {
 	}
 
 	// the two central widgets are always laid out, even if they are not visible
-	InverterWidget {
-		id: inverterWidget
+	VeBusDeviceWidget {
+		id: veBusDeviceWidget
 
 		size: VenusOS.OverviewWidget_Size_L
 		expanded: root._expandLayout
@@ -647,7 +647,7 @@ Page {
 	WidgetConnector {
 		id: inverterToAcLoadsConnector
 
-		startWidget: inverterWidget
+		startWidget: veBusDeviceWidget
 		startLocation: VenusOS.WidgetConnector_Location_Right
 		endWidget: acLoadsWidget
 		endLocation: VenusOS.WidgetConnector_Location_Left
@@ -667,7 +667,7 @@ Page {
 	WidgetConnector {
 		id: inverterToBatteryConnector
 
-		startWidget: inverterWidget
+		startWidget: veBusDeviceWidget
 		startLocation: VenusOS.WidgetConnector_Location_Bottom
 		endWidget: batteryWidget
 		endLocation: VenusOS.WidgetConnector_Location_Top

--- a/pages/controlcards/VeBusDeviceCard.qml
+++ b/pages/controlcards/VeBusDeviceCard.qml
@@ -76,9 +76,9 @@ ControlCard {
 			property var _modeDialog
 
 			width: parent.width
-			button.width: Math.max(button.implicitWidth, Theme.geometry.inverterCard.modeButton.maximumWidth)
+			button.width: Math.max(button.implicitWidth, Theme.geometry.veBusDeviceCard.modeButton.maximumWidth)
 			label.text: CommonWords.mode
-			button.text: Global.inverters.inverterModeToText(root.inverter.mode)
+			button.text: Global.veBusDevices.modeToText(root.inverter.mode)
 			enabled: root.inverter.modeAdjustable
 			separator.visible: false
 

--- a/qml.qrc
+++ b/qml.qrc
@@ -131,10 +131,10 @@
         <file>components/widgets/DcLoadsWidget.qml</file>
         <file>components/widgets/EvcsWidget.qml</file>
         <file>components/widgets/GridWidget.qml</file>
-        <file>components/widgets/InverterWidget.qml</file>
         <file>components/widgets/OverviewWidget.qml</file>
         <file>components/widgets/ShoreWidget.qml</file>
         <file>components/widgets/SolarYieldWidget.qml</file>
+        <file>components/widgets/VeBusDeviceWidget.qml</file>
         <file>components/widgets/WidgetConnector.qml</file>
         <file>components/widgets/WidgetConnectorAnchor.qml</file>
         <file>components/widgets/WidgetConnectorPath.qml</file>
@@ -148,7 +148,6 @@
         <file>data/Ess.qml</file>
         <file>data/EvChargers.qml</file>
         <file>data/Generators.qml</file>
-        <file>data/Inverters.qml</file>
         <file>data/Notifications.qml</file>
         <file>data/PvInverters.qml</file>
         <file>data/Relays.qml</file>
@@ -158,6 +157,7 @@
         <file>data/SystemDc.qml</file>
         <file>data/SystemSettings.qml</file>
         <file>data/Tanks.qml</file>
+        <file>data/VeBusDevices.qml</file>
         <file>data/VenusPlatform.qml</file>
         <file>data/common/AcInput.qml</file>
         <file>data/common/AcInputSettings.qml</file>
@@ -169,7 +169,6 @@
         <file>data/common/EssData.qml</file>
         <file>data/common/EvCharger.qml</file>
         <file>data/common/Generator.qml</file>
-        <file>data/common/Inverter.qml</file>
         <file>data/common/PvInverter.qml</file>
         <file>data/common/PvMonitor.qml</file>
         <file>data/common/Relay.qml</file>
@@ -179,6 +178,7 @@
         <file>data/common/SystemBattery.qml</file>
         <file>data/common/SystemData.qml</file>
         <file>data/common/Tank.qml</file>
+        <file>data/common/VeBusDevice.qml</file>
         <file>data/dbus/AcInputsImpl.qml</file>
         <file>data/dbus/BatteriesImpl.qml</file>
         <file>data/dbus/DBusDataManager.qml</file>
@@ -187,7 +187,6 @@
         <file>data/dbus/EssImpl.qml</file>
         <file>data/dbus/EvChargersImpl.qml</file>
         <file>data/dbus/GeneratorsImpl.qml</file>
-        <file>data/dbus/InvertersImpl.qml</file>
         <file>data/dbus/NotificationsImpl.qml</file>
         <file>data/dbus/PvInvertersImpl.qml</file>
         <file>data/dbus/RelaysImpl.qml</file>
@@ -195,6 +194,7 @@
         <file>data/dbus/SystemImpl.qml</file>
         <file>data/dbus/SystemSettingsImpl.qml</file>
         <file>data/dbus/TanksImpl.qml</file>
+        <file>data/dbus/VeBusDevicesImpl.qml</file>
         <file>data/mock/AcInputsImpl.qml</file>
         <file>data/mock/BatteriesImpl.qml</file>
         <file>data/mock/DcInputsImpl.qml</file>
@@ -202,7 +202,6 @@
         <file>data/mock/EssImpl.qml</file>
         <file>data/mock/EvChargersImpl.qml</file>
         <file>data/mock/GeneratorsImpl.qml</file>
-        <file>data/mock/InvertersImpl.qml</file>
         <file>data/mock/MockDevice.qml</file>
         <file>data/mock/MockDataManager.qml</file>
         <file>data/mock/NotificationsImpl.qml</file>
@@ -212,6 +211,7 @@
         <file>data/mock/SystemImpl.qml</file>
         <file>data/mock/SystemSettingsImpl.qml</file>
         <file>data/mock/TanksImpl.qml</file>
+        <file>data/mock/VeBusDevicesImpl.qml</file>
         <file>data/mock/config/BriefAndOverviewPageConfig.qml</file>
         <file>data/mock/config/LevelsPageConfig.qml</file>
         <file>data/mock/config/MockDataSimulator.qml</file>
@@ -224,7 +224,6 @@
         <file>data/mqtt/EssImpl.qml</file>
         <file>data/mqtt/EvChargersImpl.qml</file>
         <file>data/mqtt/GeneratorsImpl.qml</file>
-        <file>data/mqtt/InvertersImpl.qml</file>
         <file>data/mqtt/MqttDataManager.qml</file>
         <file>data/mqtt/NotificationsImpl.qml</file>
         <file>data/mqtt/PvInvertersImpl.qml</file>
@@ -233,6 +232,7 @@
         <file>data/mqtt/SystemImpl.qml</file>
         <file>data/mqtt/SystemSettingsImpl.qml</file>
         <file>data/mqtt/TanksImpl.qml</file>
+        <file>data/mqtt/VeBusDevicesImpl.qml</file>
         <file>fonts/MuseoSans-500.otf</file>
         <file>images/acloads.svg</file>
         <file>images/alternator.svg</file>
@@ -325,8 +325,8 @@
         <file>pages/TanksTab.qml</file>
         <file>pages/controlcards/ESSCard.qml</file>
         <file>pages/controlcards/GeneratorCard.qml</file>
-        <file>pages/controlcards/InverterCard.qml</file>
         <file>pages/controlcards/SwitchesCard.qml</file>
+        <file>pages/controlcards/VeBusDeviceCard.qml</file>
         <file>pages/evcs/EvChargerListPage.qml</file>
         <file>pages/evcs/EvChargerPage.qml</file>
         <file>pages/evcs/EvChargerSetupPage.qml</file>

--- a/src/enums.h
+++ b/src/enums.h
@@ -101,7 +101,7 @@ public:
 		OverviewWidget_Type_Alternator,
 		OverviewWidget_Type_Wind,
 		OverviewWidget_Type_Solar,
-		OverviewWidget_Type_Inverter,
+		OverviewWidget_Type_VeBusDevice,
 		OverviewWidget_Type_Battery,
 		OverviewWidget_Type_AcLoads,
 		OverviewWidget_Type_DcLoads,
@@ -219,19 +219,19 @@ public:
 	};
 	Q_ENUM(Generators_RunningBy)
 
-	enum Inverters_ProductType {
-		Inverters_ProductType_EuProduct = 0,
-		Inverters_ProductType_UsProduct
+	enum VeBusDevice_ProductType {
+		VeBusDevice_ProductType_EuProduct = 0,
+		VeBusDevice_ProductType_UsProduct
 	};
-	Q_ENUM(Inverters_ProductType)
+	Q_ENUM(VeBusDevice_ProductType)
 
-	enum Inverters_Mode {
-		Inverters_Mode_ChargerOnly = 1,
-		Inverters_Mode_InverterOnly,
-		Inverters_Mode_On,
-		Inverters_Mode_Off
+	enum VeBusDevice_Mode {
+		VeBusDevice_Mode_ChargerOnly = 1,
+		VeBusDevice_Mode_InverterOnly,
+		VeBusDevice_Mode_On,
+		VeBusDevice_Mode_Off
 	};
-	Q_ENUM(Inverters_Mode)
+	Q_ENUM(VeBusDevice_Mode)
 
 	enum Relays_State {
 		Relays_State_Inactive = 0,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -522,8 +522,6 @@ void registerQmlTypes()
 		"Victron.VenusOS", 2, 0, "SolarYieldWidget");
 	qmlRegisterType(QUrl(QStringLiteral("qrc:/components/widgets/WindWidget.qml")),
 		"Victron.VenusOS", 2, 0, "WindWidget");
-	qmlRegisterType(QUrl(QStringLiteral("qrc:/components/widgets/InverterWidget.qml")),
-		"Victron.VenusOS", 2, 0, "InverterWidget");
 	qmlRegisterType(QUrl(QStringLiteral("qrc:/components/widgets/BatteryWidget.qml")),
 		"Victron.VenusOS", 2, 0, "BatteryWidget");
 	qmlRegisterType(QUrl(QStringLiteral("qrc:/components/widgets/AcLoadsWidget.qml")),
@@ -532,6 +530,8 @@ void registerQmlTypes()
 		"Victron.VenusOS", 2, 0, "DcLoadsWidget");
 	qmlRegisterType(QUrl(QStringLiteral("qrc:/components/VerticalGauge.qml")),
 		"Victron.VenusOS", 2, 0, "VerticalGauge");
+	qmlRegisterType(QUrl(QStringLiteral("qrc:/components/widgets/VeBusDeviceWidget.qml")),
+		"Victron.VenusOS", 2, 0, "VeBusDeviceWidget");
 	qmlRegisterType(QUrl(QStringLiteral("qrc:/components/widgets/WidgetConnector.qml")),
 		"Victron.VenusOS", 2, 0, "WidgetConnector");
 	qmlRegisterType(QUrl(QStringLiteral("qrc:/components/widgets/WidgetConnectorAnchor.qml")),
@@ -548,10 +548,10 @@ void registerQmlTypes()
 		"Victron.VenusOS", 2, 0, "ESSCard");
 	qmlRegisterType(QUrl(QStringLiteral("qrc:/pages/controlcards/GeneratorCard.qml")),
 		"Victron.VenusOS", 2, 0, "GeneratorCard");
-	qmlRegisterType(QUrl(QStringLiteral("qrc:/pages/controlcards/InverterCard.qml")),
-		"Victron.VenusOS", 2, 0, "InverterCard");
 	qmlRegisterType(QUrl(QStringLiteral("qrc:/pages/controlcards/SwitchesCard.qml")),
 		"Victron.VenusOS", 2, 0, "SwitchesCard");
+	qmlRegisterType(QUrl(QStringLiteral("qrc:/pages/controlcards/VeBusDeviceCard.qml")),
+		"Victron.VenusOS", 2, 0, "VeBusDeviceCard");
 
 	/* dialogs */
 	qmlRegisterType(QUrl(QStringLiteral("qrc:/components/dialogs/DateSelectorDialog.qml")),

--- a/themes/geometry/FiveInch.json
+++ b/themes/geometry/FiveInch.json
@@ -230,7 +230,7 @@
 
     "geometry.generatorIconLabel.icon.width": 24,
 
-    "geometry.inverterCard.modeButton.maximumWidth": 180,
+    "geometry.veBusDeviceCard.modeButton.maximumWidth": 180,
 
     "geometry.overviewPage.widget.radius": 8,
     "geometry.overviewPage.widget.border.width": 2,

--- a/themes/geometry/SevenInch.json
+++ b/themes/geometry/SevenInch.json
@@ -230,7 +230,7 @@
 
     "geometry.generatorIconLabel.icon.width": 24,
 
-    "geometry.inverterCard.modeButton.maximumWidth": 180,
+    "geometry.veBusDeviceCard.modeButton.maximumWidth": 180,
 
     "geometry.overviewPage.widget.radius": 8,
     "geometry.overviewPage.widget.border.width": 2,


### PR DESCRIPTION
The codebase uses "inverters" to refer to com.victronenergy.vebus devices. This was probably originally intended as a shorthand for "Inverter/Charger". However, this terminology is confusing as "inverter" is not the same as "inverter/charger", and also the naming will become problematic when support is added for
com.victronenergy.inverter devices.

Naming changes:
- Global.inverters -> Global.veBus
- Inverters.qml -> VeBus.qml
- Inverter.qml -> VeBusDevice.qml
- InvertersImpl.qml -> VeBusImpl.qml
- InverterWidget.qml -> VeBusDeviceWidget.qml
- InverterCard.qml -> VeBusDeviceCard.qml