### PR TITLE
Read solar charger tracker name from /Pv/<index>/Name

### DIFF
--- a/components/SolarHistoryTableView.qml
+++ b/components/SolarHistoryTableView.qml
@@ -113,7 +113,7 @@ Column {
 		]
 		valueForModelIndex: function(trackerIndex, column) {
 			if (column === 0) {
-				return Global.solarChargers.trackerName(trackerIndex)
+				return root.solarHistory.trackerName(trackerIndex)
 			} else if (column === 1) {
 				return root._trackerHistoryTotal("yieldKwh", trackerIndex)
 			} else if (column === 2) {

--- a/data/SolarChargers.qml
+++ b/data/SolarChargers.qml
@@ -26,10 +26,13 @@ QtObject {
 		model.clear()
 	}
 
-	function trackerName(trackerIndex) {
-		//: %1 = tracker number
-		//% "Tracker #%1"
-		return qsTrId("solarchargers_tracker_name").arg(trackerIndex + 1)
+	function defaultTrackerName(trackerIndex, totalTrackerCount, deviceName) {
+		if (totalTrackerCount === 1) {
+			return deviceName
+		}
+		//: Name for a tracker of a solar charger. %1 = solar charger name, %2 = the number of this tracker for the charger
+		//% "%1 (#%2)"
+		return qsTrId("solarcharger_tracker_name").arg(deviceName).arg(trackerIndex + 1)
 	}
 
 	function chargerStateToText(state) {

--- a/data/common/SolarCharger.qml
+++ b/data/common/SolarCharger.qml
@@ -32,6 +32,11 @@ Device {
 		return _history.dailyHistory(day, trackerIndex)
 	}
 
+	function trackerName(trackerIndex) {
+		const tracker = _trackerObjects.objectAt(trackerIndex)
+		return tracker ? tracker.name || "" : ""
+	}
+
 	//--- internal members below ---
 
 	readonly property VeQuickItem _state: VeQuickItem {
@@ -87,6 +92,8 @@ Device {
 			readonly property real voltage: _voltage.value || 0
 			readonly property real current: isNaN(power) || isNaN(voltage) || voltage === 0 ? NaN : power / voltage
 
+			readonly property string name: _name.value || Global.solarChargers.defaultTrackerName(model.index, _trackerObjects.count, solarCharger.name)
+
 			readonly property VeQuickItem _voltage: VeQuickItem {
 				uid: solarCharger.trackers.count <= 1
 					 ? solarCharger.serviceUid + "/Pv/V"
@@ -97,6 +104,10 @@ Device {
 				uid: solarCharger.trackers.count === 1
 					 ? ""   // only 1 tracker, use solarCharger.power instead (i.e. same as /Yield/Power)
 					 : solarCharger.serviceUid + "/Pv/" + model.index + "/P"
+			}
+
+			readonly property VeQuickItem _name: VeQuickItem {
+				uid: solarCharger.serviceUid + "/Pv/" + model.index + "/Name"
 			}
 		}
 

--- a/data/common/SolarHistory.qml
+++ b/data/common/SolarHistory.qml
@@ -23,6 +23,19 @@ QtObject {
 		return _historyObjects.dailyHistory(day, trackerIndex)
 	}
 
+	function trackerName(trackerIndex) {
+		const nameObject = _trackerNames.objectAt(trackerIndex)
+		const name = nameObject ? nameObject.value || "" : ""
+		return name ? name : Global.solarChargers.defaultTrackerName(trackerIndex, trackerCount, deviceName)
+	}
+
+	readonly property Instantiator _trackerNames: Instantiator {
+		model: root.trackerCount
+		delegate: VeQuickItem {
+			uid: root.bindPrefix + "/Pv/" + model.index + "/Name"
+		}
+	}
+
 	readonly property Instantiator _historyObjects: Instantiator {
 		function dailyHistory(day, trackerIndex) {
 			let overallDailyHistory = objectAt(day)

--- a/data/mock/SolarChargersImpl.qml
+++ b/data/mock/SolarChargersImpl.qml
@@ -62,11 +62,21 @@ QtObject {
 
 			function initTrackers(trackerCount) {
 				Global.mockDataSimulator.setMockValue(serviceUid + "/NrOfTrackers", trackerCount)
+				let trackerIndex = 0
+
+				// Sometimes trackers have names. If available, they should show up in the UI.
+				if (trackerCount > 1 && Math.random() < 0.5) {
+					const charCode = 'A'.charCodeAt(0)
+					for (trackerIndex = 0; trackerIndex < trackerCount; ++trackerIndex) {
+						const nextTrackerName = "Charger %1 - Tracker %2".arg(root.mockDeviceCount).arg(String.fromCharCode(charCode + trackerIndex))
+						Global.mockDataSimulator.setMockValue(serviceUid + "/Pv/" + trackerIndex + "/Name", nextTrackerName)
+					}
+				}
+
 				randomizeMeasurments()
 
 				// Initialize history values
 				Global.mockDataSimulator.setMockValue(serviceUid + "/History/Overall/DaysAvailable", 30)
-				let trackerIndex = 0
 				for (let day = 0; day < 31; ++day) {
 					let dayTotals = []
 					const dayOverallHistoryUid = serviceUid + "/History/Daily/" + day

--- a/pages/settings/devicelist/inverter/PageInverter.qml
+++ b/pages/settings/devicelist/inverter/PageInverter.qml
@@ -212,11 +212,13 @@ Page {
 					id: solarHistoryComponent
 
 					SolarHistory {
+						id: solarHistory
+
 						bindPrefix: root.bindPrefix
 						deviceName: solarDevice.name
 						trackerCount: numberOfTrackers.value || 0
 
-						readonly property var solarDevice: Device {
+						readonly property Device solarDevice: Device {
 							serviceUid: root.bindPrefix
 						}
 					}

--- a/pages/solar/SolarChargerPage.qml
+++ b/pages/solar/SolarChargerPage.qml
@@ -74,7 +74,7 @@ Page {
 					valueForModelIndex: function(trackerIndex, column) {
 						const tracker = root.solarCharger.trackers.get(trackerIndex).solarTracker
 						if (column === 0) {
-							return Global.solarChargers.trackerName(trackerIndex)
+							return tracker.name
 						} else if (column === 1) {
 							// Today's yield for this tracker
 							const history = root.solarCharger.dailyHistory(0, trackerIndex)

--- a/pages/solar/SolarDeviceListPage.qml
+++ b/pages/solar/SolarDeviceListPage.qml
@@ -59,11 +59,7 @@ Page {
 						delegate: SolarDeviceNavigationItem {
 							readonly property SolarDailyHistory historyToday: solarCharger.dailyHistory(0, model.index)
 
-							text: solarCharger.trackers.count > 1
-									//: Name for a tracker of a solar charger. %1 = solar charger name, %2 = the number of this tracker for the charger
-									//% "%1 (#%2)"
-								  ? qsTrId("solardevices_tracker_name").arg(solarCharger.name).arg(model.index + 1)
-								  : solarCharger.name
+							text: solarCharger.trackerName(model.index)
 							energy: historyToday ? historyToday.yieldKwh : NaN
 							current: modelData.current
 							power: modelData.power


### PR DESCRIPTION
When showing tracker data in the solar history views, show the name of the tracker, instead of just defaulting to "<charger name> (#1)" for the first tracker, etc.

This only works for com.victronenergy.solarcharger.* services. This data is not available for com.victronenergy.inverter.* services, so when viewing history data for PV inverters from the Device List, the default naming scheme will continue to be used.