### PR TITLE
Show small 3-phase view for AC Loads widget when size <= S

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,6 +369,7 @@ set (VENUS_QML_MODULE_SOURCES
     components/settings/TemperatureRelaySettings.qml
     components/settings/VolumeUnitRadioButtonGroup.qml
 
+    components/widgets/AcWidget.qml
     components/widgets/AcInputWidget.qml
     components/widgets/AcLoadsWidget.qml
     components/widgets/AlternatorWidget.qml

--- a/components/widgets/AcInputWidget.qml
+++ b/components/widgets/AcInputWidget.qml
@@ -6,32 +6,28 @@
 import QtQuick
 import Victron.VenusOS
 
-OverviewWidget {
+AcWidget {
 	id: root
 
 	// If this is the currently active AC input, then fetch the measurements and phase data from
 	// Global.acInputs.activeInput. Otherwise, just show icon and title with 'Disconnected' status.
 	property AcInputSystemInfo inputInfo
 	property ActiveAcInput input: inputInfo && inputInfo.isActiveInput ? Global.acInputs.activeInput : null
-	property ListModel phaseModel: connected ? input.phases : null
 	readonly property bool connected: input && input.connected
-	readonly property bool isConnectedSinglePhase: connected && phaseModel && phaseModel.count === 1
 
 	type: VenusOS.OverviewWidget_Type_AcGenericInput
 	title: !!inputInfo ? Global.acInputs.sourceToText(inputInfo.source) : ""
-	secondaryTitle: root.size <= VenusOS.OverviewWidget_Size_S && extraContentLoader.sourceComponent === phaseDisplayComponent
-			? "(%1)".arg(Units.defaultUnitString(Global.systemSettings.electricalQuantity))
-			: ""
 	icon.source: !!inputInfo ? Global.acInputs.sourceIcon(inputInfo.source) : ""
 	rightPadding: sideGaugeLoader.active ? Theme.geometry_overviewPage_widget_sideGauge_margins : 0
 	quantityLabel.dataObject: connected ? input : null
-	quantityLabel.visible: connected && (size >= VenusOS.OverviewWidget_Size_M || isConnectedSinglePhase)
-	quantityLabel.font.pixelSize: size <= VenusOS.OverviewWidget_Size_S
-		|| (size === VenusOS.OverviewWidget_Size_M && extraContentLoader.sourceComponent === phaseDisplayComponent)
-			  ? Theme.font_overviewPage_widget_quantityLabel_minimumSize
-			  : Theme.font_overviewPage_widget_quantityLabel_maximumSize
-	preferLargeSize: !!phaseModel && phaseModel.count > 1
+	phaseCount: connected ? input.phases.count : 0
 	enabled: true
+	extraContentLoader.sourceComponent: ThreePhaseDisplay {
+		width: parent.width
+		model: root.input.phases
+		widgetSize: root.size
+		inputMode: true
+	}
 
 	onClicked: {
 		Global.pageManager.pushPage("/pages/settings/devicelist/ac-in/PageAcIn.qml", {
@@ -52,7 +48,7 @@ OverviewWidget {
 		active: root.connected && root.size >= VenusOS.OverviewWidget_Size_M
 		sourceComponent: ThreePhaseBarGauge {
 			valueType: VenusOS.Gauges_ValueType_NeutralPercentage
-			phaseModel: root.phaseModel
+			phaseModel: root.input.phases
 			phaseModelProperty: "current"
 			minimumValue: Global.acInputs.activeInputInfo.minimumCurrent
 			maximumValue: Global.acInputs.activeInputInfo.maximumCurrent
@@ -60,57 +56,19 @@ OverviewWidget {
 		}
 	}
 
-	extraContentChildren: Loader {
-		id: extraContentLoader
-		anchors.fill: parent
-		sourceComponent: root.connected
-				? root.phaseModel && root.phaseModel.count > 1 ? phaseDisplayComponent : null
-				: disconnectedComponent
-	}
-
-	Component {
-		id: phaseDisplayComponent
-
-		// This extra container is needed because of how Loader would otherwise auto-size the
-		// ThreePhaseDisplay column and mess with its vertical alignment.
-		Item {
-			anchors {
-				left: parent.left
-				leftMargin: Theme.geometry_overviewPage_widget_content_horizontalMargin
-				right: parent.right
-				rightMargin: Theme.geometry_overviewPage_widget_content_horizontalMargin + root.rightPadding
-				bottom: parent.bottom
-			}
-			height: phaseDisplay.height
-
-			ThreePhaseDisplay {
-				id: phaseDisplay
-
-				anchors {
-					bottom: parent.bottom
-					bottomMargin: root.size <= VenusOS.OverviewWidget_Size_M
-						  ? Theme.geometry_overviewPage_widget_content_small_verticalMargin
-						  : root.verticalMargin
-				}
-				width: parent.width
-				model: root.phaseModel
-				widgetSize: root.size
-				inputMode: true
-			}
+	Label {
+		anchors {
+			top: root.extraContent.top
+			topMargin: Theme.geometry_overviewPage_widget_extraContent_topMargin
+			left: root.extraContent.left
+			leftMargin: Theme.geometry_overviewPage_widget_content_horizontalMargin
+			right: root.extraContent.right
+			rightMargin: Theme.geometry_overviewPage_widget_content_horizontalMargin
 		}
-	}
-
-	Component {
-		id: disconnectedComponent
-
-		Label {
-			x: Theme.geometry_overviewPage_widget_content_horizontalMargin
-			y: Theme.geometry_overviewPage_widget_extraContent_topMargin
-			width: parent ? parent.width - 2*Theme.geometry_overviewPage_widget_content_horizontalMargin : 0
-			elide: Text.ElideRight
-			text: root.inputInfo && root.inputInfo.source === VenusOS.AcInputs_InputSource_Generator
-					? CommonWords.stopped
-					: CommonWords.disconnected
-		}
+		elide: Text.ElideRight
+		text: root.inputInfo && root.inputInfo.source === VenusOS.AcInputs_InputSource_Generator
+				? CommonWords.stopped
+				: CommonWords.disconnected
+		visible: !root.connected
 	}
 }

--- a/components/widgets/AcLoadsWidget.qml
+++ b/components/widgets/AcLoadsWidget.qml
@@ -6,34 +6,21 @@
 import QtQuick
 import Victron.VenusOS
 
-OverviewWidget {
+AcWidget {
 	id: root
 
 	//% "AC Loads"
 	title: qsTrId("overview_widget_acloads_title")
 	icon.source: "qrc:/images/acloads.svg"
 	type: VenusOS.OverviewWidget_Type_AcLoads
-	enabled: false
-
 	quantityLabel.dataObject: Global.system.ac.consumption
-
-	extraContentChildren: [
-		ThreePhaseDisplay {
-			anchors {
-				left: parent ? parent.left : undefined
-				leftMargin: Theme.geometry_overviewPage_widget_content_horizontalMargin
-				right: parent ? parent.right : undefined
-				rightMargin: Theme.geometry_overviewPage_widget_content_horizontalMargin
-				bottom: parent ? parent.bottom : undefined
-				bottomMargin: root.verticalMargin
-			}
-
-			visible: model != null && root.size >= VenusOS.OverviewWidget_Size_L
-			model: Global.system.ac.consumption.phases.count > 1 ? Global.system.ac.consumption.phases : null
-			widgetSize: root.size
-			valueType: VenusOS.Gauges_ValueType_RisingPercentage
-			phaseModelProperty: "current"
-			maximumValue: Global.system.ac.consumption.maximumCurrent
-		}
-	]
+	phaseCount: Global.system.ac.consumption.phases.count
+	enabled: false
+	extraContentLoader.sourceComponent: ThreePhaseDisplay {
+		model: Global.system.ac.consumption.phases
+		widgetSize: root.size
+		valueType: VenusOS.Gauges_ValueType_RisingPercentage
+		phaseModelProperty: "current"
+		maximumValue: Global.system.ac.consumption.maximumCurrent
+	}
 }

--- a/components/widgets/AcWidget.qml
+++ b/components/widgets/AcWidget.qml
@@ -1,0 +1,71 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+OverviewWidget {
+	id: root
+
+	property int phaseCount
+	readonly property alias extraContentLoader: extraContentLoader
+
+	quantityLabel.visible: !!quantityLabel.dataObject
+	preferLargeSize: phaseCount > 1
+
+	extraContentChildren: Loader {
+		id: extraContentLoader
+
+		anchors {
+			left: parent.left
+			leftMargin: Theme.geometry_overviewPage_widget_content_horizontalMargin
+			right: parent.right
+			rightMargin: Theme.geometry_overviewPage_widget_content_horizontalMargin + root.rightPadding
+			bottom: parent.bottom
+			bottomMargin: root.verticalMargin
+		}
+		active: root.phaseCount > 1
+		states: [
+			State {
+				name: "small"
+				when: root.size === VenusOS.OverviewWidget_Size_XS || root.size === VenusOS.OverviewWidget_Size_S
+				PropertyChanges {
+					target: root.quantityLabel
+					visible: !!quantityLabel.dataObject && extraContentLoader.status !== Loader.Ready
+					font.pixelSize: Theme.font_overviewPage_widget_quantityLabel_minimumSize
+				}
+				PropertyChanges {
+					target: root
+					secondaryTitle: extraContentLoader.status === Loader.Ready
+									? "(%1)".arg(Units.defaultUnitString(Global.systemSettings.electricalQuantity))
+									: ""
+				}
+				PropertyChanges {
+					target: extraContentLoader
+					anchors.bottomMargin: root.verticalMargin / 3
+				}
+			},
+			State {
+				name: "medium"
+				when: root.size === VenusOS.OverviewWidget_Size_M
+				PropertyChanges {
+					target: root.quantityLabel
+					font.pixelSize: extraContentLoader.status === Loader.Ready
+							   ? Theme.font_overviewPage_widget_quantityLabel_minimumSize
+							   : Theme.font_overviewPage_widget_quantityLabel_maximumSize
+				}
+			},
+			State {
+				name: "medium-or-larger"
+				when: root.size === VenusOS.OverviewWidget_Size_L || root.size === VenusOS.OverviewWidget_Size_XL
+				PropertyChanges {
+					target: root.quantityLabel
+					font.pixelSize: Theme.font_overviewPage_widget_quantityLabel_maximumSize
+				}
+			}
+		]
+	}
+
+}

--- a/themes/geometry/FiveInch.json
+++ b/themes/geometry/FiveInch.json
@@ -231,7 +231,6 @@
 
     "geometry_overviewPage_widget_radius": 8,
     "geometry_overviewPage_widget_border_width": 2,
-    "geometry_overviewPage_widget_content_small_verticalMargin": 4,
     "geometry_overviewPage_widget_content_expanded_verticalMargin": 10,
     "geometry_overviewPage_widget_content_verticalMargin": 8,
     "geometry_overviewPage_widget_content_horizontalMargin": 10,
@@ -271,7 +270,7 @@
     "geometry_overviewPage_widget_solar_graph_bar_radius": 8,
     "geometry_overviewPage_widget_solar_graph_margins": 8,
 
-    "geometry_three_phase_column_spacing": -4,
+    "geometry_three_phase_column_spacing": -2,
     "geometry_three_phase_gauge_spacing": 4,
 
     "geometry_levelsPage_groupedSubgauges_delegate_width": 100,

--- a/themes/geometry/SevenInch.json
+++ b/themes/geometry/SevenInch.json
@@ -231,7 +231,6 @@
 
     "geometry_overviewPage_widget_radius": 8,
     "geometry_overviewPage_widget_border_width": 2,
-    "geometry_overviewPage_widget_content_small_verticalMargin": 8,
     "geometry_overviewPage_widget_content_expanded_verticalMargin": 16,
     "geometry_overviewPage_widget_content_verticalMargin": 14,
     "geometry_overviewPage_widget_content_horizontalMargin": 14,


### PR DESCRIPTION
The AC input widget shows per-phase data even when its size <= S. The AC loads widget should do this too.

This adds AcInputWidget to do the common AC phase display configuration for AC input and AC load widgets.