### PR TITLE
Support displaying absolute quantities on the circular gauges

### DIFF
--- a/components/CircularMultiGauge.qml
+++ b/components/CircularMultiGauge.qml
@@ -102,14 +102,36 @@ Item {
 					color: Theme.color_font_primary
 					text: model.name
 				}
+
 				Label {
+					id: valueLabel
 					anchors.verticalCenter: parent.verticalCenter
 					horizontalAlignment: Text.AlignRight
 					font.pixelSize: Theme.font_size_body2
 					color: Theme.color_font_primary
-					visible: Global.systemSettings.briefView.showPercentages.value === 1
-					//% "%1%"
-					text: qsTrId("%1%").arg(isNaN(model.value) ? 0 : Math.round(model.value))
+					visible: false
+					property int unit
+					property quantityInfo quantity
+
+					states: State {
+						when: Global.systemSettings.briefView.unit.value !== VenusOS.BriefView_Unit_None
+						PropertyChanges {
+							target: valueLabel
+
+							visible: !isNaN(model.value)
+							text: quantity.number + quantity.unit
+							quantity: Units.getDisplayText(unit, value)
+							unit: {
+								if (Global.systemSettings.briefView.unit.value === VenusOS.BriefView_Unit_Percentage) {
+									return VenusOS.Units_Percentage
+								} else if (model.tankType === VenusOS.Tank_Type_Battery) {
+									return VenusOS.Units_Percentage
+								} else {
+									return Global.systemSettings.volumeUnit
+								}
+							}
+						}
+					}
 				}
 				CP.ColorImage {
 					id: iconImage

--- a/components/GaugeModel.qml
+++ b/components/GaugeModel.qml
@@ -37,8 +37,11 @@ ListModel {
 				return
 			}
 		}
+
+		const value = Global.systemSettings.briefView.unit.value === VenusOS.BriefView_Unit_Percentage || gauge.isBattery ? gauge.tankLevel : gauge.tankRemaining
+
 		insert(_insertionIndex(gauge.tankType, sortedGaugeTypes),
-			   Object.assign({}, Gauges.tankProperties(gauge.tankType), { tankType: gauge.tankType, value: gauge.tankLevel }))
+			   Object.assign({}, Gauges.tankProperties(gauge.tankType), { tankType: gauge.tankType, value: value }))
 	}
 
 	function findGauge(gauge) {
@@ -53,7 +56,8 @@ ListModel {
 	function updateGauge(gauge) {
 		const gaugeIndex = findGauge(gauge)
 		if (gaugeIndex >= 0) {
-			set(gaugeIndex, { name: gauge.tankName, icon: gauge.tankIcon, value: gauge.tankLevel })
+			const value = Global.systemSettings.briefView.unit.value === VenusOS.BriefView_Unit_Percentage || gauge.isBattery ? gauge.tankLevel : gauge.tankRemaining
+			set(gaugeIndex, { name: gauge.tankName, icon: gauge.tankIcon, value: value })
 		}
 	}
 
@@ -88,6 +92,8 @@ ListModel {
 					: !isNaN(tankModel.averageLevel) ? tankModel.averageLevel
 					: (tankModel.count === 0 || tankModel.totalCapacity === 0) ? 0
 					: ((Math.min(tankModel.totalRemaining / tankModel.totalCapacity, 1.0) * 100))
+			readonly property real tankRemaining: isBattery ? null
+															: Units.convert(tankModel.totalRemaining, VenusOS.Units_Volume_CubicMeter, Global.systemSettings.volumeUnit);
 
 			readonly property var _tankProperties: Gauges.tankProperties(tankType)
 

--- a/data/SystemSettings.qml
+++ b/data/SystemSettings.qml
@@ -159,8 +159,8 @@ QtObject {
 			}
 		}
 
-		property VeQuickItem showPercentages: VeQuickItem {
-			 uid: root.serviceUid + "/Settings/Gui/BriefView/ShowPercentages"
+		property VeQuickItem unit: VeQuickItem {
+			 uid: root.serviceUid + "/Settings/Gui/BriefView/Unit"
 		}
 	}
 

--- a/pages/settings/PageSettingsDisplayBrief.qml
+++ b/pages/settings/PageSettingsDisplayBrief.qml
@@ -47,12 +47,19 @@ Page {
 			}
 		}
 
-		footer: ListSwitch {
+		footer: ListRadioButtonGroup {
 			//: Show percentage values in Brief view
-			//% "Show %"
-			text: qsTrId("settings_briefview_show_percentage")
-			checked: Global.systemSettings.briefView.showPercentages.value === 1
-			onClicked: Global.systemSettings.briefView.showPercentages.setValue(checked ? 1 : 0)
+			//% "Brief view unit"
+			text: qsTrId("settings_briefview_unit")
+			optionModel: [
+				//% "No labels"
+				{ display: qsTrId("settings_briefview_unit_none"), value: VenusOS.BriefView_Unit_None },
+				//% "Show tank volumes"
+				{ display: qsTrId("settings_briefview_unit_absolute"), value: VenusOS.BriefView_Unit_Absolute },
+				//% "Show percentages"
+				{ display: qsTrId("settings_briefview_unit_percentages"), value: VenusOS.BriefView_Unit_Percentage },
+			]
+			dataItem.uid: Global.systemSettings.serviceUid + "/Settings/Gui/BriefView/Unit"
 		}
 	}
 }

--- a/src/enums.h
+++ b/src/enums.h
@@ -323,6 +323,13 @@ public:
 	};
 	Q_ENUM(System_State)
 
+	enum BriefView_Unit {
+		BriefView_Unit_None,
+		BriefView_Unit_Absolute,
+		BriefView_Unit_Percentage
+	};
+	Q_ENUM(BriefView_Unit)
+
 	enum Tank_Type {
 		// These values align with tank types from dbus
 		// see: https://github.com/victronenergy/venus/wiki/dbus#tank-levels

--- a/src/veqitemmockproducer.cpp
+++ b/src/veqitemmockproducer.cpp
@@ -42,7 +42,7 @@ void VeQItemMockProducer::initialize()
 
 	setValue(guiSettingUid.arg("ColorScheme"), Theme::Light);
 	setValue(guiSettingUid.arg("ElectricalPowerIndicator"), 0); // 0 = watts, 1 = amps
-	setValue(guiSettingUid.arg("BriefView/ShowPercentages"), 1);
+	setValue(guiSettingUid.arg("BriefView/Unit"), Enums::BriefView_Unit_Percentage);
 
 	static const QMap<int, QVariant> defaultLevels = {
 		{ 0, Enums::Tank_Type_Battery },


### PR DESCRIPTION
Show the remaining battery level always in percentages, but allow showing the remaining tank levels in absolute volumes.

Fixes #551.