### PR TITLE
Ensure preloaded pages are not visible by default

### DIFF
--- a/pages/MainView.qml
+++ b/pages/MainView.qml
@@ -278,6 +278,7 @@ Item {
 		Loader {
 			y: root.height + 4 // avoid fractional scaling smearing a row of pixels into visible area
 			asynchronous: true
+			visible: false
 			source: url
 
 			onStatusChanged: {


### PR DESCRIPTION
We preload the main (NavBar-activated) pages to avoid stutters at runtime when navigating.  This commit ensures that these pages are all marked as visible=false to avoid rendering them offscreen.