### PR TITLE
Hide display brightness settings on wasm

### DIFF
--- a/pages/settings/PageSettingsDisplay.qml
+++ b/pages/settings/PageSettingsDisplay.qml
@@ -19,6 +19,7 @@ Page {
 				//% "Adaptive brightness"
 				text: qsTrId("settings_adaptive_brightness")
 				dataItem.uid: Global.systemSettings.serviceUid + "/Settings/Gui/AutoBrightness"
+				allowed: Qt.platform.os != "wasm"
 			}
 
 			ListSlider {
@@ -26,7 +27,7 @@ Page {
 				text: qsTrId("settings_brightness")
 				dataItem.uid: Global.systemSettings.serviceUid + "/Settings/Gui/Brightness"
 				writeAccessLevel: VenusOS.User_AccessType_User
-				allowed: defaultAllowed && !autoBrightness.checked
+				allowed: defaultAllowed && !autoBrightness.checked && Qt.platform.os != "wasm"
 			}
 
 			ListRadioButtonGroup {


### PR DESCRIPTION
The brightness settings do not affect the browser display, only the device display, so it is misleading to show these settings in the wasm build.

Contributes to #375