### PR TITLE
Clean up couple of boot warnings

### DIFF
--- a/data/common/AcInputPhaseModel.qml
+++ b/data/common/AcInputPhaseModel.qml
@@ -15,7 +15,10 @@ ListModel {
 		if (phaseIndex < 0 || phaseIndex >= count) {
 			return
 		}
-		const v = propertyValue === undefined ? NaN : Global.acInputs.clampMeasurement(propertyValue)
+
+		const v = propertyValue === undefined ? NaN
+				: (Global.acInputs ? Global.acInputs.clampMeasurement(propertyValue) : propertyValue)
+
 		setProperty(phaseIndex, propertyName, v)
 		phaseValueChanged(phaseIndex, propertyName, v)
 	}


### PR DESCRIPTION
```
file:///data/home/root/install/bin/Victron/VenusOS/data/common/AcInputPhaseModel.qml:18: TypeError: Cannot call method 'clampMeasurement' of undefined
file:///data/home/root/install/bin/Victron/VenusOS/data/common/AcInputPhaseModel.qml:18: TypeError: Cannot call method 'clampMeasurement' of undefined
```