### PR TITLE
Always maximise GUI v2 to the viewport dimensions

### DIFF
--- a/Main.qml
+++ b/Main.qml
@@ -81,71 +81,15 @@ Window {
 	}
 
 	contentItem {
-		// on wasm just show the GUI at the top of the screen,
-		// otherwise browser chrome can cause problems on mobile devices...
-		y: (Qt.platform.os != "wasm" || scale == 1.0) ? (root.height - contentItem.height)/2 : 0
-		transformOrigin: Qt.platform.os != "wasm" ? Item.Center : Item.Top
-		x: (root.width - contentItem.width)/2
+		// on wasm just show the GUI at the top of the screen
+		transformOrigin: Qt.platform.os !== "wasm" ? Item.Center : Item.Top
 
 		// In WebAssembly builds, if we are displaying on a low-dpi mobile
 		// device, it may not have enough pixels to display the UI natively.
 		// To fix, we need to downscale everything by the appropriate factor,
 		// and take into account browser chrome stealing real-estate also.
 		onScaleChanged: Global.scalingRatio = contentItem.scale
-		scale: {
-			// no scaling required if not on wasm
-			if (Qt.platform.os != "wasm") {
-				return 1.0
-			}
-			// no scaling required if we can pad and zoom instead
-			if ((Screen.height >= Theme.geometry_screen_height)
-					&& (Screen.width >= Theme.geometry_screen_width)) {
-				return 1.0
-			}
-			var hscale = Screen.width / Theme.geometry_screen_width
-			var vscale = Screen.height / Theme.geometry_screen_height
-			// in landscape mode, give even more room, as the browser chrome
-			// will take up significant vertical space.
-			var chromeFactor = (Screen.height > Screen.width) ? 1.0 : 0.75
-			return Math.min(hscale, vscale) * chromeFactor
-		}
-
-		// In WebAssembly builds, if we are displaying on a high-dpi mobile
-		// device the aspect ratio of the screen may not match the aspect
-		// ratio expected on a CerboGX etc.
-		// The phone web browser will auto zoom to horizontal-fill,
-		// meaning that the vertical content may extend below the screen,
-		// requiring vertical scroll to see.  This is suboptimal.
-		// To fix, we need to add horizontal padding to match aspect.
-		property real wasmPadding: {
-			// no padding required if not on wasm
-			if (Qt.platform.os != "wasm") {
-				return 0
-			}
-			// no padding required if in portrait mode
-			if (Screen.height > Screen.width) {
-				return 0
-			}
-			// no padding required if we need to downscale
-			if ((Screen.height < Theme.geometry_screen_height)
-					|| (Screen.width < Theme.geometry_screen_width)) {
-				return 0
-			}
-			// no padding required if the aspect ratio matches
-			if ((Screen.height / Theme.geometry_screen_height)
-					== (Screen.width / Theme.geometry_screen_width)) {
-				return 0
-			}
-			// fix aspect ratio
-			var verticalRatio = Screen.height / Theme.geometry_screen_height
-			var expectedWidth = Theme.geometry_screen_width * verticalRatio
-			var chromeFactor = 1.2 // browser doesn't give whole screen to content area
-			var delta = (Screen.width - expectedWidth) * chromeFactor
-			if (delta < 0) {
-				return 0
-			}
-			return Math.ceil(delta)
-		}
+		scale: Math.min(root.width/Theme.geometry_screen_width, root.height/Theme.geometry_screen_height)
 
 		// Ideally each item would use focus handling to get its own key events, but in wasm the
 		// pagestack's pages do not reliably receive key events even when focused.
@@ -158,13 +102,19 @@ Window {
 	Loader {
 		id: guiLoader
 
-		anchors.centerIn: parent
-
+		clip: Qt.platform.os == "wasm"
 		width: Theme.geometry_screen_width
 		height: Theme.geometry_screen_height
-		asynchronous: true
-		clip: Qt.platform.os == "wasm"
+		anchors.horizontalCenter: parent.horizontalCenter
+		states: State {
+			when: Qt.platform.os !== "wasm"
+			AnchorChanges {
+				target: guiLoader
+				anchors.verticalCenter: parent.verticalCenter
+			}
+		}
 
+		asynchronous: true
 		active: Global.dataManagerLoaded
 		sourceComponent: ApplicationContent {
 			anchors.centerIn: parent
@@ -174,10 +124,17 @@ Window {
 	Loader {
 		id: splashLoader
 
-		anchors.centerIn: parent
+		clip: Qt.platform.os == "wasm"
 		width: Theme.geometry_screen_width
 		height: Theme.geometry_screen_height
-		clip: Qt.platform.os == "wasm"
+		anchors.horizontalCenter: parent.horizontalCenter
+		states: State {
+			when: Qt.platform.os !== "wasm"
+			AnchorChanges {
+				target: splashLoader
+				anchors.verticalCenter: parent.verticalCenter
+			}
+		}
 
 		active: Global.splashScreenVisible
 		sourceComponent: SplashView {


### PR DESCRIPTION
See the individual commits. Done on top of https://github.com/victronenergy/gui-v2/pull/920

Resolution doesn't tell you much about DPI so better to just maximize the touch GUI to the available viewport. Usually would center the GUI to the available area, but on browsers you kind of expect the website to appear on the top so positioning to the top there.

Video demonstration, first running on Linux, then on browser:
[Screencast from 2024-04-04 16-58-49.webm](https://github.com/victronenergy/gui-v2/assets/2203667/a305fbe7-9f0b-43a8-9205-00da37086e82)

Contributes to #900.