### PR TITLE
Fix crash in desktop build when running with '--mock'

### DIFF
--- a/components/AcPhase.qml
+++ b/components/AcPhase.qml
@@ -20,19 +20,19 @@ QtObject {
 								  && !isNaN(voltage)
 								  && !isNaN(power)
 
-	readonly property VeQuickItem _frequency: VeQuickItem {
-		uid: serviceUid + "/F"
+	property DataPoint _frequency: DataPoint {
+		source: serviceUid + "/F"
 	}
 
-	readonly property VeQuickItem _current: VeQuickItem {
-		uid: serviceUid + "/I"
+	property DataPoint _current: DataPoint {
+		source: serviceUid + "/I"
 	}
 
-	readonly property VeQuickItem _voltage: VeQuickItem {
-		uid: serviceUid + "/V"
+	property DataPoint _voltage: DataPoint {
+		source: serviceUid + "/V"
 	}
 
-	readonly property VeQuickItem _power: VeQuickItem {
-		uid: serviceUid + "/P"
+	property DataPoint _power: DataPoint {
+		source: serviceUid + "/P"
 	}
 }


### PR DESCRIPTION
Running the desktop build with '--mock' crashes if you create a VeQuickItem that doesn't have a value defined in the mock implementation