### PR TITLE
Invert easing for control panel open vs. close transition

### DIFF
--- a/pages/MainView.qml
+++ b/pages/MainView.qml
@@ -129,28 +129,28 @@ Item {
 					from: statusBar.height - Theme.geometry_controlCards_slide_distance
 					to: statusBar.height
 					duration: Theme.animation_controlCards_slide_duration
-					easing.type: Easing.InSine
+					easing.type: Easing.OutSine
 				}
 				OpacityAnimator {
 					target: controlCardsLoader
 					from: 0.0
 					to: 1.0
 					duration: Theme.animation_controlCards_slide_duration
-					easing.type: Easing.InSine
+					easing.type: Easing.OutSine
 				}
 				OpacityAnimator {
 					target: pageStack
 					from: 1.0
 					to: 0.0
 					duration: Theme.animation_controlCards_slide_duration
-					easing.type: Easing.InSine
+					easing.type: Easing.OutSine
 				}
 				OpacityAnimator {
 					target: navBar
 					from: 1.0
 					to: 0.0
 					duration: Theme.animation_controlCards_slide_duration
-					easing.type: Easing.InSine
+					easing.type: Easing.OutSine
 				}
 			}
 		}


### PR DESCRIPTION
Discussed easings with Serj, discussed that in and out transitions need inverted easings:
- The opening transition comes at full speed and gradually slows down (OutSine)
![image](https://github.com/victronenergy/gui-v2/assets/2203667/3ada0931-be31-4580-aaca-639c5e431d2b)
- The closing transition gradually accelerates and fades out while moving out full speed (InSine):
![image](https://github.com/victronenergy/gui-v2/assets/2203667/03627966-c930-424c-985c-7a9cfd9173d1)