### PR TITLE
Change the maximum limit voltage spinbox to change in 0.1V steps

### DIFF
--- a/pages/settings/PageSettingsDvcc.qml
+++ b/pages/settings/PageSettingsDvcc.qml
@@ -55,6 +55,7 @@ Page {
 				dataItem.uid: Global.systemSettings.serviceUid + "/Settings/SystemSetup/MaxChargeVoltage"
 				suffix: "V"
 				decimals: 1
+				stepSize: 0.1
 			}
 
 			ListDvccSwitch {


### PR DESCRIPTION
For comparison see [gui v1 spinbox](https://github.com/victronenergy/gui/blob/master/qml/PageSettingsDVCC.qml#L128). 

Fixes #845.