### PR TITLE
DataPoint: don't initialize until source is set

### DIFF
--- a/components/DataPoint.qml
+++ b/components/DataPoint.qml
@@ -120,5 +120,4 @@ QtObject {
 	}
 
 	onSourceChanged: _reset()
-	Component.onCompleted: _reset()
 }


### PR DESCRIPTION
This was triggering odd bugs where 'value' and 'valid' were not in sync.