### PR TITLE
Update cache key to force using the new cache

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -24,7 +24,7 @@ jobs:
         path: |
           /opt/hostedtoolcache
         # Adding version as cache key
-        key: ${{ runner.os }}-qt-${{ env.QT_VERSION }}-em-${{ env.EMSCRIPTEN }}
+        key: ${{ runner.os }}-qt-${{ env.QT_VERSION }}-em-${{ env.EMSCRIPTEN }}-libegl1
     - name: Install dependencies
       if: steps.cached_qt_emscripten.outputs.cache-hit != 'true'
       run: |


### PR DESCRIPTION
Seems like GitHub actions otherwise manages to find the deleted cache.