### PR TITLE
Avoid uid errors on startup in mock mode

### DIFF
--- a/data/mock/EnvironmentInputsImpl.qml
+++ b/data/mock/EnvironmentInputsImpl.qml
@@ -36,6 +36,9 @@ Item {
 
 	property Component inputComponent: Component {
 		EnvironmentInput {
+			// Set a non-empty uid to avoid bindings to empty serviceUid before Component.onCompleted is called
+			serviceUid: "mock/com.victronenergy.dummy"
+
 			onTemperatureTypeChanged: {
 				if (temperatureType >= 0 && !_customName.value) {
 					_customName.setValue(Global.environmentInputs.temperatureTypeToText(temperatureType) + " temperature sensor")

--- a/data/mock/TanksImpl.qml
+++ b/data/mock/TanksImpl.qml
@@ -52,6 +52,9 @@ QtObject {
 		Tank {
 			id: tank
 
+			// Set a non-empty uid to avoid bindings to empty serviceUid before Component.onCompleted is called
+			serviceUid: "mock/com.victronenergy.dummy"
+
 			onTypeChanged: {
 				if (type >= 0) {
 					_customName.setValue(Gauges.tankProperties(type).name)


### PR DESCRIPTION
Ensure serviceUid is initially valid in Tank and EnvironmentInput mock types, as VeQuickItem bindings in Tank.qml and EnvironmentInput.qml will be evaluated before the mock objects updates their serviceUid values in Component.onCompleted.