### PR TITLE
Allow text values in ListQuantityGroup repeater. #614

### DIFF
--- a/components/QuantityRepeater.qml
+++ b/components/QuantityRepeater.qml
@@ -11,25 +11,44 @@ Repeater {
 
 	property int minimumDelegateWidth
 
-	delegate: QuantityLabel {
-		anchors.verticalCenter: !!parent ? parent.verticalCenter : undefined
-		width: Math.max(implicitWidth, minimumDelegateWidth)
-		font.pixelSize: Theme.font_size_body2
-		value: isNaN(modelData.value) ? NaN : modelData.value
-		unit: isNaN(modelData.unit) ? VenusOS.Units_None : modelData.unit
-		precision: isNaN(modelData.precision) ? Units.defaultUnitPrecision(unit) : modelData.precision
-		valueColor: Theme.color_quantityTable_quantityValue
-		unitColor: Theme.color_quantityTable_quantityUnit
+	delegate: Row {
+		QuantityLabel {
+			anchors.verticalCenter: !!parent ? parent.verticalCenter : undefined
+			visible: !textLabel.visible
+			width: Math.max(implicitWidth, minimumDelegateWidth)
+			alignment: Qt.AlignHCenter
+			font.pixelSize: Theme.font_size_body2
+			value: isNaN(modelData.value) ? NaN : modelData.value
+			unit: modelData.unit === undefined ? VenusOS.Units_None : modelData.unit
+			precision: isNaN(modelData.precision) ? Units.defaultUnitPrecision(unit) : modelData.precision
+			valueColor: Theme.color_quantityTable_quantityValue
+			unitColor: Theme.color_quantityTable_quantityUnit
+		}
 
-		Rectangle {
-			anchors {
-				right: parent.right
-				rightMargin: -Theme.geometry_listItem_content_spacing / 2
-			}
-			width: Theme.geometry_listItem_separator_width
+		// Show a plain label instead of a QuantityLabel if modelData.value is a string instead of
+		// a number.
+		Label {
+			id: textLabel
+			anchors.verticalCenter: !!parent ? parent.verticalCenter : undefined
+			visible: typeof(modelData.value) === 'string'
+			text: visible ? modelData.value : ""
+			width: Math.max(implicitWidth, minimumDelegateWidth)
+			horizontalAlignment: Qt.AlignHCenter
+			font.pixelSize: Theme.font_size_body2
+			color: Theme.color_quantityTable_quantityValue
+		}
+
+		Item {
+			width: Theme.geometry_listItem_separator_width + (Theme.geometry_listItem_content_spacing * 2)
 			height: parent.implicitHeight
-			color: Theme.color_listItem_separator
 			visible: model.index !== root.count - 1
+
+			Rectangle {
+				anchors.horizontalCenter: parent.horizontalCenter
+				width: Theme.geometry_listItem_separator_width
+				height: parent.height
+				color: Theme.color_listItem_separator
+			}
 		}
 	}
 }

--- a/components/listitems/ListQuantityGroup.qml
+++ b/components/listitems/ListQuantityGroup.qml
@@ -12,7 +12,7 @@ ListItem {
 	property alias textModel: repeater.model
 	property alias minimumDelegateWidth: repeater.minimumDelegateWidth
 
-	content.spacing: Theme.geometry_listItem_content_spacing * 2
+	content.spacing: 0
 	content.children: [
 		QuantityRepeater {
 			id: repeater


### PR DESCRIPTION
If an entry in the ListQuantityGroup model has a 'value' that is text rather than a number, show the text in a Label.

This fixes a bug in PageBatteryDetails.qml where text values like MinVoltageCellId are not displayed.