### PR TITLE
Show dashes when Brief page battery value is invalid

### DIFF
--- a/components/CircularMultiGauge.qml
+++ b/components/CircularMultiGauge.qml
@@ -132,7 +132,7 @@ Item {
 						PropertyChanges {
 							target: valueLabel
 
-							visible: !isNaN(model.value)
+							visible: true
 							text: quantity.number + quantity.unit
 							quantity: Units.getDisplayText(unit, value)
 							unit: {

--- a/components/GaugeModel.qml
+++ b/components/GaugeModel.qml
@@ -88,7 +88,7 @@ ListModel {
 			readonly property string tankName: _tankProperties.name
 			readonly property string tankIcon: isBattery ? Global.batteries.system.icon : _tankProperties.icon
 			readonly property var tankModel: isBattery ? null : Global.tanks.tankModel(tankType)
-			readonly property real tankLevel: isBattery ? Math.round(Global.batteries.system.stateOfCharge || 0)
+			readonly property real tankLevel: isBattery ? Math.round(Global.batteries.system.stateOfCharge)
 					: !isNaN(tankModel.averageLevel) ? tankModel.averageLevel
 					: (tankModel.count === 0 || tankModel.totalCapacity === 0) ? 0
 					: ((Math.min(tankModel.totalRemaining / tankModel.totalCapacity, 1.0) * 100))


### PR DESCRIPTION
Wonder if the battery gauge should be colored differently when SOC is invalid.

Fixes #1031.