### PR TITLE
Disable wasm SolarDailyHistoryDialog opacity animations

### DIFF
--- a/components/dialogs/SolarDailyHistoryDialog.qml
+++ b/components/dialogs/SolarDailyHistoryDialog.qml
@@ -62,7 +62,9 @@ T.Dialog {
 		}
 	}
 	exit: Transition {
-		NumberAnimation { property: "opacity"; from: 1.0; to: 0.0; duration: Theme.animation_page_fade_duration }
+		NumberAnimation {
+			loops: Qt.platform.os == "wasm" ? 0 : 1 // workaround wasm crash, see https://bugreports.qt.io/browse/QTBUG-121382
+			property: "opacity"; from: 1.0; to: 0.0; duration: Theme.animation_page_fade_duration }
 	}
 
 	background: Rectangle {


### PR DESCRIPTION
Workaround wasm crash, see https://bugreports.qt.io/browse/QTBUG-121382.