### PR TITLE
Polish text

### DIFF
--- a/components/CommonWords.qml
+++ b/components/CommonWords.qml
@@ -465,7 +465,7 @@ QtObject {
 	readonly property string yield_kwh: qsTrId("common_words_yield_kwh")
 
 	//: Solar charger yield for today, in kWh (kilowatt hours)
-	//% "Yield today"
+	//% "Yield Today"
 	readonly property string yield_today: qsTrId("common_words_yield_today")
 
 	//% "Zero feed-in power limit"

--- a/components/FirmwareUpdate.qml
+++ b/components/FirmwareUpdate.qml
@@ -55,7 +55,7 @@ QtObject {
 				msg = qsTrId("settings_firmware_error_during_installation")
 				break
 			case FirmwareUpdater.Rebooting:
-				//% "Firmware installed, rebooting."
+				//% "Firmware installed, rebooting"
 				msg = qsTrId("settings_firmware_installed_rebooting")
 				break
 			}

--- a/components/dialogs/ESSMinimumSOCDialog.qml
+++ b/components/dialogs/ESSMinimumSOCDialog.qml
@@ -67,7 +67,7 @@ ModalDialog {
 				horizontalAlignment: Text.AlignHCenter
 				font.pixelSize: Theme.font_size_caption
 
-				//% "For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum."
+				//% "For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer."
 				text: qsTrId("ess_recommended")
 			}
 		}

--- a/pages/SettingsPage.qml
+++ b/pages/SettingsPage.qml
@@ -24,7 +24,7 @@ Page {
 
 		model: [
 			{
-				//% "Device List"
+				//% "Device list"
 				text: qsTrId("settings_device_list"),
 				page: "/pages/settings/devicelist/DeviceListPage.qml",
 			},
@@ -143,7 +143,7 @@ Page {
 				visible: signalK.isValid || nodeRed.isValid
 			},
 			{
-				//% "VRM Device Instances"
+				//% "VRM device instances"
 				text: qsTrId("settings_vrm_device_instances"),
 				page: "/pages/settings/PageVrmDeviceInstances.qml",
 			},

--- a/pages/evcs/EvChargerSetupPage.qml
+++ b/pages/evcs/EvChargerSetupPage.qml
@@ -40,8 +40,8 @@ Page {
 			}
 
 			ListSwitch {
-				//% "Auto start"
-				text: qsTrId("evcs_auto_start")
+				//% "Autostart"
+				text: qsTrId("evcs_autostart")
 				dataItem.uid: root.evCharger.serviceUid + "/AutoStart"
 			}
 

--- a/pages/settings/PageGenerator.qml
+++ b/pages/settings/PageGenerator.qml
@@ -147,7 +147,7 @@ Page {
 		}
 
 		ListSwitch {
-			//% "Auto start functionality"
+			//% "Autostart functionality"
 			text: qsTrId("settings_page_relay_generator_auto_start_enabled")
 			dataItem.uid: root.startStopBindPrefix + "/AutoStartEnabled"
 			visible: allowDisableAutostart

--- a/pages/settings/PageGeneratorConditions.qml
+++ b/pages/settings/PageGeneratorConditions.qml
@@ -84,7 +84,7 @@ Page {
 					stopOnAc1Item.setValue(index & 1)
 					stopOnAc2Item.setValue((index & 2) >> 1)
 					if (index > 0) {
-						//% "Make sure that the generator is not connected to AC input %1 when using this option."
+						//% "Make sure that the generator is not connected to AC input %1 when using this option"
 						Global.showToastNotification(VenusOS.Notification_Info, qsTrId("page_generator_conditions_make_sure_generator_is_not_connected").arg(index),
 																   Theme.animation_generator_stopWhenAc1Available_toastNotification_autoClose_duration)
 					}

--- a/pages/settings/PageGeneratorRuntimeService.qml
+++ b/pages/settings/PageGeneratorRuntimeService.qml
@@ -92,7 +92,7 @@ Page {
 				visible: serviceReset.isValid
 				onClicked: {
 					serviceReset.setValue(1)
-					//% "The service timer has been reset."
+					//% "The service timer has been reset"
 					Global.showToastNotification(VenusOS.Notification_Info, qsTrId("page_settings_generator_service_timer_has_been_reset"))
 				}
 

--- a/pages/settings/PageSettingsBleSensors.qml
+++ b/pages/settings/PageSettingsBleSensors.qml
@@ -49,7 +49,7 @@ Page {
 			}
 
 			ListLabel {
-				//% "Continuous scanning may interfere with Wi-Fi operation"
+				//% "Continuous scanning may interfere with Wi-Fi operation."
 				text: qsTrId("settings_continuous_scan_may_interfere")
 				visible: contScan.checked
 			}

--- a/pages/settings/PageSettingsDisplay.qml
+++ b/pages/settings/PageSettingsDisplay.qml
@@ -134,7 +134,7 @@ Page {
 						dialogDoneOptions: VenusOS.ModalDialog_DoneOptions_NoOptions
 						//% "Changing language"
 						title: qsTrId("settings_language_changing_language")
-						//% "Please wait while the language is changed"
+						//% "Please wait while the language is changed."
 						description: qsTrId("settings_language_please_wait")
 					}
 				}

--- a/pages/settings/PageSettingsDvcc.qml
+++ b/pages/settings/PageSettingsDvcc.qml
@@ -27,7 +27,7 @@ Page {
 			}
 
 			ListNavigationItem {
-				//% "Charge Current limits"
+				//% "Charge current limits"
 				text: qsTrId("settings_dvcc_charge_current_limits")
 				showAccessLevel: VenusOS.User_AccessType_Service
 				onClicked: Global.pageManager.pushPage("/pages/settings/PageChargeCurrentLimits.qml", { title: text })

--- a/pages/settings/PageSettingsGenerator.qml
+++ b/pages/settings/PageSettingsGenerator.qml
@@ -92,12 +92,12 @@ Page {
 			}
 
 			ListSwitch {
-				//% "Alarm when generator is not in auto start mode"
+				//% "Alarm when generator is not in autostart mode"
 				text: qsTrId("page_settings_generator_alarm_when_not_in_auto_start")
 				dataItem.uid: settingsBindPrefix + "/Alarms/AutoStartDisabled"
 				onClicked: {
 					if (!checked) {
-						//% "An alarm will be triggered when auto start function is left disabled for more than 10 minutes."
+						//% "An alarm will be triggered when autostart function is left disabled for more than 10 minutes"
 						Global.notificationLayer.showToastNotification(VenusOS.Notification_Info,
 								qsTrId("page_settings_generator_alarm_info"), 12000)
 					}

--- a/pages/settings/PageSettingsHub4.qml
+++ b/pages/settings/PageSettingsHub4.qml
@@ -143,7 +143,7 @@ Page {
 					//% "Use this option for peak shaving.\n\nThe peak shaving threshold is set using the AC input current limit setting.\n\nSee documentation for further information."
 					Global.showToastNotification(VenusOS.Notification_Info, qsTrId("settings_ess_use_this_option_for_peak_shaving"))
 				} else {
-					//% "Use this option in systems that do not perform peak shaving."
+					//% "Use this option in systems that do not perform peak shaving"
 					Global.showToastNotification(VenusOS.Notification_Info, qsTrId("settings_ess_do_not_perform_peak_shaving"))
 				}
 			}
@@ -158,7 +158,7 @@ Page {
 		ListRadioButtonGroup {
 			id: batteryLifeState
 
-			//% "BatteryLife state"
+			//% "Battery life state"
 			text: qsTrId("settings_ess_batteryLife_state")
 			dataItem.uid: Global.systemSettings.serviceUid + "/Settings/CGwacs/BatteryLife/State"
 			visible: defaultVisible

--- a/pages/settings/PageSettingsLarge.qml
+++ b/pages/settings/PageSettingsLarge.qml
@@ -27,7 +27,7 @@ Page {
 			}
 
 			ListLabel {
-				//% "Access Signal K at http://venus.local:3000 and via VRM"
+				//% "Access Signal K at http://venus.local:3000 and via VRM."
 				text: qsTrId("settings_large_access_signal_k")
 				visible: signalk.checked
 			}
@@ -49,7 +49,7 @@ Page {
 			}
 
 			ListLabel {
-				//% "Access Node-RED at https://venus.local:1881 and via VRM"
+				//% "Access Node-RED at https://venus.local:1881 and via VRM."
 				text: qsTrId("settings_large_access_node_red")
 				visible: nodered.currentValue > 0
 			}

--- a/pages/settings/PageSettingsSystem.qml
+++ b/pages/settings/PageSettingsSystem.qml
@@ -140,13 +140,13 @@ Page {
 			}
 
 			ListNavigationItem {
-				//% "Battery Measurements"
+				//% "Battery measurements"
 				text: qsTrId("settings_system_battery_measurements")
 				onClicked: Global.pageManager.pushPage("/pages/settings/PageSettingsBatteries.qml", { title: text })
 			}
 
 			ListNavigationItem {
-				//% "System Status"
+				//% "System status"
 				text: qsTrId("settings_system_system_status")
 				showAccessLevel: VenusOS.User_AccessType_SuperUser
 				onClicked: Global.pageManager.pushPage("/pages/settings/PageSettingsSystemStatus.qml", { title: text })

--- a/pages/settings/PageSettingsTankPump.qml
+++ b/pages/settings/PageSettingsTankPump.qml
@@ -34,7 +34,6 @@ Page {
 		id: disabledModel
 
 		ListLabel {
-			horizontalAlignment: Text.AlignHCenter
 			//% "Tank pump start/stop function is not enabled. Go to relay settings and set function to \"Tank pump\"."
 			text: qsTrId("settings_pump_function_not_enabled" )
 		}

--- a/pages/settings/PageSettingsWifi.qml
+++ b/pages/settings/PageSettingsWifi.qml
@@ -24,7 +24,7 @@ Page {
 	GradientListView {
 		id: settingsListView
 
-		header: ListTextItem {
+		header: ListLabel {
 			visible: settingsListView.count === 0
 			text: {
 				if (root._tech) {

--- a/pages/settings/debug/PageDebug.qml
+++ b/pages/settings/debug/PageDebug.qml
@@ -29,23 +29,16 @@ Page {
 				}
 			}
 
-			ListItem {
+			ListButton {
 				id: quitSwitch
-				//% "Quit Application"
-				text: qsTrId("settings_page_debug_quit_application")
-				property bool isQuitting: false
-				onIsQuittingChanged: if (isQuitting) Qt.quit()
-				content.children: [
-					Switch {
-						checked: quitSwitch.isQuitting
-						onClicked: quitSwitch.isQuitting = !quitSwitch.isQuitting
-					}
-				]
 
-				MouseArea {
-					anchors.fill: parent
-					onClicked: quitSwitch.isQuitting = !quitSwitch.isQuitting
-				}
+				//% "Quit application"
+				text: qsTrId("settings_page_debug_quit_application")
+
+				//% "Quit"
+				button.text: qsTrId("settings_page_debug_quit")
+
+				onClicked: Qt.quit()
 			}
 
 			ListNavigationItem {

--- a/pages/settings/debug/PageSettingsDemo.qml
+++ b/pages/settings/debug/PageSettingsDemo.qml
@@ -186,19 +186,19 @@ Page {
 
 					ListItemButton {
 						text: "Confirm"
-						onClicked: Global.showToastNotification(VenusOS.Notification_Confirm, "This if confirmation toast")
+						onClicked: Global.showToastNotification(VenusOS.Notification_Confirm, "Confirmation toast")
 					},
 					ListItemButton {
 						text: "Warning"
-						onClicked: Global.showToastNotification(VenusOS.Notification_Warning, "This if warning toast")
+						onClicked: Global.showToastNotification(VenusOS.Notification_Warning, "Warning toast")
 					},
 					ListItemButton {
 						text: "Alarm"
-						onClicked: Global.showToastNotification(VenusOS.Notification_Alarm, "This if alarm toast")
+						onClicked: Global.showToastNotification(VenusOS.Notification_Alarm, "Alarm toast")
 					},
 					ListItemButton {
 						text: "Info"
-						onClicked: Global.showToastNotification(VenusOS.Notification_Info, "This if info toast")
+						onClicked: Global.showToastNotification(VenusOS.Notification_Info, "Info toast")
 					}
 				]
 			}

--- a/pages/settings/devicelist/ac-in/PageAcInSetup.qml
+++ b/pages/settings/devicelist/ac-in/PageAcInSetup.qml
@@ -122,7 +122,7 @@ Page {
 			}
 
 			ListLabel {
-				text: qsTr("Set switch in an unlocked position to change settings")
+				text: qsTr("Set the switch in an unlocked position to modify the settings.")
 				visible: productId.value == em24ProductId && em24Locked()
 			}
 

--- a/pages/settings/devicelist/battery/PageBatterySettingsBattery.qml
+++ b/pages/settings/devicelist/battery/PageBatterySettingsBattery.qml
@@ -114,7 +114,7 @@ Page {
 			}
 
 			ListLabel {
-				//% "Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu"
+				//% "Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu."
 				text: qsTrId("batterysettingsbattery_time_to_go_discharge_note")
 				visible: dischargeFloorLinkedToRelay.isValid && dischargeFloorLinkedToRelay.value !== 0
 

--- a/pages/solar/SolarChargerNetworkedOperationPage.qml
+++ b/pages/solar/SolarChargerNetworkedOperationPage.qml
@@ -117,7 +117,7 @@ Page {
 
 			ListTextItem {
 				id: bmsControlled
-				//% "BMS Controlled"
+				//% "BMS controlled"
 				text: qsTrId("charger_network_bms_controlled")
 				secondaryText: CommonWords.yesOrNo(dataItem.value)
 				dataItem.uid: root.solarCharger.serviceUid + "/Settings/BmsPresent"
@@ -125,7 +125,7 @@ Page {
 			}
 
 			ListButton {
-				//% "BMS Control"
+				//% "BMS control"
 				text: qsTrId("charger_network_bms_control")
 				//: Reset the BMS control
 				//% "Reset"

--- a/pages/solar/SolarChargerPage.qml
+++ b/pages/solar/SolarChargerPage.qml
@@ -137,7 +137,7 @@ Page {
 			}
 
 			ListNavigationItem {
-				//% "Alarms and Errors"
+				//% "Alarms & Errors"
 				text: qsTrId("charger_alarms_alarms_and_errors")
 				secondaryText: enabled
 					? (root.solarCharger.errorModel.count > 0

--- a/pages/vebusdevice/PageVeBusAdvanced.qml
+++ b/pages/vebusdevice/PageVeBusAdvanced.qml
@@ -115,17 +115,17 @@ Page {
 
 				onClicked: {
 					if (firmwareVersion.value < 0x400) {
-						//% "This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro."
+						//% "This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro."
 						Global.showToastNotification(VenusOS.Notification_Info, qsTrId("vebus_device_update_firmware"), 5000)
 					}
 
 					switch (vebusSubState.value) {
 					case VenusOS.VeBusDevice_ChargeState_InitializingCharger:
-						//% "Charger not ready, equalization cannot be started."
+						//% "Charger not ready, equalization cannot be started"
 						Global.showToastNotification(VenusOS.Notification_Info, qsTrId("vebus_device_charger_not_ready"), 5000)
 						break;
 					case VenusOS.VeBusDevice_ChargeState_Bulk:
-						//% "Equalization cannot be triggered during bulk charge state."
+						//% "Equalization cannot be triggered during bulk charge state"
 						Global.showToastNotification(VenusOS.Notification_Info, qsTrId("vebus_device_no_equalisation_during_bulk"), 5000)
 						break;
 					case VenusOS.VeBusDevice_ChargeState_Equalize:


### PR DESCRIPTION
Put few hours in polishing engineering English source strings:
- Don't show period on toast with only one sentence (most already didn't)
- Use period on modal warning dialog body text and descriptive labels written in proper sentences e.g. "Manually reboot the GX device after changing these settings." (most already did)
- Use left-aligned ListLabel when displaying descriptive labels on pages (most already did)
- Talk about "autostart" and not "auto start", both forms were in use, the former is recognized by the dictionaries.
- Renamed "Alarms and Errors" to "Alarms & Errors" to align with "Date & Time" and "Display & Language"
- Wrote "Yield today" on solar charger tables as "Yield Today" to align with the rest of column titles (also used in the design)

Overall small changes, 30 strings out of total 1.5k. Tried to align the naming with GX manual https://www.victronenergy.com/media/pg/CCGX/en/index-en.html

Contributes to #724.

![image](https://github.com/victronenergy/gui-v2/assets/2203667/7e02dbc9-6931-4e04-bec8-384c37e0a57c)
