### PR TITLE
Fix theme parameter warning

### DIFF
--- a/themes/geometry/FiveInch.json
+++ b/themes/geometry/FiveInch.json
@@ -179,7 +179,7 @@
     "geometry_briefPage_edgeGauge_quantityLabel_feedback_margin": 4,
     "geometry_briefPage_edgeGauge_angleOffset_one_gauge": 3.2,
     "geometry_briefPage_edgeGauge_angleOffset_two_gauge": 2.4,
-    "geometry_briefPage_edgeGauge_angleOffset_three_gauge": 2,
+    "geometry_briefPage_edgeGauge_angleOffset_three_gauge": 2.0,
     "geometry_briefPage_edgeGauge_phaseLabel_horizontalMargin_one_gauge": 34,
     "geometry_briefPage_edgeGauge_phaseLabel_horizontalMargin_two_gauge": 1,
     "geometry_briefPage_edgeGauge_phaseLabel_horizontalMargin_three_gauge": 9,


### PR DESCRIPTION
Fix following warning:
```
../../src/themeobjects.h:1491:48: warning: implicit conversion from 'double' to 'int' changes value from 1.7 to 1 [-Wliteral-conversion]
                return m_screenSize == Theme::FiveInch ? 2 : 1.7;
                ~~~~~~                                       ^~~
1 warning generated.
```