### PR TITLE
Avoid calculating tank level on Brief Page gauges if possible

### DIFF
--- a/components/GaugeModel.qml
+++ b/components/GaugeModel.qml
@@ -84,11 +84,10 @@ ListModel {
 			readonly property string tankName: _tankProperties.name
 			readonly property string tankIcon: isBattery ? Global.batteries.system.icon : _tankProperties.icon
 			readonly property var tankModel: isBattery ? null : Global.tanks.tankModel(tankType)
-			readonly property real tankLevel: isBattery
-					? Math.round(Global.batteries.system.stateOfCharge || 0)
-					: (tankModel.count === 0 || tankModel.totalCapacity === 0
-					   ? 0
-					   : (tankModel.totalRemaining / tankModel.totalCapacity) * 100)
+			readonly property real tankLevel: isBattery ? Math.round(Global.batteries.system.stateOfCharge || 0)
+					: !isNaN(tankModel.averageLevel) ? tankModel.averageLevel
+					: (tankModel.count === 0 || tankModel.totalCapacity === 0) ? 0
+					: ((Math.min(tankModel.totalRemaining / tankModel.totalCapacity, 1.0) * 100))
 
 			readonly property var _tankProperties: Gauges.tankProperties(tankType)
 


### PR DESCRIPTION
Affects WasteWater and BlackWater tanks.

Fixes #680