### PR TITLE
Hide display off button during alerts

### DIFF
--- a/ApplicationContent.qml
+++ b/ApplicationContent.qml
@@ -42,7 +42,7 @@ Item {
 
 	ScreenBlanker {
 		id: screenBlanker
-		enabled: !Global.splashScreenVisible && !(!!Global.notifications && Global.notifications.alarm)
+		enabled: !Global.splashScreenVisible && !(!!Global.notifications && Global.notifications.alert)
 		displayOffTime: displayOffItem.isValid ? 1000*displayOffItem.value : 0.0
 		property VeQuickItem displayOffItem: VeQuickItem {
 			uid: !!Global.systemSettings ? Global.systemSettings.serviceUid + "/Settings/Gui/DisplayOff" : ""

--- a/components/StatusBar.qml
+++ b/components/StatusBar.qml
@@ -121,7 +121,7 @@ Rectangle {
 
 		StatusBarButton {
 			icon.source: "qrc:/images/icon_screen_sleep_32.svg"
-			visible: !!Global.screenBlanker && Global.screenBlanker.supported
+			visible: !!Global.screenBlanker && Global.screenBlanker.supported && Global.screenBlanker.enabled
 			enabled: !!Global.pageManager
 					 && Global.pageManager.interactivity === VenusOS.PageManager_InteractionMode_Interactive
 			onClicked: Global.screenBlanker.setDisplayOff()


### PR DESCRIPTION
- No use showing the button when the blanking is not allowed
- Disable screen blanking on /Notifications/Alert (and not /Notifications/Alarm) to align with gui-v1

Fixes #958.