### PR TITLE
Do not trigger build on README.md changes

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -1,6 +1,11 @@
 name: build-wasm
 run-name: ${{ github.actor }} is building wasm file
-on: [push]
+on:
+  push:
+    branches:
+      - '**'
+    paths-ignore:
+      - '**/README.md'
 jobs:
   build-wasm-file:
     env:


### PR DESCRIPTION
No reason to build a new wasm file each time that happens.