### PR TITLE
Performance improvements and bug fixes

### DIFF
--- a/ApplicationContent.qml
+++ b/ApplicationContent.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Utils
 
 Item {
 	id: root

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -649,7 +649,7 @@ set(Dbus_QML_MODULE_SOURCES
 
 list(APPEND TRANSLATION_SOURCES ${Dbus_QML_MODULE_SOURCES})
 
-qt_add_qml_module(Dbus
+qt_add_qml_module(VictronDbus
     URI Victron.Dbus
     STATIC
     OUTPUT_DIRECTORY Victron/Dbus
@@ -696,7 +696,7 @@ set(Mock_QML_MODULE_SOURCES
 
 list(APPEND TRANSLATION_SOURCES ${Mock_QML_MODULE_SOURCES})
 
-qt_add_qml_module(Mock
+qt_add_qml_module(VictronMock
     URI Victron.Mock
     STATIC
     OUTPUT_DIRECTORY Victron/Mock
@@ -712,7 +712,7 @@ set(Gauges_QML_MODULE_SOURCES
 
 list(APPEND TRANSLATION_SOURCES ${Gauges_QML_MODULE_SOURCES})
 
-qt_add_qml_module(Gauges
+qt_add_qml_module(VictronGauges
     URI Victron.Gauges
     STATIC
     OUTPUT_DIRECTORY Victron/Gauges
@@ -752,7 +752,7 @@ set(Mqtt_QML_MODULE_SOURCES
 
 list(APPEND TRANSLATION_SOURCES ${Mqtt_QML_MODULE_SOURCES} )
 
-qt_add_qml_module(Mqtt
+qt_add_qml_module(VictronMqtt
     URI Victron.Mqtt
     STATIC
     OUTPUT_DIRECTORY Victron/Mqtt
@@ -965,10 +965,10 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     Qt6::Xml
     Qt6::Mqtt
     VenusQMLModuleplugin
-    Gaugesplugin
-    Dbusplugin
-    Mockplugin
-    Mqttplugin
+    VictronGaugesplugin
+    VictronDbusplugin
+    VictronMockplugin
+    VictronMqttplugin
 )
 
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Emscripten")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,15 @@ if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Emscripten")
     list(APPEND VenusQMLModule_CPP_SOURCES ${VEUTIL_DBUS_SOURCES} )
 endif()
 
+set(VEUTIL_MQTT_SOURCES
+    src/veutil/inc/veutil/qt/ve_qitems_mqtt.hpp
+    src/veutil/src/qt/ve_qitems_mqtt.cpp
+)
+list(APPEND VenusQMLModule_CPP_SOURCES
+    ${VEUTIL_MQTT_SOURCES}
+)
+
+
 # VENUS_QML_MODULE
 set (VENUS_QML_MODULE_SOURCES
     ${VENUS_QML_MODULE_SINGLETON_SOURCES}
@@ -751,14 +760,6 @@ qt_add_qml_module(Mqtt
     ${QML_MODULE_OPTARGS}
 )
 # end Mqtt_QML_MODULE
-
-set(VEUTIL_MQTT_SOURCES
-    src/veutil/inc/veutil/qt/ve_qitems_mqtt.hpp
-    src/veutil/src/qt/ve_qitems_mqtt.cpp
-)
-list(APPEND SOURCES
-    ${VEUTIL_MQTT_SOURCES}
-)
 
 set(GUIv1_DBUS_SOURCES
     src/gui-v1/alarmbusitem.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,7 @@ set (VENUS_QML_MODULE_SOURCES
     components/ThreePhaseQuantityTable.qml
     components/TimeSelector.qml
     components/ToastNotification.qml
+    components/Utils.js
     components/ValueRange.qml
     components/VerticalGauge.qml
     components/ViewGradient.qml
@@ -658,22 +659,6 @@ qt_add_qml_module(Mock
 )
 # end Mock_QML_MODULE
 
-# Utils_QML_MODULE
-set(Utils_QML_MODULE_SOURCES
-    components/Utils.js
-)
-
-list(APPEND QML_MODULE_SOURCES ${Utils_QML_MODULE_SOURCES})
-
-qt_add_qml_module(Utils
-    URI Victron.Utils
-    STATIC
-    OUTPUT_DIRECTORY Victron/Utils
-    QML_FILES ${Utils_QML_MODULE_SOURCES}
-    ${QML_MODULE_OPTARGS}
-)
-# end Utils_QML_MODULE
-
 # Gauges_QML_MODULE
 set(Gauges_QML_MODULE_SOURCES
     components/Gauges.js
@@ -979,7 +964,6 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     Qt6::Mqtt
     VenusQMLModuleplugin
     Gaugesplugin
-    Utilsplugin
     Dbusplugin
     Mockplugin
     Mqttplugin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,6 @@ set (VENUS_QML_MODULE_SINGLETON_SOURCES # All qml singletons have to be added he
 )
 set_source_files_properties( ${VENUS_QML_MODULE_SINGLETON_SOURCES} PROPERTIES QT_QML_SINGLETON_TYPE TRUE )
 
-# Connman module
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Emscripten")
     list(APPEND CONNMAN_SOURCES
         src/connman-api.h # mock sources
@@ -110,21 +109,7 @@ else()
     )
 endif()
 
-qt_add_qml_module(Connman
-    URI net.connman
-    VERSION 1.0
-    STATIC
-    OUTPUT_DIRECTORY net/connman
-    SOURCES ${CONNMAN_SOURCES}
-    ${QML_MODULE_OPTARGS}
-)
-
-if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Emscripten")
-    target_include_directories(Connman PRIVATE src/connman)
-    target_link_libraries(Connman PRIVATE Qt6::DBus)
-endif()
-
-# end Connman module
+list(APPEND VenusQMLModule_CPP_SOURCES ${CONNMAN_SOURCES})
 
 # VENUS_QML_MODULE
 set (VENUS_QML_MODULE_SOURCES
@@ -531,7 +516,7 @@ set (VENUS_QML_MODULE_SOURCES
 
 list(APPEND QML_MODULE_SOURCES ${VENUS_QML_MODULE_SOURCES})
 
-set(VenusQMLModule_CPP_SOURCES
+list(APPEND VenusQMLModule_CPP_SOURCES
     src/aggregatedevicemodel.h
     src/aggregatedevicemodel.cpp
     src/basedevicemodel.h
@@ -553,6 +538,12 @@ set(VenusQMLModule_CPP_SOURCES
     src/frameratemodel.cpp
 )
 
+set(Units_CPP_SOURCES
+    src/units.h
+    src/units.cpp
+)
+list(APPEND VenusQMLModule_CPP_SOURCES ${Units_CPP_SOURCES})
+
 qt_add_qml_module(VenusQMLModule
     ${QML_MODULE_OPTARGS}
     URI Victron.VenusOS
@@ -561,7 +552,7 @@ qt_add_qml_module(VenusQMLModule
     OUTPUT_DIRECTORY Victron/VenusOS
     QML_FILES ${VENUS_QML_MODULE_SOURCES}
     SOURCES ${VenusQMLModule_CPP_SOURCES}
-    IMPORTS net.connman
+    IMPORTS  Victron.Veutil
 )
 target_link_libraries(VenusQMLModule PRIVATE
     Qt6::Core
@@ -571,7 +562,6 @@ target_link_libraries(VenusQMLModule PRIVATE
     Qt6::Svg
     Qt6::Xml
     Qt6::Mqtt
-    Connman
 )
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Emscripten")
     target_link_libraries(VenusQMLModule PRIVATE Qt6::WebSockets)
@@ -667,21 +657,6 @@ qt_add_qml_module(Mock
     ${QML_MODULE_OPTARGS}
 )
 # end Mock_QML_MODULE
-
-# Units_QML_MODULE
-set(Units_QML_MODULE_SOURCES
-    src/units.h
-    src/units.cpp
-)
-list(APPEND QML_MODULE_SOURCES ${Units_QML_MODULE_SOURCES})
-qt_add_qml_module(Units
-    URI Victron.Units
-    STATIC
-    OUTPUT_DIRECTORY Victron/Units
-    SOURCES ${Units_QML_MODULE_SOURCES}
-    ${QML_MODULE_OPTARGS}
-)
-# end Units_QML_MODULE
 
 # Utils_QML_MODULE
 set(Utils_QML_MODULE_SOURCES
@@ -1004,7 +979,6 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     Qt6::Mqtt
     VenusQMLModuleplugin
     Gaugesplugin
-    Unitsplugin
     Utilsplugin
     Dbusplugin
     Mockplugin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,41 @@ endif()
 
 list(APPEND VenusQMLModule_CPP_SOURCES ${CONNMAN_SOURCES})
 
+set(VEUTIL_CORE_SOURCES
+    src/veutil/inc/veutil/qt/firmware_updater_data.hpp
+    src/veutil/inc/veutil/qt/unit_conversion.hpp
+    src/veutil/inc/veutil/qt/ve_qitem.hpp
+    src/veutil/inc/veutil/qt/ve_qitem_child_model.hpp
+    src/veutil/inc/veutil/qt/ve_qitem_loader.hpp
+    src/veutil/inc/veutil/qt/ve_qitem_sort_table_model.hpp
+    src/veutil/inc/veutil/qt/ve_qitem_table_model.hpp
+    src/veutil/inc/veutil/qt/ve_qitem_tree_model.hpp
+    src/veutil/inc/veutil/qt/ve_quick_item.hpp
+
+    src/veutil/src/qt/unit_conversion.cpp
+    src/veutil/src/qt/ve_qitem.cpp
+    src/veutil/src/qt/ve_qitem_child_model.cpp
+    src/veutil/src/qt/ve_qitem_loader.cpp
+    src/veutil/src/qt/ve_qitem_sort_table_model.cpp
+    src/veutil/src/qt/ve_qitem_table_model.cpp
+    src/veutil/src/qt/ve_qitem_tree_model.cpp
+    src/veutil/src/qt/ve_quick_item.cpp
+)
+list(APPEND VenusQMLModule_CPP_SOURCES ${VEUTIL_CORE_SOURCES})
+
+SET(VEUTIL_DBUS_SOURCES
+    src/veutil/inc/veutil/qt/ve_dbus_connection.hpp
+    src/veutil/inc/veutil/qt/ve_qitems_dbus.hpp
+    src/veutil/inc/veutil/qt/vebus_error.hpp
+
+    src/veutil/src/qt/ve_dbus_connection.cpp
+    src/veutil/src/qt/ve_qitems_dbus.cpp
+    src/veutil/src/qt/vebus_error.cpp
+)
+if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Emscripten")
+    list(APPEND VenusQMLModule_CPP_SOURCES ${VEUTIL_DBUS_SOURCES} )
+endif()
+
 # VENUS_QML_MODULE
 set (VENUS_QML_MODULE_SOURCES
     ${VENUS_QML_MODULE_SINGLETON_SOURCES}
@@ -553,8 +588,10 @@ qt_add_qml_module(VenusQMLModule
     OUTPUT_DIRECTORY Victron/VenusOS
     QML_FILES ${VENUS_QML_MODULE_SOURCES}
     SOURCES ${VenusQMLModule_CPP_SOURCES}
-    IMPORTS  Victron.Veutil
 )
+
+target_include_directories(VenusQMLModule PRIVATE src/veutil/inc/veutil/qt)
+
 target_link_libraries(VenusQMLModule PRIVATE
     Qt6::Core
     Qt6::Gui
@@ -714,41 +751,6 @@ qt_add_qml_module(Mqtt
     ${QML_MODULE_OPTARGS}
 )
 # end Mqtt_QML_MODULE
-
-set(VEUTIL_CORE_SOURCES
-    src/veutil/inc/veutil/qt/firmware_updater_data.hpp
-    src/veutil/inc/veutil/qt/unit_conversion.hpp
-    src/veutil/inc/veutil/qt/ve_qitem.hpp
-    src/veutil/inc/veutil/qt/ve_qitem_child_model.hpp
-    src/veutil/inc/veutil/qt/ve_qitem_loader.hpp
-    src/veutil/inc/veutil/qt/ve_qitem_sort_table_model.hpp
-    src/veutil/inc/veutil/qt/ve_qitem_table_model.hpp
-    src/veutil/inc/veutil/qt/ve_qitem_tree_model.hpp
-    src/veutil/inc/veutil/qt/ve_quick_item.hpp
-
-    src/veutil/src/qt/unit_conversion.cpp
-    src/veutil/src/qt/ve_qitem.cpp
-    src/veutil/src/qt/ve_qitem_child_model.cpp
-    src/veutil/src/qt/ve_qitem_loader.cpp
-    src/veutil/src/qt/ve_qitem_sort_table_model.cpp
-    src/veutil/src/qt/ve_qitem_table_model.cpp
-    src/veutil/src/qt/ve_qitem_tree_model.cpp
-    src/veutil/src/qt/ve_quick_item.cpp
-)
-list(APPEND SOURCES ${VEUTIL_CORE_SOURCES})
-
-SET(VEUTIL_DBUS_SOURCES
-    src/veutil/inc/veutil/qt/ve_dbus_connection.hpp
-    src/veutil/inc/veutil/qt/ve_qitems_dbus.hpp
-    src/veutil/inc/veutil/qt/vebus_error.hpp
-
-    src/veutil/src/qt/ve_dbus_connection.cpp
-    src/veutil/src/qt/ve_qitems_dbus.cpp
-    src/veutil/src/qt/vebus_error.cpp
-)
-if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Emscripten")
-    list(APPEND SOURCES ${VEUTIL_DBUS_SOURCES} )
-endif()
 
 set(VEUTIL_MQTT_SOURCES
     src/veutil/inc/veutil/qt/ve_qitems_mqtt.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -550,7 +550,7 @@ set (VENUS_QML_MODULE_SOURCES
     pages/vebusdevice/VeBusDeviceModeButton.qml
 )
 
-list(APPEND QML_MODULE_SOURCES ${VENUS_QML_MODULE_SOURCES})
+list(APPEND TRANSLATION_SOURCES ${VENUS_QML_MODULE_SOURCES})
 
 list(APPEND VenusQMLModule_CPP_SOURCES
     src/aggregatedevicemodel.h
@@ -638,7 +638,7 @@ set(Dbus_QML_MODULE_SOURCES
     data/dbus/VeBusDevicesImpl.qml
 )
 
-list(APPEND QML_MODULE_SOURCES ${Dbus_QML_MODULE_SOURCES})
+list(APPEND TRANSLATION_SOURCES ${Dbus_QML_MODULE_SOURCES})
 
 qt_add_qml_module(Dbus
     URI Victron.Dbus
@@ -685,7 +685,7 @@ set(Mock_QML_MODULE_SOURCES
     data/mock/config/SettingsPageConfig.qml
 )
 
-list(APPEND QML_MODULE_SOURCES ${Mock_QML_MODULE_SOURCES})
+list(APPEND TRANSLATION_SOURCES ${Mock_QML_MODULE_SOURCES})
 
 qt_add_qml_module(Mock
     URI Victron.Mock
@@ -701,7 +701,7 @@ set(Gauges_QML_MODULE_SOURCES
     components/Gauges.js
 )
 
-list(APPEND QML_MODULE_SOURCES ${Gauges_QML_MODULE_SOURCES})
+list(APPEND TRANSLATION_SOURCES ${Gauges_QML_MODULE_SOURCES})
 
 qt_add_qml_module(Gauges
     URI Victron.Gauges
@@ -741,7 +741,7 @@ set(Mqtt_QML_MODULE_SOURCES
     data/mqtt/VeBusDevicesImpl.qml
 )
 
-list(APPEND QML_MODULE_SOURCES ${Mqtt_QML_MODULE_SOURCES} )
+list(APPEND TRANSLATION_SOURCES ${Mqtt_QML_MODULE_SOURCES} )
 
 qt_add_qml_module(Mqtt
     URI Victron.Mqtt
@@ -794,7 +794,6 @@ list(APPEND SOURCES
 
 list(APPEND TRANSLATION_SOURCES
     ${SOURCES}
-    ${QML_MODULE_SOURCES}
 )
 
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Emscripten")

--- a/Global.qml
+++ b/Global.qml
@@ -6,15 +6,7 @@
 pragma Singleton
 
 import QtQml
-
-// QTBUG-66976: if a QML-defined singleton imports the QML module
-// into which it is installed, it results in a cyclic dependency.
-//
-// So, to work around this issue:
-// - declare the other types as non-singleton instances in main.qml
-// - define a single singleton which does NOT import Victron.VenusOS
-// - initialize the properties of this singleton to point to the
-//   instance objects declared in main, in onCompleted or similar.
+import Victron.VenusOS
 
 QtObject {
 	property var main
@@ -23,7 +15,7 @@ QtObject {
 	property var mockDataSimulator    // only valid when mock mode is active
 	property var dataManager
 	property var locale: Qt.locale()  // TODO: read from settings
-	property var dataServiceModel: null
+	property VeQItemTableModel dataServiceModel: null
 	property var firmwareUpdate
 
 	property var inputPanel

--- a/Main.qml
+++ b/Main.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import QtQuick.Window
-import Victron.VenusOS
 
 Window {
 	id: root

--- a/components/AcInputsCurrentLimits.qml
+++ b/components/AcInputsCurrentLimits.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Column {
 	id: root

--- a/components/AcInputsCurrentLimits.qml
+++ b/components/AcInputsCurrentLimits.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Units
 
 Column {
 	id: root

--- a/components/AcOutput.qml
+++ b/components/AcOutput.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/components/AcPhase.qml
+++ b/components/AcPhase.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 QtObject {
 	id: root

--- a/components/AcPhase.qml
+++ b/components/AcPhase.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/components/ClassAndVrmInstance.qml
+++ b/components/ClassAndVrmInstance.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/components/Device.qml
+++ b/components/Device.qml
@@ -5,7 +5,6 @@
 
 import QtQml
 import Victron.VenusOS
-import Victron.Veutil
 
 BaseDevice {
 	id: root

--- a/components/ElectricalQuantityLabel.qml
+++ b/components/ElectricalQuantityLabel.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Units
 
 QuantityLabel {
 	id: root

--- a/components/EnvironmentGaugePanel.qml
+++ b/components/EnvironmentGaugePanel.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Units
 
 Rectangle {
 	id: root

--- a/components/ExpandedTanksView.qml
+++ b/components/ExpandedTanksView.qml
@@ -7,7 +7,6 @@ import QtQuick
 import Victron.VenusOS
 import QtQuick.Controls.impl as CP
 import Victron.Gauges
-import Victron.Units
 
 Rectangle {
 	id: root

--- a/components/FirmwareUpdate.qml
+++ b/components/FirmwareUpdate.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/components/GaugeModel.qml
+++ b/components/GaugeModel.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import QtQuick.Controls.impl as CP
-import Victron.Utils
 import Victron.Gauges
 
 /*

--- a/components/GeneratorIconLabel.qml
+++ b/components/GeneratorIconLabel.qml
@@ -7,7 +7,6 @@ import QtQuick
 import QtQuick.Controls as C
 import QtQuick.Controls.impl as CP
 import Victron.VenusOS
-import Victron.Utils
 
 Item {
 	id: root

--- a/components/GsmStatusIcon.qml
+++ b/components/GsmStatusIcon.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import QtQuick.Controls.impl as CP
 import Victron.VenusOS
-import Victron.Veutil
 
 Row {
 	id: root

--- a/components/GsmStatusIcon.qml
+++ b/components/GsmStatusIcon.qml
@@ -7,7 +7,6 @@ import QtQuick
 import QtQuick.Controls.impl as CP
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 Row {
 	id: root

--- a/components/QuantityLabel.qml
+++ b/components/QuantityLabel.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Units
 
 Item {
 	id: root

--- a/components/SideGauge.qml
+++ b/components/SideGauge.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Utils
 
 ArcGauge {
 	id: root

--- a/components/SolarDetailBox.qml
+++ b/components/SolarDetailBox.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Utils
 
 Rectangle {
 	id: root

--- a/components/SolarHistoryTableView.qml
+++ b/components/SolarHistoryTableView.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Utils
 
 Column {
 	id: root

--- a/components/SolarYieldGauge.qml
+++ b/components/SolarYieldGauge.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import QtQuick.Controls.impl as CP
-import Victron.Utils
 
 Item {
 	id: root

--- a/components/SolarYieldGraph.qml
+++ b/components/SolarYieldGraph.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Utils
 
 Item {
 	id: root

--- a/components/TankGaugeGroup.qml
+++ b/components/TankGaugeGroup.qml
@@ -7,7 +7,6 @@ import QtQuick
 import Victron.VenusOS
 import QtQuick.Controls.impl as CP
 import Victron.Gauges
-import Victron.Units
 
 Rectangle {
 	id: root

--- a/components/ThreePhaseQuantityTable.qml
+++ b/components/ThreePhaseQuantityTable.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Units
 
 QuantityTable {
 	id: root

--- a/components/TimeSelector.qml
+++ b/components/TimeSelector.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Utils
 
 Item {
 	id: root

--- a/components/ValueRange.qml
+++ b/components/ValueRange.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQml
-import Victron.Utils
 
 QtObject {
 	property real value: NaN

--- a/components/dialogs/GeneratorDialog.qml
+++ b/components/dialogs/GeneratorDialog.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Utils
 
 
 // This dialog allows the generator to be started or stopped. It is does not close immediately

--- a/components/dialogs/GeneratorStartDialog.qml
+++ b/components/dialogs/GeneratorStartDialog.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Utils
 
 GeneratorDialog {
 	id: root

--- a/components/dialogs/GeneratorStopDialog.qml
+++ b/components/dialogs/GeneratorStopDialog.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Utils
 
 GeneratorDialog {
 	id: root

--- a/components/dialogs/InverterChargerModeDialog.qml
+++ b/components/dialogs/InverterChargerModeDialog.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Utils
 
 ModalDialog {
 	id: root

--- a/components/dialogs/NumberSelectorDialog.qml
+++ b/components/dialogs/NumberSelectorDialog.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Utils
 
 ModalDialog {
 	id: root

--- a/components/dialogs/TimeSelectorDialog.qml
+++ b/components/dialogs/TimeSelectorDialog.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Utils
 
 ModalDialog {
 	id: root

--- a/components/listitems/ListDateSelector.qml
+++ b/components/listitems/ListDateSelector.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 ListButton {
 	id: root

--- a/components/listitems/ListDateSelector.qml
+++ b/components/listitems/ListDateSelector.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 ListButton {
 	id: root

--- a/components/listitems/ListItem.qml
+++ b/components/listitems/ListItem.qml
@@ -12,6 +12,7 @@ Item {
 	property alias text: primaryLabel.text
 	property alias content: content
 	property alias bottomContent: bottomContent
+	property list<Item> bottomContentChildren
 	property bool down
 	property alias backgroundRect: backgroundRect
 	property int spacing: Theme.geometry_gradientList_spacing
@@ -97,5 +98,6 @@ Item {
 		y: Math.max(primaryLabel.y + primaryLabel.height + bottomContentMargin,
 			content.y + content.height + bottomContentMargin)
 		width: parent.width
+		children: root.bottomContentChildren
 	}
 }

--- a/components/listitems/ListQuantityItem.qml
+++ b/components/listitems/ListQuantityItem.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 ListItem {
 	id: root

--- a/components/listitems/ListRadioButtonGroup.qml
+++ b/components/listitems/ListRadioButtonGroup.qml
@@ -107,7 +107,7 @@ ListNavigationItem {
 					writeAccessLevel: root.writeAccessLevel
 					C.ButtonGroup.group: radioButtonGroup
 
-					bottomContent.children: Loader {
+					bottomContentChildren: Loader {
 						id: bottomContentLoader
 
 						readonly property string caption: Array.isArray(root.optionModel)

--- a/components/listitems/ListRadioButtonGroup.qml
+++ b/components/listitems/ListRadioButtonGroup.qml
@@ -7,7 +7,6 @@ import QtQuick
 import QtQuick.Controls as C
 import QtQuick.Controls.impl as CP
 import Victron.VenusOS
-import Victron.Veutil
 
 // Each item in the model is expected to have at least 2 values:
 //      - "display": the text to display for this option

--- a/components/listitems/ListRangeSlider.qml
+++ b/components/listitems/ListRangeSlider.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 ListItem {
 	id: root

--- a/components/listitems/ListSpinBox.qml
+++ b/components/listitems/ListSpinBox.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 ListButton {
 	id: root

--- a/components/listitems/ListSpinBox.qml
+++ b/components/listitems/ListSpinBox.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 ListButton {
 	id: root

--- a/components/listitems/ListSwitch.qml
+++ b/components/listitems/ListSwitch.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 ListItem {
 	id: root

--- a/components/listitems/ListTextField.qml
+++ b/components/listitems/ListTextField.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import QtQuick.Controls.impl as CP
 import Victron.VenusOS
-import Victron.Veutil
 
 ListItem {
 	id: root

--- a/components/listitems/ListTextItem.qml
+++ b/components/listitems/ListTextItem.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 ListItem {
 	id: root

--- a/components/listitems/ListTimeSelector.qml
+++ b/components/listitems/ListTimeSelector.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 ListButton {
 	id: root

--- a/components/listitems/ListTimeSelector.qml
+++ b/components/listitems/ListTimeSelector.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 ListButton {
 	id: root

--- a/components/settings/CGwacsBatteryScheduleNavigationItem.qml
+++ b/components/settings/CGwacsBatteryScheduleNavigationItem.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 ListNavigationItem {
 	id: root

--- a/components/settings/CGwacsBatteryScheduleNavigationItem.qml
+++ b/components/settings/CGwacsBatteryScheduleNavigationItem.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 ListNavigationItem {
 	id: root

--- a/components/settings/FirmwareCheckListButton.qml
+++ b/components/settings/FirmwareCheckListButton.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 ListButton {
 	id: root

--- a/components/settings/Led.qml
+++ b/components/settings/Led.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Item {
 	id: root

--- a/components/settings/ListClearHistoryButton.qml
+++ b/components/settings/ListClearHistoryButton.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 ListButton {
 	id: root

--- a/components/settings/MountStateListButton.qml
+++ b/components/settings/MountStateListButton.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 ListButton {
 	id: root

--- a/components/settings/SettingsSlider.qml
+++ b/components/settings/SettingsSlider.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Slider {
 	id: root

--- a/components/settings/TemperatureRelayNavigationItem.qml
+++ b/components/settings/TemperatureRelayNavigationItem.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 ListNavigationItem {
 	id: root

--- a/components/settings/TemperatureRelayNavigationItem.qml
+++ b/components/settings/TemperatureRelayNavigationItem.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 ListNavigationItem {
 	id: root

--- a/components/settings/TemperatureRelaySettings.qml
+++ b/components/settings/TemperatureRelaySettings.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Column {
 	id: root

--- a/components/widgets/AcInputWidget.qml
+++ b/components/widgets/AcInputWidget.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Utils
 
 OverviewWidget {
 	id: root

--- a/components/widgets/AcLoadsWidget.qml
+++ b/components/widgets/AcLoadsWidget.qml
@@ -17,7 +17,7 @@ OverviewWidget {
 
 	quantityLabel.dataObject: Global.system.ac.consumption
 
-	extraContent.children: [
+	extraContentChildren: [
 		ThreePhaseDisplay {
 			anchors {
 				left: parent ? parent.left : undefined

--- a/components/widgets/BatteryWidget.qml
+++ b/components/widgets/BatteryWidget.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Utils
-import Victron.Units
 
 OverviewWidget {
 	id: root

--- a/components/widgets/BatteryWidget.qml
+++ b/components/widgets/BatteryWidget.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Utils
 
 OverviewWidget {
 	id: root

--- a/components/widgets/BatteryWidget.qml
+++ b/components/widgets/BatteryWidget.qml
@@ -164,7 +164,7 @@ OverviewWidget {
 		alignment: Qt.AlignRight
 	}
 
-	extraContent.children: [
+	extraContentChildren: [
 		Column {
 			anchors {
 				top: parent.top

--- a/components/widgets/DcLoadsWidget.qml
+++ b/components/widgets/DcLoadsWidget.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import QtQuick.Controls.impl as CP
 import Victron.VenusOS
-import Victron.Units
 
 OverviewWidget {
 	id: root

--- a/components/widgets/EvcsWidget.qml
+++ b/components/widgets/EvcsWidget.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Utils
 
 OverviewWidget {
 	id: root

--- a/components/widgets/EvcsWidget.qml
+++ b/components/widgets/EvcsWidget.qml
@@ -18,7 +18,7 @@ OverviewWidget {
 	enabled: true
 	quantityLabel.dataObject: { "power": Global.evChargers.power, "current": NaN }
 
-	extraContent.children: [
+	extraContentChildren: [
 		Loader {
 			anchors {
 				left: parent.left

--- a/components/widgets/OverviewWidget.qml
+++ b/components/widgets/OverviewWidget.qml
@@ -27,6 +27,7 @@ Rectangle {
 	property bool expanded
 	property bool animateGeometry
 	property bool animationEnabled
+	property list<QtObject> extraContentChildren
 
 	function getCompactHeight(s) {
 		return s === VenusOS.OverviewWidget_Size_XL ? Theme.geometry_overviewPage_widget_compact_xl_height
@@ -112,6 +113,7 @@ Rectangle {
 			top: header.bottom
 			bottom: parent.bottom
 		}
+		children: root.extraContentChildren
 		visible: root.size >= VenusOS.OverviewWidget_Size_M
 	}
 }

--- a/components/widgets/SolarYieldWidget.qml
+++ b/components/widgets/SolarYieldWidget.qml
@@ -19,7 +19,7 @@ OverviewWidget {
 	// Solar yield history is only available for PV chargers, and phase data is only available for
 	// PV inverters. So, if there are only solar chargers, show the solar history; otherwise if
 	// there is a single PV inverter, show its phase data.
-	extraContent.children: [
+	extraContentChildren: [
 		Loader {
 			readonly property int margin: sourceComponent === historyComponent
 				  ? Theme.geometry_overviewPage_widget_solar_graph_margins

--- a/components/widgets/VeBusDeviceWidget.qml
+++ b/components/widgets/VeBusDeviceWidget.qml
@@ -15,7 +15,7 @@ OverviewWidget {
 	type: VenusOS.OverviewWidget_Type_VeBusDevice
 	enabled: Global.veBusDevices.model.count > 0
 	quantityLabel.visible: false
-	extraContent.children: [
+	extraContentChildren: [
 		Label {
 			anchors {
 				left: parent.left

--- a/components/widgets/WidgetConnector.qml
+++ b/components/widgets/WidgetConnector.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import QtQuick.Shapes
 import Victron.VenusOS
-import Victron.Utils
 
 Item {
 	id: root

--- a/data/AcInputs.qml
+++ b/data/AcInputs.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/Batteries.qml
+++ b/data/Batteries.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Utils
 
 QtObject {
 	id: root

--- a/data/System.qml
+++ b/data/System.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 QtObject {
 	id: root

--- a/data/System.qml
+++ b/data/System.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/System.qml
+++ b/data/System.qml
@@ -7,7 +7,6 @@ import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
 import Victron.Utils
-import Victron.Units
 
 QtObject {
 	id: root

--- a/data/SystemAc.qml
+++ b/data/SystemAc.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Utils
 
 QtObject {
 	id: root

--- a/data/SystemAc.qml
+++ b/data/SystemAc.qml
@@ -4,8 +4,8 @@
 */
 
 import QtQuick
+import Victron.VenusOS
 import Victron.Utils
-import Victron.Units
 
 QtObject {
 	id: root

--- a/data/SystemSettings.qml
+++ b/data/SystemSettings.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Units
 
 QtObject {
 	id: root

--- a/data/SystemSettings.qml
+++ b/data/SystemSettings.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/VenusPlatform.qml
+++ b/data/VenusPlatform.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/common/AcData.qml
+++ b/data/common/AcData.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/common/AcInputPhaseModel.qml
+++ b/data/common/AcInputPhaseModel.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 ListModel {
 	id: root

--- a/data/common/AcInputPhaseModel.qml
+++ b/data/common/AcInputPhaseModel.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 ListModel {
 	id: root

--- a/data/common/AcInputServiceLoader.qml
+++ b/data/common/AcInputServiceLoader.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Loader {
 	id: root

--- a/data/common/AcInputSettings.qml
+++ b/data/common/AcInputSettings.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/common/AcInputSystemInfo.qml
+++ b/data/common/AcInputSystemInfo.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 QtObject {
 	id: root

--- a/data/common/AcInputSystemInfo.qml
+++ b/data/common/AcInputSystemInfo.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/common/ActiveAcInput.qml
+++ b/data/common/ActiveAcInput.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Device {
 	id: root

--- a/data/common/ActiveAcInput.qml
+++ b/data/common/ActiveAcInput.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Units
 
 Device {
 	id: root

--- a/data/common/Battery.qml
+++ b/data/common/Battery.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Device {
 	id: battery

--- a/data/common/Charger.qml
+++ b/data/common/Charger.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Device {
 	id: charger

--- a/data/common/DcDevice.qml
+++ b/data/common/DcDevice.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Device {
 	id: dcDevice

--- a/data/common/DcInput.qml
+++ b/data/common/DcInput.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 DcDevice {
 	id: input

--- a/data/common/DcLoad.qml
+++ b/data/common/DcLoad.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 DcDevice {
 	id: dcLoad

--- a/data/common/DcSystem.qml
+++ b/data/common/DcSystem.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 DcDevice {
 	id: dcSystem

--- a/data/common/DigitalInput.qml
+++ b/data/common/DigitalInput.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Device {
 	id: input

--- a/data/common/EnvironmentInput.qml
+++ b/data/common/EnvironmentInput.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import Victron.Veutil
 import Victron.VenusOS
 
 Device {

--- a/data/common/EnvironmentInput.qml
+++ b/data/common/EnvironmentInput.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.Veutil
 import Victron.VenusOS
-import Victron.Utils
 
 Device {
 	id: input

--- a/data/common/EssData.qml
+++ b/data/common/EssData.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 QtObject {
 	id: root

--- a/data/common/EssData.qml
+++ b/data/common/EssData.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/common/EvCharger.qml
+++ b/data/common/EvCharger.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 Device {
 	id: evCharger

--- a/data/common/EvCharger.qml
+++ b/data/common/EvCharger.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Device {
 	id: evCharger

--- a/data/common/Generator.qml
+++ b/data/common/Generator.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import Victron.Veutil
 import Victron.VenusOS
 
 Device {

--- a/data/common/Generator.qml
+++ b/data/common/Generator.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.Veutil
 import Victron.VenusOS
-import Victron.Utils
 
 Device {
 	id: generator

--- a/data/common/Inverter.qml
+++ b/data/common/Inverter.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Device {
 	id: inverter

--- a/data/common/MeteoDevice.qml
+++ b/data/common/MeteoDevice.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Device {
 	id: meteoDevice

--- a/data/common/MotorDrive.qml
+++ b/data/common/MotorDrive.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Device {
 	id: motorDrive

--- a/data/common/MultiRsDevice.qml
+++ b/data/common/MultiRsDevice.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Device {
 	id: multiRsDevice

--- a/data/common/PulseMeter.qml
+++ b/data/common/PulseMeter.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Device {
 	id: pulseMeter

--- a/data/common/PvInverter.qml
+++ b/data/common/PvInverter.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Device {
 	id: pvInverter

--- a/data/common/PvMonitor.qml
+++ b/data/common/PvMonitor.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Instantiator {
 	id: root

--- a/data/common/PvMonitor.qml
+++ b/data/common/PvMonitor.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Utils
 import Victron.Veutil
 
 Instantiator {

--- a/data/common/PvMonitor.qml
+++ b/data/common/PvMonitor.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Utils
-import Victron.Units
 import Victron.Veutil
 
 Instantiator {

--- a/data/common/Relay.qml
+++ b/data/common/Relay.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import Victron.Veutil
 import Victron.VenusOS
 
 Device {

--- a/data/common/Relay.qml
+++ b/data/common/Relay.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.Veutil
 import Victron.VenusOS
-import Victron.Utils
 
 Device {
 	id: relay

--- a/data/common/SolarCharger.qml
+++ b/data/common/SolarCharger.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 Device {
 	id: solarCharger

--- a/data/common/SolarCharger.qml
+++ b/data/common/SolarCharger.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Device {
 	id: solarCharger

--- a/data/common/SolarDailyHistory.qml
+++ b/data/common/SolarDailyHistory.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 // Stores the overall daily history for a solar charger, or the daily history for a single solar tracker.
 QtObject {

--- a/data/common/SolarHistoryErrorModel.qml
+++ b/data/common/SolarHistoryErrorModel.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 ListModel {
 	id: root

--- a/data/common/SystemBattery.qml
+++ b/data/common/SystemBattery.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: battery

--- a/data/common/SystemData.qml
+++ b/data/common/SystemData.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 QtObject {
 	id: root

--- a/data/common/SystemData.qml
+++ b/data/common/SystemData.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/common/SystemData.qml
+++ b/data/common/SystemData.qml
@@ -7,7 +7,6 @@ import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
 import Victron.Utils
-import Victron.Units
 
 QtObject {
 	id: root

--- a/data/common/Tank.qml
+++ b/data/common/Tank.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 import Victron.Gauges
 
 Device {

--- a/data/common/Tank.qml
+++ b/data/common/Tank.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 import Victron.Gauges
 
 Device {

--- a/data/common/UnsupportedDevice.qml
+++ b/data/common/UnsupportedDevice.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Device {
 	id: unsupportedDevice

--- a/data/common/VeBusDevice.qml
+++ b/data/common/VeBusDevice.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Device {
 	id: veBusDevice

--- a/data/dbus/BatteriesImpl.qml
+++ b/data/dbus/BatteriesImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	property Instantiator batteryObjects: Instantiator {

--- a/data/dbus/ChargersImpl.qml
+++ b/data/dbus/ChargersImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/dbus/DBusDataManager.qml
+++ b/data/dbus/DBusDataManager.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import Victron.Veutil
 import Victron.VenusOS
 import Victron.Dbus
 

--- a/data/dbus/DcInputsImpl.qml
+++ b/data/dbus/DcInputsImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/dbus/DcLoadsImpl.qml
+++ b/data/dbus/DcLoadsImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Instantiator {
 	id: root

--- a/data/dbus/DcSystemsImpl.qml
+++ b/data/dbus/DcSystemsImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Instantiator {
 	id: root

--- a/data/dbus/DigitalInputsImpl.qml
+++ b/data/dbus/DigitalInputsImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/dbus/EnvironmentInputsImpl.qml
+++ b/data/dbus/EnvironmentInputsImpl.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import Victron.Veutil
 import Victron.VenusOS
 
 QtObject {

--- a/data/dbus/EvChargersImpl.qml
+++ b/data/dbus/EvChargersImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/dbus/GeneratorsImpl.qml
+++ b/data/dbus/GeneratorsImpl.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import Victron.Veutil
 import Victron.VenusOS
 
 QtObject {

--- a/data/dbus/InvertersImpl.qml
+++ b/data/dbus/InvertersImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/dbus/MeteoDevicesImpl.qml
+++ b/data/dbus/MeteoDevicesImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/dbus/MotorDrivesImpl.qml
+++ b/data/dbus/MotorDrivesImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/dbus/MultiRsDevicesImpl.qml
+++ b/data/dbus/MultiRsDevicesImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/dbus/PulseMetersImpl.qml
+++ b/data/dbus/PulseMetersImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/dbus/PvInvertersImpl.qml
+++ b/data/dbus/PvInvertersImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/dbus/RelaysImpl.qml
+++ b/data/dbus/RelaysImpl.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import Victron.Veutil
 import Victron.VenusOS
 
 QtObject {

--- a/data/dbus/SolarChargersImpl.qml
+++ b/data/dbus/SolarChargersImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/dbus/TanksImpl.qml
+++ b/data/dbus/TanksImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/dbus/UnsupportedDevicesImpl.qml
+++ b/data/dbus/UnsupportedDevicesImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/dbus/VeBusDevicesImpl.qml
+++ b/data/dbus/VeBusDevicesImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/mock/AcInputsImpl.qml
+++ b/data/mock/AcInputsImpl.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.Veutil
 import Victron.VenusOS
-import Victron.Units
 import Victron.Utils
 
 QtObject {

--- a/data/mock/AcInputsImpl.qml
+++ b/data/mock/AcInputsImpl.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.Veutil
 import Victron.VenusOS
-import Victron.Utils
 
 QtObject {
 	id: root

--- a/data/mock/AcInputsImpl.qml
+++ b/data/mock/AcInputsImpl.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import Victron.Veutil
 import Victron.VenusOS
 
 QtObject {

--- a/data/mock/GeneratorsImpl.qml
+++ b/data/mock/GeneratorsImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/mock/SolarChargersImpl.qml
+++ b/data/mock/SolarChargersImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Utils
 
 QtObject {
 	id: root

--- a/data/mock/SystemImpl.qml
+++ b/data/mock/SystemImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/mock/VeBusDevicesImpl.qml
+++ b/data/mock/VeBusDevicesImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/mock/config/MockDataSimulator.qml
+++ b/data/mock/config/MockDataSimulator.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Utils
 
 QtObject {
 	id: root

--- a/data/mqtt/BatteriesImpl.qml
+++ b/data/mqtt/BatteriesImpl.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import Victron.Veutil
 import Victron.VenusOS
 
 QtObject {

--- a/data/mqtt/ChargersImpl.qml
+++ b/data/mqtt/ChargersImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/mqtt/DcInputsImpl.qml
+++ b/data/mqtt/DcInputsImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/mqtt/DcLoadsImpl.qml
+++ b/data/mqtt/DcLoadsImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Instantiator {
 	id: root

--- a/data/mqtt/DcSystemsImpl.qml
+++ b/data/mqtt/DcSystemsImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Instantiator {
 	id: root

--- a/data/mqtt/DigitalInputsImpl.qml
+++ b/data/mqtt/DigitalInputsImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/mqtt/EnvironmentInputsImpl.qml
+++ b/data/mqtt/EnvironmentInputsImpl.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import Victron.Veutil
 import Victron.VenusOS
 
 QtObject {

--- a/data/mqtt/EvChargersImpl.qml
+++ b/data/mqtt/EvChargersImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/mqtt/GeneratorsImpl.qml
+++ b/data/mqtt/GeneratorsImpl.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import Victron.Veutil
 import Victron.VenusOS
 
 QtObject {

--- a/data/mqtt/InvertersImpl.qml
+++ b/data/mqtt/InvertersImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/mqtt/MeteoDevicesImpl.qml
+++ b/data/mqtt/MeteoDevicesImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/mqtt/MotorDrivesImpl.qml
+++ b/data/mqtt/MotorDrivesImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/mqtt/MqttDataManager.qml
+++ b/data/mqtt/MqttDataManager.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import Victron.Veutil
 import Victron.VenusOS
 import Victron.Mqtt
 

--- a/data/mqtt/MultiRsDevicesImpl.qml
+++ b/data/mqtt/MultiRsDevicesImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/mqtt/PulseMetersImpl.qml
+++ b/data/mqtt/PulseMetersImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/mqtt/PvInvertersImpl.qml
+++ b/data/mqtt/PvInvertersImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/mqtt/RelaysImpl.qml
+++ b/data/mqtt/RelaysImpl.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import Victron.Veutil
 import Victron.VenusOS
 
 QtObject {

--- a/data/mqtt/SolarChargersImpl.qml
+++ b/data/mqtt/SolarChargersImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/mqtt/TanksImpl.qml
+++ b/data/mqtt/TanksImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/mqtt/UnsupportedDevicesImpl.qml
+++ b/data/mqtt/UnsupportedDevicesImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/data/mqtt/VeBusDevicesImpl.qml
+++ b/data/mqtt/VeBusDevicesImpl.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/pages/BriefMonitorPanel.qml
+++ b/pages/BriefMonitorPanel.qml
@@ -8,7 +8,6 @@ import QtQuick.Controls as C
 import QtQuick.Controls.impl as CP
 import Victron.VenusOS
 import Victron.Utils
-import Victron.Units
 
 Column {
 	id: root

--- a/pages/BriefMonitorPanel.qml
+++ b/pages/BriefMonitorPanel.qml
@@ -7,7 +7,6 @@ import QtQuick
 import QtQuick.Controls as C
 import QtQuick.Controls.impl as CP
 import Victron.VenusOS
-import Victron.Utils
 
 Column {
 	id: root

--- a/pages/BriefPage.qml
+++ b/pages/BriefPage.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Utils
-import Victron.Units
 import Victron.Gauges
 
 Page {

--- a/pages/BriefPage.qml
+++ b/pages/BriefPage.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Utils
 import Victron.Gauges
 
 Page {

--- a/pages/ControlCardsPage.qml
+++ b/pages/ControlCardsPage.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import QtQuick.Window
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/EnvironmentTab.qml
+++ b/pages/EnvironmentTab.qml
@@ -7,7 +7,6 @@ import QtQuick
 import Victron.VenusOS
 import QtQuick.Controls.impl as CP
 import Victron.Utils
-import Victron.Units
 
 Flickable {
 	id: root

--- a/pages/EnvironmentTab.qml
+++ b/pages/EnvironmentTab.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import QtQuick.Controls.impl as CP
-import Victron.Utils
 
 Flickable {
 	id: root

--- a/pages/NotificationLayer.qml
+++ b/pages/NotificationLayer.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Utils
 
 Item {
 	id: root

--- a/pages/OverviewPage.qml
+++ b/pages/OverviewPage.qml
@@ -59,7 +59,7 @@ Page {
 		let firstLargeWidget = null
 		let widget = null
 		for (i = 0; i < _leftWidgets.length; ++i) {
-			if (_leftWidgets[i].extraContent.children.length > 0) {
+			if (_leftWidgets[i].extraContentChildren.length > 0) {
 				firstLargeWidget = _leftWidgets[i]
 				break
 			}

--- a/pages/OverviewPage.qml
+++ b/pages/OverviewPage.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/SettingsPage.qml
+++ b/pages/SettingsPage.qml
@@ -11,7 +11,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import net.connman
 
 Page {
 	id: root

--- a/pages/SettingsPage.qml
+++ b/pages/SettingsPage.qml
@@ -10,7 +10,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/TanksTab.qml
+++ b/pages/TanksTab.qml
@@ -12,7 +12,6 @@
 import QtQuick
 import Victron.VenusOS
 import QtQuick.Controls.impl as CP
-import Victron.Utils
 
 ListView {
 	id: root

--- a/pages/controlcards/GeneratorCard.qml
+++ b/pages/controlcards/GeneratorCard.qml
@@ -7,7 +7,6 @@ import QtQuick
 import QtQuick.Controls as C
 import QtQuick.Controls.impl as CP
 import Victron.VenusOS
-import Victron.Utils
 
 ControlCard {
 	id: root

--- a/pages/evcs/EvChargerListPage.qml
+++ b/pages/evcs/EvChargerListPage.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Units
 
 Page {
 	id: root

--- a/pages/evcs/EvChargerPage.qml
+++ b/pages/evcs/EvChargerPage.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/CanbusServiceFinder.qml
+++ b/pages/settings/CanbusServiceFinder.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Loader {
 	id: root

--- a/pages/settings/GeneratorCondition.qml
+++ b/pages/settings/GeneratorCondition.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 ListNavigationItem {
 	id: root

--- a/pages/settings/GeneratorCondition.qml
+++ b/pages/settings/GeneratorCondition.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 ListNavigationItem {
 	id: root

--- a/pages/settings/IpAddressListView.qml
+++ b/pages/settings/IpAddressListView.qml
@@ -8,7 +8,6 @@ import QtQuick.Controls as C
 import QtQuick.Controls.impl as CP
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 GradientListView {
 	id: root

--- a/pages/settings/IpAddressListView.qml
+++ b/pages/settings/IpAddressListView.qml
@@ -7,7 +7,6 @@ import QtQuick
 import QtQuick.Controls as C
 import QtQuick.Controls.impl as CP
 import Victron.VenusOS
-import Victron.Veutil
 
 GradientListView {
 	id: root

--- a/pages/settings/PageCanbusStatus.qml
+++ b/pages/settings/PageCanbusStatus.qml
@@ -100,7 +100,7 @@ Page {
 
 				//% "State"
 				text: qsTrId("settings_state")
-				bottomContent.children: ListTextGroup {
+				bottomContentChildren: ListTextGroup {
 					id: busOffCounters
 				}
 			}
@@ -109,7 +109,7 @@ Page {
 				id: rxGroup
 
 				text: "RX"
-				bottomContent.children: ListTextGroup {
+				bottomContentChildren: ListTextGroup {
 					id: rxErrorGroup
 				}
 			}
@@ -118,7 +118,7 @@ Page {
 				id: txGroup
 
 				text: "TX"
-				bottomContent.children: ListTextGroup {
+				bottomContentChildren: ListTextGroup {
 					id: txErrorGroup
 				}
 			}

--- a/pages/settings/PageCanbusStatus.qml
+++ b/pages/settings/PageCanbusStatus.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageChargeCurrentLimits.qml
+++ b/pages/settings/PageChargeCurrentLimits.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/PageChargeCurrentLimits.qml
+++ b/pages/settings/PageChargeCurrentLimits.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageDeviceInfo.qml
+++ b/pages/settings/PageDeviceInfo.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 import QtQuick.Controls.impl as CP
 
 Page {

--- a/pages/settings/PageDeviceInfo.qml
+++ b/pages/settings/PageDeviceInfo.qml
@@ -7,7 +7,6 @@ import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
 import QtQuick.Controls.impl as CP
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/PageGenerator.qml
+++ b/pages/settings/PageGenerator.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/PageGenerator.qml
+++ b/pages/settings/PageGenerator.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageGeneratorAcLoad.qml
+++ b/pages/settings/PageGeneratorAcLoad.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/PageGeneratorConditions.qml
+++ b/pages/settings/PageGeneratorConditions.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/PageGeneratorConditions.qml
+++ b/pages/settings/PageGeneratorConditions.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageGeneratorRuntimeService.qml
+++ b/pages/settings/PageGeneratorRuntimeService.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageGps.qml
+++ b/pages/settings/PageGps.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageHub4Debug.qml
+++ b/pages/settings/PageHub4Debug.qml
@@ -27,7 +27,7 @@ Page {
 				to: 15000
 				stepSize: 10
 
-				bottomContent.children: [
+				bottomContentChildren: [
 					SettingsSlider {
 						id: gridSetpointSlider
 

--- a/pages/settings/PageHub4Debug.qml
+++ b/pages/settings/PageHub4Debug.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageRelayGenerator.qml
+++ b/pages/settings/PageRelayGenerator.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 PageGenerator {
 	id: root

--- a/pages/settings/PageRelayGenerator.qml
+++ b/pages/settings/PageRelayGenerator.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 PageGenerator {
 	id: root

--- a/pages/settings/PageSettingsBatteries.qml
+++ b/pages/settings/PageSettingsBatteries.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsBleSensors.qml
+++ b/pages/settings/PageSettingsBleSensors.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsBleSensors.qml
+++ b/pages/settings/PageSettingsBleSensors.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsCGwacs.qml
+++ b/pages/settings/PageSettingsCGwacs.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsCGwacs.qml
+++ b/pages/settings/PageSettingsCGwacs.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsCGwacsOverview.qml
+++ b/pages/settings/PageSettingsCGwacsOverview.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsCGwacsOverview.qml
+++ b/pages/settings/PageSettingsCGwacsOverview.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsCanbus.qml
+++ b/pages/settings/PageSettingsCanbus.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsCanbus.qml
+++ b/pages/settings/PageSettingsCanbus.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsCanbus.qml
+++ b/pages/settings/PageSettingsCanbus.qml
@@ -128,7 +128,7 @@ Page {
 				visible: root._isVecan || root._isRvc
 				dataItem.uid: (root._isRvc ? root._rvcSettingsPrefix : root._vecanSettingsPrefix) + "/VenusUniqueId"
 
-				bottomContent.children: ListLabel {
+				bottomContentChildren: ListLabel {
 					visible: text.length > 0
 					color: Theme.color_font_secondary
 					text: root._isVecan
@@ -171,7 +171,7 @@ Page {
 							+ (uniqueIdOkLabel.visible ? uniqueIdOkLabel.height : 0))
 						: 0
 
-				bottomContent.children: [
+				bottomContentChildren: [
 					ListLabel {
 						id: uniqueIdConflictLabel
 						topPadding: 0

--- a/pages/settings/PageSettingsDisplay.qml
+++ b/pages/settings/PageSettingsDisplay.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsDvcc.qml
+++ b/pages/settings/PageSettingsDvcc.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 import QtQuick.Controls as C
 
 Page {

--- a/pages/settings/PageSettingsDvcc.qml
+++ b/pages/settings/PageSettingsDvcc.qml
@@ -7,7 +7,6 @@ import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
 import QtQuick.Controls as C
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsFirmwareOffline.qml
+++ b/pages/settings/PageSettingsFirmwareOffline.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsFirmwareOnline.qml
+++ b/pages/settings/PageSettingsFirmwareOnline.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsFronius.qml
+++ b/pages/settings/PageSettingsFronius.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import Victron.Utils
 import Victron.VenusOS
 import Victron.Veutil
 

--- a/pages/settings/PageSettingsFronius.qml
+++ b/pages/settings/PageSettingsFronius.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root // TODO: update this UI when a design is available

--- a/pages/settings/PageSettingsFroniusInverter.qml
+++ b/pages/settings/PageSettingsFroniusInverter.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsFroniusInverter.qml
+++ b/pages/settings/PageSettingsFroniusInverter.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsFroniusInverters.qml
+++ b/pages/settings/PageSettingsFroniusInverters.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsFroniusInverters.qml
+++ b/pages/settings/PageSettingsFroniusInverters.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsFroniusSetIpAddresses.qml
+++ b/pages/settings/PageSettingsFroniusSetIpAddresses.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import QtQuick.Controls as C
 import Victron.VenusOS
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsFroniusShowIpAddresses.qml
+++ b/pages/settings/PageSettingsFroniusShowIpAddresses.qml
@@ -7,7 +7,6 @@ import QtQuick
 import QtQuick.Controls as C
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsFroniusShowIpAddresses.qml
+++ b/pages/settings/PageSettingsFroniusShowIpAddresses.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import QtQuick.Controls as C
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsGeneral.qml
+++ b/pages/settings/PageSettingsGeneral.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsGenerator.qml
+++ b/pages/settings/PageSettingsGenerator.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsGenerator.qml
+++ b/pages/settings/PageSettingsGenerator.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsGpsList.qml
+++ b/pages/settings/PageSettingsGpsList.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsGsm.qml
+++ b/pages/settings/PageSettingsGsm.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsGsm.qml
+++ b/pages/settings/PageSettingsGsm.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsHub4.qml
+++ b/pages/settings/PageSettingsHub4.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsHub4Feedin.qml
+++ b/pages/settings/PageSettingsHub4Feedin.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsIo.qml
+++ b/pages/settings/PageSettingsIo.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsIo.qml
+++ b/pages/settings/PageSettingsIo.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import net.connman
 import Victron.Utils
 
 Page {

--- a/pages/settings/PageSettingsIo.qml
+++ b/pages/settings/PageSettingsIo.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsLogger.qml
+++ b/pages/settings/PageSettingsLogger.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsLogger.qml
+++ b/pages/settings/PageSettingsLogger.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsModbusTcp.qml
+++ b/pages/settings/PageSettingsModbusTcp.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsModbusTcpServices.qml
+++ b/pages/settings/PageSettingsModbusTcpServices.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsModbusTcpServices.qml
+++ b/pages/settings/PageSettingsModbusTcpServices.qml
@@ -44,7 +44,7 @@ Page {
 
 			text: root._formatName(productName.value, serviceName.value)
 
-			bottomContent.children: [
+			bottomContentChildren: [
 				ListTextItem {
 					id: serviceDetails
 					implicitHeight: serviceDetails.primaryLabel.height

--- a/pages/settings/PageSettingsRelay.qml
+++ b/pages/settings/PageSettingsRelay.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsRelayTempSensors.qml
+++ b/pages/settings/PageSettingsRelayTempSensors.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsRelayTempSensors.qml
+++ b/pages/settings/PageSettingsRelayTempSensors.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsRemoteConsole.qml
+++ b/pages/settings/PageSettingsRemoteConsole.qml
@@ -83,7 +83,7 @@ Page {
 				text: qsTrId("settings_remoteconsole_enable_on_lan")
 				dataItem.uid: Global.systemSettings.serviceUid + "/Settings/System/VncLocal"
 
-				bottomContent.children: ListLabel {
+				bottomContentChildren: ListLabel {
 					visible: text.length > 0
 					topPadding: 0
 					bottomPadding: 0

--- a/pages/settings/PageSettingsRemoteConsole.qml
+++ b/pages/settings/PageSettingsRemoteConsole.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsRootfsSelect.qml
+++ b/pages/settings/PageSettingsRootfsSelect.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsRvcDevice.qml
+++ b/pages/settings/PageSettingsRvcDevice.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsRvcDevice.qml
+++ b/pages/settings/PageSettingsRvcDevice.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsRvcDeviceConfiguration.qml
+++ b/pages/settings/PageSettingsRvcDeviceConfiguration.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsRvcDevices.qml
+++ b/pages/settings/PageSettingsRvcDevices.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsRvcDevices.qml
+++ b/pages/settings/PageSettingsRvcDevices.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsServices.qml
+++ b/pages/settings/PageSettingsServices.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsSystem.qml
+++ b/pages/settings/PageSettingsSystem.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsSystem.qml
+++ b/pages/settings/PageSettingsSystem.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsSystemStatus.qml
+++ b/pages/settings/PageSettingsSystemStatus.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsTankPump.qml
+++ b/pages/settings/PageSettingsTankPump.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsTankPump.qml
+++ b/pages/settings/PageSettingsTankPump.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsTcpIp.qml
+++ b/pages/settings/PageSettingsTcpIp.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import net.connman
 import Victron.Utils
 
 Page {

--- a/pages/settings/PageSettingsTcpIp.qml
+++ b/pages/settings/PageSettingsTcpIp.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsVecanDevices.qml
+++ b/pages/settings/PageSettingsVecanDevices.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import QtQuick.Controls.impl as CP
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsVecanDevices.qml
+++ b/pages/settings/PageSettingsVecanDevices.qml
@@ -7,7 +7,6 @@ import QtQuick
 import QtQuick.Controls.impl as CP
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsWifi.qml
+++ b/pages/settings/PageSettingsWifi.qml
@@ -7,7 +7,6 @@ import QtQuick
 import QtQuick.Controls as C
 import QtQuick.Controls.impl as CP
 import Victron.VenusOS
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsWifi.qml
+++ b/pages/settings/PageSettingsWifi.qml
@@ -7,7 +7,6 @@ import QtQuick
 import QtQuick.Controls as C
 import QtQuick.Controls.impl as CP
 import Victron.VenusOS
-import net.connman
 import Victron.Utils
 
 Page {

--- a/pages/settings/PageSettingsWifiWithAccessPoint.qml
+++ b/pages/settings/PageSettingsWifiWithAccessPoint.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsWifiWithAccessPoint.qml
+++ b/pages/settings/PageSettingsWifiWithAccessPoint.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import net.connman
 
 Page {
 	id: root

--- a/pages/settings/PageTzInfo.qml
+++ b/pages/settings/PageTzInfo.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/PageVrmDeviceInstances.qml
+++ b/pages/settings/PageVrmDeviceInstances.qml
@@ -7,7 +7,6 @@ import QtQuick
 import QtQuick.Controls as C
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 // Allows VRM instances to be changed for devices on the system.
 //

--- a/pages/settings/PageVrmDeviceInstances.qml
+++ b/pages/settings/PageVrmDeviceInstances.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import QtQuick.Controls as C
 import Victron.VenusOS
-import Victron.Veutil
 
 // Allows VRM instances to be changed for devices on the system.
 //

--- a/pages/settings/debug/HubData.qml
+++ b/pages/settings/debug/HubData.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/debug/ObjectAcConnection.qml
+++ b/pages/settings/debug/ObjectAcConnection.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	property string bindPrefix

--- a/pages/settings/debug/PageDebugVeQItems.qml
+++ b/pages/settings/debug/PageDebugVeQItems.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/debug/PagePowerDebug.qml
+++ b/pages/settings/debug/PagePowerDebug.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/debug/PageSettingsDemo.qml
+++ b/pages/settings/debug/PageSettingsDemo.qml
@@ -202,7 +202,7 @@ Page {
 			ListItem {
 				text: "Custom bottom content item"
 
-				bottomContent.children: [
+				bottomContentChildren: [
 					ListLabel {
 						topPadding: 0
 						bottomPadding: 0

--- a/pages/settings/devicelist/AcInDeviceModel.qml
+++ b/pages/settings/devicelist/AcInDeviceModel.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 BaseDeviceModel {
 	id: root

--- a/pages/settings/devicelist/DeviceListPage.qml
+++ b/pages/settings/devicelist/DeviceListPage.qml
@@ -11,7 +11,6 @@
 import QtQuick
 import QtQuick.Controls.impl as CP
 import Victron.VenusOS
-import Victron.Units
 
 Page {
 	id: root

--- a/pages/settings/devicelist/PageMeteo.qml
+++ b/pages/settings/devicelist/PageMeteo.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Units
 
 Page {
 	id: root

--- a/pages/settings/devicelist/PageMeteo.qml
+++ b/pages/settings/devicelist/PageMeteo.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/devicelist/PageMeteoSettings.qml
+++ b/pages/settings/devicelist/PageMeteoSettings.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Utils
-import Victron.Units
 
 Page {
 	id: root

--- a/pages/settings/devicelist/PageMeteoSettings.qml
+++ b/pages/settings/devicelist/PageMeteoSettings.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/devicelist/PageNotYetImplemented.qml
+++ b/pages/settings/devicelist/PageNotYetImplemented.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/devicelist/PageNotYetImplemented.qml
+++ b/pages/settings/devicelist/PageNotYetImplemented.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/devicelist/PageUnsupportedDevice.qml
+++ b/pages/settings/devicelist/PageUnsupportedDevice.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/devicelist/PageUnsupportedDevice.qml
+++ b/pages/settings/devicelist/PageUnsupportedDevice.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/devicelist/ac-in/PageAcIn.qml
+++ b/pages/settings/devicelist/ac-in/PageAcIn.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/devicelist/ac-in/PageAcInModelDefault.qml
+++ b/pages/settings/devicelist/ac-in/PageAcInModelDefault.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Units
 
 ObjectModel {
 	id: root

--- a/pages/settings/devicelist/ac-in/PageAcInModelDefault.qml
+++ b/pages/settings/devicelist/ac-in/PageAcInModelDefault.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 ObjectModel {
 	id: root

--- a/pages/settings/devicelist/ac-in/PageAcInModelGenset.qml
+++ b/pages/settings/devicelist/ac-in/PageAcInModelGenset.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 ObjectModel {
 	id: root

--- a/pages/settings/devicelist/ac-in/PageAcInModelGenset.qml
+++ b/pages/settings/devicelist/ac-in/PageAcInModelGenset.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Units
 import Victron.Utils
 
 ObjectModel {

--- a/pages/settings/devicelist/ac-in/PageAcInModelGenset.qml
+++ b/pages/settings/devicelist/ac-in/PageAcInModelGenset.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 ObjectModel {
 	id: root

--- a/pages/settings/devicelist/ac-in/PageAcInSetup.qml
+++ b/pages/settings/devicelist/ac-in/PageAcInSetup.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/devicelist/ac-in/PageSmappeeCTList.qml
+++ b/pages/settings/devicelist/ac-in/PageSmappeeCTList.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/devicelist/ac-in/PageSmappeeCTList.qml
+++ b/pages/settings/devicelist/ac-in/PageSmappeeCTList.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml
+++ b/pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml
+++ b/pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml
+++ b/pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/devicelist/battery/BatteryDetails.qml
+++ b/pages/settings/devicelist/battery/BatteryDetails.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/pages/settings/devicelist/battery/BatterySettingsAlarmModel.qml
+++ b/pages/settings/devicelist/battery/BatterySettingsAlarmModel.qml
@@ -5,8 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
-import Victron.Units
 
 ObjectModel {
 	id: root

--- a/pages/settings/devicelist/battery/BatterySettingsRelayModel.qml
+++ b/pages/settings/devicelist/battery/BatterySettingsRelayModel.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Units
 
 ObjectModel {
 	id: root

--- a/pages/settings/devicelist/battery/BatterySettingsRelayModel.qml
+++ b/pages/settings/devicelist/battery/BatterySettingsRelayModel.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 ObjectModel {
 	id: root

--- a/pages/settings/devicelist/battery/FuseInfo.qml
+++ b/pages/settings/devicelist/battery/FuseInfo.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 QtObject {
 	id: root

--- a/pages/settings/devicelist/battery/PageBattery.qml
+++ b/pages/settings/devicelist/battery/PageBattery.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/devicelist/battery/PageBattery.qml
+++ b/pages/settings/devicelist/battery/PageBattery.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/devicelist/battery/PageBatteryDetails.qml
+++ b/pages/settings/devicelist/battery/PageBatteryDetails.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Units
 
 Page {
 	id: root

--- a/pages/settings/devicelist/battery/PageBatteryDetails.qml
+++ b/pages/settings/devicelist/battery/PageBatteryDetails.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/devicelist/battery/PageBatteryHistory.qml
+++ b/pages/settings/devicelist/battery/PageBatteryHistory.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/devicelist/battery/PageBatteryHistory.qml
+++ b/pages/settings/devicelist/battery/PageBatteryHistory.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/devicelist/battery/PageBatteryModuleAlarms.qml
+++ b/pages/settings/devicelist/battery/PageBatteryModuleAlarms.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/devicelist/battery/PageBatterySettings.qml
+++ b/pages/settings/devicelist/battery/PageBatterySettings.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/devicelist/battery/PageBatterySettingsBattery.qml
+++ b/pages/settings/devicelist/battery/PageBatterySettingsBattery.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/devicelist/battery/PageLynxDistributorList.qml
+++ b/pages/settings/devicelist/battery/PageLynxDistributorList.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml
+++ b/pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/devicelist/battery/PageLynxIonSystem.qml
+++ b/pages/settings/devicelist/battery/PageLynxIonSystem.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/devicelist/dc-in/PageAlternator.qml
+++ b/pages/settings/devicelist/dc-in/PageAlternator.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/devicelist/dc-in/PageAlternatorModel.qml
+++ b/pages/settings/devicelist/dc-in/PageAlternatorModel.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 ObjectModel {
 	id: root

--- a/pages/settings/devicelist/dc-in/PageDcMeter.qml
+++ b/pages/settings/devicelist/dc-in/PageDcMeter.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/devicelist/dc-in/PageDcMeterHistory.qml
+++ b/pages/settings/devicelist/dc-in/PageDcMeterHistory.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/settings/devicelist/dc-in/PageDcMeterHistory.qml
+++ b/pages/settings/devicelist/dc-in/PageDcMeterHistory.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/devicelist/dc-in/PageDcMeterModel.qml
+++ b/pages/settings/devicelist/dc-in/PageDcMeterModel.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 ObjectModel {
 	id: root

--- a/pages/settings/devicelist/tank/PageTankAlarm.qml
+++ b/pages/settings/devicelist/tank/PageTankAlarm.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Units
 
 Page {
 	id: root

--- a/pages/settings/devicelist/tank/PageTankAlarm.qml
+++ b/pages/settings/devicelist/tank/PageTankAlarm.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/devicelist/tank/PageTankSensor.qml
+++ b/pages/settings/devicelist/tank/PageTankSensor.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Units
 
 Page {
 	id: root

--- a/pages/settings/devicelist/tank/PageTankSensor.qml
+++ b/pages/settings/devicelist/tank/PageTankSensor.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/devicelist/tank/PageTankSetup.qml
+++ b/pages/settings/devicelist/tank/PageTankSetup.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Units
 import Victron.Gauges
 
 Page {

--- a/pages/settings/devicelist/tank/PageTankSetup.qml
+++ b/pages/settings/devicelist/tank/PageTankSetup.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 import Victron.Gauges
 
 Page {

--- a/pages/settings/devicelist/tank/PageTankShape.qml
+++ b/pages/settings/devicelist/tank/PageTankShape.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import QtQuick.Controls.impl as CP
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/settings/devicelist/tank/PageTankShape.qml
+++ b/pages/settings/devicelist/tank/PageTankShape.qml
@@ -7,7 +7,6 @@ import QtQuick
 import QtQuick.Controls.impl as CP
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Units
 
 Page {
 	id: root

--- a/pages/solar/SolarChargerPage.qml
+++ b/pages/solar/SolarChargerPage.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/vebusdevice/OverviewVeBusDevicePage.qml
+++ b/pages/vebusdevice/OverviewVeBusDevicePage.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Units
 
 Page {
 	id: root

--- a/pages/vebusdevice/OverviewVeBusDevicePage.qml
+++ b/pages/vebusdevice/OverviewVeBusDevicePage.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/vebusdevice/PageAcSensors.qml
+++ b/pages/vebusdevice/PageAcSensors.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Units
 
 Page {
 	id: root

--- a/pages/vebusdevice/PageVeBus.qml
+++ b/pages/vebusdevice/PageVeBus.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Units
 
 Page {
 	id: root

--- a/pages/vebusdevice/PageVeBus.qml
+++ b/pages/vebusdevice/PageVeBus.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/vebusdevice/PageVeBusAdvanced.qml
+++ b/pages/vebusdevice/PageVeBusAdvanced.qml
@@ -7,7 +7,6 @@ import QtQuick
 import QtQml
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Units
 
 Page {
 	id: root

--- a/pages/vebusdevice/PageVeBusAdvanced.qml
+++ b/pages/vebusdevice/PageVeBusAdvanced.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import QtQml
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/vebusdevice/PageVeBusAlarmSettings.qml
+++ b/pages/vebusdevice/PageVeBusAlarmSettings.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Units
 
 Page {
 	id: root

--- a/pages/vebusdevice/PageVeBusAlarms.qml
+++ b/pages/vebusdevice/PageVeBusAlarms.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/vebusdevice/PageVeBusBms.qml
+++ b/pages/vebusdevice/PageVeBusBms.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Units
 
 Page {
 	id: root

--- a/pages/vebusdevice/PageVeBusDebug.qml
+++ b/pages/vebusdevice/PageVeBusDebug.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Units
 
 Page {
 	id: root

--- a/pages/vebusdevice/PageVeBusDebug.qml
+++ b/pages/vebusdevice/PageVeBusDebug.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/vebusdevice/PageVeBusDeviceInfo.qml
+++ b/pages/vebusdevice/PageVeBusDeviceInfo.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import QtQuick.Controls.impl as CP
-import Victron.Utils
 
 PageDeviceInfo {
 	id: root

--- a/pages/vebusdevice/PageVeBusError11Device.qml
+++ b/pages/vebusdevice/PageVeBusError11Device.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/vebusdevice/PageVeBusError11Menu.qml
+++ b/pages/vebusdevice/PageVeBusError11Menu.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 ListNavigationItem {
 	id: root

--- a/pages/vebusdevice/PageVeBusError11View.qml
+++ b/pages/vebusdevice/PageVeBusError11View.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Page {
 	id: root

--- a/pages/vebusdevice/PageVeBusKwhCounters.qml
+++ b/pages/vebusdevice/PageVeBusKwhCounters.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Units
 
 Page {
 	id: root

--- a/pages/vebusdevice/PageVeBusSerialNumbers.qml
+++ b/pages/vebusdevice/PageVeBusSerialNumbers.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import Victron.Veutil
 import Victron.VenusOS
 import QtQuick.Controls.impl as CP
 

--- a/pages/vebusdevice/PageVeBusSerialNumbers.qml
+++ b/pages/vebusdevice/PageVeBusSerialNumbers.qml
@@ -7,7 +7,6 @@ import QtQuick
 import Victron.Veutil
 import Victron.VenusOS
 import QtQuick.Controls.impl as CP
-import Victron.Utils
 
 Page {
 	id: root

--- a/pages/vebusdevice/ThreePhaseIOTable.qml
+++ b/pages/vebusdevice/ThreePhaseIOTable.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 Row {
 	id: root

--- a/pages/vebusdevice/ThreePhaseIOTable.qml
+++ b/pages/vebusdevice/ThreePhaseIOTable.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import Victron.Veutil
-import Victron.Units
 
 Row {
 	id: root

--- a/pages/vebusdevice/VeBusDeviceActiveAcInputTextItem.qml
+++ b/pages/vebusdevice/VeBusDeviceActiveAcInputTextItem.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 ListTextItem {
 	property var veBusDevice

--- a/pages/vebusdevice/VeBusDeviceAlarmGroup.qml
+++ b/pages/vebusdevice/VeBusDeviceAlarmGroup.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 import QtQml
 
 Item {

--- a/pages/vebusdevice/VeBusDeviceModeButton.qml
+++ b/pages/vebusdevice/VeBusDeviceModeButton.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import Victron.Veutil
 
 /*
 	'VeBusDeviceModeButton' allow the user to plug in any style of button via 'sourceComponent', and handles raising all of the toast notifications

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -213,19 +213,6 @@ void initBackend(bool *enableFpsCounter)
 	}
 }
 
-void registerQmlTypes()
-{
-	// These types do not use dbus, so are safe to import even in the Qt Wasm build.
-	qmlRegisterType<VeQuickItem>("Victron.Veutil", 1, 0, "VeQuickItem");
-	qmlRegisterType<VeQItem>("Victron.Veutil", 1, 0, "VeQItem");
-	qmlRegisterType<VeQItemChildModel>("Victron.Veutil", 1, 0, "VeQItemChildModel");
-	qmlRegisterType<VeQItemSortDelegate>("Victron.Veutil", 1, 0, "VeQItemSortDelegate");
-	qmlRegisterType<VeQItemSortTableModel>("Victron.Veutil", 1, 0, "VeQItemSortTableModel");
-	qmlRegisterType<VeQItemTableModel>("Victron.Veutil", 1, 0, "VeQItemTableModel");
-
-	qmlRegisterUncreatableType<FirmwareUpdaterData>("Victron.Veutil", 1, 0, "FirmwareUpdater", "FirmwareUpdater cannot be created");
-}
-
 } // namespace
 
 
@@ -239,8 +226,6 @@ int main(int argc, char *argv[])
 	// The native vkb gets used instead, so a keyboard is still available when required.
 	qputenv("QT_IM_MODULE", QByteArray("qtvirtualkeyboard"));
 #endif
-
-	registerQmlTypes();
 
 	QGuiApplication app(argc, argv);
 	QGuiApplication::setApplicationName("Venus");


### PR DESCRIPTION
Reduce the number of qml modules to a minimum. Fix qml bugs found while investigating the qml type compiler.

I couldn't get rid of the Gauges module, as it imports Victron.VenusOS, and causes a circular dependency.
I couldn't include the changes I did for moving from QtQuick.Controls to Templates, as they caused build issues in some configurations. If NO_CACHEGEN was set to false(the default), then qmlcachegen would hang during the build. Killing the build did not kill qmlcachegen, I had to kill it via task manager.
