### PR TITLE
Prevent Levels page from disappearing when changing mock configs

### DIFF
--- a/data/mock/EnvironmentInputsImpl.qml
+++ b/data/mock/EnvironmentInputsImpl.qml
@@ -81,15 +81,25 @@ Item {
 		target: Global.mockDataSimulator || null
 
 		function onSetEnvironmentInputsRequested(config) {
-			Global.environmentInputs.model.clear()
-			while (_createdObjects.length > 0) {
-				_createdObjects.pop().destroy()
+			// Do not remove all objects in the model before adding the new ones, as Levels page
+			// will disappear.
+			const hasCreatedObjects = _createdObjects.length > 0
+			while (_createdObjects.length > 1) {
+				let obj = _createdObjects.pop()
+				obj._deviceInstance.setValue(-1)
+				obj.destroy()
 			}
 
 			if (config) {
 				for (let i = 0; i < config.length; ++i) {
 					root.addInput(config[i])
 				}
+			}
+
+			if (hasCreatedObjects) {
+				let lastObject = _createdObjects.shift()
+				lastObject._deviceInstance.setValue(-1)
+				lastObject.destroy()
 			}
 		}
 	}

--- a/data/mock/TanksImpl.qml
+++ b/data/mock/TanksImpl.qml
@@ -87,15 +87,25 @@ QtObject {
 		target: Global.mockDataSimulator || null
 
 		function onSetTanksRequested(config) {
-			Global.tanks.reset()
-			while (_createdObjects.length > 0) {
-				_createdObjects.pop().destroy()
+			// Do not remove all objects in the model before adding the new ones, as Levels page
+			// will disappear.
+			const hasCreatedObjects = _createdObjects.length > 0
+			while (_createdObjects.length > 1) {
+				let obj = _createdObjects.pop()
+				obj._deviceInstance.setValue(-1)
+				obj.destroy()
 			}
 
 			if (config) {
 				for (let i = 0; i < config.length; ++i) {
 					root.addTank(config[i])
 				}
+			}
+
+			if (hasCreatedObjects) {
+				let lastObject = _createdObjects.shift()
+				lastObject._deviceInstance.setValue(-1)
+				lastObject.destroy()
 			}
 		}
 	}


### PR DESCRIPTION
Add new test objects before removing the old ones. Otherwise, the Levels page disappears as soon as the models are cleared, and the user is moved to the Overview page.