### PR TITLE
Brief: prevent AC input gauge label from overlapping with center text

### DIFF
--- a/components/CircularMultiGauge.qml
+++ b/components/CircularMultiGauge.qml
@@ -83,8 +83,9 @@ Item {
 		anchors.topMargin: strokeWidth/2
 		anchors.bottom: parent.verticalCenter
 		anchors.left: parent.left
+		anchors.leftMargin: Theme.geometry_circularMultiGauge_label_leftMargin
 		anchors.right: parent.horizontalCenter
-		anchors.rightMargin: Theme.geometry_circularMultiGauge_labels_rightMargin + gauges.labelMargin
+		anchors.rightMargin: Theme.geometry_circularMultiGauge_icon_rightMargin + gauges.labelMargin
 
 		Repeater {
 			model: gauges.model
@@ -93,23 +94,29 @@ Item {
 				anchors.verticalCenterOffset: index * _stepSize/2
 				anchors.right: parent.right
 				anchors.rightMargin: Math.max(0, Theme.geometry_circularMultiGauge_icons_maxWidth - iconImage.width)
-				spacing: Theme.geometry_circularMultiGauge_row_spacing
 				visible: model.index < Theme.geometry_briefPage_centerGauge_maximumGaugeCount
+				height: iconImage.height
 
 				Label {
+					anchors.verticalCenter: parent.verticalCenter
+					rightPadding: Theme.geometry_circularMultiGauge_label_rightMargin
 					horizontalAlignment: Text.AlignRight
-					font.pixelSize: Theme.font_size_body2
+					font.pixelSize: valueLabel.visible ? Theme.font_size_body1 : Theme.font_size_body2
 					color: Theme.color_font_primary
 					text: model.name
+					width: textCol.width - valueLabel.width - iconImage.width
+					elide: Text.ElideRight
 				}
 
 				Label {
 					id: valueLabel
 					anchors.verticalCenter: parent.verticalCenter
+					rightPadding: Theme.geometry_circularMultiGauge_value_rightMargin
 					horizontalAlignment: Text.AlignRight
-					font.pixelSize: Theme.font_size_body2
+					font.pixelSize: Theme.font_size_body1
 					color: Theme.color_font_primary
 					visible: false
+
 					property int unit
 					property quantityInfo quantity
 
@@ -133,6 +140,7 @@ Item {
 						}
 					}
 				}
+
 				CP.ColorImage {
 					id: iconImage
 					source: model.icon

--- a/data/mock/config/MockDataSimulator.qml
+++ b/data/mock/config/MockDataSimulator.qml
@@ -198,6 +198,22 @@ QtObject {
 			event.accepted = true
 			break
 		case Qt.Key_U:
+			// Change the unit display of the Brief view center gauges
+			if (event.modifiers & Qt.ControlModifier) {
+				const v = root.mockValue(Global.systemSettings.serviceUid + "/Settings/Gui/BriefView/Unit")
+				let newBriefUnit = ""
+				if (v === VenusOS.BriefView_Unit_None) {
+					newBriefUnit = VenusOS.BriefView_Unit_Absolute
+				} else if (v === VenusOS.BriefView_Unit_Absolute) {
+					newBriefUnit = VenusOS.BriefView_Unit_Percentage
+				} else {
+					newBriefUnit = VenusOS.BriefView_Unit_None
+				}
+				root.setMockValue(Global.systemSettings.serviceUid + "/Settings/Gui/BriefView/Unit", newBriefUnit)
+				return
+			}
+
+			// Change the system unit
 			Global.systemSettings.setElectricalQuantity(
 					Global.systemSettings.electricalQuantity === VenusOS.Units_Watt
 					? VenusOS.Units_Amp

--- a/themes/geometry/FiveInch.json
+++ b/themes/geometry/FiveInch.json
@@ -144,8 +144,10 @@
 
     "geometry_circularMultiGauge_strokeWidth": 16,
     "geometry_circularMultiGauge_spacing": 16,
-    "geometry_circularMultiGauge_row_spacing": 6,
-    "geometry_circularMultiGauge_labels_rightMargin": 14,
+    "geometry_circularMultiGauge_label_leftMargin": -20,
+    "geometry_circularMultiGauge_label_rightMargin": 4,
+    "geometry_circularMultiGauge_value_rightMargin": 2,
+    "geometry_circularMultiGauge_icon_rightMargin": 12,
     "geometry_circularMultiGauge_icons_maxWidth": 18,
 
     "geometry_circularSingularGauge_strokeWidth": 16,

--- a/themes/geometry/SevenInch.json
+++ b/themes/geometry/SevenInch.json
@@ -144,8 +144,10 @@
 
     "geometry_circularMultiGauge_strokeWidth": 16,
     "geometry_circularMultiGauge_spacing": 16,
-    "geometry_circularMultiGauge_row_spacing": 7,
-    "geometry_circularMultiGauge_labels_rightMargin": 14,
+    "geometry_circularMultiGauge_label_leftMargin": 0,
+    "geometry_circularMultiGauge_label_rightMargin": 6,
+    "geometry_circularMultiGauge_value_rightMargin": 2,
+    "geometry_circularMultiGauge_icon_rightMargin": 14,
     "geometry_circularMultiGauge_icons_maxWidth": 18,
 
     "geometry_circularSingularGauge_strokeWidth": 16,
@@ -169,7 +171,7 @@
     "geometry_briefPage_edgeGauge_spacing": 44,
     "geometry_briefPage_edgeGauge_spacingAngle": 4,
     "geometry_briefPage_edgeGauge_quantityLabel_spacing": 2,
-    "geometry_briefPage_edgeGauge_quantityLabel_horizontalMargin": 64,
+    "geometry_briefPage_edgeGauge_quantityLabel_horizontalMargin": 60,
     "geometry_briefPage_edgeGauge_quantityLabel_topMargin": 24,
     "geometry_briefPage_edgeGauge_quantityLabel_bottomMargin": 20,
     "geometry_briefPage_edgeGauge_quantityLabel_feedback_margin": 4,


### PR DESCRIPTION
Adjust the font sizes and margins, and elide the center gauge labels if necessary, to prevent the text overlap. This is particularly a problem when the center gauge is configured to shows the name, percentage and icon.