### PR TITLE
Improve switches and radio buttons

### DIFF
--- a/components/RadioButtonControlValue.qml
+++ b/components/RadioButtonControlValue.qml
@@ -21,6 +21,7 @@ ControlValue {
 		anchors.verticalCenter: parent.verticalCenter
 		font.pixelSize: Theme.font_size_body2
 		down: mouseArea.containsPress || pressed
+		checkable: false
 
 		onClicked: root.clicked()
 	}

--- a/components/controls/Switch.qml
+++ b/components/controls/Switch.qml
@@ -12,6 +12,7 @@ import Victron.VenusOS
 CT.Switch {
 	id: root
 
+	checkable: false
 	implicitWidth: Math.max(
 		implicitBackgroundWidth + leftInset + rightInset,
 		implicitContentWidth + leftPadding + rightPadding)

--- a/components/dialogs/GeneratorStartDialog.qml
+++ b/components/dialogs/GeneratorStartDialog.qml
@@ -46,6 +46,7 @@ GeneratorDialog {
 			//% "Timed run"
 			text: qsTrId("controlcard_generator_startdialog_timed_run")
 			checked: root.generator.manualStartTimer > 0
+			checkable: true
 		}
 
 		TimeSelector {

--- a/components/listitems/ListRadioButton.qml
+++ b/components/listitems/ListRadioButton.qml
@@ -22,16 +22,14 @@ ListItem {
 		RadioButton {
 			id: radioButton
 
-			// Alternative to binding "enabled: !checked". No clicked() signal
-			// got emitted when the button was disabled on checked=false.
-			onClicked: if (root.checked) root.clicked()
+			checkable: false
+			onClicked: root.clicked()
 		}
 	]
 
 	ListPressArea {
 		id: pressArea
 
-		enabled: !root.checked
 		radius: backgroundRect.radius
 		anchors {
 			fill: parent

--- a/components/listitems/ListRadioButtonGroup.qml
+++ b/components/listitems/ListRadioButtonGroup.qml
@@ -81,14 +81,12 @@ ListNavigationItem {
 					id: radioButton
 
 					function select(password) {
-						if (root.updateOnClick) {
-							if (dataItem.uid.length > 0) {
+						if (!checked) {
+							if (root.updateOnClick && dataItem.uid.length > 0) {
 								dataItem.setValue(Array.isArray(root.optionModel) ? modelData.value : model.value)
-							} else {
-								root.currentIndex = model.index
 							}
+							root.optionClicked(model.index, password)
 						}
-						root.optionClicked(model.index, password)
 
 						if (root.popDestination !== undefined) {
 							popTimer.restart()

--- a/components/listitems/ListRadioButtonGroup.qml
+++ b/components/listitems/ListRadioButtonGroup.qml
@@ -36,7 +36,7 @@ ListNavigationItem {
 			? optionModel[currentIndex].value
 			: undefined
 
-	property bool updateOnClick: true
+	property bool updateDataOnClick: true
 	property var popDestination: null   // if undefined, will not automatically pop page when value is selected
 
 	property int defaultIndex: -1
@@ -82,7 +82,7 @@ ListNavigationItem {
 
 					function select(password) {
 						if (!checked) {
-							if (root.updateOnClick && dataItem.uid.length > 0) {
+							if (root.updateDataOnClick && dataItem.uid.length > 0) {
 								dataItem.setValue(Array.isArray(root.optionModel) ? modelData.value : model.value)
 							}
 							root.optionClicked(model.index, password)

--- a/components/listitems/ListSwitch.qml
+++ b/components/listitems/ListSwitch.qml
@@ -13,7 +13,7 @@ ListItem {
 	property alias checked: switchItem.checked
 	property alias checkable: switchItem.checkable
 	property alias secondaryText: secondaryLabel.text
-	property bool updateOnClick: true
+	property bool updateDataOnClick: true
 	property bool invertSourceValue
 
 	property int valueTrue: 1
@@ -22,7 +22,7 @@ ListItem {
 	signal clicked()
 
 	function _setChecked(c) {
-		if (updateOnClick) {
+		if (updateDataOnClick) {
 			if (root.dataItem.uid.length > 0) {
 				if (invertSourceValue) {
 					dataItem.setValue(c ? valueFalse : valueTrue)

--- a/components/listitems/ListSwitch.qml
+++ b/components/listitems/ListSwitch.qml
@@ -11,6 +11,7 @@ ListItem {
 
 	readonly property alias dataItem: dataItem
 	property alias checked: switchItem.checked
+	property alias checkable: switchItem.checkable
 	property alias secondaryText: secondaryLabel.text
 	property bool updateOnClick: true
 	property bool invertSourceValue
@@ -28,8 +29,6 @@ ListItem {
 				} else {
 					dataItem.setValue(c ? valueTrue : valueFalse)
 				}
-			} else {
-				switchItem.checked = c
 			}
 		}
 		clicked()
@@ -49,6 +48,7 @@ ListItem {
 		},
 		Switch {
 			id: switchItem
+
 			checked: invertSourceValue ? dataItem.value === valueFalse : dataItem.value === valueTrue
 			checkable: false
 			onClicked: root._setChecked(!checked)

--- a/components/settings/ChargeScheduleItem.qml
+++ b/components/settings/ChargeScheduleItem.qml
@@ -112,6 +112,7 @@ ListNavigationItem {
 
 						text: CommonWords.enabled
 						checked: itemDay.isValid && itemDay.value >= 0
+						checkable: true
 						onCheckedChanged: {
 							if (checked ^ itemDay.value >= 0) {
 								itemDay.setValue(toggleDay(itemDay.value))

--- a/pages/controlcards/GeneratorCard.qml
+++ b/pages/controlcards/GeneratorCard.qml
@@ -40,7 +40,6 @@ ControlCard {
 		label.text: qsTrId("controlcard_generator_label_autostart")
 		button.checked: root.generator.autoStart
 		button.enabled: root.generator.state !== VenusOS.Generators_State_Running
-		button.checkable: false // control the checked state locally
 		separator.visible: false
 
 		Connections {

--- a/pages/settings/DvccCommonSettings.qml
+++ b/pages/settings/DvccCommonSettings.qml
@@ -30,7 +30,6 @@ Column {
 
 		//% "Limit charge current"
 		text: qsTrId("settings_dvcc_limit_charge_current")
-		updateOnClick: false
 		checked: maxChargeCurrent.dataItem.isValid && maxChargeCurrent.dataItem.value >= 0
 		allowed: defaultAllowed && dvccSwitch.checked
 		onClicked: {

--- a/pages/settings/PageGeneratorConditions.qml
+++ b/pages/settings/PageGeneratorConditions.qml
@@ -73,7 +73,6 @@ Page {
 				currentIndex: stopOnAc1Item.value === 1
 					   ? 1 : stopOnAc2Item.value === 1
 							  ? 2 : 0
-				updateOnClick: false
 				optionModel: [
 					{ display: CommonWords.disabled, value: 0 },
 					{ display: CommonWords.acInput(0), value: 1 },

--- a/pages/settings/PageSettingsCGwacs.qml
+++ b/pages/settings/PageSettingsCGwacs.qml
@@ -32,7 +32,6 @@ Page {
 		model: ObjectModel {
 			ListRadioButtonGroup {
 				text: CommonWords.ac_input_role
-				updateOnClick: false
 				optionModel: Global.acInputs.roles.map(function(role) {
 					return { display: role.name, value: role.role }
 				})

--- a/pages/settings/PageSettingsDisplay.qml
+++ b/pages/settings/PageSettingsDisplay.qml
@@ -88,7 +88,6 @@ Page {
 				currentIndex: optionModel.currentIndex
 				secondaryText: optionModel.currentDisplayText
 				popDestination: undefined // don't pop page automatically.
-				updateOnClick: false // handle option clicked manually.
 
 				onOptionClicked: function(index) {
 					// The SystemSettings data point listener will trigger retranslateUi()
@@ -175,7 +174,7 @@ Page {
 				text: qsTrId("settings_display_onscreen_ui")
 				dataItem.uid: Global.systemSettings.serviceUid + "/Settings/Gui/RunningVersion"
 				writeAccessLevel: VenusOS.User_AccessType_User
-				updateOnClick: false
+				updateDataOnClick: false
 				optionModel: [
 					{
 						//% "Standard version"

--- a/pages/settings/PageSettingsDvcc.qml
+++ b/pages/settings/PageSettingsDvcc.qml
@@ -38,7 +38,6 @@ Page {
 
 				//% "Limit managed battery charge voltage"
 				text: qsTrId("settings_dvcc_limit_managed_battery_charge_voltage")
-				updateOnClick: false
 				checked: maxChargeVoltage.dataItem.isValid && maxChargeVoltage.dataItem.value > 0
 				allowed: defaultAllowed && commonSettings.dvccActive
 				onClicked: {

--- a/pages/settings/PageSettingsGeneral.qml
+++ b/pages/settings/PageSettingsGeneral.qml
@@ -77,7 +77,7 @@ Page {
 				//% "Security profile"
 				text: qsTrId("settings_security_profile")
 				dataItem.uid: Global.systemSettings.serviceUid + "/Settings/System/SecurityProfile"
-				updateOnClick: false // handle option clicked manually.
+				updateDataOnClick: false // handle option clicked manually.
 				popDestination: undefined
 				//% "Please select..."
 				defaultSecondaryText: qsTrId("settings_security_profile_indeterminate")
@@ -334,7 +334,7 @@ Page {
 				primaryLabel.anchors.verticalCenterOffset: -(demoModeCaption.height / 2)
 				dataItem.uid: Global.systemSettings.serviceUid + "/Settings/Gui/DemoMode"
 				popDestination: undefined // don't pop page automatically.
-				updateOnClick: false // handle option clicked manually.
+				updateDataOnClick: false // handle option clicked manually.
 				optionModel: [
 					{ display: CommonWords.disabled, value: 0 },
 					//% "ESS demo"

--- a/pages/settings/PageSettingsGsm.qml
+++ b/pages/settings/PageSettingsGsm.qml
@@ -167,6 +167,7 @@ Page {
 									//% "Use default APN"
 									text: qsTrId("page_settings_gsm_use_default_apn")
 									checked: apnSetting.value === ""
+									checkable: true
 									onCheckedChanged: {
 										if (apnSetting.isValid && checked) {
 											apnSetting.setValue("")
@@ -192,6 +193,7 @@ Page {
 				//% "Use authentication"
 				text: qsTrId("page_settings_gsm_use_authentication")
 				checked: authUser.value !== "" && authPass.value !== ""
+				checkable: true
 				onCheckedChanged: {
 					if (!checked) {
 						authUser.dataItem.setValue("")

--- a/pages/settings/PageSettingsHub4.qml
+++ b/pages/settings/PageSettingsHub4.qml
@@ -170,10 +170,10 @@ Page {
 				&& essMode.value !== VenusOS.Ess_Hub4ModeState_Disabled
 				&& !(maxChargeCurrentControl.isValid && maxChargeCurrentControl.value)
 
-			onCheckedChanged: {
-				if (checked && maxChargePower.value < 0) {
+			onClicked: {
+				if (maxChargePower.value < 0) {
 					maxChargePower.dataItem.setValue(1000)
-				} else if (!checked && maxChargePower.value >= 0) {
+				} else if (maxChargePower.value >= 0) {
 					maxChargePower.dataItem.setValue(-1)
 				}
 			}
@@ -201,10 +201,10 @@ Page {
 				&& essMode.value !== VenusOS.Ess_Hub4ModeState_Disabled
 				&& batteryLifeState.dataItem.value !== VenusOS.Ess_BatteryLifeState_KeepCharged
 
-			onCheckedChanged: {
-				if (checked && maxDischargePower.value < 0) {
+			onClicked: {
+				if (maxDischargePower.value < 0) {
 					maxDischargePower.dataItem.setValue(1000)
-				} else if (!checked && maxDischargePower.value >= 0) {
+				} else if (maxDischargePower.value >= 0) {
 					maxDischargePower.dataItem.setValue(-1)
 				}
 			}

--- a/pages/settings/PageSettingsHub4.qml
+++ b/pages/settings/PageSettingsHub4.qml
@@ -37,8 +37,6 @@ Page {
 				}
 				return -1
 			}
-			updateOnClick: false
-
 			onOptionClicked: function(index) {
 				Global.ess.setStateRequested(optionModel[index].value)
 			}

--- a/pages/settings/PageSettingsHub4Feedin.qml
+++ b/pages/settings/PageSettingsHub4Feedin.qml
@@ -46,11 +46,12 @@ Page {
 				text: qsTrId("settings_ess_limit_system_feed_in")
 				allowed: defaultAllowed && (acFeedin.checked || feedInDc.checked)
 				checked: maxFeedInPower.value >= 0
-				onCheckedChanged: {
-					if (checked && maxFeedInPower.value < 0)
+				onClicked: {
+					if (maxFeedInPower.value < 0) {
 						maxFeedInPower.dataItem.setValue(1000)
-					else if (!checked && maxFeedInPower.value >= 0)
+					} else if (maxFeedInPower.value >= 0) {
 						maxFeedInPower.dataItem.setValue(-1)
+					}
 				}
 			}
 

--- a/pages/settings/PageSettingsHub4Peakshaving.qml
+++ b/pages/settings/PageSettingsHub4Peakshaving.qml
@@ -64,7 +64,6 @@ Page {
 					}
 				]
 				currentIndex: !enabled ? 1 : peakshaveItem.value || 0
-				updateOnClick: false
 				onOptionClicked: function(index) {
 					const newValue = optionModel[index].value
 					peakshaveItem.setValue(newValue)

--- a/pages/settings/PageSettingsLogger.qml
+++ b/pages/settings/PageSettingsLogger.qml
@@ -44,7 +44,7 @@ Page {
 				//% "VRM portal"
 				text: qsTrId("settings_logging_vrm_portal")
 				dataItem.uid: Global.systemSettings.serviceUid + "/Settings/Network/VrmPortal"
-				updateOnClick: false
+				updateDataOnClick: false
 				popDestination: undefined   // do not automatically pop page when value is selected
 				optionModel: [
 					{ display: CommonWords.off, value: VenusOS.Vrm_PortalMode_Off },
@@ -196,7 +196,7 @@ Page {
 				//% "Reboot device when no contact"
 				text: qsTrId("settings_no_contact_reboot")
 				dataItem.uid: Global.systemSettings.serviceUid + "/Settings/Watchdog/VrmTimeout"
-				updateOnClick: false
+				updateDataOnClick: false
 				checked: dataItem.value !== 0
 				onClicked: dataItem.setValue(checked ? 0 : 3600)
 			}

--- a/pages/settings/PageSettingsWifi.qml
+++ b/pages/settings/PageSettingsWifi.qml
@@ -107,8 +107,6 @@ Page {
 				text: qsTrId("settings_wifi_create_ap")
 				checked: accessPoint.value === 1
 				allowed: defaultAllowed && accessPoint.isValid
-				updateOnClick: false
-
 				onClicked: {
 					if (checked) {
 						Global.dialogLayer.open(confirmApDialogComponent)

--- a/pages/settings/PageTzInfo.qml
+++ b/pages/settings/PageTzInfo.qml
@@ -155,7 +155,6 @@ Page {
 								text: "UTC"
 								writeAccessLevel: VenusOS.User_AccessType_User
 								checked: tzData.city === text
-								updateOnClick: false
 								onClicked: {
 									if (!checked) {
 										tzData.saveTimeZone("", text)
@@ -177,7 +176,7 @@ Page {
 								optionModel: modelData
 								secondaryText: ""
 								writeAccessLevel: VenusOS.User_AccessType_User
-								updateOnClick: false
+								updateDataOnClick: false
 								popDestination: root
 								currentIndex: {
 									if (tzData.region === modelData.region) {

--- a/pages/settings/debug/PageSettingsDemo.qml
+++ b/pages/settings/debug/PageSettingsDemo.qml
@@ -25,7 +25,12 @@ Page {
 
 			ListSwitch {
 				text: "Switch"
-				onClicked: console.log("Switch now checked?", checked)
+				property bool value
+				checked: value
+				onClicked: {
+					value = !checked
+					console.log("Switch now checked?", checked)
+				}
 			}
 
 			ListSwitch {
@@ -61,6 +66,7 @@ Page {
 				currentIndex: 1
 
 				onOptionClicked: function(index) {
+					currentIndex = index
 					console.log("Radio button clicked at index", index)
 				}
 			}
@@ -94,6 +100,7 @@ Page {
 				secondaryText: optionModel.get(2).display
 
 				onOptionClicked: function(index) {
+					currentIndex = index
 					console.log("Radio button clicked at index", index)
 					secondaryText = optionModel.get(index).display
 				}

--- a/pages/vebusdevice/PageVeBusAdvanced.qml
+++ b/pages/vebusdevice/PageVeBusAdvanced.qml
@@ -175,6 +175,7 @@ Page {
 				currentIndex: 0
 				allowed: false
 				onOptionClicked: function(index) {
+					currentIndex = index
 					if (localValue !== VenusOS.VeBusDevice_ChargeState_InitializingCharger) {
 						interruptTimer.start()
 						if (localValue !== VenusOS.VeBusDevice_ChargeState_Bulk) {

--- a/pages/vebusdevice/PageVeBusAdvanced.qml
+++ b/pages/vebusdevice/PageVeBusAdvanced.qml
@@ -142,8 +142,6 @@ Page {
 			ListRadioButtonGroup {
 				id: stopEq
 
-				readonly property int localValue: optionModel[currentIndex].value
-
 				//% "Interrupt equalization"
 				text: qsTrId("vebus_device_interrupt_equalization")
 				optionModel: [
@@ -172,10 +170,10 @@ Page {
 						readOnly: false
 					}
 				]
-				currentIndex: 0
+				currentIndex: 1 // float state is always selected
 				allowed: false
 				onOptionClicked: function(index) {
-					currentIndex = index
+					const localValue = optionModel[index].value
 					if (localValue !== VenusOS.VeBusDevice_ChargeState_InitializingCharger) {
 						interruptTimer.start()
 						if (localValue !== VenusOS.VeBusDevice_ChargeState_Bulk) {


### PR DESCRIPTION
- Fix list switch toggling directly on the switch item
- Don't update checked status until the data item updates accordingly
- Avoid nuking the checked bindings (so if somebody updates the value remotely they still update)
- Set update updateOnClick=false if you don't want automatic behavior
- Earlier ListSwitch updated the checked status twice, once by Switch checkable, secondly by the select() function (latter nuked any app side binding)
- Tapping the current item now dismisses the radio button page, but still doesn't emit optionClicked()
- Expose checkable on the component API, many vanilla Switches and RadioButton assumed onCheckedChanged

Also, changes the default behavior of switches and radio buttons to not automatically toggle the checked state.

Fixes #955.