### PR TITLE
Align dialog scaling with the application content

### DIFF
--- a/Global.qml
+++ b/Global.qml
@@ -59,6 +59,7 @@ QtObject {
 	property string firmwareInstalledBuild // don't clear this on UI reload.  it needs to survive reconnection.
 	property bool firmwareInstalledBuildUpdated // as above.
 	property bool isDesktop
+	property real scalingRatio: 1.0
 
 	signal aboutToFocusTextField(var textField, int toTextFieldY, var flickable)
 	signal keyPressed(var event)

--- a/Main.qml
+++ b/Main.qml
@@ -80,20 +80,18 @@ Window {
 		}
 	}
 
-	Item {
-		anchors.horizontalCenter: parent.horizontalCenter
-		width: Theme.geometry_screen_width + wasmPadding
-		height: Theme.geometry_screen_height
-
+	contentItem {
 		// on wasm just show the GUI at the top of the screen,
 		// otherwise browser chrome can cause problems on mobile devices...
-		y: (Qt.platform.os != "wasm" || scale == 1.0) ? (parent.height-height)/2 : 0
+		y: (Qt.platform.os != "wasm" || scale == 1.0) ? (root.height - contentItem.height)/2 : 0
 		transformOrigin: Qt.platform.os != "wasm" ? Item.Center : Item.Top
+		x: (root.width - contentItem.width)/2
 
 		// In WebAssembly builds, if we are displaying on a low-dpi mobile
 		// device, it may not have enough pixels to display the UI natively.
 		// To fix, we need to downscale everything by the appropriate factor,
 		// and take into account browser chrome stealing real-estate also.
+		onScaleChanged: Global.scalingRatio = contentItem.scale
 		scale: {
 			// no scaling required if not on wasm
 			if (Qt.platform.os != "wasm") {
@@ -151,51 +149,46 @@ Window {
 
 		// Ideally each item would use focus handling to get its own key events, but in wasm the
 		// pagestack's pages do not reliably receive key events even when focused.
-		focus: true
 		Keys.onPressed: function(event) {
 			Global.keyPressed(event)
 			event.accepted = false
 		}
+	}
 
-		Loader {
-			id: guiLoader
+	Loader {
+		id: guiLoader
 
+		anchors.centerIn: parent
+
+		width: Theme.geometry_screen_width
+		height: Theme.geometry_screen_height
+		asynchronous: true
+		clip: Qt.platform.os == "wasm"
+
+		active: Global.dataManagerLoaded
+		sourceComponent: ApplicationContent {
 			anchors.centerIn: parent
-
-			width: Theme.geometry_screen_width
-			height: Theme.geometry_screen_height
-			asynchronous: true
-			clip: Qt.platform.os == "wasm"
-
-			active: Global.dataManagerLoaded
-			sourceComponent: Component {
-				ApplicationContent {
-					anchors.centerIn: parent
-				}
-			}
 		}
+	}
 
-		Loader {
-			id: splashLoader
+	Loader {
+		id: splashLoader
 
+		anchors.centerIn: parent
+		width: Theme.geometry_screen_width
+		height: Theme.geometry_screen_height
+		clip: Qt.platform.os == "wasm"
+
+		active: Global.splashScreenVisible
+		sourceComponent: SplashView {
 			anchors.centerIn: parent
-			width: Theme.geometry_screen_width
-			height: Theme.geometry_screen_height
-			clip: Qt.platform.os == "wasm"
-
-			active: Global.splashScreenVisible
-			sourceComponent: Component {
-				SplashView {
-					anchors.centerIn: parent
-				}
-			}
 		}
+	}
 
-		VenusFontLoader {
-			id: fontLoader
+	VenusFontLoader {
+		id: fontLoader
 
-			Component.onCompleted: Global.fontLoader = fontLoader
-		}
+		Component.onCompleted: Global.fontLoader = fontLoader
 	}
 
 	FrameRateVisualizer {}

--- a/components/dialogs/DialogShadow.qml
+++ b/components/dialogs/DialogShadow.qml
@@ -4,18 +4,12 @@
 */
 
 import QtQuick
-import QtQuick.Controls as C
 import Victron.VenusOS
 
 Rectangle {
-	property var backgroundRect
-	property var dialog
-
-	// TODO: do this with shader, or with border image taking noise sample.
-	anchors.fill: backgroundRect
-	anchors.margins: -border.width
-	color: "transparent"
-	border.color: Qt.rgba(0.0, 0.0, 0.0, 0.7)
-	border.width: Math.max(dialog.parent.width - parent.width, dialog.parent.height - parent.height)
-	radius: backgroundRect.radius + border.width
+	z: -1
+	anchors.centerIn: parent
+	color: Qt.rgba(0.0, 0.0, 0.0, 0.7)
+	width: Screen.width / Global.scalingRatio
+	height: Screen.height / Global.scalingRatio
 }

--- a/components/dialogs/ModalDialog.qml
+++ b/components/dialogs/ModalDialog.qml
@@ -38,8 +38,8 @@ T.Dialog {
 	readonly property string rejectTextClose: qsTrId("modaldialog_close")
 
 	anchors.centerIn: parent
-	implicitWidth: background.implicitWidth
-	implicitHeight: background.implicitHeight
+	implicitWidth: Theme.geometry_modalDialog_width
+	implicitHeight: Theme.geometry_modalDialog_height
 	verticalPadding: 0
 	horizontalPadding: 0
 	modal: true
@@ -56,16 +56,11 @@ T.Dialog {
 	}
 
 	background: Rectangle {
-		implicitWidth: Theme.geometry_modalDialog_width
-		implicitHeight: Theme.geometry_modalDialog_height
 		radius: Theme.geometry_modalDialog_radius
 		color: Theme.color_background_secondary
 		border.color: Theme.color_modalDialog_border
 
-		DialogShadow {
-			backgroundRect: parent
-			dialog: root
-		}
+		DialogShadow {}
 	}
 
 	header: Item {

--- a/components/dialogs/SolarDailyHistoryDialog.qml
+++ b/components/dialogs/SolarDailyHistoryDialog.qml
@@ -75,10 +75,7 @@ T.Dialog {
 		radius: Theme.geometry_modalDialog_radius
 		color: Theme.color_background_secondary
 
-		DialogShadow {
-			backgroundRect: parent
-			dialog: root
-		}
+		DialogShadow {}
 
 		Rectangle {
 			id: highlightBar


### PR DESCRIPTION
GUI v2 has a dialog layer, which is a child of the transform item that gets scaled down on wasm builds, but Qt Quick Control dialogs get reparented outside the dialog layer before being shown. The new parent (Overlay.overlay) itself is parented to the invisible root item of the scene (Window.contentItem). To include the dialog in the scaling move the viewport transformations to the root item instead. Adapt DialogShadow to counter the scaling as we want the dimming to be applied to the whole Qt window.

Fixes #918.