### PR TITLE
Don't break switch binding to the /AutoStartEnabled

### DIFF
--- a/pages/controlcards/GeneratorCard.qml
+++ b/pages/controlcards/GeneratorCard.qml
@@ -52,7 +52,6 @@ ControlCard {
 			function onClicked() {
 				if (!autostartSwitch.button.checked) {
 					root.generator.setAutoStart(true)
-					autostartSwitch.button.checked = true
 				} else {
 					// check if they really want to disable
 					Global.dialogLayer.open(confirmationDialogComponent)
@@ -74,7 +73,6 @@ ControlCard {
 
 				onAccepted: {
 					root.generator.setAutoStart(false)
-					autostartSwitch.button.checked = false
 				}
 			}
 		}


### PR DESCRIPTION
If the autostart value changed elsewhere the switch on the generator card wasn't updated.

Fixes #682.