### PR TITLE
Only show firmware update messages when relevant settings are open

### DIFF
--- a/ApplicationContent.qml
+++ b/ApplicationContent.qml
@@ -25,11 +25,6 @@ Item {
 		Component.onCompleted: Global.mainView = mainView
 	}
 
-	FirmwareUpdate {
-		id: firmwareUpdate
-		Component.onCompleted: Global.firmwareUpdate = firmwareUpdate
-	}
-
 	MouseArea {
 		id: idleModeMouseArea
 		anchors.fill: parent

--- a/Global.qml
+++ b/Global.qml
@@ -22,7 +22,6 @@ QtObject {
 	property var dataManager
 	property var locale: Qt.locale()  // TODO: read from settings
 	property var dataServiceModel: null
-	property var firmwareUpdate
 
 	property var inputPanel
 	property var dialogLayer
@@ -87,7 +86,6 @@ QtObject {
 		dataManager = null
 		locale = Qt.locale()
 		dataServiceModel = null
-		firmwareUpdate = null
 		inputPanel = null
 		dialogLayer = null
 		notificationLayer = null

--- a/components/settings/FirmwareCheckListButton.qml
+++ b/components/settings/FirmwareCheckListButton.qml
@@ -10,16 +10,17 @@ ListButton {
 	id: root
 
 	property int updateType
+	property FirmwareUpdate firmwareUpdate
 
-	button.text: Global.firmwareUpdate.state === FirmwareUpdater.Checking
+	button.text: firmwareUpdate.state === FirmwareUpdater.Checking
 			 //% "Checking..."
 		   ? qsTrId("settings_firmware_checking")
 			 //% "Press to check"
 		   : qsTrId("settings_firmware_press_to_check")
-	enabled: !Global.firmwareUpdate.busy
+	enabled: !firmwareUpdate.busy
 	writeAccessLevel: VenusOS.User_AccessType_User
 
 	onClicked: {
-		Global.firmwareUpdate.checkForUpdate(updateType)
+		firmwareUpdate.checkForUpdate(updateType)
 	}
 }

--- a/pages/settings/PageSettingsFirmwareOffline.qml
+++ b/pages/settings/PageSettingsFirmwareOffline.qml
@@ -9,6 +9,8 @@ import Victron.Veutil
 Page {
 	id: root
 
+	property FirmwareUpdate firmwareUpdate: FirmwareUpdate {}
+
 	GradientListView {
 		id: settingsListView
 
@@ -18,6 +20,7 @@ Page {
 				//% "Check for updates on SD/USB"
 				text: qsTrId("settings_firmware_check_for_updates_on_sd_usb")
 				updateType: VenusOS.Firmware_UpdateType_Offline
+				firmwareUpdate: root.firmwareUpdate
 			}
 
 			ListButton {
@@ -26,22 +29,22 @@ Page {
 				//% "Firmware found"
 				text: qsTrId("settings_firmware_found")
 				button.text: {
-					if (Global.firmwareUpdate.state === FirmwareUpdater.DownloadingAndInstalling) {
+					if (root.firmwareUpdate.state === FirmwareUpdater.DownloadingAndInstalling) {
 						//: %1 = firmware version
 						//% "Installing %1"
-						return qsTrId("settings_firmware_offline_installing").arg(Global.firmwareUpdate.offlineAvailableVersion)
+						return qsTrId("settings_firmware_offline_installing").arg(root.firmwareUpdate.offlineAvailableVersion)
 					} else {
 						//: %1 = firmware version
 						//% "Press to update to %1"
-						return qsTrId("settings_firmware_offline_press_to_install").arg(Global.firmwareUpdate.offlineAvailableVersion)
+						return qsTrId("settings_firmware_offline_press_to_install").arg(root.firmwareUpdate.offlineAvailableVersion)
 					}
 				}
 
-				enabled: !Global.firmwareUpdate.busy
+				enabled: !root.firmwareUpdate.busy
 				writeAccessLevel: VenusOS.User_AccessType_User
-				visible: !!Global.firmwareUpdate.offlineAvailableVersion
+				visible: !!root.firmwareUpdate.offlineAvailableVersion
 				onClicked: {
-					Global.firmwareUpdate.installUpdate(VenusOS.Firmware_UpdateType_Offline)
+					root.firmwareUpdate.installUpdate(VenusOS.Firmware_UpdateType_Offline)
 				}
 			}
 

--- a/pages/settings/PageSettingsFirmwareOnline.qml
+++ b/pages/settings/PageSettingsFirmwareOnline.qml
@@ -9,6 +9,8 @@ import Victron.Veutil
 Page {
 	id: root
 
+	property FirmwareUpdate firmwareUpdate: FirmwareUpdate {}
+
 	GradientListView {
 		id: settingsListView
 
@@ -70,6 +72,7 @@ Page {
 				//% "Check for updates"
 				text: qsTrId("settings_firmware_check_for_updates")
 				updateType: VenusOS.Firmware_UpdateType_Online
+				firmwareUpdate: root.firmwareUpdate
 			}
 
 			ListButton {
@@ -78,27 +81,27 @@ Page {
 				//% "Update available"
 				text: qsTrId("settings_firmware_update_available")
 				button.text: {
-					if (Global.firmwareUpdate.state === FirmwareUpdater.DownloadingAndInstalling) {
+					if (root.firmwareUpdate.state === FirmwareUpdater.DownloadingAndInstalling) {
 						if (progress.value) {
 							//: Firmware update progress. %1 = firmware version, %2 = current update progress
 							//% "Installing %1 %2%"
-							return qsTrId("settings_firmware_online_installing_progress").arg(Global.firmwareUpdate.onlineAvailableVersion).arg(progress.value)
+							return qsTrId("settings_firmware_online_installing_progress").arg(root.firmwareUpdate.onlineAvailableVersion).arg(progress.value)
 						}
 						//: %1 = firmware version
 						//% "Installing %1..."
-						return qsTrId("settings_firmware_online_installing").arg(Global.firmwareUpdate.onlineAvailableVersion)
+						return qsTrId("settings_firmware_online_installing").arg(root.firmwareUpdate.onlineAvailableVersion)
 					} else {
 						//: %1 = firmware version
 						//% "Press to update to %1"
-						return qsTrId("settings_firmware_online_press_to_update_to").arg(Global.firmwareUpdate.onlineAvailableVersion)
+						return qsTrId("settings_firmware_online_press_to_update_to").arg(root.firmwareUpdate.onlineAvailableVersion)
 					}
 				}
 
-				enabled: !Global.firmwareUpdate.busy
+				enabled: !root.firmwareUpdate.busy
 				writeAccessLevel: VenusOS.User_AccessType_User
-				visible: Global.firmwareUpdate.onlineAvailableVersion && Global.firmwareUpdate.state !== FirmwareUpdater.Checking
+				visible: root.firmwareUpdate.onlineAvailableVersion && root.firmwareUpdate.state !== FirmwareUpdater.Checking
 				onClicked: {
-					Global.firmwareUpdate.installUpdate(VenusOS.Firmware_UpdateType_Online)
+					root.firmwareUpdate.installUpdate(VenusOS.Firmware_UpdateType_Online)
 				}
 
 				DataPoint {


### PR DESCRIPTION
Create FirmwareUpdate objects within the scope of
PageSettingsFirmwareOffline and PageSettingsFirmwareOnline. Otherwise, status messages (e.g. about whether a newer version is available) is seen even when the settings pages are not visible, which is confusing.