### PR TITLE
Avoid issue opening sub-pages in expanded mode

### DIFF
--- a/ApplicationContent.qml
+++ b/ApplicationContent.qml
@@ -57,7 +57,8 @@ Item {
 		anchors.fill: parent
 
 		onPressed: function(mouse) {
-			mouse.accepted = false
+			// block touch during navigation bar fadeout
+			mouse.accepted = mainView.navBarAnimatingOut
 			if (pageManager.idleModeTimer.running) {
 				pageManager.idleModeTimer.restart()
 			}

--- a/pages/MainView.qml
+++ b/pages/MainView.qml
@@ -17,6 +17,8 @@ Item {
 			   : !!swipeView ? swipeView.currentItem
 			   : null
 
+	property alias navBarAnimatingOut: animateNavBarOut.running
+
 	// To reduce the animation load, disable page animations when the PageStack is transitioning
 	// between pages, or when flicking between the main pages. Note that animations are still
 	// allowed when dragging between the main pages, as it looks odd if animations stop abruptly


### PR DESCRIPTION
If the user taps Overview page widget or navigation bar during animateNavBarOut animation the page opens without the status bar and navigation bar.

Happens quite rarely so kept the solution simple. Might have been better to start rewinding immediately from the expanded mode, but that is not so trivial with animators where you always have to specify the starting point of the animation. Also simultaneous page opening and collapsing animations might have looked funky.

Fixes #1021.