### PR TITLE
Implement redesigned press effect for the buttons and list items

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ if (${LOAD_QML_FROM_FILESYSTEM})
 endif()
 
 set(REQUIRED_QT_VERSION 6.5.2) # require at least qt 6.5.2 for qt_add_qml_module to work properly
-find_package(Qt6 ${REQUIRED_QT_VERSION} COMPONENTS Core Gui Qml Quick Svg Xml Mqtt LinguistTools REQUIRED)
+find_package(Qt6 ${REQUIRED_QT_VERSION} COMPONENTS Core Gui Qml Quick Svg Xml Mqtt LinguistTools ShaderTools REQUIRED)
 
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Emscripten")
     set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
@@ -264,6 +264,8 @@ set (VENUS_QML_MODULE_SOURCES
     components/controls/ComboBox.qml
     components/controls/Label.qml
     components/controls/ListItemButton.qml
+    components/controls/PressArea.qml
+    components/controls/PressEffect.qml
     components/controls/ProgressBar.qml
     components/controls/RadioButton.qml
     components/controls/RangeSlider.qml
@@ -647,6 +649,16 @@ qt_add_qml_module(VenusQMLModule
     OUTPUT_DIRECTORY Victron/VenusOS
     QML_FILES ${VENUS_QML_MODULE_SOURCES}
     SOURCES ${VenusQMLModule_CPP_SOURCES}
+)
+
+qt6_add_shaders(VenusQMLModule "venus-shaders"
+    BATCHABLE
+    PRECOMPILE
+    OPTIMIZED
+    PREFIX
+        "/"
+    FILES
+        "components/controls/presseffect.frag"
 )
 
 list(APPEND TRANSLATION_SOURCES ${VenusQMLModule_CPP_SOURCES})

--- a/components/IconButton.qml
+++ b/components/IconButton.qml
@@ -5,8 +5,9 @@
 
 import QtQuick
 import QtQuick.Controls.impl as CP
+import Victron.VenusOS
 
-MouseArea {
+PressArea {
 	id: root
 
 	property alias icon: icon

--- a/components/NavButton.qml
+++ b/components/NavButton.qml
@@ -14,6 +14,7 @@ Button {
 	icon.height: Theme.geometry_navigationBar_button_icon_height
 	spacing: Theme.geometry_navigationBar_button_spacing
 	display: C.AbstractButton.TextUnderIcon
+	radius: 0
 
 	color: down
 		   ? Theme.color_navigationBar_button_on

--- a/components/RadioButtonControlValue.qml
+++ b/components/RadioButtonControlValue.qml
@@ -25,7 +25,7 @@ ControlValue {
 		onClicked: root.clicked()
 	}
 
-	MouseArea {
+	PressArea {
 		id: mouseArea
 
 		anchors.fill: parent

--- a/components/StatusBar.qml
+++ b/components/StatusBar.qml
@@ -39,7 +39,23 @@ Rectangle {
 		}
 	}
 
-	Button {
+	component StatusBarButton : Button {
+		radius: 0
+		width: Theme.geometry_statusBar_button_width
+		height: Theme.geometry_statusBar_button_height
+		backgroundColor: "transparent"  // don't show background when disabled
+		display: C.AbstractButton.IconOnly
+		color: Theme.color_ok
+		opacity: enabled ? 1.0 : 0.0
+		Behavior on opacity {
+			enabled: root.animationEnabled
+			OpacityAnimator {
+				duration: Theme.animation_page_idleOpacity_duration
+			}
+		}
+	}
+
+	StatusBarButton {
 		id: leftButton
 
 		anchors {
@@ -47,10 +63,6 @@ Rectangle {
 			leftMargin: Theme.geometry_statusBar_horizontalMargin
 			verticalCenter: parent.verticalCenter
 		}
-		width: Theme.geometry_statusBar_button_width
-		height: Theme.geometry_statusBar_button_height
-		display: C.AbstractButton.IconOnly
-		color: Theme.color_ok
 		icon.source: root.leftButton === VenusOS.StatusBar_LeftButton_ControlsInactive
 					 ? "qrc:/images/icon_controls_off_32.svg"
 					 : root.leftButton === VenusOS.StatusBar_LeftButton_ControlsActive
@@ -60,12 +72,6 @@ Rectangle {
 		enabled: !!Global.pageManager
 				&& Global.pageManager.interactivity === VenusOS.PageManager_InteractionMode_Interactive
 				&& root.leftButton != VenusOS.StatusBar_LeftButton_None
-		backgroundColor: "transparent"  // don't show background when disabled
-		opacity: enabled ? 1.0 : 0.0
-		Behavior on opacity {
-			enabled: root.animationEnabled
-			OpacityAnimator { duration: Theme.animation_page_idleOpacity_duration }
-		}
 
 		onClicked: root.leftButtonClicked()
 	}
@@ -111,7 +117,7 @@ Rectangle {
 		onClicked: Global.notifications.acknowledgeAll()
 	}
 
-	Button {
+	StatusBarButton {
 		id: rightButtonItem
 
 		anchors {
@@ -123,19 +129,7 @@ Rectangle {
 		enabled: !!Global.pageManager
 				&& Global.pageManager.interactivity === VenusOS.PageManager_InteractionMode_Interactive
 				&& root.rightButton != VenusOS.StatusBar_RightButton_None
-		opacity: enabled ? 1.0 : 0.0
-		Behavior on opacity {
-			enabled: root.animationEnabled
-			OpacityAnimator {
-				duration: Theme.animation_page_idleOpacity_duration
-			}
-		}
 
-		width: Theme.geometry_statusBar_button_width
-		height: Theme.geometry_statusBar_button_height
-		display: C.AbstractButton.IconOnly
-		color: Theme.color_ok
-		backgroundColor: "transparent"
 		icon.source: root.rightButton === VenusOS.StatusBar_RightButton_SidePanelActive
 				? "qrc:/images/icon_sidepanel_on_32.svg"
 				: root.rightButton === VenusOS.StatusBar_RightButton_SidePanelInactive

--- a/components/ToastNotification.qml
+++ b/components/ToastNotification.qml
@@ -86,7 +86,7 @@ Item {
 			color: Theme.color_toastNotification_foreground
 		}
 
-		MouseArea {
+		PressArea {
 			id: dismiss
 			anchors {
 				right: parent.right

--- a/components/controls/Button.qml
+++ b/components/controls/Button.qml
@@ -24,6 +24,10 @@ CT.Button {
 	property alias border: backgroundRect.border
 	property alias radius: backgroundRect.radius
 
+	onPressed: pressEffect.start(pressX/width, pressY/height)
+	onReleased: pressEffect.stop()
+	onCanceled: pressEffect.stop()
+
 	down: pressed || checked
 	spacing: Theme.geometry_button_spacing
 	topPadding: 0
@@ -47,6 +51,12 @@ CT.Button {
 		border.width: root.flat ? 0 : Theme.geometry_button_border_width
 		border.color: Theme.color_ok
 		radius: Theme.geometry_button_radius
+
+		PressEffect {
+			id: pressEffect
+			radius: backgroundRect.radius
+			anchors.fill: parent
+		}
 	}
 
 	contentItem: CP.IconLabel {

--- a/components/controls/PressArea.qml
+++ b/components/controls/PressArea.qml
@@ -1,0 +1,22 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+MouseArea {
+	id: root
+
+	property bool effectEnabled: true
+	property alias radius: pressEffect.radius
+
+	onPressed: if (effectEnabled) pressEffect.start(mouseX/width, mouseY/height)
+	onReleased: if (effectEnabled) pressEffect.stop()
+	onCanceled: if (effectEnabled) pressEffect.stop()
+
+	PressEffect {
+		id: pressEffect
+	}
+}

--- a/components/controls/PressEffect.qml
+++ b/components/controls/PressEffect.qml
@@ -1,0 +1,82 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+ShaderEffect {
+	id: shaderEffect
+
+	function start(x, y) {
+		shaderEffect.touchPos = Qt.point(x, y)
+		releaseEffect.stop()
+		pressEffect.start()
+		_stopPending = false
+	}
+
+	function stop() {
+		if (!pressEffect.running) {
+			releaseEffect.start()
+		} else {
+			_stopPending = true
+		}
+	}
+
+	property bool _stopPending
+	property real radius
+	property real progress
+	property point touchPos
+	property real aspectRatio: height > 0 ? width/height : 1.0
+	property real radiusRatio: height > 0 ? root.radius/height : 0.0
+	property color color: Qt.rgba(Theme.color_font_primary.r, Theme.color_font_primary.g, Theme.color_font_primary.b, 0.1)
+
+	opacity: 0.0
+	anchors.fill: parent
+	fragmentShader:  "qrc:/components/controls/presseffect.frag.qsb"
+
+	ParallelAnimation {
+		id: pressEffect
+
+		onStopped: if (_stopPending) releaseEffect.start()
+
+		OpacityAnimator {
+			target: shaderEffect
+			from: 0.0
+			to: 1.0
+			duration: 400
+			easing.type: Easing.OutSine
+		}
+
+		UniformAnimator {
+			target: shaderEffect
+			uniform: "progress"
+			from: 0.0
+			to: 1.0
+			duration: 400
+			easing.type: Easing.OutSine
+		}
+	}
+
+	ParallelAnimation {
+		id: releaseEffect
+
+		OpacityAnimator {
+			target: shaderEffect
+			from: 1.0
+			to: 0.0
+			duration: 300
+			easing.type: Easing.InSine
+		}
+
+		UniformAnimator {
+			target: shaderEffect
+			uniform: "progress"
+			from: shaderEffect.progress
+			to: 1.0
+			duration: 300
+			easing.type: Easing.InSine
+		}
+	}
+}

--- a/components/controls/presseffect.frag
+++ b/components/controls/presseffect.frag
@@ -1,0 +1,47 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+#version 440
+
+layout(location = 0) in vec2 qt_TexCoord0;
+layout(location = 0) out vec4 fragColor;
+
+layout(std140, binding = 0) uniform buf {
+    mat4 qt_Matrix;
+    float qt_Opacity;
+
+    vec4 color;
+    vec2 touchPos;
+    float progress;
+    float aspectRatio;
+    float radiusRatio;
+} ubuf;
+
+void main() {
+    float maxRadius = 0.7071 *	max(ubuf.aspectRatio, 1.0); // sqrt(0.5)
+    float radius = ubuf.progress * maxRadius;
+
+    // Move the animation center from the touch position to center of the area
+    vec2 absoluteCenter = vec2(0.5, 0.5);
+    vec2 circleCenter = (1.0 - ubuf.progress) * ubuf.touchPos + ubuf.progress*absoluteCenter;
+
+    vec2 normal = vec2(qt_TexCoord0.x - circleCenter.x, qt_TexCoord0.y - circleCenter.y);
+
+    // Skew the normal vector so the circle appears perfectly round
+    vec2 aspectVector = vec2(ubuf.aspectRatio, 1.0);
+    normal *= aspectVector;
+
+    // Circle equation x² + y² = r²
+    float circleMask = step(dot(normal, normal), radius*radius);
+
+    // Skew the geometries so the corners appear perfectly round
+    vec2 position = qt_TexCoord0.xy * aspectVector;
+    vec2 size = vec2(0.5, 0.5) * aspectVector;
+    vec2 center = absoluteCenter * aspectVector;
+    float distance = length(max(abs(position - center) - size + ubuf.radiusRatio, 0.0)) - ubuf.radiusRatio;
+    float cornerMask = 1.0 - smoothstep(0.0, 0.01, distance);
+
+    fragColor = ubuf.color * circleMask * cornerMask * ubuf.qt_Opacity;
+}

--- a/components/dialogs/SolarDailyHistoryDialog.qml
+++ b/components/dialogs/SolarDailyHistoryDialog.qml
@@ -87,15 +87,19 @@ T.Dialog {
 			radius: Theme.geometry_solarChart_bar_radius
 		}
 
-		IconButton {
+		component ArrowButton : IconButton {
+			icon.sourceSize.height: Theme.geometry_solarDailyHistoryDialog_arrow_icon_size
+			icon.color: containsPress ? Theme.color_gray4 : Theme.color_gray5
+			icon.source: "qrc:/images/icon_arrow_32.svg"
+			effectEnabled: false
+		}
+
+		ArrowButton {
 			anchors {
 				right: parent.left
 				rightMargin: Theme.geometry_solarDailyHistoryDialog_arrow_horizontalMargin
 				verticalCenter: parent.verticalCenter
 			}
-			icon.sourceSize.height: Theme.geometry_solarDailyHistoryDialog_arrow_icon_size
-			icon.color: containsPress ? Theme.color_gray4 : Theme.color_gray5
-			icon.source: "qrc:/images/icon_arrow_32.svg"
 			visible: root.day > root.minimumDay
 
 			onClicked: {
@@ -104,15 +108,12 @@ T.Dialog {
 			}
 		}
 
-		IconButton {
+		ArrowButton {
 			anchors {
 				left: parent.right
 				leftMargin: Theme.geometry_solarDailyHistoryDialog_arrow_horizontalMargin
 				verticalCenter: parent.verticalCenter
 			}
-			icon.sourceSize.height: Theme.geometry_solarDailyHistoryDialog_arrow_icon_size
-			icon.color: containsPress ? Theme.color_gray4 : Theme.color_gray5
-			icon.source: "qrc:/images/icon_arrow_32.svg"
 			visible: root.day < root.maximumDay
 			rotation: 180
 
@@ -165,7 +166,7 @@ T.Dialog {
 				: Theme.geometry_solarDailyHistoryDialog_minimumHeight - Theme.geometry_solarDailyHistoryDialog_header_height
 		}
 
-		MouseArea {
+		PressArea {
 			anchors.fill: tableView
 			enabled: errorView.expanded
 			onClicked: errorView.expanded = false

--- a/components/listitems/ListItem.qml
+++ b/components/listitems/ListItem.qml
@@ -44,7 +44,7 @@ Item {
 		id: backgroundRect
 
 		height: root.height - root.spacing
-		color: root.down ? Theme.color_listItem_down_background : Theme.color_listItem_background
+		color: Theme.color_listItem_background
 		// TODO how to indicate read-only setting?
 
 		// Show thin colored indicator on left side if settings is only visible to super/service users

--- a/components/listitems/ListNavigationItem.qml
+++ b/components/listitems/ListNavigationItem.qml
@@ -15,7 +15,7 @@ ListItem {
 
 	signal clicked()
 
-	down: mouseArea.containsPress
+	down: pressArea.containsPress
 	enabled: userHasReadAccess
 
 	content.children: [
@@ -39,10 +39,14 @@ ListItem {
 		}
 	]
 
-	MouseArea {
-		id: mouseArea
+	PressArea {
+		id: pressArea
 
-		anchors.fill: parent
+		radius: backgroundRect.radius
+		anchors {
+			fill: parent
+			bottomMargin: root.spacing
+		}
 		onClicked: root.clicked()
 	}
 }

--- a/components/listitems/ListRadioButton.qml
+++ b/components/listitems/ListRadioButton.qml
@@ -15,7 +15,7 @@ ListItem {
 
 	signal clicked()
 
-	down: mouseArea.containsPress
+	down: pressArea.containsPress
 	enabled: userHasWriteAccess
 
 	content.children: [
@@ -26,10 +26,15 @@ ListItem {
 		}
 	]
 
-	MouseArea {
-		id: mouseArea
+	PressArea {
+		id: pressArea
 
-		anchors.fill: parent
+		radius: backgroundRect.radius
+		anchors {
+			fill: parent
+			bottomMargin: root.spacing
+		}
+
 		onClicked: root.clicked()
 	}
 }

--- a/components/listitems/ListSwitch.qml
+++ b/components/listitems/ListSwitch.qml
@@ -32,7 +32,7 @@ ListItem {
 		clicked()
 	}
 
-	down: mouseArea.containsPress
+	down: pressArea.containsPress
 	enabled: userHasWriteAccess && (dataItem.uid === "" || dataItem.isValid)
 
 	content.children: [
@@ -49,10 +49,15 @@ ListItem {
 		}
 	]
 
-	MouseArea {
-		id: mouseArea
+	PressArea {
+		id: pressArea
 
-		anchors.fill: parent
+		radius: backgroundRect.radius
+		anchors {
+			fill: parent
+			bottomMargin: root.spacing
+		}
+
 		onClicked: root._setChecked(!switchItem.checked)
 	}
 

--- a/components/widgets/AcInputWidget.qml
+++ b/components/widgets/AcInputWidget.qml
@@ -9,6 +9,13 @@ import Victron.VenusOS
 OverviewWidget {
 	id: root
 
+	onClicked: {
+		Global.pageManager.pushPage("/pages/settings/devicelist/ac-in/PageAcIn.qml", {
+			"title": root.input.name,
+			"bindPrefix": root.input.serviceUid
+		})
+	}
+
 	property ActiveAcInput input: Global.acInputs.activeInput
 	property ListModel phaseModel: input && input.connected ? input.phases : null
 
@@ -104,16 +111,6 @@ OverviewWidget {
 			elide: Text.ElideRight
 			text: CommonWords.stopped
 			color: Theme.color_font_secondary
-		}
-	}
-
-	MouseArea {
-		anchors.fill: parent
-		onClicked: {
-			Global.pageManager.pushPage("/pages/settings/devicelist/ac-in/PageAcIn.qml", {
-				"title": root.input.name,
-				"bindPrefix": root.input.serviceUid
-			})
 		}
 	}
 }

--- a/components/widgets/BatteryWidget.qml
+++ b/components/widgets/BatteryWidget.qml
@@ -9,6 +9,15 @@ import Victron.VenusOS
 OverviewWidget {
 	id: root
 
+	onClicked: {
+		if (Global.batteries.model.count === 1) {
+			Global.pageManager.pushPage("/pages/settings/devicelist/battery/PageBattery.qml",
+					{ "battery": Global.batteries.model.deviceAt(0) })
+		} else {
+			Global.pageManager.pushPage("/pages/battery/BatteryListPage.qml")
+		}
+	}
+
 	readonly property var batteryData: Global.batteries.system
 
 	readonly property int _normalizedStateOfCharge: Math.round(batteryData.stateOfCharge || 0)
@@ -225,17 +234,4 @@ OverviewWidget {
 			alignment: Qt.AlignRight
 		}
 	]
-
-	MouseArea {
-		anchors.fill: parent
-		onClicked: {
-			if (Global.batteries.model.count === 1) {
-				Global.pageManager.pushPage("/pages/settings/devicelist/battery/PageBattery.qml",
-						{ "battery": Global.batteries.model.deviceAt(0) })
-			} else {
-				Global.pageManager.pushPage("/pages/battery/BatteryListPage.qml")
-			}
-		}
-	}
-
 }

--- a/components/widgets/DcInputWidget.qml
+++ b/components/widgets/DcInputWidget.qml
@@ -9,6 +9,13 @@ import Victron.VenusOS
 OverviewWidget {
 	id: root
 
+	onClicked: {
+		Global.pageManager.pushPage(root.detailUrl, {
+			"title": root.input.name,
+			"bindPrefix": root.input.serviceUid
+		})
+	}
+
 	property var input
 	property string detailUrl: "/pages/settings/devicelist/dc-in/PageDcMeter.qml"
 
@@ -16,14 +23,4 @@ OverviewWidget {
 	quantityLabel.dataObject: input
 	icon.source: "qrc:/images/icon_dc_24.svg"
 	enabled: true
-
-	MouseArea {
-		anchors.fill: parent
-		onClicked: {
-			Global.pageManager.pushPage(root.detailUrl, {
-				"title": root.input.name,
-				"bindPrefix": root.input.serviceUid
-			})
-		}
-	}
 }

--- a/components/widgets/DcLoadsWidget.qml
+++ b/components/widgets/DcLoadsWidget.qml
@@ -10,6 +10,8 @@ import Victron.VenusOS
 OverviewWidget {
 	id: root
 
+	onClicked: Global.pageManager.pushPage(consumptionPageComponent, { "title": root.title })
+
 	//% "DC Loads"
 	title: qsTrId("overview_widget_dcloads_title")
 	icon.source: "qrc:/images/dcloads.svg"
@@ -17,13 +19,6 @@ OverviewWidget {
 	enabled: (Global.dcLoads.model.count + Global.dcSystems.model.count) > 0
 
 	quantityLabel.dataObject: Global.system.dc
-
-	MouseArea {
-		anchors.fill: parent
-		onClicked: {
-			Global.pageManager.pushPage(consumptionPageComponent, { "title": root.title })
-		}
-	}
 
 	Component {
 		id: consumptionPageComponent
@@ -46,10 +41,14 @@ OverviewWidget {
 						Units.getCombinedDisplayText(VenusOS.Units_Watt, device.power),
 					]
 
-					MouseArea {
-						id: delegateMouseArea
+					PressArea {
+						id: delegatePressArea
 
-						anchors.fill: parent
+						radius: backgroundRect.radius
+						anchors {
+							fill: parent
+							bottomMargin: deviceDelegate.spacing
+						}
 						onClicked: {
 							Global.pageManager.pushPage("/pages/settings/devicelist/dc-in/PageDcMeter.qml",
 									{ "title": device.name, "bindPrefix": device.serviceUid })
@@ -61,7 +60,7 @@ OverviewWidget {
 						anchors.verticalCenter: parent.verticalCenter
 						source: "qrc:/images/icon_arrow_32.svg"
 						rotation: 180
-						color: delegateMouseArea.containsPress ? Theme.color_listItem_down_forwardIcon : Theme.color_listItem_forwardIcon
+						color: delegatePressArea.containsPress ? Theme.color_listItem_down_forwardIcon : Theme.color_listItem_forwardIcon
 					}
 				}
 			}

--- a/components/widgets/EvcsWidget.qml
+++ b/components/widgets/EvcsWidget.qml
@@ -9,6 +9,15 @@ import Victron.VenusOS
 OverviewWidget {
 	id: root
 
+	onClicked: {
+		if (Global.evChargers.model.count === 1) {
+			Global.pageManager.pushPage("/pages/evcs/EvChargerPage.qml",
+					{ "evCharger": Global.evChargers.model.deviceAt(0) })
+		} else {
+			Global.pageManager.pushPage("/pages/evcs/EvChargerListPage.qml")
+		}
+	}
+
 	//: Abbreviation of Electric Vehicle Charging Station
 	//% "EVCS"
 	title: qsTrId("overview_widget_evcs_title")
@@ -32,18 +41,6 @@ OverviewWidget {
 					: null
 		}
 	]
-
-	MouseArea {
-		anchors.fill: parent
-		onClicked: {
-			if (Global.evChargers.model.count === 1) {
-				Global.pageManager.pushPage("/pages/evcs/EvChargerPage.qml",
-						{ "evCharger": Global.evChargers.model.deviceAt(0) })
-			} else {
-				Global.pageManager.pushPage("/pages/evcs/EvChargerListPage.qml")
-			}
-		}
-	}
 
 	Component {
 		id: singleEvChargerComponent

--- a/components/widgets/InverterChargerWidget.qml
+++ b/components/widgets/InverterChargerWidget.qml
@@ -9,6 +9,24 @@ import Victron.VenusOS
 OverviewWidget {
 	id: root
 
+	onClicked: {
+		return
+		if (Global.inverterChargers.veBusDevices.count
+				+ Global.inverterChargers.multiDevices.count
+				+ Global.inverterChargers.inverterDevices.count > 1) {
+			Global.pageManager.pushPage("/pages/invertercharger/InverterChargerListPage.qml")
+		} else {
+			const device = Global.inverterChargers.first
+			if (device.serviceUid.indexOf('inverter') >= 0) {
+				Global.pageManager.pushPage("/pages/invertercharger/OverviewInverterPage.qml",
+						{ "serviceUid": device.serviceUid, "title": device.name })
+			} else {
+				Global.pageManager.pushPage("/pages/invertercharger/OverviewInverterChargerPage.qml",
+						{ "inverterCharger": device })
+			}
+		}
+	}
+
 	//% "Inverter / Charger"
 	title: qsTrId("overview_widget_inverter_title")
 	icon.source: "qrc:/images/inverter_charger.svg"
@@ -28,23 +46,4 @@ OverviewWidget {
 			wrapMode: Text.Wrap
 		}
 	]
-	MouseArea {
-		anchors.fill: parent
-		onClicked: {
-			if (Global.inverterChargers.veBusDevices.count
-					+ Global.inverterChargers.multiDevices.count
-					+ Global.inverterChargers.inverterDevices.count > 1) {
-				Global.pageManager.pushPage("/pages/invertercharger/InverterChargerListPage.qml")
-			} else {
-				const device = Global.inverterChargers.first
-				if (device.serviceUid.indexOf('inverter') >= 0) {
-					Global.pageManager.pushPage("/pages/invertercharger/OverviewInverterPage.qml",
-							{ "serviceUid": device.serviceUid, "title": device.name })
-				} else {
-					Global.pageManager.pushPage("/pages/invertercharger/OverviewInverterChargerPage.qml",
-							{ "inverterCharger": device })
-				}
-			}
-		}
-	}
 }

--- a/components/widgets/OverviewWidget.qml
+++ b/components/widgets/OverviewWidget.qml
@@ -16,6 +16,8 @@ Rectangle {
 	property alias title: widgetHeader.title
 	property alias quantityLabel: quantityLabel
 
+	signal clicked
+
 	property int rightPadding
 	property alias extraContent: extraContent
 	property var connectors: []
@@ -115,5 +117,11 @@ Rectangle {
 		}
 		children: root.extraContentChildren
 		visible: root.size >= VenusOS.OverviewWidget_Size_M
+	}
+
+	PressArea {
+		radius: root.radius
+		anchors.fill: parent
+		onClicked: root.clicked()
 	}
 }

--- a/components/widgets/SolarYieldWidget.qml
+++ b/components/widgets/SolarYieldWidget.qml
@@ -9,6 +9,19 @@ import Victron.VenusOS
 OverviewWidget {
 	id: root
 
+	onClicked: {
+		const singleDeviceOnly = (Global.solarChargers.model.count + Global.pvInverters.model.count) === 1
+		if (singleDeviceOnly && Global.solarChargers.model.count === 1) {
+			Global.pageManager.pushPage("/pages/solar/SolarChargerPage.qml",
+					{ "solarCharger": Global.solarChargers.model.deviceAt(0) })
+		} else if (singleDeviceOnly && Global.pvInverters.model === 1) {
+			Global.pageManager.pushPage("/pages/solar/PvInverterPage.qml",
+					{ "pvInverter": Global.pvInverters.model.deviceAt(0) })
+		} else {
+			Global.pageManager.pushPage("/pages/solar/SolarDeviceListPage.qml", { "title": root.title })
+		}
+	}
+
 	//% "Solar yield"
 	title: qsTrId("overview_widget_solaryield_title")
 	icon.source: "qrc:/images/solaryield.svg"
@@ -60,23 +73,6 @@ OverviewWidget {
 
 		SolarYieldGraph {
 			height: root.extraContent.height - (2 * Theme.geometry_overviewPage_widget_solar_graph_margins)
-		}
-	}
-
-	MouseArea {
-		anchors.fill: parent
-
-		onClicked: {
-			const singleDeviceOnly = (Global.solarChargers.model.count + Global.pvInverters.model.count) === 1
-			if (singleDeviceOnly && Global.solarChargers.model.count === 1) {
-				Global.pageManager.pushPage("/pages/solar/SolarChargerPage.qml",
-						{ "solarCharger": Global.solarChargers.model.deviceAt(0) })
-			} else if (singleDeviceOnly && Global.pvInverters.model === 1) {
-				Global.pageManager.pushPage("/pages/solar/PvInverterPage.qml",
-						{ "pvInverter": Global.pvInverters.model.deviceAt(0) })
-			} else {
-				Global.pageManager.pushPage("/pages/solar/SolarDeviceListPage.qml", { "title": root.title })
-			}
 		}
 	}
 }

--- a/pages/NotificationsPage.qml
+++ b/pages/NotificationsPage.qml
@@ -95,14 +95,11 @@ SwipeViewPage {
 					id: activeDelegate
 
 					// When the delegate is clicked, acknowledge it.
-					// Change the delegate color when pressed, but do not restore the original color
-					// when acknowledging an inactive delegate, else the color flashes just before
-					// it fades out in the remove animation.
-					MouseArea {
+					PressArea {
 						anchors.fill: parent
 						enabled: !activeDelegate.notification.acknowledged
-						onPressed: activeDelegate.color = Theme.color_listItem_down_background
-						onCanceled: activeDelegate.color = Theme.color_background_secondary
+						radius: activeDelegate.radius
+
 						onReleased: {
 							activeDelegate.notification.setAcknowledged(true)
 							if (activeDelegate.notification.active) {

--- a/pages/TanksTab.qml
+++ b/pages/TanksTab.qml
@@ -119,9 +119,10 @@ ListView {
 					gaugeTanks: tankTypeDelegate.tankModel
 					mergeTanks: tankTypeDelegate.mergeTanks
 
-					MouseArea {
+					PressArea {
 						anchors.fill: parent
 						enabled: tankTypeDelegate.tankModel.count > 1
+						radius: gaugeGroup.radius
 						onClicked: {
 							expandedTanksLoader.tankModel = tankTypeDelegate.tankModel
 							expandedTanksLoader.active = true

--- a/pages/battery/BatteryListPage.qml
+++ b/pages/battery/BatteryListPage.qml
@@ -103,9 +103,10 @@ Page {
 				color: mouseArea.containsPress ? Theme.color_listItem_down_forwardIcon : Theme.color_listItem_forwardIcon
 			}
 
-			MouseArea {
+			PressArea {
 				id: mouseArea
 
+				radius: parent.radius
 				anchors.fill: parent
 				onClicked: {
 					Global.pageManager.pushPage("/pages/settings/devicelist/battery/PageBattery.qml",

--- a/pages/settings/PageSettingsVecanDevices.qml
+++ b/pages/settings/PageSettingsVecanDevices.qml
@@ -37,10 +37,11 @@ Page {
 				color: listDelegate.containsPress ? Theme.color_listItem_down_forwardIcon : Theme.color_listItem_forwardIcon
 			}
 
-			MouseArea {
+			PressArea {
 				id: mouseArea
 
 				parent: listDelegate.backgroundRect
+				radius: listDelegate.backgroundRect.radius
 				anchors.fill: parent
 				onClicked: {
 					Global.pageManager.pushPage("/pages/settings/PageSettingsVecanDevice.qml",

--- a/pages/settings/debug/PageDebug.qml
+++ b/pages/settings/debug/PageDebug.qml
@@ -23,8 +23,12 @@ Page {
 					}
 				]
 
-				MouseArea {
-					anchors.fill: parent
+				PressArea {
+					radius: frameRateSwitch.backgroundRect.radius
+					anchors {
+						fill: parent
+						bottomMargin: frameRateSwitch.spacing
+					}
 					onClicked: FrameRateModel.enabled = !FrameRateModel.enabled
 				}
 			}

--- a/pages/settings/devicelist/DeviceListPage.qml
+++ b/pages/settings/devicelist/DeviceListPage.qml
@@ -269,10 +269,14 @@ Page {
 				visible: deviceMouseArea.enabled
 			}
 
-			MouseArea {
+			PressArea {
 				id: deviceMouseArea
 
-				anchors.fill: parent
+				anchors {
+					fill: parent
+					bottomMargin: deviceDelegate.spacing
+				}
+				radius: deviceDelegate.backgroundRect.radius
 				enabled: !!_displayInfo && _displayInfo.url.length > 0
 				onClicked: {
 					Global.pageManager.pushPage(_displayInfo.url, _displayInfo.params)


### PR DESCRIPTION
- Follows the press effect animation made by Serj
- Migrate the list items to use the new press effect
- Dialog text buttons, status bar icon buttons, Overview widgets, radio button list items, toasts, etc. now have a press effect
- Interactive elements should give press feedback, indicating they are in fact interactive
- The press effect can be useful in demonstrating the size of touch area

[Screencast from 2024-03-06 16-17-06.webm](https://github.com/victronenergy/gui-v2/assets/2203667/9a887bee-352e-4fd1-ac1a-c20ba8aeb55c)

Fixes JB#722.