### PR TITLE
Improve rendering of BarGauge

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,10 +219,12 @@ set (VENUS_QML_MODULE_SOURCES
     components/ArcGaugeQuantityRow.qml
     components/AsymmetricRoundedRectangle.qml
     components/BarGauge.qml
+    components/BarGaugeBase.qml
     components/BriefSidePanelWidget.qml
     components/ButtonControlValue.qml
     components/CircularMultiGauge.qml
     components/CircularSingleGauge.qml
+    components/ClippingBarGauge.qml
     components/ControlCard.qml
     components/ControlValue.qml
     components/CpuMonitor.qml

--- a/components/BarGauge.qml
+++ b/components/BarGauge.qml
@@ -8,59 +8,18 @@ import QtQuick.Effects as Effects
 import Victron.VenusOS
 import Victron.Gauges
 
-Rectangle {
-	id: bgRect
+BarGaugeBase {
+	id: root
 
-	property int valueType: VenusOS.Gauges_ValueType_NeutralPercentage
-	readonly property int valueStatus: Gauges.getValueStatus(_value * 100, valueType)
-	property color foregroundColor: Theme.statusColorValue(valueStatus)
-	property color backgroundColor: Theme.statusColorValue(valueStatus, true)
-	property real value: 0.0
-	property int orientation: Qt.Vertical
-	property bool animationEnabled
-
-	color: backgroundColor
-	width: orientation === Qt.Vertical ? Theme.geometry_barGauge_vertical_width_large : parent.width
-	height: orientation === Qt.Vertical ? parent.height : Theme.geometry_barGauge_horizontal_height
-	radius: orientation === Qt.Vertical ? width / 2 : height / 2
-
-	readonly property real _value: isNaN(value) ? 0 : Math.min(1.0, Math.max(0, value))
-
-	// Only update the nextPos when the width/height have been initialized.
-	readonly property real _nextPos: (width !== Infinity && height !== Infinity)
-			? orientation === Qt.Vertical
-				? height - (height * _value)    // slide in from bottom to top
-				: -width + (width * _value)     // slide in from left to right
-			: 0
-
-	on_NextPosChanged: if (visible) _updateGauge()
-	onVisibleChanged: if (visible) _updateGauge()
-
-	function _updateGauge() {
-		if (animationEnabled) {
-			const animator = orientation === Qt.Vertical ? yAnimator : xAnimator
-			const currValue = orientation === Qt.Vertical ? fgRect.y : fgRect.x
-			if (!animator.running && currValue !== _nextPos) {
-				animator.from = currValue
-				animator.to = _nextPos
-				animator.start()
-			}
-		} else {
-			if (orientation === Qt.Vertical) {
-				fgRect.y = _nextPos
-			} else {
-				fgRect.x = _nextPos
-			}
-		}
-	}
+	fgRect: foregroundRect
 
 	Rectangle {
 		id: maskRect
 		layer.enabled: true
 		visible: false
-		width: bgRect.width
-		height: bgRect.height
-		radius: bgRect.radius
+		width: root.width
+		height: root.height
+		radius: root.radius
 		color: "black" // opacity mask, not visible.
 		z: 1
 	}
@@ -74,28 +33,11 @@ Rectangle {
 		z: 2
 
 		Rectangle {
-			id: fgRect
-
+			id: foregroundRect
 			width: parent.width
 			height: parent.height
-			color: foregroundColor
-
-			// Use animators instead of a behavior on x/y. Otherwise, there can be a "jump" when
-			// receiving two value updates in close succession.
-			XAnimator {
-				id: xAnimator
-				target: fgRect
-				easing.type: Easing.InOutQuad
-				duration: Theme.animation_briefPage_sidePanel_sliderValueChange_duration
-				onRunningChanged: if (!running) Qt.callLater(_updateGauge) // if _nextPos changed during previous animation
-			}
-			YAnimator {
-				id: yAnimator
-				target: fgRect
-				easing.type: Easing.InOutQuad
-				duration: Theme.animation_briefPage_sidePanel_sliderValueChange_duration
-				onRunningChanged: if (!running) Qt.callLater(_updateGauge) // if _nextPos changed during previous animation
-			}
+			color: root.foregroundColor
+			z: 2 // drawn above the background, but below the border
 		}
 	}
 

--- a/components/BarGaugeBase.qml
+++ b/components/BarGaugeBase.qml
@@ -1,0 +1,75 @@
+/*
+** Copyright (C) 2023 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+import Victron.Gauges
+
+Rectangle {
+	id: bgRect
+
+	property int valueType: VenusOS.Gauges_ValueType_NeutralPercentage
+	readonly property int valueStatus: Gauges.getValueStatus(_value * 100, valueType)
+	property color foregroundColor: Theme.statusColorValue(valueStatus)
+	property color backgroundColor: Theme.statusColorValue(valueStatus, true)
+	property color surfaceColor: Theme.color_levelsPage_gauge_separatorBarColor
+	property real value: 0.0
+	property int orientation: Qt.Vertical
+	property bool animationEnabled
+
+	color: backgroundColor
+	width: orientation === Qt.Vertical ? Theme.geometry_barGauge_vertical_width_large : parent.width
+	height: orientation === Qt.Vertical ? parent.height : Theme.geometry_barGauge_horizontal_height
+	radius: orientation === Qt.Vertical ? width / 2 : height / 2
+
+	readonly property real _value: isNaN(value) ? 0 : Math.min(1.0, Math.max(0, value))
+
+	// Only update the nextPos when the width/height have been initialized.
+	readonly property real _nextPos: (width !== Infinity && height !== Infinity)
+			? orientation === Qt.Vertical
+				? height - (height * _value)    // slide in from bottom to top
+				: -width + (width * _value)     // slide in from left to right
+			: 0
+
+	on_NextPosChanged: if (visible) _updateGauge()
+	onVisibleChanged: if (visible) _updateGauge()
+
+	function _updateGauge() {
+		if (animationEnabled) {
+			const animator = orientation === Qt.Vertical ? yAnimator : xAnimator
+			const currValue = orientation === Qt.Vertical ? fgRect.y : fgRect.x
+			if (!animator.running && currValue !== _nextPos) {
+				animator.from = currValue
+				animator.to = _nextPos
+				animator.start()
+			}
+		} else {
+			if (orientation === Qt.Vertical) {
+				fgRect.y = _nextPos
+			} else {
+				fgRect.x = _nextPos
+			}
+		}
+	}
+
+	// Use animators instead of a behavior on x/y. Otherwise, there can be a "jump" when
+	// receiving two value updates in close succession.
+	XAnimator {
+		id: xAnimator
+		target: fgRect
+		easing.type: Easing.InOutQuad
+		duration: Theme.animation_briefPage_sidePanel_sliderValueChange_duration
+		onRunningChanged: if (!running) Qt.callLater(_updateGauge) // if _nextPos changed during previous animation
+	}
+	YAnimator {
+		id: yAnimator
+		target: fgRect
+		easing.type: Easing.InOutQuad
+		duration: Theme.animation_briefPage_sidePanel_sliderValueChange_duration
+		onRunningChanged: if (!running) Qt.callLater(_updateGauge) // if _nextPos changed during previous animation
+	}
+
+	property Rectangle fgRect
+}

--- a/components/ClippingBarGauge.qml
+++ b/components/ClippingBarGauge.qml
@@ -1,0 +1,37 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+import Victron.Gauges
+
+BarGaugeBase  {
+	id: root
+
+	clip: true
+	fgRect: foregroundRect
+
+	Rectangle {
+		id: foregroundRect
+		width: root.width
+		height: root.height
+		color: root.foregroundColor
+		z: 2 // drawn above the background, but below the border
+	}
+
+	Rectangle {
+		id: borderRect
+		color: "transparent"
+		radius: root.radius + border.width // "exterior" radius = "internal" radius + border.width
+		width: parent.width + 2*border.width
+		height: parent.height + 2*border.width
+		x: -border.width
+		y: -border.width
+		z: 5 // drawn above everything else.
+		// wide enough to perfectly cover the "missing" pixels due to interior rounding.
+		border.width: Math.ceil(((Math.SQRT2*(2*root.radius)) - (2*root.radius))/2)
+		border.color: root.surfaceColor
+	}
+}

--- a/components/TankGauge.qml
+++ b/components/TankGauge.qml
@@ -7,18 +7,19 @@ import QtQuick
 import Victron.VenusOS
 import QtQuick.Controls.impl as CP
 
-BarGauge {
+ClippingBarGauge {
 	id: root
 
 	property bool isGrouped: false
 	property bool expanded
 
 	radius: Theme.geometry_levelsPage_tankGauge_radius
+	surfaceColor: Theme.color_levelsPage_gauge_separatorBarColor
 
 	Rectangle {
 		width: parent.width
 		height: 2
-		color: Theme.color_levelsPage_gauge_separatorBarColor
+		color: root.surfaceColor
 		y: parent.height/4
 		z: 5
 	}
@@ -26,7 +27,7 @@ BarGauge {
 	Rectangle {
 		width: parent.width
 		height: 2
-		color: Theme.color_levelsPage_gauge_separatorBarColor
+		color: root.surfaceColor
 		y: 2*parent.height/4
 		z: 5
 	}
@@ -34,7 +35,7 @@ BarGauge {
 	Rectangle {
 		width: parent.width
 		height: 2
-		color: Theme.color_levelsPage_gauge_separatorBarColor
+		color: root.surfaceColor
 		y: 3*parent.height/4
 		z: 5
 	}

--- a/components/TankGauge.qml
+++ b/components/TankGauge.qml
@@ -20,6 +20,7 @@ BarGauge {
 		height: 2
 		color: Theme.color_levelsPage_gauge_separatorBarColor
 		y: parent.height/4
+		z: 5
 	}
 
 	Rectangle {
@@ -27,6 +28,7 @@ BarGauge {
 		height: 2
 		color: Theme.color_levelsPage_gauge_separatorBarColor
 		y: 2*parent.height/4
+		z: 5
 	}
 
 	Rectangle {
@@ -34,11 +36,13 @@ BarGauge {
 		height: 2
 		color: Theme.color_levelsPage_gauge_separatorBarColor
 		y: 3*parent.height/4
+		z: 5
 	}
 
 	CP.ColorImage {
 		anchors.horizontalCenter: parent.horizontalCenter
 		y: (root.height / 4 / 2) - (height / 2)
+		z: 5
 
 		visible: !root.isGrouped
 				 && ((root.valueType === VenusOS.Gauges_ValueType_FallingPercentage && value <= 0.05)


### PR DESCRIPTION
- Always calculate the _nextPos on _value change, regardless of item visibility
- If animating to _nextPos, ensure we stop any current animation and set the "from" value appropriate, to avoid "over animating".

Fixes #1003