### PR TITLE
make the wasm version work over https

### DIFF
--- a/.github/patches/index.html.patch
+++ b/.github/patches/index.html.patch
@@ -13,7 +13,7 @@
                  status.innerHTML = 'Loading...';
  
                  const instance = await qtLoad({
-+                    arguments: ['--mqtt', 'ws://' + document.location.host + ':9001/'],
++                    arguments: ['--mqtt', (location.protocol === 'https:' ? 'wss://' + document.location.host + '/websocket-mqtt' : 'ws://' + document.location.host + ':9001/')],
                      qt: {
                          onLoaded: () => showUi(screen),
                          onExit: exitData =>


### PR DESCRIPTION
It is not tested as an action, since github warns for running actions on forks...