### PR TITLE
Don't allow page push/pop during the fake page transition

### DIFF
--- a/components/PageStack.qml
+++ b/components/PageStack.qml
@@ -12,6 +12,8 @@ C.StackView {
 
 	property Page _poppedPage
 
+	readonly property bool _busy: busy || fakePushAnimation.running || fakePopAnimation.running
+
 	// Slide new drill-down pages in from the right
 	pushEnter: Transition {
 		XAnimator {
@@ -63,7 +65,7 @@ C.StackView {
 		target: !!Global.pageManager ? Global.pageManager.emitter : null
 
 		function onPagePushRequested(obj, properties) {
-			if (root.busy) {
+			if (root._busy) {
 				return
 			}
 
@@ -89,8 +91,8 @@ C.StackView {
 		}
 
 		function onPagePopRequested(toPage) {
-			if (root.busy
-					|| (!!root.currentItem.tryPop && !root.currentItem.tryPop())) {
+			if (root._busy
+					|| (!!root.currentItem && !!root.currentItem.tryPop && !root.currentItem.tryPop())) {
 				return
 			}
 			if (root.depth === 1) {


### PR DESCRIPTION
Would be cool to allow quick back-stepping where you didn't have to wait for the 250ms between the back button presses, but this (disabling push/pop during transition) aligns with the current page stack behavior.

Fixes #832.