### PR TITLE
Remove the "Alarm relay on" relay setting

### DIFF
--- a/pages/settings/PageSettingsRelay.qml
+++ b/pages/settings/PageSettingsRelay.qml
@@ -52,23 +52,6 @@ Page {
 			}
 
 			ListSwitch {
-				id: relaySwitch
-
-				//% "Alarm relay on"
-				text: qsTrId("settings_relay_alarm_relay_on")
-				updateOnClick: false
-				checked: root._relay0Object && _relay0Object.state === VenusOS.Relays_State_Active
-
-				visible: relayFunction.currentValue === VenusOS.Relay_Function_Alarm
-				onClicked: {
-					// TODO in gui-v1 the relay state change considers relay polarity and alarm status.
-					// In gui-v2 we will connect to venus-platform or some backend to do this.
-					const newState = checked ? VenusOS.Relays_State_Inactive : VenusOS.Relays_State_Active
-					root._relay0Object.setState(newState)
-				}
-			}
-
-			ListSwitch {
 				id: manualSwitch
 
 				text: relay1State.isValid


### PR DESCRIPTION
This corresponds to change 260305cd92cb405374fc093a770e62c769773d8a in gui-v1. The toggle is no longer required as venus-platform now manages the alarm state dependingo nthe relay configuration.

Fixes #855