### PR TITLE
Drop confirmation toast

### DIFF
--- a/components/ToastNotification.qml
+++ b/components/ToastNotification.qml
@@ -35,8 +35,7 @@ Item {
 		anchors.fill: parent
 
 		radius: Theme.geometry_toastNotification_radius
-		color: root.category === VenusOS.Notification_Confirm ? Theme.color_toastNotification_background_confirmation
-			 : root.category === VenusOS.Notification_Warning ? Theme.color_toastNotification_background_warning
+		color: root.category === VenusOS.Notification_Warning ? Theme.color_toastNotification_background_warning
 			 : root.category === VenusOS.Notification_Alarm ? Theme.color_toastNotification_background_error
 			 : Theme.color_toastNotification_background_informative
 
@@ -53,8 +52,7 @@ Item {
 			radius: parent.radius
 			flat: true
 
-			color: root.category === VenusOS.Notification_Confirm ? Theme.color_toastNotification_highlight_confirmation
-				 : root.category === VenusOS.Notification_Warning ? Theme.color_toastNotification_highlight_warning
+			color: root.category === VenusOS.Notification_Warning ? Theme.color_toastNotification_highlight_warning
 				 : root.category === VenusOS.Notification_Alarm ? Theme.color_toastNotification_highlight_error
 				 : Theme.color_toastNotification_highlight_informative
 
@@ -63,8 +61,7 @@ Item {
 				anchors.centerIn: parent
 
 				color: Theme.color_toastNotification_foreground
-				source: root.category === VenusOS.Notification_Confirm ? "qrc:/images/icon_checkmark_32.svg"
-					  : root.category === VenusOS.Notification_Warning ? "qrc:/images/icon_warning_32.svg"
+				source: root.category === VenusOS.Notification_Warning ? "qrc:/images/icon_warning_32.svg"
 					  : root.category === VenusOS.Notification_Alarm ? "qrc:/images/icon_warning_32.svg"
 					  : "qrc:/images/icon_info_32.svg"
 			}

--- a/data/mock/config/MockDataSimulator.qml
+++ b/data/mock/config/MockDataSimulator.qml
@@ -171,12 +171,10 @@ QtObject {
 			break
 		case Qt.Key_O:
 			const notifType = (event.modifiers & Qt.ShiftModifier)
-				? VenusOS.Notification_Confirm
-				: (event.modifiers & Qt.AltModifier)
-				  ? VenusOS.Notification_Warning
-				  : (event.modifiers & Qt.ControlModifier)
-					? VenusOS.Notification_Alarm
-					: VenusOS.Notification_Info
+				? VenusOS.Notification_Warning
+				: (event.modifiers & Qt.ControlModifier)
+				  ? VenusOS.Notification_Alarm
+				  : VenusOS.Notification_Info
 			notificationsConfig.showToastNotification(notifType)
 			event.accepted = true
 			break

--- a/pages/settings/debug/PageSettingsDemo.qml
+++ b/pages/settings/debug/PageSettingsDemo.qml
@@ -182,10 +182,6 @@ Page {
 				content.children: [
 
 					ListItemButton {
-						text: "Confirm"
-						onClicked: Global.showToastNotification(VenusOS.Notification_Confirm, "Confirmation toast")
-					},
-					ListItemButton {
 						text: "Warning"
 						onClicked: Global.showToastNotification(VenusOS.Notification_Warning, "Warning toast")
 					},


### PR DESCRIPTION
Fixes warning "Could not set initial property category"..

Notification type Notification_Confirmation got dropped by recent notification page design changes and I don't see anything using it either. Alternatively could re-instate the enumeration.

Contributes to #975