### PR TITLE
Remove unnecessary property overrides that match the default value

### DIFF
--- a/pages/settings/PageSettingsLarge.qml
+++ b/pages/settings/PageSettingsLarge.qml
@@ -23,7 +23,6 @@ Page {
 				text: qsTrId("settings_large_signal_k")
 				dataItem.uid: Global.venusPlatform.serviceUid + "/Services/SignalK/Enabled"
 				allowed: dataItem.isValid
-				writeAccessLevel: VenusOS.User_AccessType_Installer
 			}
 
 			ListLabel {
@@ -39,7 +38,6 @@ Page {
 				text: qsTrId("settings_large_node_red")
 				dataItem.uid: Global.venusPlatform.serviceUid + "/Services/NodeRed/Mode"
 				allowed: dataItem.isValid
-				writeAccessLevel: VenusOS.User_AccessType_Installer
 				optionModel: [
 					{ display: CommonWords.disabled, value: VenusOS.NodeRed_Mode_Disabled },
 					{ display: CommonWords.enabled, value: VenusOS.NodeRed_Mode_Enabled },

--- a/pages/settings/devicelist/battery/PageBatterySettingsBattery.qml
+++ b/pages/settings/devicelist/battery/PageBatterySettingsBattery.qml
@@ -137,7 +137,6 @@ Page {
 				//% "Current offset"
 				text: qsTrId("batterysettingsbattery_current_offset")
 				dataItem.uid: root.bindPrefix + "/Settings/Battery/CurrentOffset"
-				showAccessLevel: VenusOS.User_AccessType_User
 				allowed: defaultAllowed && dataItem.isValid
 			}
 

--- a/pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml
+++ b/pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml
@@ -37,7 +37,6 @@ Page {
 			ListSpinBox {
 				//% "Offset"
 				text: qsTrId("temperature_offset")
-				writeAccessLevel: VenusOS.User_AccessType_Installer
 				dataItem.uid: root.bindPrefix + "/Offset"
 				allowed: defaultAllowed && dataItem.isValid
 				from: -100
@@ -47,7 +46,6 @@ Page {
 			ListSpinBox {
 				//% "Scale"
 				text: qsTrId("temperature_scale")
-				writeAccessLevel: VenusOS.User_AccessType_Installer
 				dataItem.uid: root.bindPrefix + "/Scale"
 				allowed: defaultAllowed && dataItem.isValid
 				from: 0


### PR DESCRIPTION
The default value of ListItem
- show access level is already VenusOS.User_AccessType_User
- write access level is already VenusOS.User_AccessType_Installer