### PR TITLE
Make sure the editor stays visible when the keyboard is opened

### DIFF
--- a/Global.qml
+++ b/Global.qml
@@ -61,7 +61,7 @@ QtObject {
 	property bool isDesktop
 	property real scalingRatio: 1.0
 
-	signal aboutToFocusTextField(var textField, int toTextFieldY, var flickable)
+	signal aboutToFocusTextField(var textField, var flickable)
 	signal keyPressed(var event)
 
 	function showToastNotification(category, text, autoCloseInterval = 0) {

--- a/components/InputPanel.qml
+++ b/components/InputPanel.qml
@@ -47,18 +47,17 @@ QtVirtualKeyboard.InputPanel {
 
 	states: State {
 		name: "visible"
-		when: Qt.inputMethod.visible
+		when: Qt.inputMethod.visible && !!root.focusedFlickable
 
 		PropertyChanges {
 			target: root.focusedFlickable
-			contentY: root.toContentY
-			height: root.toHeight
+			height: Theme.geometry_screen_height - root.height - Theme.geometry_statusBar_height
 		}
 	}
 
 	transitions: Transition {
 		NumberAnimation {
-			properties: "contentY,height"
+			properties: "height"
 			duration: Theme.animation_inputPanel_slide_duration
 			easing.type: Easing.InOutQuad
 		}
@@ -67,33 +66,10 @@ QtVirtualKeyboard.InputPanel {
 	Connections {
 		target: Global
 
-		function onAboutToFocusTextField(textField, toTextFieldY, flickable) {
+		function onAboutToFocusTextField(textField, flickable) {
 			if (!textField || !flickable) {
 				console.warn("onAboutToFocusTextField(): invalid item/flickable:", textField, flickable)
 				return
-			}
-			const inputPanelY = mainViewItem.height - root.height
-			const toWinY = textField.mapToItem(mainViewItem, 0, toTextFieldY).y
-			const delta = toWinY - inputPanelY
-
-			if (delta > 0) {
-				// Scroll the flickable upwards to show the item above the vkb.
-				root.toContentY = flickable.contentY + delta
-
-				if (flickable.contentY + delta + flickable.height > flickable.contentHeight) {
-					// Item is too close to bottom of flickable, so it will still be hidden after
-					// scrolling upwards. Reduce the flickable height so that item can be seen.
-					root.toHeight = flickable.height - inputPanelY
-						+ ((!!Global.pageManager && !!Global.pageManager.navBar) ? Global.pageManager.navBar.height : 0)
-				} else {
-					// No flickable height changes required.
-					root.toHeight = flickable.height
-				}
-			} else {
-				// No position changes required, but PropertyChanges requires a valid target, so
-				// set the dest values to the current values.
-				root.toContentY = flickable.contentY
-				root.toHeight = flickable.height
 			}
 			root.focusedItem = textField
 			root.focusedFlickable = flickable

--- a/pages/settings/PageSettingsDisplayMinMax.qml
+++ b/pages/settings/PageSettingsDisplayMinMax.qml
@@ -10,6 +10,7 @@ Page {
 	id: root
 
 	GradientListView {
+
 		model: ObjectModel {
 			ListSwitch {
 				//: Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.

--- a/themes/geometry/FiveInch.json
+++ b/themes/geometry/FiveInch.json
@@ -102,6 +102,7 @@
 
     "geometry_textField_height": 40,
     "geometry_textField_horizontalMargin": 16,
+    "geometry_textField_autoscrollMargin": 32,
 
     "geometry_toastNotification_horizontalMargin" : 24,
     "geometry_toastNotification_bottomMargin" : 8,

--- a/themes/geometry/SevenInch.json
+++ b/themes/geometry/SevenInch.json
@@ -102,6 +102,7 @@
 
     "geometry_textField_height": 40,
     "geometry_textField_horizontalMargin": 16,
+    "geometry_textField_autoscrollMargin": 32,
 
     "geometry_toastNotification_horizontalMargin" : 24,
     "geometry_toastNotification_bottomMargin" : 8,


### PR DESCRIPTION
- Tracking cursor visibility is more robust to dynamic flickable content
  area changes than trying to predict in advance where the text field will land
- Easier to extend text editing use cases later to multi-line text areas,
  copy&paste, allowing scrolling during more complex text editing use cases
- Also adjusts the viewport if the field is too close to the top edge of the viewport
- Maintain nice margin around the focused text field

Fixes #991.