### PR TITLE
Fix values and spelling in SolarCharger_State

### DIFF
--- a/data/SolarChargers.qml
+++ b/data/SolarChargers.qml
@@ -43,7 +43,7 @@ QtObject {
 		case VenusOS.SolarCharger_State_Fault:
 			//% "Fault"
 			return qsTrId("solarchargers_state_fault")
-		case VenusOS.SolarCharger_State_Buik:
+		case VenusOS.SolarCharger_State_Bulk:
 			//% "Bulk"
 			return qsTrId("solarchargers_state_bulk")
 		case VenusOS.SolarCharger_State_Absorption:

--- a/src/enums.h
+++ b/src/enums.h
@@ -495,8 +495,8 @@ public:
 
 	enum SolarCharger_State {
 		SolarCharger_State_Off,
-		SolarCharger_State_Fault,
-		SolarCharger_State_Buik,
+		SolarCharger_State_Fault = 2,
+		SolarCharger_State_Bulk,
 		SolarCharger_State_Absorption,
 		SolarCharger_State_Float,
 		SolarCharger_State_Storage,


### PR DESCRIPTION
The fault state is 2, not 1. This was pushing all the other states off by one.

Also fix the spelling for the bulk state.