### PR TITLE
Avoid overlap of solar yield quantity label with the graph

### DIFF
--- a/themes/geometry/SevenInch.json
+++ b/themes/geometry/SevenInch.json
@@ -195,7 +195,7 @@
     "geometry_briefPage_sidePanel_header_spacing": 2,
     "geometry_briefPage_sidePanel_separatorBar_height": 2,
     "geometry_briefPage_sidePanel_forecastRow_spacing": 44,
-    "geometry_briefPage_sidePanel_solarYield_width": 160,
+    "geometry_briefPage_sidePanel_solarYield_width": 150,
     "geometry_briefPage_sidePanel_generator_slider_height": 8,
     "geometry_briefPage_sidePanel_generator_columnSpacing": 2,
     "geometry_briefPage_sidePanel_loads_columnSpacing": 2,


### PR DESCRIPTION
Fix:
![image](https://github.com/victronenergy/gui-v2/assets/2203667/19e4e7ba-e9b8-4c35-8831-6dd8b32c7ebf)

Not an issue on the five-inch variant.

Fixes #1014.