### PR TITLE
Hide accepted generator dialogs quickly

### DIFF
--- a/components/dialogs/GeneratorDialog.qml
+++ b/components/dialogs/GeneratorDialog.qml
@@ -28,7 +28,7 @@ ModalDialog {
 	id: root
 
 	property Generator generator
-	property int finalGeneratorState: VenusOS.Generators_State_Stopped
+	readonly property int generatorState: root.generator ? root.generator.state : -1
 	property var runGeneratorAction
 
 	title: CommonWords.generator
@@ -124,12 +124,5 @@ ModalDialog {
 
 	onAboutToShow: {
 		acceptButtonBackground.state = "default"
-	}
-
-	readonly property int _generatorState: root.generator ? root.generator.state : -1
-	on_GeneratorStateChanged: {
-		if (root.open && root.generator.state === root.finalGeneratorState) {
-			root.accept()
-		}
 	}
 }

--- a/components/dialogs/GeneratorStartDialog.qml
+++ b/components/dialogs/GeneratorStartDialog.qml
@@ -11,7 +11,16 @@ GeneratorDialog {
 
 	//% "Start Now"
 	acceptText: qsTrId("controlcard_generator_startdialog_start_now")
-	finalGeneratorState: VenusOS.Generators_State_Running
+
+	onGeneratorStateChanged: {
+		if (root.open) {
+			if (generatorState == VenusOS.Generators_State_Running
+					|| generatorState == VenusOS.Generators_State_WarmUp) {
+				root.accept()
+			}
+		}
+	}
+
 	runGeneratorAction: function() {
 		root.generator.start(timedRunSwitch.checked ? Utils.composeDuration(timeSelector.hour, timeSelector.minute) : 0)
 	}

--- a/components/dialogs/GeneratorStopDialog.qml
+++ b/components/dialogs/GeneratorStopDialog.qml
@@ -11,7 +11,17 @@ GeneratorDialog {
 
 	//% "Stop Now"
 	acceptText: qsTrId("controlcard_generator_stopdialog_stop_now")
-	finalGeneratorState: VenusOS.Generators_State_Stopped
+
+	onGeneratorStateChanged: {
+		if (root.open) {
+			if (generatorState == VenusOS.Generators_State_Stopped
+					|| generatorState == VenusOS.Generators_State_Stopping
+					|| generatorState == VenusOS.Generators_State_CoolDown) {
+				root.accept()
+			}
+		}
+	}
+
 	runGeneratorAction: function() {
 		root.generator.stop()
 	}

--- a/pages/controlcards/GeneratorCard.qml
+++ b/pages/controlcards/GeneratorCard.qml
@@ -117,6 +117,7 @@ ControlCard {
 		// when it is visible below the open start/stop dialogs.
 		checked: _generatorStateBeforeDialogOpen < 0
 				 ? root.generator.state === VenusOS.Generators_State_Running
+				   || root.generator.state === VenusOS.Generators_State_WarmUp
 				 : _generatorStateBeforeDialogOpen === VenusOS.Generators_State_Running
 
 		text: checked
@@ -128,7 +129,8 @@ ControlCard {
 
 		onClicked: {
 			_generatorStateBeforeDialogOpen = root.generator.state
-			if (root.generator.state === VenusOS.Generators_State_Running) {
+			if (root.generator.state === VenusOS.Generators_State_Running
+					|| root.generator.state === VenusOS.Generators_State_WarmUp) {
 				Global.dialogLayer.open(generatorStopDialogComponent)
 			} else {
 				Global.dialogLayer.open(generatorStartDialogComponent)


### PR DESCRIPTION
- The stopped generator goes quickly from the running to the cool-down state, but takes dozen seconds to go to the stopping and finally to the stopped states
- Similarly the started generator goes quickly from the stopped to the warmup state, but 20+ seconds to reach the running state
- Instead of waiting for the end state, hide the dialog already during cool-down and warmup
- Allow quickly toggling the generator on/off like with the switch used in gui v1 and gui v2 settings

Fixes #837.