### PR TITLE
Provide command-line parameter to skip the splash screen

### DIFF
--- a/Main.qml
+++ b/Main.qml
@@ -18,6 +18,11 @@ Window {
 	width: Qt.platform.os != "wasm" ? Theme.geometry_screen_width : Screen.width
 	height: Qt.platform.os != "wasm" ? Theme.geometry_screen_height : Screen.height
 
+	function skipSplashScreen() {
+		Global.allPagesLoaded = true
+		Global.splashScreenVisible = false
+	}
+
 	function retranslateUi() {
 		console.warn("Retranslating UI")
 		// If we have to retranslate at startup prior to instantiating mainView

--- a/pages/MainView.qml
+++ b/pages/MainView.qml
@@ -178,17 +178,27 @@ Item {
 		SequentialAnimation {
 			running: !Global.splashScreenVisible
 
+			// Force the final animation values in case the Animators are
+			// not run (skipping the splash screen causes the animations to
+			// start before the parent is visible).
+			onStopped: {
+				navBar.y = yAnimator.to
+				navBar.opacity = opacityAnimator.to
+			}
+
 			PauseAnimation {
 				duration: Theme.animation_navBar_initialize_delayedStart_duration
 			}
 			ParallelAnimation {
 				YAnimator {
+					id: yAnimator
 					target: navBar
 					from: root.height - navBar.height + Theme.geometry_navigationBar_initialize_margin
 					to: root.height - navBar.height
 					duration: Theme.animation_navBar_initialize_fade_duration
 				}
 				OpacityAnimator {
+					id: opacityAnimator
 					target: navBar
 					from: 0.0
 					to: 1.0

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,7 +62,7 @@ QString calculateMqttAddressFromPortalId(const QString &portalId)
 	return calculateMqttAddressFromShard(shardStr);
 }
 
-void initBackend(bool *enableFpsCounter)
+void initBackend(bool *enableFpsCounter, bool *skipSplashScreen)
 {
 	Victron::VenusOS::BackendConnection *backend = Victron::VenusOS::BackendConnection::create();
 
@@ -145,6 +145,10 @@ void initBackend(bool *enableFpsCounter)
 		QGuiApplication::tr("Enable FPS counter"));
 	parser.addOption(fpsCounter);
 
+	QCommandLineOption skipSplash("skip-splash",
+		QGuiApplication::tr("Skip splash screen"));
+	parser.addOption(skipSplash);
+
 	QCommandLineOption mockMode({ "k", "mock" },
 		QGuiApplication::tr("Use mock data source for testing."));
 	parser.addOption(mockMode);
@@ -212,6 +216,9 @@ void initBackend(bool *enableFpsCounter)
 	if (parser.isSet(fpsCounter) || queryFpsCounter.contains(QStringLiteral("enable"))) {
 		*enableFpsCounter = true;
 	}
+	if (parser.isSet(skipSplash)) {
+		*skipSplashScreen = true;
+	}
 }
 
 } // namespace
@@ -233,9 +240,10 @@ int main(int argc, char *argv[])
 	QGuiApplication::setApplicationVersion("2.0");
 
 	bool enableFpsCounter = false;
+	bool skipSplashScreen = false;
 
 	QQmlEngine engine;
-	initBackend(&enableFpsCounter);
+	initBackend(&enableFpsCounter, &skipSplashScreen);
 	engine.addImageProvider(QStringLiteral("digits"), new Victron::VenusOS::DigitImageProvider);
 	QObject::connect(&engine, &QQmlEngine::quit, &app, &QGuiApplication::quit);
 
@@ -272,6 +280,10 @@ int main(int argc, char *argv[])
 	/* Write to window properties here to perform any additional initialization
 	   before initial binding evaluation. */
 	component.completeCreate();
+
+	if (skipSplashScreen) {
+		QMetaObject::invokeMethod(window, "skipSplashScreen");
+	}
 
 #if defined(VENUS_DESKTOP_BUILD)
 	const bool desktop(true);


### PR DESCRIPTION
- Also fixes the nav bar not showing when skipping splash screen
- Skipping the splash screen reduces the launch time on desktop from 9 to 2 seconds