### PR TITLE
Improve spacing between quantity table columns

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,6 +226,7 @@ set (VENUS_QML_MODULE_SOURCES
     components/Page.qml
     components/PageStack.qml
     components/ProgressArc.qml
+    components/QuantityTableMetrics.qml
     components/QuantityLabel.qml
     components/QuantityRepeater.qml
     components/QuantityTableSummary.qml

--- a/components/QuantityTableMetrics.qml
+++ b/components/QuantityTableMetrics.qml
@@ -1,0 +1,41 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+FontMetrics {
+	property bool smallTextMode
+	property real availableWidth
+	property bool equalWidthColumns
+	property int count
+	property int spacing: Theme.geometry_quantityTable_horizontalSpacing
+
+	// If specified, allows for a custom column width for the 'Units_None' column.
+	// Eg. label columns with cells like "L1", "L2" can be thinner to allow wider columns elsewhere.
+	property int firstColumnWidth
+
+	font.family: Global.fontLoader.name
+	font.pixelSize: smallTextMode ? Theme.font_size_body2 : Theme.font_size_body3
+
+	function columnWidth(unit) {
+		if (!!firstColumnWidth) {
+			if (unit === VenusOS.Units_None) {
+				return firstColumnWidth
+			}
+			return (availableWidth - firstColumnWidth) / (count - 1)
+		}
+
+		if (equalWidthColumns) {
+			return availableWidth / count
+		}
+
+		// Give the unit symbol some extra space on the column.
+		const maxTextWidth = unit === VenusOS.Units_Energy_KiloWattHour
+						   ? advanceWidth("9999kWH")
+						   : advanceWidth("9999W")
+		return maxTextWidth + spacing
+	}
+}

--- a/components/QuantityTableSummary.qml
+++ b/components/QuantityTableSummary.qml
@@ -10,26 +10,25 @@ Row {
 	id: root
 
 	property var model: []
-	property bool smallTextMode
-	property bool equalWidthColumns
+	property alias metrics: quantityMetrics
 
-	function _quantityColumnWidth(unit) {
-		if (equalWidthColumns) {
-			return width / model.length
-		}
-		// Give the unit symbol some extra space on the column.
-		const widthMultiplier = (unit === VenusOS.Units_Energy_KiloWattHour) ? 1.2 : 1
-		return ((width - Theme.geometry_quantityTable_header_widthBoost) / model.length) * widthMultiplier
+	QuantityTableMetrics {
+		id: quantityMetrics
+
+		count: model.length
+		availableWidth: root.width - root.leftPadding
 	}
 
 	width: parent ? parent.width : 0
 	height: quantityRow.height + (2 * Theme.geometry_quantityTableSummary_verticalMargin)
+	// Omit the right padding to give the table a little more space.
+	leftPadding: Theme.geometry_listItem_content_horizontalMargin
 
 	Item {
 		id: firstColumn
 
 		anchors.verticalCenter: parent.verticalCenter
-		width: root.width - quantityRow.width
+		width: root.width - quantityRow.width - x
 		height: firstColumnSubLabel.y + firstColumnSubLabel.height
 
 		Label {
@@ -53,7 +52,7 @@ Row {
 			width: parent.width
 			elide: Text.ElideRight
 			rightPadding: Theme.geometry_listItem_content_spacing
-			font.pixelSize: root.smallTextMode ? Theme.font_size_body2 : Theme.font_size_body3
+			font.pixelSize: metrics.smallTextMode ? Theme.font_size_body2 : Theme.font_size_body3
 			text: root.model[0].text
 			color: firstColumnTitleLabel.text ? Theme.color_font_primary : Theme.color_quantityTable_quantityValue
 			opacity: firstColumnTitleLabel.text.length ? 1 : 0
@@ -85,7 +84,7 @@ Row {
 			model: root.model.length - 1
 
 			delegate: Column {
-				width: root._quantityColumnWidth(root.model[model.index + 1].unit)
+				width: metrics.columnWidth(root.model[model.index + 1].unit)
 				spacing: Theme.geometry_quantityTableSummary_verticalSpacing
 
 				Label {
@@ -94,6 +93,7 @@ Row {
 					font.pixelSize: Theme.font_size_caption
 					text: root.model[model.index + 1].title
 					color: Theme.color_quantityTable_quantityValue
+					fontSizeMode: Text.HorizontalFit
 				}
 
 				Loader {

--- a/components/SolarHistoryTableView.qml
+++ b/components/SolarHistoryTableView.qml
@@ -64,10 +64,8 @@ Column {
 	QuantityTableSummary {
 		id: tableSummary
 
-		// Omit right margin to give the table a little more space.
-		x: Theme.geometry_listItem_content_horizontalMargin
-		width: parent.width - Theme.geometry_listItem_content_horizontalMargin
-		smallTextMode: root.smallTextMode
+		metrics.smallTextMode: root.smallTextMode
+		metrics.spacing: 2*Theme.geometry_quantityTable_horizontalSpacing
 
 		model: [
 			{
@@ -98,10 +96,11 @@ Column {
 	QuantityTable {
 		id: trackerTable
 
-		width: parent.width
 		bottomPadding: Theme.geometry_quantityTable_bottomMargin
 		visible: !root.summaryOnly && root.solarHistory.trackerCount > 1
 		headerVisible: false
+		metrics.smallTextMode: root.smallTextMode
+		metrics.spacing: 2*Theme.geometry_quantityTable_horizontalSpacing
 
 		rowCount: root.solarHistory.trackerCount
 		units: [

--- a/components/ThreePhaseQuantityTable.qml
+++ b/components/ThreePhaseQuantityTable.qml
@@ -39,8 +39,8 @@ QuantityTable {
 		return NaN
 	}
 
-	availableWidth: width - 2*Theme.geometry_listItem_content_horizontalMargin
-	firstColumnWidth: Theme.geometry_vebusDeviceListPage_quantityTable_firstColumn_width
+	metrics.availableWidth: width - 2*Theme.geometry_listItem_content_horizontalMargin
+	metrics.firstColumnWidth: Theme.geometry_vebusDeviceListPage_quantityTable_firstColumn_width
 	units: [
 		{ unit: VenusOS.Units_None },
 		{ unit: VenusOS.Units_Watt },

--- a/pages/evcs/EvChargerListPage.qml
+++ b/pages/evcs/EvChargerListPage.qml
@@ -23,9 +23,7 @@ Page {
 				QuantityTableSummary {
 					id: summary
 
-					x: Theme.geometry_listItem_content_horizontalMargin
-					width: parent.width - (2 * Theme.geometry_listItem_content_horizontalMargin)
-
+					width: parent.width - Theme.geometry_listItem_content_horizontalMargin
 					model: [
 						{
 							title: "",
@@ -41,13 +39,7 @@ Page {
 							title: CommonWords.energy,
 							value: Global.evChargers.energy,
 							unit: VenusOS.Units_Energy_KiloWattHour
-						},
-						{
-							// Extra empty column to create spacing
-							title: "",
-							value: NaN,
-							unit: VenusOS.Units_None
-						},
+						}
 					]
 				}
 			}

--- a/pages/evcs/EvChargerPage.qml
+++ b/pages/evcs/EvChargerPage.qml
@@ -27,9 +27,7 @@ Page {
 						return actual + "/" + max
 					}
 
-					x: Theme.geometry_listItem_content_horizontalMargin
-					width: parent.width - Theme.geometry_listItem_content_horizontalMargin
-					equalWidthColumns: true
+					metrics.equalWidthColumns: true
 
 					model: [
 						{
@@ -71,7 +69,7 @@ Page {
 						topMargin: Theme.geometry_gradientList_spacing
 					}
 					visible: root.evCharger.phases.count > 1
-					equalWidthColumns: true
+					metrics.equalWidthColumns: true
 					headerVisible: false
 
 					rowCount: root.evCharger.phases.count

--- a/pages/solar/PvInverterPage.qml
+++ b/pages/solar/PvInverterPage.qml
@@ -21,9 +21,6 @@ Page {
 				QuantityTableSummary {
 					id: phaseSummary
 
-					x: Theme.geometry_listItem_content_horizontalMargin
-					width: parent.width - Theme.geometry_listItem_content_horizontalMargin
-
 					model: [
 						{
 							title: root.pvInverter.statusCode >= 0 ? CommonWords.status : "",

--- a/pages/solar/SolarChargerPage.qml
+++ b/pages/solar/SolarChargerPage.qml
@@ -22,9 +22,6 @@ Page {
 				QuantityTableSummary {
 					id: trackerSummary
 
-					x: Theme.geometry_listItem_content_horizontalMargin
-					width: parent.width - Theme.geometry_listItem_content_horizontalMargin
-
 					model: [
 						{
 							title: CommonWords.state,

--- a/themes/geometry/FiveInch.json
+++ b/themes/geometry/FiveInch.json
@@ -359,7 +359,7 @@
 
     "geometry_quantityTable_row_height": 32,
     "geometry_quantityTable_bottomMargin": 14,
-    "geometry_quantityTable_header_widthBoost": 90,
+    "geometry_quantityTable_horizontalSpacing": 18,
 
     "geometry_quantityTableSummary_verticalMargin": 8,
     "geometry_quantityTableSummary_verticalSpacing": 4,

--- a/themes/geometry/SevenInch.json
+++ b/themes/geometry/SevenInch.json
@@ -359,7 +359,7 @@
 
     "geometry_quantityTable_row_height": 32,
     "geometry_quantityTable_bottomMargin": 14,
-    "geometry_quantityTable_header_widthBoost": 120,
+    "geometry_quantityTable_horizontalSpacing": 48,
 
     "geometry_quantityTableSummary_verticalMargin": 8,
     "geometry_quantityTableSummary_verticalSpacing": 4,


### PR DESCRIPTION
Just small adjustment to the column sizes to make sure there are enough margins around the wider energy (kWh) column. Fixes #479.

![image](https://github.com/victronenergy/gui-v2/assets/2203667/85dd5370-eefd-4a80-9c3d-07616f312361)
