### PR TITLE
Delay idleModeTimer until splash screen has closed.

### DIFF
--- a/pages/PageManager.qml
+++ b/pages/PageManager.qml
@@ -30,7 +30,8 @@ QtObject {
 			|| root.interactivity === VenusOS.PageManager_InteractionMode_Idle
 
 	property Timer idleModeTimer: Timer {
-		running: root.currentPage !== null && root.currentPage !== undefined
+		running: !Global.splashScreenVisible
+			&& root.currentPage !== null && root.currentPage !== undefined
 			&& root.currentPage.fullScreenWhenIdle
 			&& root.interactivity === VenusOS.PageManager_InteractionMode_Interactive
 			&& BackendConnection.applicationVisible


### PR DESCRIPTION
If the UI loads before the splash screen has finished, the idleModeTimer starts too early, resulting in an odd visual effect where the nav bar disappears and reappears when tapped.