### PR TITLE
Fix BriefPage lower right gauge opacity binding

### DIFF
--- a/pages/BriefPage.qml
+++ b/pages/BriefPage.qml
@@ -225,8 +225,9 @@ SwipeViewPage {
 		sourceComponent: SideGauge {
 			alignment: Qt.AlignRight | Qt.AlignBottom
 			animationEnabled: root.animationEnabled
-			value: visible ? dcLoadsRange.valueAsRatio * 100 : 0           
+			value: visible ? dcLoadsRange.valueAsRatio * 100 : 0
 			x: -root._gaugeArcMargin
+			opacity: root._gaugeArcOpacity
 
 			ArcGaugeQuantityRow {
 				alignment: parent.alignment


### PR DESCRIPTION
Ensure that the DC Loads gauge opacity animates to zero when the side monitor panel is open.