### PR TITLE
Pause Overview page animations during high CPU load

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -657,6 +657,8 @@ list(APPEND VenusQMLModule_CPP_SOURCES
     src/notificationsmodel.cpp
     src/clocktime.h
     src/clocktime.cpp
+    src/cpuinfo.h
+    src/cpuinfo.cpp
     src/frameratemodel.h
     src/frameratemodel.cpp
     src/quantityinfo.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,7 @@ set (VENUS_QML_MODULE_SOURCES
     components/CircularSingleGauge.qml
     components/ControlCard.qml
     components/ControlValue.qml
+    components/CpuMonitor.qml
     components/Device.qml
     components/ElectricalQuantityLabel.qml
     components/EnvironmentGauge.qml

--- a/Global.qml
+++ b/Global.qml
@@ -23,6 +23,7 @@ QtObject {
 	property var dialogLayer
 	property var notificationLayer
 	property ScreenBlanker screenBlanker
+	property bool displayCpuUsage
 
 	// data sources
 	property var acInputs

--- a/components/CpuMonitor.qml
+++ b/components/CpuMonitor.qml
@@ -1,0 +1,24 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+Rectangle {
+	height: label.height
+	width: label.width + Theme.geometry_button_spacing
+
+	QuantityLabel {
+		id: label
+
+		value: cpuInfo.usage
+		unit: VenusOS.Units_Percentage
+		anchors.centerIn: parent
+
+		CpuInfo {
+			id: cpuInfo
+		}
+	}
+}

--- a/components/widgets/WidgetConnector.qml
+++ b/components/widgets/WidgetConnector.qml
@@ -74,6 +74,11 @@ Item {
 			// Animate at a constant rate of pixels/sec, based on the diagonal length of the shape
 			electronAnim.duration = electronTravelDistance / Theme.geometry_overviewPage_connector_electron_velocity * 1000
 		}
+
+		// Force drawing manually if the animations are paused
+		if (overviewPageRootAnimation.paused) {
+			pathUpdater.update()
+		}
 	}
 
 	visible: defaultVisible
@@ -90,13 +95,13 @@ Item {
 		PropertyChanges { target: connectorPath; y: connectorPath.expandedY; yDistance: connectorPath.expandedYDistance }
 		PropertyChanges { target: connectorPath; startAnchorY: connectorPath.startAnchorExpandedY }
 		PropertyChanges { target: connectorPath; endAnchorY: connectorPath.endAnchorExpandedY }
+		PropertyChanges { target: root; _transitionUpdating: 1.0 }
 	}
 
 	transitions: Transition {
 		enabled: root.animateGeometry
-
 		NumberAnimation {
-			properties: "y,yDistance,startAnchorY,endAnchorY"
+			properties: "y, yDistance, startAnchorY, endAnchorY, _transitionUpdating"
 			duration: Theme.animation_page_idleResize_duration
 			easing.type: Easing.InOutQuad
 		}
@@ -252,6 +257,10 @@ Item {
 			pathUpdater.progress = startToEnd ? progress : 1.0 - progress
 		}
 	}
+
+	// Force drawing during the expanding transition even if the animations are paused
+	property real _transitionUpdating
+	on_TransitionUpdatingChanged: if (overviewPageRootAnimation.paused) pathUpdater.update()
 
 	WidgetConnectorPathUpdater {
 		id: pathUpdater

--- a/pages/MainView.qml
+++ b/pages/MainView.qml
@@ -354,4 +354,15 @@ Item {
 
 		Component.onCompleted: pageManager.statusBar = statusBar
 	}
+
+	Loader {
+		active: Global.displayCpuUsage
+		anchors {
+			bottom: parent.bottom
+			right: parent.right
+		}
+		sourceComponent: CpuMonitor {
+			color: root.backgroundColor
+		}
+	}
 }

--- a/pages/OverviewPage.qml
+++ b/pages/OverviewPage.qml
@@ -561,10 +561,19 @@ SwipeViewPage {
 		}
 	}
 
+	CpuInfo {
+		id: cpuInfo
+
+		enabled: root.animationEnabled
+		upperLimit: 85
+		lowerLimit: 50
+	}
+
 	FrameAnimation {
 		id: overviewPageRootAnimation
 
-		running: root.visible
+		paused: cpuInfo.overLimit
+		running: root.animationEnabled
 		property int index
 		property real previousElapsed
 
@@ -719,7 +728,7 @@ SwipeViewPage {
 		size: VenusOS.OverviewWidget_Size_L
 		expanded: root._expandLayout
 		animateGeometry: root._animateGeometry
-		animationEnabled: root.animationEnabled
+		animationEnabled: root.animationEnabled && !cpuInfo.overLimit
 		connectors: [ batteryToDcLoadsConnector ]
 
 		WidgetConnectorAnchor {

--- a/pages/settings/debug/PageDebug.qml
+++ b/pages/settings/debug/PageDebug.qml
@@ -11,26 +11,41 @@ Page {
 
 	GradientListView {
 		model: ObjectModel {
-			ListItem {
-				id: frameRateSwitch
-				//% "Enable frame-rate visualizer"
-				text: qsTrId("settings_page_debug_enable_fps_visualizer")
-				content.children: [
-					Switch {
-						id: switchItem
-						checked: FrameRateModel.enabled
-						onClicked: FrameRateModel.enabled = !FrameRateModel.enabled
-					}
-				]
+
+			component SwitchItem : ListItem {
+				id: switchItem
+
+				signal clicked
+				property alias checked: childSwitch.checked
+
+				content.children: Switch {
+					id: childSwitch
+					onClicked: switchItem.clicked()
+				}
 
 				PressArea {
-					radius: frameRateSwitch.backgroundRect.radius
+					radius: switchItem.backgroundRect.radius
 					anchors {
 						fill: parent
-						bottomMargin: frameRateSwitch.spacing
+						bottomMargin: switchItem.spacing
 					}
-					onClicked: FrameRateModel.enabled = !FrameRateModel.enabled
+					onClicked: switchItem.clicked()
 				}
+			}
+
+			SwitchItem {
+				//% "Enable frame-rate visualizer"
+				text: qsTrId("settings_page_debug_enable_fps_visualizer")
+				checked: FrameRateModel.enabled
+				onClicked: FrameRateModel.enabled = !FrameRateModel.enabled
+			}
+
+			SwitchItem {
+				//% "Display CPU usage"
+				text: qsTrId("settings_page_debug_display_cpu_usage")
+				checked: Global.displayCpuUsage
+				onClicked: Global.displayCpuUsage = !Global.displayCpuUsage
+				allowed: defaultAllowed && Qt.platform.os === "linux"
 			}
 
 			ListButton {

--- a/src/cpuinfo.cpp
+++ b/src/cpuinfo.cpp
@@ -1,0 +1,69 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+#include "cpuinfo.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+using namespace Victron::VenusOS;
+
+int get_cpu_usage(unsigned long long &previousBusy, unsigned long long &previousIdle) {
+	// Read CPU stats
+	FILE *file = fopen("/proc/stat", "r");
+	if (file == nullptr) {
+		qWarning() << "Could not open /proc/stat";
+		return -1;
+	}
+
+	unsigned long long user, nice, system, idleTotal, busyTotal;
+	fscanf(file, "cpu %llu %llu %llu %llu", &user, &nice, &system, &idleTotal);
+	busyTotal = user + nice + system;
+	fclose(file);
+
+
+	// Calculate CPU usage
+	unsigned long long busy = busyTotal - previousBusy;
+	unsigned long long idle = idleTotal - previousIdle;
+	previousBusy = busyTotal;
+	previousIdle = idleTotal;
+	return qRound((busy * 100.0) / (busy + idle));
+}
+
+CpuInfo::CpuInfo(QObject *parent)
+	: QObject(parent)
+{
+#ifdef Q_OS_LINUX
+	m_timer.setInterval(2000);
+	if (m_enabled) {
+		m_timer.start();
+	}
+
+	connect(this, &CpuInfo::enabledChanged, this, [this] {
+		if (m_enabled) {
+			m_timer.start();
+		} else {
+			m_timer.stop();
+		}
+	});
+
+	connect(&m_timer, &QTimer::timeout,
+		this, [this] {
+			int usage = get_cpu_usage(m_previousBusy, m_previousIdle);
+			if (m_usage != usage) {
+				m_usage = usage;
+				if (m_overLimit && usage < m_lowerLimit) {
+					m_overLimit = false;
+					emit overLimitChanged();
+				} else if (!m_overLimit && usage > m_upperLimit) {
+					m_overLimit = true;
+					emit overLimitChanged();
+				}
+				emit usageChanged();
+			}
+	});
+#endif
+}

--- a/src/cpuinfo.h
+++ b/src/cpuinfo.h
@@ -1,0 +1,47 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+#ifndef CPUINFO_H
+#define CPUINFO_H
+
+#include <QObject>
+#include <QQmlEngine>
+#include <QTimer>
+
+namespace Victron {
+namespace VenusOS {
+
+class CpuInfo : public QObject
+{
+	Q_OBJECT
+	QML_ELEMENT
+	Q_PROPERTY(int usage MEMBER m_usage NOTIFY usageChanged)
+	Q_PROPERTY(bool enabled MEMBER m_enabled NOTIFY enabledChanged)
+	Q_PROPERTY(int upperLimit MEMBER m_upperLimit NOTIFY upperLimitChanged)
+	Q_PROPERTY(int lowerLimit MEMBER m_lowerLimit NOTIFY lowerLimitChanged)
+	Q_PROPERTY(bool overLimit MEMBER m_overLimit NOTIFY overLimitChanged)
+public:
+	explicit CpuInfo(QObject *parent = nullptr);
+Q_SIGNALS:
+	void usageChanged();
+	void enabledChanged();
+	void upperLimitChanged();
+	void lowerLimitChanged();
+	void overLimitChanged();
+private:
+	int m_usage = 0;
+	int m_lowerLimit = 0;
+	int m_upperLimit = 100;
+	bool m_overLimit = false;
+	bool m_enabled = true;
+	unsigned long long m_previousBusy = 0;
+	unsigned long long m_previousIdle = 0;
+	QTimer m_timer;
+};
+
+}
+}
+
+#endif // CPUINFO_H

--- a/src/widgetconnectorpathupdater.h
+++ b/src/widgetconnectorpathupdater.h
@@ -32,7 +32,6 @@ public:
 	Q_INVOKABLE void add(QQuickItem *electron);
 	Q_INVOKABLE void remove(QQuickItem *electron);
 
-protected slots:
 	Q_INVOKABLE void update() const;
 
 signals:


### PR DESCRIPTION
To simulate high CPU load call `while : ; do : ; done` inside the Ekrano GX terminal.

Calculates the total CPU usage caused by all the processes running on the system so different to what you get from top that displays CPU usage per process. On my laptop venus-gui-v2 uses 8% CPU (top) while the system total CPU (from /proc/stat) usage hovers around 4%. On Cerbo venus-gui-v2 uses 35% CPU while the system total CPU usage hovers around 40-50%. On Ekrano venus-gui-v2 uses 7% while the system total CPU usage overs around 12%.

Hands-on video demonstrating the pausing of animations:
https://github.com/victronenergy/gui-v2/assets/2203667/fc40dffa-6cbe-4f80-9d2d-d00b06f5d561

Also introduces an option to display CPU usage on the debug page.

Contributes to #914.