### PR TITLE
Fix naming of 'DC system' devices in Device List

### DIFF
--- a/data/DcInputs.qml
+++ b/data/DcInputs.qml
@@ -70,6 +70,8 @@ QtObject {
 		case "dcsource":
 			// use the monitor mode to determine a sub-type
 			break
+		case "dcsystem":
+			return VenusOS.DcInputs_InputType_DcSystem
 		default:
 			break
 		}
@@ -114,6 +116,9 @@ QtObject {
 		case VenusOS.DcInputs_InputType_DcGenerator:
 			//% "DC generator"
 			return qsTrId("dcInputs_dc_generator")
+		case VenusOS.DcInputs_InputType_DcSystem:
+			//% "DC system"
+			return qsTrId("dcInputs_dc_system")
 		case VenusOS.DcInputs_InputType_FuelCell:
 			//% "Fuel cell"
 			return qsTrId("dcInputs_fuelcell")

--- a/src/enums.h
+++ b/src/enums.h
@@ -152,6 +152,7 @@ public:
 		DcInputs_InputType_Alternator,
 		DcInputs_InputType_DcCharger,
 		DcInputs_InputType_DcGenerator,
+		DcInputs_InputType_DcSystem,
 		DcInputs_InputType_FuelCell,
 		DcInputs_InputType_ShaftGenerator,
 		DcInputs_InputType_WaterGenerator,


### PR DESCRIPTION
In the Device List subpages, 'dcsystem' services should always appear as 'DC system', and should not appear as 'DC Generator'.