### PR TITLE
Patch Makefile for GX installation

### DIFF
--- a/.github/patches/Makefile
+++ b/.github/patches/Makefile
@@ -6,7 +6,7 @@ ifeq ($(EXTRAFONTS),)
 	EXTRAFONTS=/usr/lib/fonts/DroidSansFallback.ttf /usr/lib/fonts/NotoSansThai.ttf /usr/lib/fonts/DejaVuSans.ttf
 endif
 
-FILES=index.html qtloader.js qtloader-controller.js venus-gui-v2.js \
+FILES=index.html qtloader.js venus-gui-v2.js \
 	  venus-gui-v2.wasm.sha256 venus-gui-v2.wasm.gz victronenergy.svg
 
 all: venus-gui-v2.wasm.sha256 venus-gui-v2.wasm.gz
@@ -14,13 +14,13 @@ all: venus-gui-v2.wasm.sha256 venus-gui-v2.wasm.gz
 venus-gui-v2.wasm.sha256:
 	sha256sum venus-gui-v2.wasm > venus-gui-v2.wasm.sha256
 
-venus-gui-v2.wasm.gz: venus-gui-v2.wasm.sha256
+venus-gui-v2.wasm.gz:
 	gzip -k -9 venus-gui-v2.wasm
 
 .PHONY: clean
 
 clean:
-	rm venus-gui-v2.wasm.sha256 venus-gui-v2.wasm.gz
+	rm -f venus-gui-v2.wasm.sha256 venus-gui-v2.wasm.gz
 
 install: all
 	install -d $(DESTDIR)$(PREFIX)/


### PR DESCRIPTION
- Fix dependency in the Makefile
- Also force rm so make clean can run multiple times in a row without complaining about non-existing files.
- remove no longer existent qtloader-controller.js from FILES