### PR TITLE
Allow upscaling gui-v2 (wasm) to the available space

### DIFF
--- a/Main.qml
+++ b/Main.qml
@@ -91,7 +91,7 @@ Window {
 		// To fix, we need to downscale everything by the appropriate factor,
 		// and take into account browser chrome stealing real-estate also.
 		onScaleChanged: Global.scalingRatio = contentItem.scale
-		scale: Math.min(1.0, root.width/Theme.geometry_screen_width, root.height/Theme.geometry_screen_height)
+		scale: Math.min(root.width/Theme.geometry_screen_width, root.height/Theme.geometry_screen_height)
 
 		// Ideally each item would use focus handling to get its own key events, but in wasm the
 		// pagestack's pages do not reliably receive key events even when focused.


### PR DESCRIPTION
Icons and gauges may look a bit fuzzy, but most people won't notice.

The empty space around VRM website popup looks worse.

Reverts 5473b1a39

Contributes to #900.