### PR TITLE
Use DoubleValidator decimals to enforce min/max range precision

### DIFF
--- a/components/listitems/ListQuantityField.qml
+++ b/components/listitems/ListQuantityField.qml
@@ -14,15 +14,7 @@ ListTextField {
 	property int decimals: Units.defaultUnitPrecision(unit)
 
 	suffix: Units.defaultUnitString(unit)
-	textField.validator: DoubleValidator {}
+	textField.validator: DoubleValidator { decimals: root.decimals }
 	textField.inputMethodHints: Qt.ImhDigitsOnly
-	textField.text: tryAcceptInput(value)
-
-	tryAcceptInput: function(inputText) {
-		const n = Number(inputText)
-		if (isNaN(n)) {
-			return "--"
-		}
-		return n.toFixed(root.decimals)
-	}
+	textField.text: Number(value).toFixed(decimals)
 }

--- a/components/listitems/ListTextField.qml
+++ b/components/listitems/ListTextField.qml
@@ -15,7 +15,6 @@ ListItem {
 	property alias secondaryText: textField.text
 	property alias placeholderText: textField.placeholderText
 	property string suffix
-	property var tryAcceptInput
 	property var flickable: root.ListView ? root.ListView.view : null
 	readonly property bool hasActiveFocus: textField.activeFocus
 
@@ -59,18 +58,6 @@ ListItem {
 		property string _textWhenFocused
 		property bool _accepted
 
-		function _tryAcceptInput(keyEvent) {
-			if (!!root.tryAcceptInput) {
-				const result = root.tryAcceptInput(text)
-				if (result === undefined) {
-					keyEvent.accepted = true
-					return
-				}
-				text = result
-			}
-			keyEvent.accepted = false
-		}
-
 		width: Math.max(
 				Theme.geometry_listItem_textField_minimumWidth,
 				Math.min(implicitWidth + leftPadding + rightPadding, Theme.geometry_listItem_textField_maximumWidth))
@@ -78,9 +65,6 @@ ListItem {
 		text: dataItem.isValid ? dataItem.value : ""
 		rightPadding: suffixLabel.text.length ? suffixLabel.implicitWidth : leftPadding
 		horizontalAlignment: root.suffix ? Text.AlignRight : Text.AlignHCenter
-
-		Keys.onEnterPressed: function (keyEvent) { textField._tryAcceptInput(keyEvent) }
-		Keys.onReturnPressed: function (keyEvent) { textField._tryAcceptInput(keyEvent) }
 
 		onAccepted: {
 			let newValue = text


### PR DESCRIPTION
This prevents the user from entering values with a precision that does not match the specified number of decimals.