### PR TITLE
Fix text for DVCC "Auto selected" and Modbustcp device name settings

### DIFF
--- a/data/mock/SystemSettingsImpl.qml
+++ b/data/mock/SystemSettingsImpl.qml
@@ -91,6 +91,7 @@ QtObject {
 		setMockSystemValue("AutoSelectedTemperatureService", "-")
 		setMockSettingValue("SystemSetup/SharedTemperatureSense", 2)
 		setMockSystemValue("Control/BatteryCurrentSense", 0)
+		setMockSystemValue("ActiveBmsService", "com.victronenergy.battery.ttyUSB1")
 
 		setMockSystemValue("SystemType", "ESS")
 		setMockSettingValue("CGwacs/AcPowerSetPoint", 50)
@@ -182,7 +183,7 @@ QtObject {
 
 		setMockSettingValue("Services/Modbus", 0)
 		setMockModbusTcpValue("Services/Count", 2)
-		setMockModbusTcpValue("Services/0/ServiceName", "com.victronenergy.battery.ttyUSB0")
+		setMockModbusTcpValue("Services/0/ServiceName", "com.victronenergy.battery.ttyUSB1")
 		setMockModbusTcpValue("Services/0/UnitId", 288)
 		setMockModbusTcpValue("Services/1/ServiceName", "com.victronenergy.solarcharger.ttyUSB1")
 		setMockModbusTcpValue("Services/1/UnitId", 289)

--- a/pages/settings/PageSettingsDvcc.qml
+++ b/pages/settings/PageSettingsDvcc.qml
@@ -191,14 +191,15 @@ Page {
 					uid: Global.system.serviceUid + "/ActiveBmsService"
 				}
 
+				// TODO the uid is wrong on MQTT, need something like mqtt/<type>/ProductName
+				// but it is currently mqtt/com.victronenergy.<service>/ProductName
 				VeQuickItem {
 					id: bmsProductName
-					uid: bmsService.isValid ? bmsService.value + "/ProductName" : ""
+					uid: bmsService.isValid ? "%1/%2/ProductName".arg(BackendConnection.uidPrefix()).arg(bmsService.value) : ""
 				}
-
 				VeQuickItem {
 					id: bmsCustomName
-					uid: bmsService.isValid ? bmsService.value + "/CustomName" : ""
+					uid: bmsService.isValid ? "%1/%2/CustomName".arg(BackendConnection.uidPrefix()).arg(bmsService.value) : ""
 				}
 			}
 		}

--- a/pages/settings/PageSettingsModbusTcpServices.qml
+++ b/pages/settings/PageSettingsModbusTcpServices.qml
@@ -58,9 +58,11 @@ Page {
 				uid: serviceDelegate.servicePath + "/ServiceName"
 			}
 
+			// TODO the uid is wrong on MQTT, need something like mqtt/<type>/ProductName
+			// but it is currently mqtt/com.victronenergy.<service>/ProductName
 			VeQuickItem {
 				id: productName
-				uid: serviceName.value ? serviceName.value + "/ProductName" : ""
+				uid: serviceName.isValid ? "%1/%2/ProductName".arg(BackendConnection.uidPrefix()).arg(serviceName.value) : ""
 			}
 
 			VeQuickItem {


### PR DESCRIPTION
The /ActiveBmsService and /ServiceName values are of the form com.victronenergy.<service>, so they need a 'dbus/' prefix before they can be used as uids for VeQuickItem. Otherwise, VeQuickItem produces an error like this:

UID "com.victronenergy.<type>/CustomName" contains invalid part: "com.victronenergy.<type>"

This fix does not work on MQTT. See #873