### PR TITLE
Improve conversion to preferred units and use veutil for conversions

### DIFF
--- a/components/ElectricalQuantityLabel.qml
+++ b/components/ElectricalQuantityLabel.qml
@@ -11,7 +11,7 @@ QuantityLabel {
 	id: root
 
 	property var dataObject
-	readonly property bool unitAmps: !!dataObject && !isNaN(dataObject.current) && Global.systemSettings.electricalQuantity.value === VenusOS.Units_Amp
+	readonly property bool unitAmps: !!dataObject && !isNaN(dataObject.current) && Global.systemSettings.electricalQuantity === VenusOS.Units_Amp
 	value: dataObject == null ? NaN // double equals to catch undefined and null
 		: unitAmps ? dataObject.current
 		: dataObject.power

--- a/components/EnvironmentGaugePanel.qml
+++ b/components/EnvironmentGaugePanel.qml
@@ -89,17 +89,13 @@ Rectangle {
 		animationEnabled: root.animationEnabled
 		icon.source: "qrc:/images/icon_temp_32.svg"
 
-		text: Global.systemSettings.temperatureUnit.value === VenusOS.Units_Temperature_Fahrenheit ? "F" : "C"
+		text: Global.systemSettings.temperatureUnitSuffix
 		value: Math.round(root.temperature)
-		unit: Global.systemSettings.temperatureUnit.value
+		unit: Global.systemSettings.temperatureUnit
 
 		// TODO min, max and highlight need to come from dbus backend, but not yet available.
-		minimumValue: Global.systemSettings.temperatureUnit.value === VenusOS.Units_Temperature_Celsius
-				? Theme.geometry_levelsPage_environment_temperatureGauge_minimumValue
-				: Units.celsiusToFahrenheit(Theme.geometry_levelsPage_environment_temperatureGauge_minimumValue)
-		maximumValue: Global.systemSettings.temperatureUnit.value === VenusOS.Units_Temperature_Celsius
-				? Theme.geometry_levelsPage_environment_temperatureGauge_maximumValue
-				: Units.celsiusToFahrenheit(Theme.geometry_levelsPage_environment_temperatureGauge_maximumValue)
+		minimumValue: Global.systemSettings.convertFromCelsius(Theme.geometry_levelsPage_environment_temperatureGauge_minimumValue)
+		maximumValue: Global.systemSettings.convertFromCelsius(Theme.geometry_levelsPage_environment_temperatureGauge_maximumValue)
 		highlightedValue: Theme.geometry_levelsPage_environment_temperatureGauge_highlightedValue
 		minimumValueColor: Theme.color_blue
 		maximumValueColor: Theme.color_red

--- a/components/ExpandedTanksView.qml
+++ b/components/ExpandedTanksView.qml
@@ -123,7 +123,7 @@ Rectangle {
 					fontSizeMode: Text.HorizontalFit
 					font.pixelSize: Theme.font_size_caption
 					color: Theme.color_font_secondary
-					text: Units.getCapacityDisplayText(Global.systemSettings.volumeUnit.value,
+					text: Units.getCapacityDisplayText(Global.systemSettings.volumeUnit,
 							model.device.capacity,
 							model.device.remaining,
 							Theme.geometry_quantityLabel_valueLength)

--- a/components/TankGaugeGroup.qml
+++ b/components/TankGaugeGroup.qml
@@ -154,7 +154,7 @@ Rectangle {
 		fontSizeMode: Text.HorizontalFit
 		font.pixelSize: Theme.font_size_caption
 		color: Theme.color_font_secondary
-		text: Units.getCapacityDisplayText(Global.systemSettings.volumeUnit.value,
+		text: Units.getCapacityDisplayText(Global.systemSettings.volumeUnit,
 				isNaN(root.totalCapacity) ? 0 : root.totalCapacity,
 				isNaN(root.totalRemaining) ? 0 : root.totalRemaining,
 				Theme.geometry_quantityLabel_valueLength)

--- a/components/listitems/ListTemperatureItem.qml
+++ b/components/listitems/ListTemperatureItem.qml
@@ -5,14 +5,11 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Units
 
 ListQuantityItem {
 	id: root
 
-	readonly property real temperature: Global.systemSettings.convertFromCelsius(dataItem.value)
-
-	value: Units.getDisplayText(Global.systemSettings.temperatureUnit, temperature, 1).number
+	value: Global.systemSettings.convertFromCelsius(dataItem.value)
 	unit: Global.systemSettings.temperatureUnit
 	precision: 1
 }

--- a/components/listitems/ListTemperatureItem.qml
+++ b/components/listitems/ListTemperatureItem.qml
@@ -10,9 +10,9 @@ import Victron.Units
 ListQuantityItem {
 	id: root
 
-	readonly property real temperature: Units.convertFromCelsius(dataItem.value, Global.systemSettings.temperatureUnit.value)
+	readonly property real temperature: Global.systemSettings.convertFromCelsius(dataItem.value)
 
-	value: Units.getDisplayText(Global.systemSettings.temperatureUnit.value, temperature, 1).number
-	unit: Global.systemSettings.temperatureUnit.value
+	value: Units.getDisplayText(Global.systemSettings.temperatureUnit, temperature, 1).number
+	unit: Global.systemSettings.temperatureUnit
 	precision: 1
 }

--- a/components/settings/TemperatureRelaySettings.qml
+++ b/components/settings/TemperatureRelaySettings.qml
@@ -70,16 +70,17 @@ Column {
 		//% "Activation value"
 		text: qsTrId("settings_relay_activation_value")
 		dataItem.uid: "%1/%2/SetValue".arg(root.settingsBindPrefix).arg(root.relayNumber)
-		from: -50
-		to: 100
-
-		// TODO the unit string shouldn't be determined here. Fix when units are updated to use velib unit features.
-		suffix: Global.systemSettings.temperatureUnit.value === VenusOS.Units_Temperature_Fahrenheit ? "F" : "C"
+		from: Global.systemSettings.convertFromCelsius(-50)
+		to: Global.systemSettings.convertFromCelsius(100)
+		suffix: Global.systemSettings.temperatureUnitSuffix
 
 		onValueChanged: {
 			if (value === cClear.value) {
 				showEqualValuesWarningToast()
 			}
+		}
+		onSelectorAccepted: function(newValue) {
+			cSet.setValue(Global.systemSettings.convertToCelsius(newValue))
 		}
 	}
 
@@ -97,6 +98,9 @@ Column {
 			if (value === cSet.value) {
 				showEqualValuesWarningToast()
 			}
+		}
+		onSelectorAccepted: function(newValue) {
+			cClear.setValue(Global.systemSettings.convertToCelsius(newValue))
 		}
 	}
 }

--- a/components/settings/VolumeUnitRadioButtonGroup.qml
+++ b/components/settings/VolumeUnitRadioButtonGroup.qml
@@ -21,15 +21,15 @@ ListRadioButtonGroup {
 		//% "Gallons (Imperial)"
 		{ display: qsTrId("components_volumeunit_gallons_imperial"), value: VenusOS.Units_Volume_GallonImperial },
 	]
-	currentIndex: Global.systemSettings.volumeUnit.value === VenusOS.Units_Volume_Liter
+	currentIndex: Global.systemSettings.volumeUnit === VenusOS.Units_Volume_Liter
 			? 1
-			: Global.systemSettings.volumeUnit.value === VenusOS.Units_Volume_GallonUS
+			: Global.systemSettings.volumeUnit === VenusOS.Units_Volume_GallonUS
 			  ? 2
-			  : Global.systemSettings.volumeUnit.value === VenusOS.Units_Volume_GallonImperial
+			  : Global.systemSettings.volumeUnit === VenusOS.Units_Volume_GallonImperial
 				? 3
 				: 0
 
 	onOptionClicked: function(index) {
-		Global.systemSettings.volumeUnit.setValue(optionModel[index].value)
+		Global.systemSettings.setVolumeUnit(optionModel[index].value)
 	}
 }

--- a/components/widgets/AcInputWidget.qml
+++ b/components/widgets/AcInputWidget.qml
@@ -51,7 +51,7 @@ OverviewWidget {
 				id: valueRange
 
 				value: sideGauge.visible ? root.quantityLabel.value : NaN
-				maximumValue: Global.systemSettings.electricalQuantity.value === VenusOS.Units_Amp
+				maximumValue: Global.systemSettings.electricalQuantity === VenusOS.Units_Amp
 					? Global.acInputs.currentLimit
 					: NaN
 			}

--- a/components/widgets/BatteryWidget.qml
+++ b/components/widgets/BatteryWidget.qml
@@ -158,10 +158,8 @@ OverviewWidget {
 			rightMargin: Theme.geometry_overviewPage_widget_battery_temperature_rightMargin
 		}
 
-		value: Math.round(Global.systemSettings.temperatureUnit.value === VenusOS.Units_Temperature_Celsius
-				? batteryData.temperature_celsius
-				: Units.celsiusToFahrenheit(batteryData.temperature_celsius))
-		unit: !!Global.systemSettings.temperatureUnit.value ? Global.systemSettings.temperatureUnit.value : VenusOS.Units_Temperature_Celsius
+		value: Global.systemSettings.convertFromCelsius(batteryData.temperature_celsius)
+		unit: Global.systemSettings.temperatureUnit
 		font.pixelSize: Theme.font_size_body2
 		alignment: Qt.AlignRight
 	}

--- a/data/mock/config/MockDataSimulator.qml
+++ b/data/mock/config/MockDataSimulator.qml
@@ -195,35 +195,35 @@ QtObject {
 			event.accepted = true
 			break
 		case Qt.Key_U:
-			Global.systemSettings.electricalQuantity.setValue(
-					Global.systemSettings.electricalQuantity.value === VenusOS.Units_Watt
+			Global.systemSettings.setElectricalQuantity(
+					Global.systemSettings.electricalQuantity === VenusOS.Units_Watt
 					? VenusOS.Units_Amp
 					: VenusOS.Units_Watt)
-			Global.systemSettings.temperatureUnit.setValue(
-					Global.systemSettings.temperatureUnit.value === VenusOS.Units_Temperature_Celsius
+			Global.systemSettings.setTemperatureUnit(
+					Global.systemSettings.temperatureUnit === VenusOS.Units_Temperature_Celsius
 					? VenusOS.Units_Temperature_Fahrenheit
 					: VenusOS.Units_Temperature_Celsius)
-			Global.systemSettings.volumeUnit.setValue(
-					Global.systemSettings.volumeUnit.value === VenusOS.Units_Volume_CubicMeter
+			Global.systemSettings.setVolumeUnit(
+					Global.systemSettings.volumeUnit === VenusOS.Units_Volume_CubicMeter
 					? VenusOS.Units_Volume_Liter
-					: Global.systemSettings.volumeUnit.value === VenusOS.Units_Volume_Liter
+					: Global.systemSettings.volumeUnit === VenusOS.Units_Volume_Liter
 					  ? VenusOS.Units_Volume_GallonUS
-					  : Global.systemSettings.volumeUnit.value === VenusOS.Units_Volume_GallonUS
+					  : Global.systemSettings.volumeUnit === VenusOS.Units_Volume_GallonUS
 						? VenusOS.Units_Volume_GallonImperial
 						: VenusOS.Units_Volume_CubicMeter)
 
 			pageConfigTitle.text = "Units: "
-					+ (Global.systemSettings.electricalQuantity.value === VenusOS.Units_Watt
+					+ (Global.systemSettings.electricalQuantity === VenusOS.Units_Watt
 					   ? "Watts"
 					   : "Amps") + " | "
-					+ (Global.systemSettings.temperatureUnit.value === VenusOS.Units_Temperature_Celsius
+					+ (Global.systemSettings.temperatureUnit === VenusOS.Units_Temperature_Celsius
 					   ? "Celsius"
 					   : "Fahrenheit") + " | "
-					+ (Global.systemSettings.volumeUnit.value === VenusOS.Units_Volume_CubicMeter
+					+ (Global.systemSettings.volumeUnit === VenusOS.Units_Volume_CubicMeter
 					   ? "Cubic meters"
-					   : Global.systemSettings.volumeUnit.value === VenusOS.Units_Volume_Liter
+					   : Global.systemSettings.volumeUnit === VenusOS.Units_Volume_Liter
 						 ? "Liters"
-						 : Global.systemSettings.volumeUnit.value === VenusOS.Units_Volume_GallonUS
+						 : Global.systemSettings.volumeUnit === VenusOS.Units_Volume_GallonUS
 						   ? "Gallons (US)"
 						   : "Gallons (Imperial)")
 			event.accepted = true

--- a/pages/BriefPage.qml
+++ b/pages/BriefPage.qml
@@ -119,7 +119,7 @@ Page {
 
 			// AC and DC amp values cannot be combined. If there are both AC and DC values, show
 			// Watts even if Amps is preferred.
-			quantityLabel.unit: Global.systemSettings.electricalQuantity.value === VenusOS.Units_Amp
+			quantityLabel.unit: Global.systemSettings.electricalQuantity === VenusOS.Units_Amp
 					&& ((Global.acInputs.current || 0) === 0 || (Global.dcInputs.current || 0) === 0)
 					   ? VenusOS.Units_Amp
 					   : VenusOS.Units_Watt

--- a/pages/EnvironmentTab.qml
+++ b/pages/EnvironmentTab.qml
@@ -85,9 +85,7 @@ Flickable {
 						? VenusOS.EnvironmentGaugePanel_Size_Expanded
 						: VenusOS.EnvironmentGaugePanel_Size_Compact
 				title: model.device.name
-				temperature: Global.systemSettings.temperatureUnit.value === VenusOS.Units_Temperature_Fahrenheit
-						? Units.celsiusToFahrenheit(model.device.temperature_celsius)
-						: model.device.temperature_celsius
+				temperature: Global.systemSettings.convertFromCelsius(model.device.temperature_celsius)
 				humidity: model.device.humidity
 				temperatureGaugeGradient: temperatureGradient
 				humidityGaugeGradient: humidityGradient

--- a/pages/battery/BatteryListPage.qml
+++ b/pages/battery/BatteryListPage.qml
@@ -64,8 +64,8 @@ Page {
 								{ value: modelData.current, unit: VenusOS.Units_Amp },
 								{ value: modelData.power, unit: VenusOS.Units_Watt },
 								{
-									value: Global.systemSettings.convertTemperature(modelData.temperature_celsius),
-									unit: Global.systemSettings.temperatureUnit.value
+									value: Global.systemSettings.convertFromCelsius(modelData.temperature_celsius),
+									unit: Global.systemSettings.temperatureUnit
 								}
 							]
 						}

--- a/pages/settings/PageSettingsDisplayUnits.qml
+++ b/pages/settings/PageSettingsDisplayUnits.qml
@@ -23,10 +23,10 @@ Page {
 					//% "Current (Amps)"
 					{ display: qsTrId("settings_units_amps"), value: VenusOS.Units_Amp },
 				]
-				currentIndex: Global.systemSettings.electricalQuantity.value === VenusOS.Units_Amp ? 1 : 0
+				currentIndex: Global.systemSettings.electricalQuantity === VenusOS.Units_Amp ? 1 : 0
 
 				onOptionClicked: function(index) {
-					Global.systemSettings.electricalQuantity.setValue(optionModel[index].value)
+					Global.systemSettings.setElectricalQuantity(optionModel[index].value)
 				}
 			}
 
@@ -38,10 +38,10 @@ Page {
 					//% "Fahrenheit"
 					{ display: qsTrId("settings_units_fahrenheit"), value: VenusOS.Units_Temperature_Fahrenheit },
 				]
-				currentIndex: Global.systemSettings.temperatureUnit.value === VenusOS.Units_Temperature_Fahrenheit ? 1 : 0
+				currentIndex: Global.systemSettings.temperatureUnit === VenusOS.Units_Temperature_Fahrenheit ? 1 : 0
 
 				onOptionClicked: function(index) {
-					Global.systemSettings.temperatureUnit.setValue(optionModel[index].value)
+					Global.systemSettings.setTemperatureUnit(optionModel[index].value)
 				}
 			}
 

--- a/pages/settings/devicelist/DeviceListPage.qml
+++ b/pages/settings/devicelist/DeviceListPage.qml
@@ -80,11 +80,9 @@ Page {
 				if (isNaN(device.temperature)) {
 					summary = [ levelText ]
 				} else {
-					const tankTemp = Global.systemSettings.temperatureUnit.value === VenusOS.Units_Temperature_Celsius
-							? device.temperature
-							: Units.celsiusToFahrenheit(device.temperature)
+					const tankTemp = Global.systemSettings.convertFromCelsius(device.temperature)
 					summary = [
-						Units.getCombinedDisplayText(Global.systemSettings.temperatureUnit.value, tankTemp),
+						Units.getCombinedDisplayText(Global.systemSettings.temperatureUnit, tankTemp),
 						levelText
 					]
 				}
@@ -119,16 +117,14 @@ Page {
 			break;
 
 		case "temperature":
-			const inputTemp = Global.systemSettings.temperatureUnit.value === VenusOS.Units_Temperature_Celsius
-					? device.temperature_celsius
-					: Units.celsiusToFahrenheit(device.temperature_celsius)
+			const inputTemp = Global.systemSettings.convertFromCelsius(device.temperature_celsius)
 			if (isNaN(device.humidity)) {
 				summary = [
-					Units.getCombinedDisplayText(Global.systemSettings.temperatureUnit.value, inputTemp),
+					Units.getCombinedDisplayText(Global.systemSettings.temperatureUnit, inputTemp),
 				]
 			} else {
 				summary = [
-					Units.getCombinedDisplayText(Global.systemSettings.temperatureUnit.value, inputTemp),
+					Units.getCombinedDisplayText(Global.systemSettings.temperatureUnit, inputTemp),
 					Units.getCombinedDisplayText(VenusOS.Units_Percentage, device.humidity),
 				]
 			}
@@ -166,7 +162,7 @@ Page {
 			break;
 
 		case "pulsemeter":
-			summary = [ Units.getCombinedDisplayText(Global.systemSettings.volumeUnit.value, device.aggregate) ]
+			summary = [ Units.getCombinedDisplayText(Global.systemSettings.volumeUnit, device.aggregate) ]
 			break;
 
 		case "unsupported":

--- a/pages/settings/devicelist/ac-in/PageAcInModelGenset.qml
+++ b/pages/settings/devicelist/ac-in/PageAcInModelGenset.qml
@@ -204,8 +204,8 @@ ObjectModel {
 							text: qsTrId("ac-in-genset_coolant_temperature")
 							visible: defaultVisible && dataItem.isValid
 							dataItem.uid: root.bindPrefix + "/Engine/CoolantTemperature"
-							value: Units.convertFromCelsius(dataItem.value, Global.systemSettings.temperatureUnit.value)
-							unit: Global.systemSettings.temperatureUnit.value
+							value: Global.systemSettings.convertFromCelsius(dataItem.value)
+							unit: Global.systemSettings.temperatureUnit
 						}
 
 						ListQuantityItem {
@@ -213,8 +213,8 @@ ObjectModel {
 							text: qsTrId("ac-in-genset_exhaust_temperature")
 							visible: defaultVisible && dataItem.isValid
 							dataItem.uid: root.bindPrefix + "/Engine/ExaustTemperature"
-							value: Units.convertFromCelsius(dataItem.value, Global.systemSettings.temperatureUnit.value)
-							unit: Global.systemSettings.temperatureUnit.value
+							value: Global.systemSettings.convertFromCelsius(dataItem.value)
+							unit: Global.systemSettings.temperatureUnit
 						}
 
 						ListQuantityItem {
@@ -222,8 +222,8 @@ ObjectModel {
 							text: qsTrId("ac-in-genset_winding_temperature")
 							visible: defaultVisible && dataItem.isValid
 							dataItem.uid: root.bindPrefix + "/Engine/WindingTemperature"
-							value: Units.convertFromCelsius(dataItem.value, Global.systemSettings.temperatureUnit.value)
-							unit: Global.systemSettings.temperatureUnit.value
+							value: Global.systemSettings.convertFromCelsius(dataItem.value)
+							unit: Global.systemSettings.temperatureUnit
 						}
 
 						ListTextItem {

--- a/pages/settings/devicelist/ac-in/PageAcInModelGenset.qml
+++ b/pages/settings/devicelist/ac-in/PageAcInModelGenset.qml
@@ -199,31 +199,25 @@ ObjectModel {
 							visible: defaultVisible && dataItem.isValid
 						}
 
-						ListQuantityItem {
+						ListTemperatureItem {
 							//% "Coolant temperature"
 							text: qsTrId("ac-in-genset_coolant_temperature")
 							visible: defaultVisible && dataItem.isValid
 							dataItem.uid: root.bindPrefix + "/Engine/CoolantTemperature"
-							value: Global.systemSettings.convertFromCelsius(dataItem.value)
-							unit: Global.systemSettings.temperatureUnit
 						}
 
-						ListQuantityItem {
+						ListTemperatureItem {
 							//% "Exhaust temperature"
 							text: qsTrId("ac-in-genset_exhaust_temperature")
 							visible: defaultVisible && dataItem.isValid
 							dataItem.uid: root.bindPrefix + "/Engine/ExaustTemperature"
-							value: Global.systemSettings.convertFromCelsius(dataItem.value)
-							unit: Global.systemSettings.temperatureUnit
 						}
 
-						ListQuantityItem {
+						ListTemperatureItem {
 							//% "Winding temperature"
 							text: qsTrId("ac-in-genset_winding_temperature")
 							visible: defaultVisible && dataItem.isValid
 							dataItem.uid: root.bindPrefix + "/Engine/WindingTemperature"
-							value: Global.systemSettings.convertFromCelsius(dataItem.value)
-							unit: Global.systemSettings.temperatureUnit
 						}
 
 						ListTextItem {

--- a/pages/settings/devicelist/battery/BatterySettingsAlarmModel.qml
+++ b/pages/settings/devicelist/battery/BatterySettingsAlarmModel.qml
@@ -5,6 +5,7 @@
 
 import QtQuick
 import Victron.VenusOS
+import Victron.Veutil
 import Victron.Units
 
 ObjectModel {
@@ -78,10 +79,10 @@ ObjectModel {
 		secondDataItem.uid: root.bindPrefix + "/Settings/Alarm/LowBatteryTemperatureClear"
 		visible: defaultVisible && dataItem.isValid
 		toSourceValue: function(v) {
-			return Units.toKelvin(v, Global.systemSettings.temperatureUnit.value)
+			return Units.convert(v, Global.systemSettings.temperatureUnit, VenusOS.Units_Temperature_Kelvin)
 		}
 		fromSourceValue: function(v) {
-			return Units.fromKelvin(v, Global.systemSettings.temperatureUnit.value)
+			return Units.convert(v, VenusOS.Units_Temperature_Kelvin, Global.systemSettings.temperatureUnit)
 		}
 	}
 
@@ -93,10 +94,10 @@ ObjectModel {
 		secondDataItem.uid: root.bindPrefix + "/Settings/Alarm/HighBatteryTemperature"
 		visible: defaultVisible && dataItem.isValid
 		toSourceValue: function(v) {
-			return Units.toKelvin(v, Global.systemSettings.temperatureUnit.value)
+			return Units.convert(v, Global.systemSettings.temperatureUnit, VenusOS.Units_Temperature_Kelvin)
 		}
 		fromSourceValue: function(v) {
-			return Units.fromKelvin(v, Global.systemSettings.temperatureUnit.value)
+			return Units.convert(v, VenusOS.Units_Temperature_Kelvin, Global.systemSettings.temperatureUnit)
 		}
 	}
 }

--- a/pages/settings/devicelist/battery/BatterySettingsRelayModel.qml
+++ b/pages/settings/devicelist/battery/BatterySettingsRelayModel.qml
@@ -134,10 +134,10 @@ ObjectModel {
 		secondDataItem.uid: root.bindPrefix + "/Settings/Relay/LowBatteryTemperatureClear"
 		visible: defaultVisible && dataItem.isValid && showSetting(0)
 		toSourceValue: function(v) {
-			return Units.toKelvin(v, Global.systemSettings.temperatureUnit.value)
+			return Units.convert(v, Global.systemSettings.temperatureUnit, VenusOS.Units_Temperature_Kelvin)
 		}
 		fromSourceValue: function(v) {
-			return Units.fromKelvin(v, Global.systemSettings.temperatureUnit.value)
+			return Units.convert(v, VenusOS.Units_Temperature_Kelvin, Global.systemSettings.temperatureUnit)
 		}
 	}
 
@@ -149,10 +149,10 @@ ObjectModel {
 		secondDataItem.uid: root.bindPrefix + "/Settings/Relay/HighBatteryTemperature"
 		visible: defaultVisible && dataItem.isValid && showSetting(0)
 		toSourceValue: function(v) {
-			return Units.toKelvin(v, Global.systemSettings.temperatureUnit.value)
+			return Units.convert(v, Global.systemSettings.temperatureUnit, VenusOS.Units_Temperature_Kelvin)
 		}
 		fromSourceValue: function(v) {
-			return Units.fromKelvin(v, Global.systemSettings.temperatureUnit.value)
+			return Units.convert(v, VenusOS.Units_Temperature_Kelvin, Global.systemSettings.temperatureUnit)
 		}
 	}
 }

--- a/pages/settings/devicelist/battery/PageBattery.qml
+++ b/pages/settings/devicelist/battery/PageBattery.qml
@@ -113,8 +113,8 @@ Page {
 				//% "Battery temperature"
 				text: qsTrId("battery_temp")
 				visible: defaultVisible && !isNaN(root.battery.temperature_celsius)
-				value: Global.systemSettings.convertTemperature(root.battery.temperature_celsius)
-				unit: Global.systemSettings.temperatureUnit.value
+				value: Global.systemSettings.convertFromCelsius(root.battery.temperature_celsius)
+				unit: Global.systemSettings.temperatureUnit
 			}
 
 			ListQuantityItem {
@@ -122,8 +122,8 @@ Page {
 				text: qsTrId("battery_air_temp")
 				dataItem.uid: root.battery.serviceUid + "/AirTemperature"
 				visible: defaultVisible && dataItem.isValid
-				value: dataItem.value ? Global.systemSettings.convertTemperature(dataItem.value) : NaN
-				unit: Global.systemSettings.temperatureUnit.value
+				value: Global.systemSettings.convertFromCelsius(dataItem.value)
+				unit: Global.systemSettings.temperatureUnit
 			}
 
 			ListQuantityItem {

--- a/pages/settings/devicelist/battery/PageBattery.qml
+++ b/pages/settings/devicelist/battery/PageBattery.qml
@@ -117,13 +117,11 @@ Page {
 				unit: Global.systemSettings.temperatureUnit
 			}
 
-			ListQuantityItem {
+			ListTemperatureItem {
 				//% "Air temperature"
 				text: qsTrId("battery_air_temp")
 				dataItem.uid: root.battery.serviceUid + "/AirTemperature"
 				visible: defaultVisible && dataItem.isValid
-				value: Global.systemSettings.convertFromCelsius(dataItem.value)
-				unit: Global.systemSettings.temperatureUnit
 			}
 
 			ListQuantityItem {

--- a/pages/settings/devicelist/battery/PageBatteryDetails.qml
+++ b/pages/settings/devicelist/battery/PageBatteryDetails.qml
@@ -39,12 +39,12 @@ Page {
 				text: qsTrId("batterydetails_minimum_cell_temperature")
 				textModel: [
 					{
-						value: Global.systemSettings.convertTemperature(details.minTemperatureCellId.value),
-						unit: Global.systemSettings.temperatureUnit.value
+						value: Global.systemSettings.convertFromCelsius(details.minTemperatureCellId.value),
+						unit: Global.systemSettings.temperatureUnit
 					},
 					{
-						value: Global.systemSettings.convertTemperature(details.minCellTemperature.value),
-						unit: Global.systemSettings.temperatureUnit.value
+						value: Global.systemSettings.convertFromCelsius(details.minCellTemperature.value),
+						unit: Global.systemSettings.temperatureUnit
 					}
 				]
 			}
@@ -54,12 +54,12 @@ Page {
 				text: qsTrId("batterydetails_maximum_cell_temperature")
 				textModel: [
 					{
-						value: Global.systemSettings.convertTemperature(details.maxTemperatureCellId.value),
-						unit: Global.systemSettings.temperatureUnit.value
+						value: Global.systemSettings.convertFromCelsius(details.maxTemperatureCellId.value),
+						unit: Global.systemSettings.temperatureUnit
 					},
 					{
-						value: Global.systemSettings.convertTemperature(details.maxCellTemperature.value),
-						unit: Global.systemSettings.temperatureUnit.value
+						value: Global.systemSettings.convertFromCelsius(details.maxCellTemperature.value),
+						unit: Global.systemSettings.temperatureUnit
 					}
 				]
 			}

--- a/pages/settings/devicelist/battery/PageBatteryHistory.qml
+++ b/pages/settings/devicelist/battery/PageBatteryHistory.qml
@@ -165,7 +165,8 @@ Page {
 				text: CommonWords.minimum_temperature
 				visible: defaultVisible && hasTemperature.value === 1 && dataItem.isValid
 				dataItem.uid: root.bindPrefix + "/History/MinimumTemperature"
-				unit: Global.systemSettings.temperatureUnit.value
+				value: Global.systemSettings.convertFromCelsius(dataItem.value)
+				unit: Global.systemSettings.temperatureUnit
 
 				VeQuickItem {
 					id: hasTemperature
@@ -177,7 +178,8 @@ Page {
 				text: CommonWords.maximum_temperature
 				visible: defaultVisible && hasTemperature.value === 1 && dataItem.isValid
 				dataItem.uid: root.bindPrefix + "/History/MaximumTemperature"
-				unit: Global.systemSettings.temperatureUnit.value
+				value: Global.systemSettings.convertFromCelsius(dataItem.value)
+				unit: Global.systemSettings.temperatureUnit
 			}
 
 			ListQuantityItem {

--- a/pages/settings/devicelist/battery/PageBatteryHistory.qml
+++ b/pages/settings/devicelist/battery/PageBatteryHistory.qml
@@ -161,12 +161,10 @@ Page {
 				precision: 2
 			}
 
-			ListQuantityItem {
+			ListTemperatureItem {
 				text: CommonWords.minimum_temperature
 				visible: defaultVisible && hasTemperature.value === 1 && dataItem.isValid
 				dataItem.uid: root.bindPrefix + "/History/MinimumTemperature"
-				value: Global.systemSettings.convertFromCelsius(dataItem.value)
-				unit: Global.systemSettings.temperatureUnit
 
 				VeQuickItem {
 					id: hasTemperature
@@ -174,12 +172,10 @@ Page {
 				}
 			}
 
-			ListQuantityItem {
+			ListTemperatureItem {
 				text: CommonWords.maximum_temperature
 				visible: defaultVisible && hasTemperature.value === 1 && dataItem.isValid
 				dataItem.uid: root.bindPrefix + "/History/MaximumTemperature"
-				value: Global.systemSettings.convertFromCelsius(dataItem.value)
-				unit: Global.systemSettings.temperatureUnit
 			}
 
 			ListQuantityItem {

--- a/pages/settings/devicelist/battery/PageLynxIonSystem.qml
+++ b/pages/settings/devicelist/battery/PageLynxIonSystem.qml
@@ -64,12 +64,12 @@ Page {
 				text: qsTrId("lynxionsystem_min_max_cell_temperature")
 				textModel: [
 					{
-						value: Global.systemSettings.convertTemperature(minCellTemperature.value),
-						unit: Global.systemSettings.temperatureUnit.value
+						value: Global.systemSettings.convertFromCelsius(minCellTemperature.value),
+						unit: Global.systemSettings.temperatureUnit
 					},
 					{
-						value: Global.systemSettings.convertTemperature(maxCellTemperature.value),
-						unit: Global.systemSettings.temperatureUnit.value
+						value: Global.systemSettings.convertFromCelsius(maxCellTemperature.value),
+						unit: Global.systemSettings.temperatureUnit
 					}
 				]
 				visible: minCellTemperature.isValid && maxCellTemperature.isValid

--- a/pages/settings/devicelist/dc-in/PageAlternatorModel.qml
+++ b/pages/settings/devicelist/dc-in/PageAlternatorModel.qml
@@ -38,8 +38,8 @@ ObjectModel {
 	ListQuantityItem {
 		text: CommonWords.temperature
 		dataItem.uid: root.bindPrefix + "/Dc/0/Temperature"
-		value: dataItem.isValid ? Global.systemSettings.convertTemperature(dataItem.value) : NaN
-		unit: Global.systemSettings.temperatureUnit.value
+		value: Global.systemSettings.convertFromCelsius(dataItem.value)
+		unit: Global.systemSettings.temperatureUnit
 	}
 
 	ListTextItem {

--- a/pages/settings/devicelist/dc-in/PageAlternatorModel.qml
+++ b/pages/settings/devicelist/dc-in/PageAlternatorModel.qml
@@ -35,11 +35,9 @@ ObjectModel {
 		}
 	}
 
-	ListQuantityItem {
+	ListTemperatureItem {
 		text: CommonWords.temperature
 		dataItem.uid: root.bindPrefix + "/Dc/0/Temperature"
-		value: Global.systemSettings.convertFromCelsius(dataItem.value)
-		unit: Global.systemSettings.temperatureUnit
 	}
 
 	ListTextItem {

--- a/pages/settings/devicelist/dc-in/PageDcMeterHistory.qml
+++ b/pages/settings/devicelist/dc-in/PageDcMeterHistory.qml
@@ -88,20 +88,16 @@ Page {
 				precision: 2
 			}
 
-			ListQuantityItem {
+			ListTemperatureItem {
 				text: CommonWords.minimum_temperature
 				visible: defaultVisible && showTemperature
 				dataItem.uid: root.bindPrefix + "/History/MinimumTemperature"
-				value: Global.systemSettings.convertFromCelsius(dataItem.value)
-				unit: Global.systemSettings.temperatureUnit
 			}
 
-			ListQuantityItem {
+			ListTemperatureItem {
 				text: CommonWords.maximum_temperature
 				visible: defaultVisible && showTemperature
 				dataItem.uid: root.bindPrefix + "/History/MaximumTemperature"
-				value: Global.systemSettings.convertFromCelsius(dataItem.value)
-				unit: Global.systemSettings.temperatureUnit
 			}
 
 			ListQuantityItem {

--- a/pages/settings/devicelist/dc-in/PageDcMeterHistory.qml
+++ b/pages/settings/devicelist/dc-in/PageDcMeterHistory.qml
@@ -92,14 +92,16 @@ Page {
 				text: CommonWords.minimum_temperature
 				visible: defaultVisible && showTemperature
 				dataItem.uid: root.bindPrefix + "/History/MinimumTemperature"
-				unit: Global.systemSettings.temperatureUnit.value
+				value: Global.systemSettings.convertFromCelsius(dataItem.value)
+				unit: Global.systemSettings.temperatureUnit
 			}
 
 			ListQuantityItem {
 				text: CommonWords.maximum_temperature
 				visible: defaultVisible && showTemperature
 				dataItem.uid: root.bindPrefix + "/History/MaximumTemperature"
-				unit: Global.systemSettings.temperatureUnit.value
+				value: Global.systemSettings.convertFromCelsius(dataItem.value)
+				unit: Global.systemSettings.temperatureUnit
 			}
 
 			ListQuantityItem {

--- a/pages/settings/devicelist/dc-in/PageDcMeterModel.qml
+++ b/pages/settings/devicelist/dc-in/PageDcMeterModel.qml
@@ -44,11 +44,9 @@ ObjectModel {
 		}
 	}
 
-	ListQuantityItem {
+	ListTemperatureItem {
 		text: CommonWords.temperature
 		dataItem.uid: root.bindPrefix + "/Dc/0/Temperature"
-		value: Global.systemSettings.convertFromCelsius(dataItem.value)
-		unit: Global.systemSettings.temperatureUnit
 		visible: defaultVisible && dataItem.isValid
 	}
 

--- a/pages/settings/devicelist/dc-in/PageDcMeterModel.qml
+++ b/pages/settings/devicelist/dc-in/PageDcMeterModel.qml
@@ -47,8 +47,8 @@ ObjectModel {
 	ListQuantityItem {
 		text: CommonWords.temperature
 		dataItem.uid: root.bindPrefix + "/Dc/0/Temperature"
-		value: dataItem.isValid ? Global.systemSettings.convertTemperature(dataItem.value) : NaN
-		unit: Global.systemSettings.temperatureUnit.value
+		value: Global.systemSettings.convertFromCelsius(dataItem.value)
+		unit: Global.systemSettings.temperatureUnit
 		visible: defaultVisible && dataItem.isValid
 	}
 

--- a/pages/settings/devicelist/tank/PageTankSensor.qml
+++ b/pages/settings/devicelist/tank/PageTankSensor.qml
@@ -36,11 +36,9 @@ Page {
 				unit: Global.systemSettings.volumeUnit
 			}
 
-			ListQuantityItem {
+			ListTemperatureItem {
 				text: CommonWords.temperature
 				dataItem.uid: root.bindPrefix + "/Temperature"
-				value: Global.systemSettings.convertFromCelsius(dataItem.value)
-				unit: Global.systemSettings.temperatureUnit
 				visible: defaultVisible && dataItem.isValid
 			}
 

--- a/pages/settings/devicelist/tank/PageTankSensor.qml
+++ b/pages/settings/devicelist/tank/PageTankSensor.qml
@@ -32,19 +32,15 @@ Page {
 				//% "Remaining"
 				text: qsTrId("devicelist_tanksensor_remaining")
 				dataItem.uid: root.bindPrefix + "/Remaining"
-				value: Units.convertVolumeForUnit(dataItem.value, Global.systemSettings.volumeUnit.value)
-				unit: Global.systemSettings.volumeUnit.value
+				value: Global.systemSettings.convertFromCubicMeters(dataItem.value)
+				unit: Global.systemSettings.volumeUnit
 			}
 
 			ListQuantityItem {
 				text: CommonWords.temperature
 				dataItem.uid: root.bindPrefix + "/Temperature"
-				value: dataItem.isValid
-					   ? Global.systemSettings.temperatureUnit.value === VenusOS.Units_Temperature_Celsius
-						   ? dataItem.value
-						   : Units.celsiusToFahrenheit(dataItem.value)
-					   : NaN
-				unit: Global.systemSettings.temperatureUnit.value
+				value: Global.systemSettings.convertFromCelsius(dataItem.value)
+				unit: Global.systemSettings.temperatureUnit
 				visible: defaultVisible && dataItem.isValid
 			}
 

--- a/pages/settings/devicelist/tank/PageTankSetup.qml
+++ b/pages/settings/devicelist/tank/PageTankSetup.qml
@@ -21,18 +21,18 @@ Page {
 
 				//% "Capacity"
 				text: qsTrId("devicelist_tanksetup_capacity")
-				suffix: Units.defaultUnitString(Global.systemSettings.volumeUnit.value)
-				stepSize: Global.systemSettings.volumeUnit.value === VenusOS.Units_Volume_CubicMeter
+				suffix: Units.defaultUnitString(Global.systemSettings.volumeUnit)
+				stepSize: Global.systemSettings.volumeUnit === VenusOS.Units_Volume_CubicMeter
 						  ? 5   // Cubic meters (this becomes 0.005 when ListSpinBox adjusts it for decimals)
 						  : 1   // Liters, Gallons
-				decimals: Units.defaultUnitPrecision(Global.systemSettings.volumeUnit.value)
-				from: Units.convertVolumeForUnit(capacity.min, Global.systemSettings.volumeUnit.value)
-				to: Units.convertVolumeForUnit(capacity.max, Global.systemSettings.volumeUnit.value)
+				decimals: Units.defaultUnitPrecision(Global.systemSettings.volumeUnit)
+				from: Global.systemSettings.convertFromCubicMeters(capacity.min)
+				to: Global.systemSettings.convertFromCubicMeters(capacity.max)
 				value: capacity.value === undefined ? 0
-					 : Units.convertVolumeForUnit(capacity.value, Global.systemSettings.volumeUnit.value)
+					 : Global.systemSettings.convertFromCubicMeters(capacity.value)
 
 				onSelectorAccepted: function(newValue) {
-					capacity.setValue(Units.convertVolumeForUnit(newValue, VenusOS.Units_Volume_CubicMeter))
+					capacity.setValue(Global.systemSettings.convertToCubicMeters(newValue))
 				}
 
 				VeQuickItem {

--- a/pages/vebusdevice/PageVeBus.qml
+++ b/pages/vebusdevice/PageVeBus.qml
@@ -252,7 +252,7 @@ Page {
 				dataItem.uid: veBusDevice.serviceUid + "/Dc/0/Temperature"
 				//% "Battery temperature"
 				text: qsTrId("vebus_device_page_battery_temperature")
-				unit: Global.systemSettings.temperatureUnit.value
+				unit: Global.systemSettings.temperatureUnit
 			}
 
 			VeBusDeviceActiveAcInputTextItem {

--- a/src/enums.h
+++ b/src/enums.h
@@ -67,12 +67,11 @@ public:
 	Q_ENUM(StatusBar_RightButton)
 
 	enum Units_Type {
-		// Volume unit values are those expected by com.victronenergy.settings/Settings/System/VolumeUnit
-		Units_Volume_CubicMeter = 0,
-		Units_Volume_Liter = 1,
-		Units_Volume_GallonImperial = 2,
-		Units_Volume_GallonUS = 3,
-
+		Units_None = 0,
+		Units_Volume_CubicMeter,
+		Units_Volume_Liter,
+		Units_Volume_GallonImperial,
+		Units_Volume_GallonUS,
 		Units_Percentage,
 		Units_Volt,
 		Units_VoltAmpere,
@@ -87,8 +86,6 @@ public:
 		Units_Temperature_Fahrenheit,
 		Units_RevolutionsPerMinute,
 		Units_Speed_MetresPerSecond,
-
-		Units_None = 1000
 	};
 	Q_ENUM(Units_Type)
 	

--- a/src/units.h
+++ b/src/units.h
@@ -43,15 +43,6 @@ public:
 	Q_INVOKABLE QString defaultUnitString(Victron::VenusOS::Enums::Units_Type unit) const;
 	Q_INVOKABLE QString scaledUnitString(Victron::VenusOS::Enums::Units_Type unit) const;
 
-	Q_INVOKABLE qreal convertVolumeForUnit(
-		qreal value_m3,
-		Victron::VenusOS::Enums::Units_Type toUnit) const;
-
-	Q_INVOKABLE qreal celsiusToFahrenheit(qreal celsius) const;
-	Q_INVOKABLE qreal fromKelvin(qreal value, Victron::VenusOS::Enums::Units_Type toUnit) const;
-	Q_INVOKABLE qreal toKelvin(qreal value, Victron::VenusOS::Enums::Units_Type fromUnit) const;
-	Q_INVOKABLE qreal convertFromCelsius(qreal celsius, Victron::VenusOS::Enums::Units_Type unit) const;
-
 	Q_INVOKABLE Victron::Units::quantityInfo scaledQuantity(
 		qreal value,
 		qreal unitMatchValue,
@@ -70,11 +61,12 @@ public:
 		qreal value,
 		int precision = -1) const;
 
-	Q_INVOKABLE QString getCapacityDisplayText(
-		Victron::VenusOS::Enums::Units_Type unit,
+	Q_INVOKABLE QString getCapacityDisplayText(Victron::VenusOS::Enums::Units_Type unit,
 		qreal capacity_m3,
 		qreal remaining_m3,
 		int precision) const;
+
+	Q_INVOKABLE qreal convert(qreal value, Victron::VenusOS::Enums::Units_Type fromUnit, Victron::VenusOS::Enums::Units_Type toUnit) const;
 
 	Q_INVOKABLE qreal sumRealNumbers(qreal a, qreal b) const;
 };


### PR DESCRIPTION
Rework the unit conversion handling and the API for the user-preferred unit access:

- Make temperature, volume and electrical quantity units accessible as Global.systemSettings 'temperatureUnit', 'volumeUnit' and 'electricalQuantity' integers instead of as VeQuickItem objects, so that they can be accessed as e.g. Global.systemSettings.volumeUnit instead of as Global.systemSettings.volumeUnit.value
- Add convenience conversion functions to Global.systemSettings e.g. convertFromCelsius() and convertFromCubicMeters() to convert to/from the user-preferred unit
- Use veutil unit_conversion.hpp for all unit conversions, instead of implementing the conversion in unit.cpp
- Ensure settings pages show temperature in user-preferred unit
- Fix TemperatureRelaySettings.qml to ensure temperature settings are saved in celsius