### PR TITLE
Reload web browser page when firmware version change detected

### DIFF
--- a/Global.qml
+++ b/Global.qml
@@ -55,6 +55,9 @@ QtObject {
 	property bool allPagesLoaded
 	property bool changingLanguage
 
+	property string firmwareInstalledBuild // don't clear this on UI reload.  it needs to survive reconnection.
+	property bool firmwareInstalledBuildUpdated // as above.
+
 	signal aboutToFocusTextField(var textField, int toTextFieldY, var flickable)
 	signal keyPressed(var event)
 

--- a/pages/DialogLayer.qml
+++ b/pages/DialogLayer.qml
@@ -9,13 +9,34 @@ import Victron.VenusOS
 Item {
 	id: root
 
+	anchors.fill: parent
+
 	function open(dialogComponent, properties) {
-		const dialog = dialogComponent.createObject(Global.dialogLayer, properties)
+		const dialog = dialogComponent.createObject(root, properties)
 		dialog.closed.connect(function() {
 			dialog.destroy()
 		})
 		dialog.open()
 	}
 
-	anchors.fill: parent
+	// For WebAssembly, if the firmware changed on device, this might
+	// mean that the webassembly blob served by its webserver has changed.
+	// We need to trigger a page reload to ensure we are running the right one.
+	property Component _firmwareVersionRestartDialog: Component {
+		ModalWarningDialog {
+			dialogDoneOptions: VenusOS.ModalDialog_DoneOptions_NoOptions
+			//% "Firmware version update detected"
+			title: qsTrId("firmware_installed_build_version_update_detected")
+			//% "Page will automatically reload in ten seconds to load the latest version."
+			description: qsTrId("firmware_installed_build_page_will_reload")
+			Timer {
+				running: true
+				interval: 10*1000
+				onTriggered: Qt.quit() // the aboutToQuit handler will trigger page reload.
+			}
+		}
+	}
+
+	property bool _needPageReload: Qt.platform.os == "wasm" && Global.firmwareInstalledBuildUpdated
+	on_NeedPageReloadChanged: if (_needPageReload) open(_firmwareVersionRestartDialog)
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -232,6 +232,11 @@ int main(int argc, char *argv[])
 	QGuiApplication::setApplicationName("Venus");
 	QGuiApplication::setApplicationVersion("2.0");
 
+#if defined(VENUS_WEBASSEMBLY_BUILD)
+	QObject::connect(&app, &QGuiApplication::aboutToQuit,
+		&app, [] { emscripten_run_script("location.reload()"); }, Qt::QueuedConnection);
+#endif
+
 	bool enableFpsCounter = false;
 	bool skipSplashScreen = false;
 


### PR DESCRIPTION
If the device has its firmware updated, it may have a new build of the UI included.  To ensure that the version of the UI which is being used via the browser matches the version of the UI which is being used on device, we need to reload the page so that the up-to-date wasm binary is reloaded.