### PR TITLE
Show temperature inputs regardless of status

### DIFF
--- a/data/common/EnvironmentInput.qml
+++ b/data/common/EnvironmentInput.qml
@@ -24,7 +24,6 @@ Device {
 		uid: serviceUid + "/Status"
 	}
 
-	valid: deviceInstance >= 0 && _status.value === VenusOS.EnvironmentInput_Status_Ok
 	onValidChanged: {
 		if (valid) {
 			Global.environmentInputs.addInput(input)


### PR DESCRIPTION
As long as the input is present, it should be shown.