### PR TITLE
Move BriefPage animations to render thread

### DIFF
--- a/components/ArcGauge.qml
+++ b/components/ArcGauge.qml
@@ -34,15 +34,16 @@ Item {
 		layer.smooth: true
 		layer.textureSize: Qt.size(antialiased.width*2, antialiased.height*2)
 
-		ProgressArc {
+		CheapProgressArc {
 			id: arc
 
 			readonly property int status: Gauges.getValueStatus(gauge.value, gauge.valueType)
 
-			width: radius*2
-			height: width
-			x: arcX !== undefined ? arcX : (gauge.alignment & Qt.AlignRight ? (gauge.width - 2*radius) : 0)
-			y: arcY !== undefined ? arcY : ((gauge.height - height) / 2)
+			anchors.fill: parent
+			arcWidth: radius*2
+			arcHeight: arcWidth
+			arcX: gauge.arcX !== undefined ? gauge.arcX : (gauge.alignment & Qt.AlignRight ? (gauge.width - arc.arcWidth) : 0)
+			arcY: gauge.arcY !== undefined ? gauge.arcY : ((gauge.height - arc.arcHeight) / 2)
 			progressColor: Theme.statusColorValue(status)
 			remainderColor: Theme.statusColorValue(status, true)
 		}

--- a/components/CheapProgressArc.qml
+++ b/components/CheapProgressArc.qml
@@ -1,0 +1,112 @@
+/*
+** Copyright (C) 2021 Victron Energy B.V.
+*/
+
+import QtQuick
+import QtQuick.Shapes
+import Victron.VenusOS
+import QtQuick.Effects as Effects
+
+Item {
+	id: control
+
+	property real arcX
+	property real arcY
+	property real arcWidth
+	property real arcHeight
+
+	property real value // 0 - 100
+	property real radius
+	property real strokeWidth: Theme.geometry.progressArc.strokeWidth
+	property bool animationEnabled
+	property alias progressColor: progress.color
+	property alias remainderColor: remainder.strokeColor
+	property alias startAngle: remainder.startAngle
+	property alias endAngle: remainder.endAngle
+	property alias useLargeArc: remainder.useLargeArc
+	property int direction: PathArc.Clockwise
+	property color fillColor: "transparent"
+
+	property real transitionAngle: startAngle + ((endAngle - startAngle) * Math.min(Math.max((isNaN(control.value) ? 0 : control.value), 0.0), 100.0) / 100.0)
+
+	Item {
+		id: remainderContainer
+		anchors.fill: parent
+		layer.enabled: true
+
+		Shape {
+			id: remainderShape
+
+			// The arc shape bounds are defined by the radius of the curve, not the parent bounds.
+			// Thus, it will likely be very large.  Don't enable a layer on it.
+			width: control.arcWidth
+			height: control.arcHeight
+			x: control.arcX
+			y: control.arcY
+
+			Arc {
+				id: remainder
+
+				radius: control.radius
+				direction: control.direction
+				strokeWidth: control.strokeWidth
+				strokeColor: Theme.color.darkOk
+				fillColor: control.fillColor
+			}
+		}
+	}
+
+	Item {
+		id: progressContainer
+		visible: false
+		anchors.fill: parent
+		layer.enabled: true
+
+		Rectangle {
+			id: progress
+			color: Theme.color.ok
+			width: parent.width
+			height: parent.height
+
+			y: {
+				if (control.startAngle >= 270 && control.startAngle <= 360
+						&& control.endAngle >= 270 && control.endAngle <= 360) {
+					// quarter gauge in the upper left.
+					// grow from bottom to top.
+					return (height - (height * (control.value/100.0)))
+				} else if (control.startAngle >= 180 && control.startAngle <= 270
+						&& control.endAngle >= 180 && control.endAngle <= 270) {
+					// quarter gauge in lower left
+					// grow from top to bottom.
+					return (-height + (height * (control.value/100.0)))
+				} else if (control.startAngle >= 90 && control.startAngle <= 180
+						&& control.endAngle >= 90 && control.endAngle <= 180) {
+					// quarter gauge in lower right.
+					// grow from top to bottom.
+					return (-height + (height * (control.value/100.0)))
+				} else {
+					// either quarter gauge in upper right, or half-spanning gauge.
+					// grow from bottom to top.
+					return (height - (height * (control.value/100.0)))
+				}
+			}
+
+			Behavior on y {
+				enabled: control.animationEnabled
+				YAnimator {
+					duration: Theme.animation.progressArc.duration
+					easing.type: Easing.InOutQuad
+				}
+			}
+		}
+	}
+
+	Effects.MultiEffect {
+		anchors.fill: parent
+		visible: true
+		maskEnabled: true
+		maskThresholdMin: 0.05
+		maskSource: remainderContainer
+		source: progressContainer
+	}
+}

--- a/components/ProgressArc.qml
+++ b/components/ProgressArc.qml
@@ -6,8 +6,13 @@ import QtQuick
 import QtQuick.Shapes
 import Victron.VenusOS
 
-Shape {
+Item {
 	id: control
+
+	property real arcX
+	property real arcY
+	property real arcWidth
+	property real arcHeight
 
 	property real value // 0 - 100
 	property real radius
@@ -23,25 +28,34 @@ Shape {
 
 	property real transitionAngle: startAngle + ((endAngle - startAngle) * Math.min(Math.max((isNaN(control.value) ? 0 : control.value), 0.0), 100.0) / 100.0)
 
-	Arc {
-		id: remainder
+	Shape {
+		// The arc shape bounds are defined by the radius of the curve, not the parent bounds.
+		// Thus, it will likely be very large.  Don't enable a layer on it.
+		width: control.arcWidth
+		height: control.arcHeight
+		x: control.arcX
+		y: control.arcY
 
-		radius: control.radius
-		direction: control.direction
-		strokeWidth: control.strokeWidth
-		strokeColor: Theme.color.darkOk
-		fillColor: control.fillColor
-	}
+		Arc {
+			id: remainder
 
-	Arc {
-		id: progress
+			radius: control.radius
+			direction: control.direction
+			strokeWidth: control.strokeWidth
+			strokeColor: Theme.color.darkOk
+			fillColor: control.fillColor
+		}
 
-		radius: control.radius
-		startAngle: remainder.startAngle
-		endAngle: control.transitionAngle
-		direction: control.direction
-		strokeWidth: control.strokeWidth
-		strokeColor: Theme.color.ok
-		fillColor: control.fillColor
+		Arc {
+			id: progress
+
+			radius: control.radius
+			startAngle: remainder.startAngle
+			endAngle: control.transitionAngle
+			direction: control.direction
+			strokeWidth: control.strokeWidth
+			strokeColor: Theme.color.ok
+			fillColor: control.fillColor
+		}
 	}
 }

--- a/components/SideGauge.qml
+++ b/components/SideGauge.qml
@@ -26,7 +26,9 @@ ArcGauge {
 	radius: Theme.geometry.briefPage.edgeGauge.radius
 	useLargeArc: false
 	strokeWidth: Theme.geometry.arc.strokeWidth
-	arcY: alignment & Qt.AlignTop ? _arcOffset : alignment & Qt.AlignVCenter ? undefined : _arcOffset - _maxArcHeight
+	arcY: alignment & Qt.AlignTop ? _arcOffset
+		: alignment & Qt.AlignVCenter ? undefined
+		: _arcOffset - _maxArcHeight
 
 	ArcGaugeQuantityLabel {
 		id: quantityLabel

--- a/components/SolarYieldGauge.qml
+++ b/components/SolarYieldGauge.qml
@@ -23,7 +23,7 @@ Item {
 		model: powerSampler.sampledAverages.length + 1
 
 		delegate: ScaledArcGauge {
-			animationEnabled: root.animationEnabled
+			animationEnabled: false // never animate the solar gauge.  It's too expensive.
 			width: Theme.geometry.briefPage.edgeGauge.width
 			x: index*strokeWidth
 			opacity: 1.0 - index * 0.3

--- a/qml.qrc
+++ b/qml.qrc
@@ -12,6 +12,7 @@
         <file>components/ArcGaugeQuantityLabel.qml</file>
         <file>components/AsymmetricRoundedRectangle.qml</file>
         <file>components/ButtonControlValue.qml</file>
+        <file>components/CheapProgressArc.qml</file>
         <file>components/CircularMultiGauge.qml</file>
         <file>components/CircularSingleGauge.qml</file>
         <file>components/CommonWords.qml</file>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -339,6 +339,8 @@ void registerQmlTypes()
 		"Victron.VenusOS", 2, 0, "AsymmetricRoundedRectangle");
 	qmlRegisterType(QUrl(QStringLiteral("qrc:/components/ButtonControlValue.qml")),
 		"Victron.VenusOS", 2, 0, "ButtonControlValue");
+	qmlRegisterType(QUrl(QStringLiteral("qrc:/components/CheapProgressArc.qml")),
+		"Victron.VenusOS", 2, 0, "CheapProgressArc");
 	qmlRegisterType(QUrl(QStringLiteral("qrc:/components/CircularMultiGauge.qml")),
 		"Victron.VenusOS", 2, 0, "CircularMultiGauge");
 	qmlRegisterType(QUrl(QStringLiteral("qrc:/components/CircularSingleGauge.qml")),


### PR DESCRIPTION
Instead of animating the endAngle of an Arc segment (which must be animated on the GUI thread, and involves a bunch of CPU-bound binding expression evaluations) we now animate the y property of a highlight rectangle (with opacity mask effect to clip to the remainder arc).  This y property can be animated with a YAnimator on the render thread instead (which just updates scene graph nodes and thus converts into pure GPU calls, basically).

There are two downsides:
1) we lose the rounded top of the progress arc
2) aliasing is worse, and CerboGX doesn't yet support MSAA