### PR TITLE
Hide alternator state in settings if not valid

### DIFF
--- a/pages/settings/devicelist/dc-in/PageAlternatorModel.qml
+++ b/pages/settings/devicelist/dc-in/PageAlternatorModel.qml
@@ -37,6 +37,7 @@ ObjectModel {
 	ListTextItem {
 		text: CommonWords.state
 		secondaryText: Global.system.systemStateToText(dataItem.value)
+		allowed: defaultAllowed && dataItem.isValid
 		dataItem.uid: root.bindPrefix + "/State"
 	}
 


### PR DESCRIPTION
Add support for additional alternators #786 listed bunch of alternators, which have been added already, but also mentioned the need to hide invalid items. All the other ones were covered, but the state item.

Contributes to #786.