### PR TITLE
Set the isMulti property correctly for inverter/chargers

### DIFF
--- a/components/InverterModeDialogLauncher.qml
+++ b/components/InverterModeDialogLauncher.qml
@@ -15,12 +15,18 @@ QtObject {
 			? Global.inverterChargers.inverterChargerModeToText(_modeItem.value)
 			: Global.inverterChargers.inverterModeToText(_modeItem.value)
 
+	readonly property bool isMulti: _numberOfAcInputs.value === undefined ? false : (_numberOfAcInputs.value > 0)
+
 	property VeQuickItem _isInverterChargerItem: VeQuickItem {
 		uid: root.serviceUid + "/IsInverterCharger"
 	}
 
 	property VeQuickItem _modeItem: VeQuickItem {
 		uid: root.serviceUid + "/Mode"
+	}
+
+	readonly property VeQuickItem _numberOfAcInputs: VeQuickItem {
+		uid: root.serviceUid + "/Ac/NumberOfAcInputs"
 	}
 
 	property Component _inverterModeDialogComponent: Component {
@@ -31,6 +37,7 @@ QtObject {
 
 	property Component _inverterChargerModeDialogComponent: Component {
 		InverterChargerModeDialog {
+			isMulti: root.isMulti
 			onAccepted: root._modeItem.setValue(mode)
 		}
 	}

--- a/pages/vebusdevice/VeBusDeviceModeButton.qml
+++ b/pages/vebusdevice/VeBusDeviceModeButton.qml
@@ -71,6 +71,7 @@ Loader {
 		id: modeDialogComponent
 
 		InverterChargerModeDialog {
+			isMulti: root.isMulti
 			onAccepted: root.veBusDevice.setMode(mode)
 		}
 	}


### PR DESCRIPTION
A pure inverter doesn't have AC inputs, only outputs. An inverter/charger can have AC inputs, and is considered multi. A multi device can be set explicitly to be in either inverter or charger mode via the appropriate dialog, but the mode settings are enabled or disabled based on the isMulti condition.

Fixes #1040