### PR TITLE
Fix Windows builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1079,7 +1079,6 @@ file(COPY
       "i18n/${PROJECT_NAME}_cs.ts"
       "i18n/${PROJECT_NAME}_da.ts"
       "i18n/${PROJECT_NAME}_de.ts"
-      "i18n/${PROJECT_NAME}_en.ts"
       "i18n/${PROJECT_NAME}_es.ts"
       "i18n/${PROJECT_NAME}_fr.ts"
       "i18n/${PROJECT_NAME}_it.ts"
@@ -1091,6 +1090,12 @@ file(COPY
       "i18n/${PROJECT_NAME}_th.ts"
       "i18n/${PROJECT_NAME}_tr.ts"
       "i18n/${PROJECT_NAME}_uk.ts"
+    DESTINATION "i18n") # build directory
+# use the base translation file as the _en.ts
+# don't use a symlink because that doesn't work on Windows.
+file(RENAME "${CMAKE_CURRENT_BINARY_DIR}/i18n/${PROJECT_NAME}.ts"
+            "${CMAKE_CURRENT_BINARY_DIR}/i18n/${PROJECT_NAME}_en.ts")
+file(COPY "i18n/${PROJECT_NAME}.ts"
     DESTINATION "i18n") # build directory
 
 # This adds 2 new targets, venus-gui-v2_lupdate and venus-gui-v2_lrelease. Parallel builds (eg. 'make -j') do not rebuild venus-gui-v2_lrelease correctly without further 'add_dependencies' hackery

--- a/data/SystemSettings.qml
+++ b/data/SystemSettings.qml
@@ -198,8 +198,13 @@ QtObject {
 			if (value !== undefined && !Global.changingLanguage
 					&& value != Language.toCode(Language.current)) {
 				Global.changingLanguage = true
-				Language.setCurrentLanguageCode(value)
-				Qt.callLater(Global.main.retranslateUi)
+				if (!Language.setCurrentLanguageCode(value)) {
+					// failed.  set the settings value back to the previous one.
+					setValue(Language.toCode(Language.current))
+					Qt.callLater(function() { Global.changingLanguage = false })
+				} else {
+					Qt.callLater(Global.main.retranslateUi)
+				}
 			}
 		}
 	}

--- a/data/mock/config/MockDataSimulator.qml
+++ b/data/mock/config/MockDataSimulator.qml
@@ -157,7 +157,7 @@ QtObject {
 			event.accepted = true
 			break
 		case Qt.Key_L:
-			Language.current = (Language.current === Language.English ? Language.French : Language.English)
+			Language.setCurrentLanguage((Language.current === Language.English ? Language.French : Language.English))
 			pageConfigTitle.text = "Language: " + Language.toString(Language.current)
 			event.accepted = true
 			break

--- a/i18n/venus-gui-v2_en.ts
+++ b/i18n/venus-gui-v2_en.ts
@@ -1,1 +1,0 @@
-venus-gui-v2.ts

--- a/pages/settings/PageSettingsDisplay.qml
+++ b/pages/settings/PageSettingsDisplay.qml
@@ -131,11 +131,22 @@ Page {
 					id: changingLanguageDialog
 
 					ModalWarningDialog {
-						dialogDoneOptions: VenusOS.ModalDialog_DoneOptions_NoOptions
+						id: dlg
+						property bool languageChangeFailed
+						dialogDoneOptions: dlg.languageChangeFailed
+							? VenusOS.ModalDialog_DoneOptions_OkOnly
+							: VenusOS.ModalDialog_DoneOptions_NoOptions
 						//% "Changing language"
 						title: qsTrId("settings_language_changing_language")
-						//% "Please wait while the language is changed."
-						description: qsTrId("settings_language_please_wait")
+						description: dlg.languageChangeFailed
+							  //% "Failed to change language!"
+							? qsTrId("settings_language_change_failed")
+							  //% "Please wait while the language is changed."
+							: qsTrId("settings_language_please_wait")
+						Connections {
+							target: Language
+							function onLanguageChangeFailed() { dlg.languageChangeFailed = true }
+						}
 					}
 				}
 			}

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -266,11 +266,15 @@ QLocale::Language Language::fromCode(const QString &code)
 	return QLocale::codeToLanguage(code);
 }
 
-void Language::setCurrentLanguage(QLocale::Language language)
+bool Language::setCurrentLanguage(QLocale::Language language)
 {
 	if (language != m_currentLanguage && installTranslatorForLanguage(language)) {
 		emit currentLanguageChanged();
 		emit fontFileUrlChanged();
+		return true;
+	} else {
+		emit languageChangeFailed();
+		return false;
 	}
 }
 
@@ -279,13 +283,14 @@ QUrl Language::fontFileUrl() const
 	return m_fontFileUrl;
 }
 
-void Language::setCurrentLanguageCode(const QString &code)
+bool Language::setCurrentLanguageCode(const QString &code)
 {
 	const QLocale::Language lang = QLocale::codeToLanguage(code);
 	if (lang != QLocale::AnyLanguage) {
-		setCurrentLanguage(lang);
+		return setCurrentLanguage(lang);
 	} else {
 		qCWarning(venusGui) << "Unknown language code specified:" << code;
+		return false;
 	}
 }
 

--- a/src/language.h
+++ b/src/language.h
@@ -89,7 +89,7 @@ class Language : public QObject
 	Q_OBJECT
 	QML_ELEMENT
 	QML_SINGLETON
-	Q_PROPERTY(QLocale::Language current READ getCurrentLanguage WRITE setCurrentLanguage NOTIFY currentLanguageChanged FINAL)
+	Q_PROPERTY(QLocale::Language current READ getCurrentLanguage NOTIFY currentLanguageChanged FINAL)
 	Q_PROPERTY(QUrl fontFileUrl READ fontFileUrl NOTIFY fontFileUrlChanged FINAL)
 
 public:
@@ -103,15 +103,16 @@ public:
 
 	Q_INVOKABLE QString toString(QLocale::Language language) const;
 	Q_INVOKABLE QString toCode(QLocale::Language language) const;
-	Q_INVOKABLE void setCurrentLanguageCode(const QString &code);
+	Q_INVOKABLE bool setCurrentLanguageCode(const QString &code);
 	Q_INVOKABLE QLocale::Language fromCode(const QString &code);
 
 	QLocale::Language getCurrentLanguage() const;
-	void setCurrentLanguage(QLocale::Language language);
+	Q_INVOKABLE bool setCurrentLanguage(QLocale::Language language);
 
 	QUrl fontFileUrl() const;
 
 Q_SIGNALS:
+	void languageChangeFailed();
 	void currentLanguageChanged();
 	void fontFileUrlChanged();
 


### PR DESCRIPTION
Don't symlink venus-gui-v2.ts to venus-gui-v2_en.ts because that doesn't work properly on Windows.

Instead, copy venus-gui-v2.ts to builddir/i18n/venus-gui-v2_en.ts as well as to builddir/i18n/venus-gui-v2.ts.