### PR TITLE
Temporary fix: add a fudge factor for `100`%/degrees fixed width

### DIFF
--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -61,7 +61,7 @@ const FontInfo& Theme::fontInfo(const QFont &font) const
 	newFi.advanceWidth = metrics.boundingRect(QStringLiteral("44")).width() - (2*newFi.numberWidth);
 	newFi.dotDeltaWidth = newFi.numberWidth - metrics.boundingRect(QChar('.')).width();
 	newFi.minusDeltaWidth = newFi.numberWidth - metrics.boundingRect(QChar('-')).width();
-	newFi.oneHundredWidth = metrics.boundingRect(QStringLiteral("100")).width();
+	newFi.oneHundredWidth = metrics.boundingRect(QStringLiteral("100")).width() + 6; // fudge factor...
 	m_fontInfo.append(newFi);
 	return m_fontInfo[m_fontInfo.count() - 1];
 }


### PR DESCRIPTION
QFontMetricsF is returning smaller width for string "100" with the font (and font size) used in our UI than is necessary to lay out the string without eliding (presumably because the actual text is laid out with an advance or similar spacing by default).

We are going to fix this properly in future with monospaced digit glyphs (see issue #588) but for now fix this issue (#636) via a workaround.