### PR TITLE
Improve support for editing QML source giles on the cerbo

### DIFF
--- a/ApplicationContent.qml
+++ b/ApplicationContent.qml
@@ -88,18 +88,15 @@ Item {
 	// Qt for WebAssembly due to QTBUG-104109).
 	// Note the VKB layer is the top-most layer, to allow the idleModeMouseArea beneath to call
 	// testCloseOnClick() when clicking outside of the focused text field, to auto-close the VKB.
-	Component.onCompleted: {
-		if (Qt.platform.os !== "wasm") {
-			_inputComponent = Qt.createComponent(Global.appUrl("/components/InputPanel.qml"), Component.Asynchronous)
-			_inputComponent.statusChanged.connect(function() {
-				if (_inputComponent.status === Component.Ready) {
-					Global.inputPanel = _inputComponent.createObject(root, { mainViewItem: mainView })
-				} else if (_inputComponent.status === Component.Error) {
-					console.warn("Cannot load InputPanel:", _inputComponent.errorString())
-				}
-			})
-		} else {
-			console.log("Not creating InputPanel, this is a wasm build")
+
+	Loader {
+		id: loader
+
+		asynchronous: true
+		active: Qt.platform.os !== "wasm"
+		sourceComponent: InputPanel {
+			mainViewItem: mainView
 		}
+		onLoaded: Global.inputPanel = item
 	}
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -853,7 +853,7 @@ if (${LOAD_QML_FROM_FILESYSTEM})
     set(thisModule VictronMock)
     qt_query_qml_module(${thisModule} QML_FILES module_qml_files QMLDIR module_qmldir)
     install(FILES ${module_qmldir} DESTINATION ${CMAKE_INSTALL_BINDIR}/Victron/Mock)
-    install(DIRECTORY data         DESTINATION ${CMAKE_INSTALL_BINDIR}/Victron/Mock)
+    install(DIRECTORY data/mock         DESTINATION ${CMAKE_INSTALL_BINDIR}/Victron/Mock/data)
     add_custom_command(
         TARGET ${thisModule}
         COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/StripRegexFromFile.cmake" ${module_qmldir} "^prefer.*$"
@@ -879,8 +879,8 @@ qt_add_qml_module(VictronGauges
 if (${LOAD_QML_FROM_FILESYSTEM})
     set(thisModule VictronGauges)
     qt_query_qml_module(${thisModule} QML_FILES module_qml_files QMLDIR module_qmldir)
-    install(FILES ${module_qmldir}    DESTINATION ${CMAKE_INSTALL_BINDIR}/Gauges)
-    install(FILES ${module_qml_files} DESTINATION ${CMAKE_INSTALL_BINDIR}/Gauges/components)
+    install(FILES ${module_qmldir}    DESTINATION ${CMAKE_INSTALL_BINDIR}/Victron/Gauges)
+    install(FILES ${module_qml_files} DESTINATION ${CMAKE_INSTALL_BINDIR}/Victron/Gauges/components)
     add_custom_command(
         TARGET ${thisModule}
         COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/StripRegexFromFile.cmake" ${module_qmldir} "^prefer.*$"

--- a/Global.qml
+++ b/Global.qml
@@ -64,18 +64,6 @@ QtObject {
 	signal aboutToFocusTextField(var textField, int toTextFieldY, var flickable)
 	signal keyPressed(var event)
 
-	function appUrl(urlPath) {
-		let url = urlPath
-		if (!url.startsWith("qrc:")) {
-			if (url.startsWith("/")) {
-				url = "qrc:/qt/qml/Victron/VenusOS" + url
-			} else {
-				console.warn("appUrl(): relative paths are not supported!")
-			}
-		}
-		return url
-	}
-
 	function showToastNotification(category, text, autoCloseInterval = 0) {
 		notificationLayer.showToastNotification(category, text, autoCloseInterval)
 	}

--- a/Main.qml
+++ b/Main.qml
@@ -6,6 +6,8 @@
 import QtQuick
 import QtQuick.Window
 
+// *** This file cannot be edited directly on the cerbo filesystem. It is loaded from the binary ***
+
 Window {
 	id: root
 

--- a/components/NavBar.qml
+++ b/components/NavBar.qml
@@ -108,7 +108,7 @@ Rectangle {  // Use an opaque background so that page disappears behind nav bar 
 					height: width
 					radius: Theme.geometry_notificationsPage_delegate_marker_radius
 					color: Theme.color_critical
-					visible: model.url === Global.appUrl("/pages/NotificationsPage.qml")
+					visible: model.url.endsWith("NotificationsPage.qml")
 							 && !!Global.notifications
 							 && Global.notifications.alert
 				}

--- a/components/PageStack.qml
+++ b/components/PageStack.qml
@@ -70,7 +70,7 @@ C.StackView {
 				return
 			}
 
-			let objectOrUrl = typeof(obj) === "string" ? Global.appUrl(obj) : obj
+			let objectOrUrl = typeof(obj) === "string" ? ".." + obj : obj
 			if (typeof(obj) === "string") {
 				// pre-construct the object to make sure there are no errors
 				// to avoid messing up the page stack state.

--- a/data/DataManager.qml
+++ b/data/DataManager.qml
@@ -54,21 +54,39 @@ Item {
 		switch (BackendConnection.type) {
 		case BackendConnection.DBusSource:
 			console.warn("Loading D-Bus data backend...")
-			dataManagerLoader.source = "qrc:/qt/qml/Victron/Dbus/data/dbus/DBusDataManager.qml"
+			dataManagerLoader.sourceComponent = dbus
 			break
 		case BackendConnection.MqttSource:
 			console.warn("Loading MQTT data backend...")
-			dataManagerLoader.source = "qrc:/qt/qml/Victron/Mqtt/data/mqtt/MqttDataManager.qml"
+			dataManagerLoader.sourceComponent = mqtt
 			break
 		case BackendConnection.MockSource:
 			console.warn("Loading mock data backend...")
-			dataManagerLoader.source = "qrc:/qt/qml/Victron/Mock/data/mock/MockDataManager.qml"
+			dataManagerLoader.sourceComponent = mock
 			break
 		default:
 			console.warn("Unsupported data backend!", BackendConnection.type)
 			return
 		}
 		dataManagerLoader.active = true
+	}
+
+	Component {
+		id: dbus
+
+		DBusDataManager {}
+	}
+
+	Component {
+		id: mqtt
+
+		MqttDataManager {}
+	}
+
+	Component {
+		id: mock
+
+		MockDataManager {}
 	}
 
 	on_ShouldInitializeChanged: _setBackendSource()

--- a/pages/MainView.qml
+++ b/pages/MainView.qml
@@ -90,7 +90,7 @@ Item {
 
 		z: 1
 		opacity: 0.0
-		source: Global.appUrl("/pages/ControlCardsPage.qml")
+		sourceComponent: ControlCardsPage { }
 		active: root.controlsActive
 		enabled: root.controlsActive || controlsOutAnimation.running
 


### PR DESCRIPTION
I think this now works for all QML source files, except for Main.qml - this is loaded from .cpp, and needs to use the resource system. We could move most stuff out of Main.qml and into a new file if we think it's necessary.


