### PR TITLE
Fix broken idle mode

### DIFF
--- a/pages/PageManager.qml
+++ b/pages/PageManager.qml
@@ -28,8 +28,9 @@ QtObject {
 
 	property Timer idleModeTimer: Timer {
 		running: !Global.splashScreenVisible
-			&& root.currentPage !== null && root.currentPage !== undefined
-			&& root.currentPage.fullScreenWhenIdle
+			&& !!Global.mainView
+			&& Global.mainView.currentPage !== null && Global.mainView.currentPage !== undefined
+			&& Global.mainView.currentPage.fullScreenWhenIdle
 			&& root.interactivity === VenusOS.PageManager_InteractionMode_Interactive
 			&& BackendConnection.applicationVisible
 		interval: Theme.animation_page_idleResize_timeout


### PR DESCRIPTION
After 3038b8cc5c74023a5f306bef28b0280069f7816f the application no longer went into idle mode, as currentPage moved into MainView.qml.