### PR TITLE
Avoid label overlap on the Overview page battery widget

### DIFF
--- a/components/QuantityLabel.qml
+++ b/components/QuantityLabel.qml
@@ -15,6 +15,8 @@ Item {
 	property alias valueColor: valueLabel.color
 	property alias unitColor: unitLabel.color
 	property alias unitVisible: unitLabel.visible
+	readonly property alias valueText: valueLabel.text
+	readonly property alias unitText: unitLabel.text
 	property int alignment: Qt.AlignHCenter
 	property alias precision: quantityInfo.precision
 	property alias formatHints: quantityInfo.formatHints

--- a/components/widgets/BatteryWidget.qml
+++ b/components/widgets/BatteryWidget.qml
@@ -23,6 +23,26 @@ OverviewWidget {
 	readonly property int _normalizedStateOfCharge: Math.round(batteryData.stateOfCharge || 0)
 	readonly property bool _animationReady: animationEnabled && !isNaN(batteryData.stateOfCharge)
 
+	// Calculate whether current and power quantities fit on the footer together, if not use smaller font.
+	// Discharging battery has negative amperes and its not unusual for the watts to be in the 1k+ range.
+	// No need to do the same check for the shorter voltage label on the left.
+	readonly property bool _useSmallFont: root.width/2 - 2*batteryPowerDisplay.anchors.rightMargin
+										  < quantityLabelWidth(batteryCurrentDisplay.valueText, batteryCurrentDisplay.unitText)/2
+										  + quantityLabelWidth(batteryPowerDisplay.valueText, batteryPowerDisplay.unitText)
+
+	function quantityLabelWidth(valueText, unitText){
+		const valueTextRect = quantityLabelFont.tightBoundingRect(valueText)
+		return quantityLabelFont.font, (valueTextRect.x + valueTextRect.width
+										+ Theme.geometry_quantityLabel_spacing
+										+ quantityLabelFont.advanceWidth(unitText))
+	}
+
+	FontMetrics {
+		id: quantityLabelFont
+		font.pixelSize: Theme.font_size_body2
+		font.family: "Museo Sans 500 Mono digits"
+	}
+
 	title: CommonWords.battery
 	icon.source: batteryData.icon
 	type: VenusOS.OverviewWidget_Type_Battery
@@ -150,7 +170,7 @@ OverviewWidget {
 
 			value: batteryData.voltage
 			unit: VenusOS.Units_Volt
-			font.pixelSize: Theme.font_size_body2
+			font.pixelSize: root._useSmallFont ? Theme.font_size_body1 : Theme.font_size_body2
 			alignment: Qt.AlignLeft
 		},
 
@@ -164,7 +184,7 @@ OverviewWidget {
 			}
 			value: batteryData.current
 			unit: VenusOS.Units_Amp
-			font.pixelSize: Theme.font_size_body2
+			font.pixelSize: root._useSmallFont ? Theme.font_size_body1 : Theme.font_size_body2
 		},
 
 		QuantityLabel {
@@ -178,7 +198,7 @@ OverviewWidget {
 			}
 			value: batteryData.power
 			unit: VenusOS.Units_Watt
-			font.pixelSize: Theme.font_size_body2
+			font.pixelSize: root._useSmallFont ? Theme.font_size_body1 : Theme.font_size_body2
 			alignment: Qt.AlignRight
 		}
 	]


### PR DESCRIPTION
Reduces font size if there is a risk of overlap:
![image](https://github.com/victronenergy/gui-v2/assets/2203667/53aafded-8549-45de-9339-3ba27aaf0b6b)

Long value labels are possible, big batteries produce power in thousands of watts range and if the battery is discharging the amps may be negative with additional "-" character.

Not too proud of this solution, but couldn't come up with more elegant solution either. One long value label is not a problem, but two large adjacent ones start overlapping. Alternatively could always make the font smaller, but that would make the common layout variant look sparse.

Fixes #1012.