### PR TITLE
Don't draw the out-of-screen keyboard

### DIFF
--- a/components/InputPanel.qml
+++ b/components/InputPanel.qml
@@ -28,9 +28,11 @@ QtVirtualKeyboard.InputPanel {
 		return false
 	}
 
+	visible: Qt.inputMethod.visible || yAnimator.running
 	y: Qt.inputMethod.visible ? Theme.geometry_screen_height - root.height : Theme.geometry_screen_height
 	Behavior on y {
 		YAnimator {
+			id: yAnimator
 			duration: Theme.animation_inputPanel_slide_duration
 			easing.type: Easing.InOutQuad
 		}


### PR DESCRIPTION
Reduces the overall CPU usage caused by drawing. On Cerbo minimal animation CPU consumption goes from 40% to 24%.

Contributes to #639.