### PR TITLE
Don't require QtVirtualKeyboard to be installed

### DIFF
--- a/ApplicationContent.qml
+++ b/ApplicationContent.qml
@@ -84,19 +84,22 @@ Item {
 		Component.onCompleted: Global.notificationLayer = notificationLayer
 	}
 
+	// We only want the VKB on CerboGX/EkranoGX devices.
+	// WebAssembly should use the native platform VKB.
+	// Desktop platforms should use hardware keyboard.
 	// Create the InputPanel dynamically in case QtQuick.VirtualKeyboard is not available (e.g. on
 	// Qt for WebAssembly due to QTBUG-104109).
 	// Note the VKB layer is the top-most layer, to allow the idleModeMouseArea beneath to call
 	// testCloseOnClick() when clicking outside of the focused text field, to auto-close the VKB.
-
 	Loader {
 		id: loader
 
 		asynchronous: true
-		active: Qt.platform.os !== "wasm"
-		sourceComponent: InputPanel {
-			mainViewItem: mainView
+		active: Qt.platform.os == "linux" && !Global.isDesktop
+		source: "qrc:/qt/qml/Victron/VenusOS/components/InputPanel.qml"
+		onLoaded: {
+			item.mainViewItem = mainView
+			Global.inputPanel = item
 		}
-		onLoaded: Global.inputPanel = item
 	}
 }

--- a/components/InputPanel.qml
+++ b/components/InputPanel.qml
@@ -7,6 +7,11 @@ import QtQuick
 import QtQuick.VirtualKeyboard as QtVirtualKeyboard
 import Victron.VenusOS
 
+// *** This file can be edited directly on the cerbo filesystem,
+// *** but you will also need to edit ApplicationContent.qml
+// *** so that the loader's source property is:
+// *** "file:///opt/victronenergy/gui-v2/Victron/VenusOS/components/InputPanel.qml"
+
 QtVirtualKeyboard.InputPanel {
 	id: root
 


### PR DESCRIPTION
Some platforms (desktop and WebAssembly) don't require the QtQuick.VirtualKeyboard module to be installed, as they either have hardware keyboards (desktop) or native platform VKB support (iOS/Android).

It is only on CerboGX/EkranoGX that we require QtVirtualKeyboard.

As such, don't declare a component whose type requires the existence of the QtVirtualKeyboard module.  Instead, load it at runtime via a source url, and only on Linux platform.

This does mean that in order to edit the InputPanel.qml file, the user also needs to edit the ApplicationContent.qml file to load it from disk rather than from qrc.