### PR TITLE
Fix toggling to the previous mock config

### DIFF
--- a/data/mock/config/MockDataSimulator.qml
+++ b/data/mock/config/MockDataSimulator.qml
@@ -55,6 +55,7 @@ QtObject {
 
 	function previousConfig() {
 		const pageConfig = _configs[currentNavBarUrl()]
+		if (pageConfig.configIndex === -1) pageConfig.configIndex = 0
 		const prevIndex = Utils.modulo(pageConfig.configIndex - 1, pageConfig.configCount())
 		setConfigIndex(pageConfig, prevIndex)
 	}


### PR DESCRIPTION
Config index starts at -1, toggling left to the previous config jumps to the second last item instead of the last item.