### PR TITLE
Re-enable animation between battery and inverter/charger

### DIFF
--- a/data/System.qml
+++ b/data/System.qml
@@ -51,7 +51,7 @@ QtObject {
 
 		readonly property VeQuickItem _serviceName: VeQuickItem { uid: root.serviceUid + "/VebusService" }
 		readonly property VeQuickItem _deviceInstance: VeQuickItem { uid: root.serviceUid + "/VebusInstance" }
-		readonly property VeQuickItem _power: VeQuickItem { uid: serviceUid ? serviceUid + "/Dc/0/Power" : "" }
+		readonly property VeQuickItem _power: VeQuickItem { uid: veBus.serviceUid ? veBus.serviceUid + "/Dc/0/Power" : "" }
 	}
 
 	function reset() {


### PR DESCRIPTION
Fixes #567.

Not sure if this is a correct fix, but after the change System.qml and SystemImpl.qml uid paths start to match and the animation starts flowing on both the Ekrano (demo mode) and mocked desktop, 