### PR TITLE
Show app version in debug settings

### DIFF
--- a/pages/settings/debug/PageDebug.qml
+++ b/pages/settings/debug/PageDebug.qml
@@ -11,7 +11,6 @@ Page {
 
 	GradientListView {
 		model: ObjectModel {
-
 			ListItem {
 				id: frameRateSwitch
 				//% "Enable frame-rate visualizer"
@@ -79,6 +78,12 @@ Page {
 				text: "Qt memory"
 				// TODO implement when venus-platform provides equivalent of QuickView.imageCacheSize()
 				// onClicked: Global.pageManager.pushPage("/pages/settings/debug/PageDebugMemoryQt.qml", { title: text })
+			}
+
+			ListTextItem {
+				//% "Application version"
+				text: qsTrId("settings_page_debug_application_version")
+				secondaryText: Theme.applicationVersion
 			}
 		}
 	}

--- a/src/theme.h
+++ b/src/theme.h
@@ -34,6 +34,7 @@ class Theme : public QObject
 	QML_NAMED_ELEMENT(ThemeBase)
 	Q_PROPERTY(ScreenSize screenSize READ screenSize WRITE setScreenSize NOTIFY screenSizeChanged)
 	Q_PROPERTY(ColorScheme colorScheme READ colorScheme WRITE setColorScheme NOTIFY colorSchemeChanged)
+	Q_PROPERTY(QString applicationVersion READ applicationVersion CONSTANT)
 
 public:
 	enum ScreenSize {
@@ -93,6 +94,10 @@ public:
 	Q_INVOKABLE qreal charactersOneHundredWidth(const QFont &font) const;
 
 	Q_INVOKABLE bool objectHasQObjectParent(QObject *obj) const { return obj && obj->parent(); }
+
+	QString applicationVersion() const {
+		return QStringLiteral("v%1.%2.%3").arg(PROJECT_VERSION_MAJOR).arg(PROJECT_VERSION_MINOR).arg(PROJECT_VERSION_PATCH);
+	};
 
 Q_SIGNALS:
 	void screenSizeChanged(Victron::VenusOS::Theme::ScreenSize screenSize);


### PR DESCRIPTION
We should find a better home for the applicationVersion property, but this is probably okay for now.

Fixes issue #706