### PR TITLE
631 fix vebus device drilldown issues

### DIFF
--- a/pages/settings/PageDeviceInfo.qml
+++ b/pages/settings/PageDeviceInfo.qml
@@ -57,6 +57,7 @@ Page {
 				dataItem.uid: root.bindPrefix + "/CustomName"
 				dataItem.invalidate: false
 				textField.maximumLength: 32
+				visible: dataItem.isValid
 				placeholderText: CommonWords.custom_name
 			}
 


### PR DESCRIPTION
Re. slack report:
issue 1: cannot reproduce - clicking the on/off/charger only button works as expected
![Screenshot from 2024-02-27 14-50-36](https://github.com/victronenergy/gui-v2/assets/6416318/2af125b2-4a64-4110-8926-58264a9f4632)

issue 2: cannot reproduce - clicking the button works as expected

issue 3: can reproduce. Fixed.

issue 4: This has been fixed elsewhere.
![Screenshot from 2024-02-27 16-06-37](https://github.com/victronenergy/gui-v2/assets/6416318/a62fadb2-63a1-4eb9-950c-f3ffa6345d9f)

issue 5: I think you need a grid meter to see this. If you do have a grid meter, it looks ok
![Screenshot from 2024-02-27 16-32-20](https://github.com/victronenergy/gui-v2/assets/6416318/74c0563e-b5c7-4784-bdd8-e4579ff8b8c7)

issue 6: Fixed
![Screenshot from 2024-02-27 16-57-01](https://github.com/victronenergy/gui-v2/assets/6416318/a2ac3530-fa19-433f-bcce-a01bb1be9dc2)
