### PR TITLE
Some text wrapping and truncation improvements

### DIFF
--- a/components/CircularMultiGauge.qml
+++ b/components/CircularMultiGauge.qml
@@ -17,6 +17,7 @@ Item {
 	property bool animationEnabled
 	property real labelMargin
 	property alias labelOpacity: textCol.opacity
+	property int leftGaugeCount
 
 	// Step change in the size of the bounding boxes of successive gauges
 	readonly property real _stepSize: 2 * (strokeWidth + Theme.geometry_circularMultiGauge_spacing)
@@ -104,7 +105,13 @@ Item {
 					font.pixelSize: valueLabel.visible ? Theme.font_size_body1 : Theme.font_size_body2
 					color: Theme.color_font_primary
 					text: model.name
+
+					// With three gauges on the left there is a risk that the last labels on
+					// on the multi-gauge overlap with the labels on the top-left gauge.
+					//
+					// Increase the space for the two top-most labels or if there are less left gauges.
 					width: textCol.width - valueLabel.width - iconImage.width
+						+ (model.index < 2 || gauges.leftGaugeCount < 3 ? Theme.geometry_circularMultiGauge_label_extraWidth : 0)
 					elide: Text.ElideRight
 				}
 

--- a/components/widgets/InverterChargerWidget.qml
+++ b/components/widgets/InverterChargerWidget.qml
@@ -36,14 +36,21 @@ OverviewWidget {
 	extraContentChildren: [
 		Label {
 			anchors {
+				top: parent.top
 				left: parent.left
 				leftMargin: Theme.geometry_overviewPage_widget_content_horizontalMargin
 				right: parent.right
 				rightMargin: Theme.geometry_overviewPage_widget_content_horizontalMargin
+				bottom: parent.bottom
 			}
-			font.pixelSize: Theme.font_overviewPage_widget_quantityLabel_maximumSize
 			text: Global.system.systemStateToText(Global.system.state)
+			font.pixelSize: Theme.font_overviewPage_widget_quantityLabel_maximumSize
+			minimumPixelSize: Theme.font_overviewPage_widget_quantityLabel_minimumSize
+			fontSizeMode: Text.VerticalFit
+
 			wrapMode: Text.Wrap
+			maximumLineCount: 4
+			elide: Text.ElideRight
 		}
 	]
 

--- a/pages/BriefPage.qml
+++ b/pages/BriefPage.qml
@@ -173,6 +173,7 @@ SwipeViewPage {
 			animationEnabled: root.animationEnabled
 			labelOpacity: root._gaugeLabelOpacity
 			labelMargin: root._gaugeLabelMargin
+			leftGaugeCount: root._leftGaugeCount
 		}
 	}
 

--- a/pages/controlcards/ESSCard.qml
+++ b/pages/controlcards/ESSCard.qml
@@ -64,15 +64,18 @@ ControlCard {
 				anchors {
 					left: parent.left
 					leftMargin: Theme.geometry_controlCard_contentMargins
+					right: infoIcon.left
 					verticalCenter: parent.verticalCenter
 				}
 				color: Theme.color_font_secondary
 				font.pixelSize: Theme.font_size_body1
+				wrapMode: Text.Wrap
 				//% "Battery life limit: %1%"
 				text: qsTrId("ess_battery_life_limit").arg(Math.max(Global.ess.minimumStateOfCharge, Global.ess.stateOfChargeLimit))
 			}
 
 			CP.IconImage {
+				id: infoIcon
 				anchors {
 					right: parent.right
 					rightMargin: Theme.geometry_controlCard_contentMargins

--- a/themes/geometry/FiveInch.json
+++ b/themes/geometry/FiveInch.json
@@ -151,6 +151,7 @@
     "geometry_circularMultiGauge_value_rightMargin": 2,
     "geometry_circularMultiGauge_icon_rightMargin": 12,
     "geometry_circularMultiGauge_icons_maxWidth": 18,
+    "geometry_circularMultiGauge_label_extraWidth": 112,
 
     "geometry_circularSingularGauge_strokeWidth": 16,
 

--- a/themes/geometry/SevenInch.json
+++ b/themes/geometry/SevenInch.json
@@ -151,6 +151,7 @@
     "geometry_circularMultiGauge_value_rightMargin": 2,
     "geometry_circularMultiGauge_icon_rightMargin": 14,
     "geometry_circularMultiGauge_icons_maxWidth": 18,
+    "geometry_circularMultiGauge_label_extraWidth": 112,
 
     "geometry_circularSingularGauge_strokeWidth": 16,
 


### PR DESCRIPTION
- Overview widget label overflow
- ESS widget info label overflow
- Too aggressive truncation of the Brief page gauge labels

![image](https://github.com/victronenergy/gui-v2/assets/2203667/7bb244ef-380a-4268-9159-159581e73e8b)

Contributes to #995.