### PR TITLE
Add modelId property to DeviceModel. #328

### DIFF
--- a/data/AcInputs.qml
+++ b/data/AcInputs.qml
@@ -17,7 +17,7 @@ QtObject {
 	property real currentLimit: connectedInput != null ? connectedInput.currentLimit : NaN
 
 	property DeviceModel model: DeviceModel {
-		objectName: "acInputs"
+		modelId: "acInputs"
 	}
 
 	function addInput(input) {

--- a/data/Batteries.qml
+++ b/data/Batteries.qml
@@ -11,7 +11,7 @@ QtObject {
 	id: root
 
 	property DeviceModel model: DeviceModel {
-		objectName: "batteries"
+		modelId: "batteries"
 	}
 
 	property var system: SystemBattery {}

--- a/data/DcInputs.qml
+++ b/data/DcInputs.qml
@@ -13,7 +13,7 @@ QtObject {
 	property real current: NaN
 
 	property DeviceModel model: DeviceModel {
-		objectName: "dcInputs"
+		modelId: "dcInputs"
 	}
 
 	function addInput(input) {

--- a/data/EnvironmentInputs.qml
+++ b/data/EnvironmentInputs.qml
@@ -10,7 +10,7 @@ QtObject {
 	id: root
 
 	property DeviceModel model: DeviceModel {
-		objectName: "environmentInputs"
+		modelId: "environmentInputs"
 	}
 
 	function addInput(input) {

--- a/data/EvChargers.qml
+++ b/data/EvChargers.qml
@@ -13,7 +13,7 @@ QtObject {
 	property real energy: NaN
 
 	property DeviceModel model: DeviceModel {
-		objectName: "evChargers"
+		modelId: "evChargers"
 	}
 
 	readonly property var maxCurrentPresets: [6, 8, 10, 14, 16, 24, 32].map(function(v) { return { value: v } })

--- a/data/Generators.qml
+++ b/data/Generators.qml
@@ -10,7 +10,7 @@ QtObject {
 	id: root
 
 	property DeviceModel model: DeviceModel {
-		objectName: "generators"
+		modelId: "generators"
 	}
 	property var first: model.firstObject
 

--- a/data/PvInverters.qml
+++ b/data/PvInverters.qml
@@ -10,7 +10,7 @@ QtObject {
 	id: root
 
 	property DeviceModel model: DeviceModel {
-		objectName: "pvInverters"
+		modelId: "pvInverters"
 	}
 
 	function addInverter(inverter) {

--- a/data/Relays.qml
+++ b/data/Relays.qml
@@ -10,10 +10,10 @@ QtObject {
 	id: root
 
 	property DeviceModel model: DeviceModel {
-		objectName: "relays"
+		modelId: "relays"
 	}
 	property DeviceModel manualRelays: DeviceModel {
-		objectName: "manualRelays"
+		modelId: "relays-manual"
 	}
 
 	function addRelay(relay) {

--- a/data/SolarChargers.qml
+++ b/data/SolarChargers.qml
@@ -11,7 +11,7 @@ QtObject {
 
 	// Model of all solar chargers
 	property DeviceModel model: DeviceModel {
-		objectName: "solarChargers"
+		modelId: "solarChargers"
 	}
 
 	function addCharger(charger) {

--- a/data/Tanks.qml
+++ b/data/Tanks.qml
@@ -32,73 +32,73 @@ QtObject {
 		readonly property int type: VenusOS.Tank_Type_Fuel
 		property real totalCapacity
 		property real totalRemaining
-		objectName: "Fuel"
+		modelId: "tanks-Fuel"
 	}
 	readonly property DeviceModel freshWaterTanks: DeviceModel {
 		readonly property int type: VenusOS.Tank_Type_FreshWater
 		property real totalCapacity
 		property real totalRemaining
-		objectName: "FreshWater"
+		modelId: "tanks-FreshWater"
 	}
 	readonly property DeviceModel wasteWaterTanks: DeviceModel {
 		readonly property int type: VenusOS.Tank_Type_WasteWater
 		property real totalCapacity
 		property real totalRemaining
-		objectName: "WasteWater"
+		modelId: "tanks-WasteWater"
 	}
 	readonly property DeviceModel liveWellTanks: DeviceModel {
 		readonly property int type: VenusOS.Tank_Type_LiveWell
 		property real totalCapacity
 		property real totalRemaining
-		objectName: "LiveWell"
+		modelId: "tanks-LiveWell"
 	}
 	readonly property DeviceModel oilTanks: DeviceModel {
 		readonly property int type: VenusOS.Tank_Type_Oil
 		property real totalCapacity
 		property real totalRemaining
-		objectName: "Oil"
+		modelId: "tanks-Oil"
 	}
 	readonly property DeviceModel blackWaterTanks: DeviceModel {
 		readonly property int type: VenusOS.Tank_Type_BlackWater
 		property real totalCapacity
 		property real totalRemaining
-		objectName: "BlackWater"
+		modelId: "tanks-BlackWater"
 	}
 	readonly property DeviceModel gasolineTanks: DeviceModel {
 		readonly property int type: VenusOS.Tank_Type_Gasoline
 		property real totalCapacity
 		property real totalRemaining
-		objectName: "Gasoline"
+		modelId: "tanks-Gasoline"
 	}
 	readonly property DeviceModel dieselTanks: DeviceModel {
 		readonly property int type: VenusOS.Tank_Type_Diesel
 		property real totalCapacity
 		property real totalRemaining
-		objectName: "Diesel"
+		modelId: "tanks-Diesel"
 	}
 	readonly property DeviceModel lpgTanks: DeviceModel {
 		readonly property int type: VenusOS.Tank_Type_LPG
 		property real totalCapacity
 		property real totalRemaining
-		objectName: "LPG"
+		modelId: "tanks-LPG"
 	}
 	readonly property DeviceModel lngTanks: DeviceModel {
 		readonly property int type: VenusOS.Tank_Type_LNG
 		property real totalCapacity
 		property real totalRemaining
-		objectName: "LNG"
+		modelId: "tanks-LNG"
 	}
 	readonly property DeviceModel hydraulicOilTanks: DeviceModel {
 		readonly property int type: VenusOS.Tank_Type_HydraulicOil
 		property real totalCapacity
 		property real totalRemaining
-		objectName: "HydraulicOil"
+		modelId: "tanks-HydraulicOil"
 	}
 	readonly property DeviceModel rawWaterTanks: DeviceModel {
 		readonly property int type: VenusOS.Tank_Type_RawWater
 		property real totalCapacity
 		property real totalRemaining
-		objectName: "RawWater"
+		modelId: "tanks-RawWater"
 	}
 
 	readonly property int totalTankCount: fuelTanks.count

--- a/data/VeBusDevices.qml
+++ b/data/VeBusDevices.qml
@@ -10,7 +10,7 @@ QtObject {
 	id: root
 
 	property DeviceModel model: DeviceModel {
-		objectName: "veBusDevices"
+		modelId: "veBusDevices"
 	}
 
 	property real totalNominalInverterPower: NaN

--- a/data/common/DeviceModel.qml
+++ b/data/common/DeviceModel.qml
@@ -8,5 +8,7 @@ import Victron.VenusOS
 BaseDeviceModel {
 	id: root
 
+	objectName: modelId
+
 	// Nothing here yet; placeholder to add extra API for QML-only device model features.
 }

--- a/src/basedevicemodel.cpp
+++ b/src/basedevicemodel.cpp
@@ -79,6 +79,19 @@ int BaseDeviceModel::count() const
 	return static_cast<int>(m_devices.count());
 }
 
+QString BaseDeviceModel::modelId() const
+{
+	return m_modelId;
+}
+
+void BaseDeviceModel::setModelId(const QString &modelId)
+{
+	if (m_modelId != modelId) {
+		m_modelId = modelId;
+		emit modelIdChanged();
+	}
+}
+
 QVariant BaseDeviceModel::data(const QModelIndex &index, int role) const
 {
 	const int row = index.row();

--- a/src/basedevicemodel.h
+++ b/src/basedevicemodel.h
@@ -50,6 +50,7 @@ class BaseDeviceModel : public QAbstractListModel
 {
 	Q_OBJECT
 	Q_PROPERTY(int count READ count NOTIFY countChanged)
+	Q_PROPERTY(QString modelId READ modelId WRITE setModelId NOTIFY modelIdChanged)
 	Q_PROPERTY(BaseDevice *firstObject READ firstObject NOTIFY firstObjectChanged)
 
 public:
@@ -61,6 +62,9 @@ public:
 
 	BaseDevice *firstObject() const;    // the object with the lowest DeviceInstance
 	int count() const;
+
+	QString modelId() const;    // must be unique across all BaseDeviceModel instances
+	void setModelId(const QString &modelId);
 
 	int rowCount(const QModelIndex &parent) const override;
 	QVariant data(const QModelIndex& index, int role) const override;
@@ -76,6 +80,7 @@ public:
 Q_SIGNALS:
 	void countChanged();
 	void firstObjectChanged();
+	void modelIdChanged();
 
 protected:
 	QHash<int, QByteArray> roleNames() const override;
@@ -87,6 +92,7 @@ private:
 	QHash<int, QByteArray> m_roleNames;
 	QVector<QPointer<BaseDevice> > m_devices;
 	QPointer<BaseDevice> m_firstObject;
+	QString m_modelId;
 };
 
 } /* VenusOS */


### PR DESCRIPTION
This will allow the aggregate model to identify devices uniquely, in the case where a device of the same service may appear in multiple device models. For example, an inverter/charger may appear in both Global.veBusDevices.model and Global.acInputs.model.