### PR TITLE
Align baseline of quantity number and unit

### DIFF
--- a/components/QuantityLabel.qml
+++ b/components/QuantityLabel.qml
@@ -56,7 +56,7 @@ Item {
 
 			// At smaller font sizes, allow the unit to be vertically aligned at a sub-pixel value,
 			// else it is noticeably misaligned by less than 1 pixel.
-			anchors.verticalCenter: parent.verticalCenter
+			anchors.baseline: valueLabel.baseline
 			anchors.alignWhenCentered: font.pixelSize >= Theme.font_size_body1
 			text: quantityInfo.unit
 			color: Theme.color_font_secondary


### PR DESCRIPTION
Issue (occurs with Thai, Chinese, Cyrillic fonts):
![image](https://github.com/victronenergy/gui-v2/assets/2203667/346ec503-59ca-4634-8d07-8b97b862d943)

E.g. number "-303" and unit "W" above don't vertically align.

Was planning to do this earlier already, but couldn't get the baseline info from the generated bitmap glyphs.

Contributes to #993.