### PR TITLE
Don't accumulate current shown on Brief&Overview pages

### DIFF
--- a/data/SystemAc.qml
+++ b/data/SystemAc.qml
@@ -41,7 +41,7 @@ QtObject {
 			}
 			power = totalPower
 			if (index === 0) {
-				_firstPhaseCurrent = Units.sumRealNumbers(_firstPhaseCurrent, data.current)
+				_firstPhaseCurrent = data.current
 			}
 		}
 


### PR DESCRIPTION
You can change to amps from Display & Language -> Units -> Electrical power display -> Select Current (Amps).

Amperes are only shown on an one-phase system. Changed to only display the output current (Jesus commented last week that the top right gauge should follow `Ac/ConsumptionOnOutput/L1/Current` in  https://github.com/victronenergy/venus/issues/1217).

Fixes #777.