### PR TITLE
Avoid UniformAnimator crash on dialog closing (wasm)

### DIFF
--- a/components/controls/PressEffect.qml
+++ b/components/controls/PressEffect.qml
@@ -49,12 +49,21 @@ ShaderEffect {
 			easing.type: Easing.OutSine
 		}
 
+		// Disable UniformAnimator on WebAssembly due to QTBUG-124152
 		UniformAnimator {
 			target: shaderEffect
 			uniform: "progress"
 			from: 0.0
 			to: 1.0
-			duration: 400
+			duration: Qt.platform.os !== "wasm" ? 400 : 0
+			easing.type: Easing.OutSine
+		}
+		NumberAnimation {
+			target: shaderEffect
+			property: "progress"
+			from: 0.0
+			to: 1.0
+			duration: Qt.platform.os === "wasm" ? 400 : 0
 			easing.type: Easing.OutSine
 		}
 	}
@@ -70,12 +79,22 @@ ShaderEffect {
 			easing.type: Easing.InSine
 		}
 
+		// Disable UniformAnimator on WebAssembly due to QTBUG-124152
 		UniformAnimator {
 			target: shaderEffect
 			uniform: "progress"
 			from: shaderEffect.progress
 			to: 1.0
-			duration: 300
+			duration: Qt.platform.os !== "wasm" ? 300 : 0
+			easing.type: Easing.InSine
+		}
+
+		NumberAnimation {
+			target: shaderEffect
+			property: "progress"
+			from: shaderEffect.progress
+			to: 1.0
+			duration: Qt.platform.os === "wasm" ? 300 : 0
 			easing.type: Easing.InSine
 		}
 	}


### PR DESCRIPTION
Tried to stop(), complete(), pause() the UniformAnimator before the item deletion, but could still reproduce the crash so instead just avoid using the UniformAnimator on WebAssembly builds. Could alternatively have also added a bit of delay to the dialog destruction, but then could not really be sure the crash wouldn't reproduce in some other use case involving button presses and item deletions.

Fixes #917.