### PR TITLE
Fix selection on the rounded radio button

### DIFF
--- a/components/listitems/ListRadioButton.qml
+++ b/components/listitems/ListRadioButton.qml
@@ -15,20 +15,23 @@ ListItem {
 
 	signal clicked()
 
-	down: pressArea.containsPress
+	down: pressArea.containsPress || radioButton.down
 	enabled: userHasWriteAccess
 
 	content.children: [
 		RadioButton {
 			id: radioButton
 
-			onClicked: root.clicked()
+			// Alternative to binding "enabled: !checked". No clicked() signal
+			// got emitted when the button was disabled on checked=false.
+			onClicked: if (root.checked) root.clicked()
 		}
 	]
 
 	ListPressArea {
 		id: pressArea
 
+		enabled: !root.checked
 		radius: backgroundRect.radius
 		anchors {
 			fill: parent

--- a/components/listitems/ListRadioButtonGroup.qml
+++ b/components/listitems/ListRadioButtonGroup.qml
@@ -97,7 +97,7 @@ ListNavigationItem {
 					text: Array.isArray(root.optionModel)
 						  ? modelData.display || ""
 						  : model.display || ""
-					enabled: !checked && (Array.isArray(root.optionModel)
+					enabled: (Array.isArray(root.optionModel)
 						  ? !modelData.readOnly
 						  : !model.readOnly)
 					primaryLabel.font.family: Array.isArray(root.optionModel)


### PR DESCRIPTION
Note the issue affected 95 ListRadioButtonGroups in settings, not RadioButtonControlValues in ESS, Inverter and Inverter-Charged cards in the Control cards page.

Fixes #936.