### PR TITLE
Remove "Running version" selection in settings

### DIFF
--- a/pages/settings/PageSettingsDisplay.qml
+++ b/pages/settings/PageSettingsDisplay.qml
@@ -127,24 +127,6 @@ Page {
 					Global.pageManager.pushPage("/pages/settings/PageSettingsDisplayUnits.qml", {"title": text})
 				}
 			}
-
-			ListRadioButtonGroup {
-				text: "Onscreen UI (GX Touch & Ekrano)"
-				dataItem.uid: Global.systemSettings.serviceUid + "/Settings/Gui/RunningVersion"
-				writeAccessLevel: VenusOS.User_AccessType_User
-
-				onOptionClicked: function(index) {
-					if (index === 0) {
-						Global.venusPlatform.reboot()
-						Global.dialogLayer.showRebootDialog()
-					}
-				}
-
-				optionModel: [
-					{ display: "Standard version", value: 1 },
-					{ display: "Gui-v2 (beta) version", value: 2 },
-				]
-			}
 		}
 	}
 }


### PR DESCRIPTION
This removal is temporary. The setting will be restored when some venus-platform changes are made to allow the system changes to take effect when the running version is changed.