### PR TITLE
Show ESS limit charge setting

### DIFF
--- a/pages/settings/PageSettingsHub4.qml
+++ b/pages/settings/PageSettingsHub4.qml
@@ -189,7 +189,7 @@ Page {
 			checked: maxChargePower.value >= 0
 			allowed: defaultAllowed
 				&& essMode.value !== VenusOS.Ess_Hub4ModeState_Disabled
-				&& !maxChargeCurrentControl.isValid
+				&& !(maxChargeCurrentControl.isValid && maxChargeCurrentControl.value)
 
 			onCheckedChanged: {
 				if (checked && maxChargePower.value < 0) {


### PR DESCRIPTION
Should now align with gui-v1, and the user is now able to change the `Settings/CGwacs/MaxChargePower` setting.

Fixes #1005.