### PR TITLE
Avoid crash when QML tries to delete global CmAgent

### DIFF
--- a/src/connman/cmmanager.cpp
+++ b/src/connman/cmmanager.cpp
@@ -18,7 +18,7 @@ CmManager::CmManager(QObject *parent) :
 	mManager("net.connman", "/", VeDbusConnection::getConnection()),
 	mWatcher("net.connman", VeDbusConnection::getConnection(),
 			 QDBusServiceWatcher::WatchForRegistration | QDBusServiceWatcher::WatchForUnregistration),
-	mAgent(parent)
+	mAgent(this)
 {
 	registerConnmanDataTypes();
 


### PR DESCRIPTION
PageSettingsTcpIp.qml fetches CmAgent from singleton:

```
property CmAgent _agent
Component.onCompleted: ... _agent = Connman.registerAgent(_agentPath);
```

CmAgent is created in C++ side, but has not been assigned a parent, making QML think it has the ownership of the object (["ownership IS transferred to QML if and only if the QObject has no parent"](https://wiki.qt.io/Shared_Pointers_and_QML_Ownership)). When the page is closed and QML tries to delete CmAgent object free() throws critical error and the process is closed with SIGABRT.

Fixes https://github.com/victronenergy/gui-v2/issues/728.