### PR TITLE
Round spinbox initial value to the chosen decimal

### DIFF
--- a/components/dialogs/NumberSelectorDialog.qml
+++ b/components/dialogs/NumberSelectorDialog.qml
@@ -26,7 +26,7 @@ ModalDialog {
 	}
 
 	onAboutToShow: {
-		spinBox.value = value * _multiplier()
+		spinBox.value = Math.round(value * _multiplier())
 
 		if (presets.length) {
 			let presetsIndex = -1


### PR DESCRIPTION
The original bug report #784 describes tank capacities shown with wrong values, which is very likely due to different rounding rules.

When the bug was filed only the ListSpinBox button displayed the capacity values rounded to the precision using Number.toFixed(), but later as part #620 rounding was introduced to the capacities shown below the tank gauges too, formatted using the Units API. The capacity shown by the ListSpinBox NumberSelectorDialog still lacked rounding, fixed here.

![image](https://github.com/victronenergy/gui-v2/assets/2203667/00e54d48-53e9-4f2a-a560-d6ea9933bb06)

Fixes #784.