### PR TITLE
Extend text field to fit longer placeholder text

### DIFF
--- a/components/controls/TextField.qml
+++ b/components/controls/TextField.qml
@@ -16,7 +16,7 @@ CT.TextField {
 	leftPadding: Theme.geometry_textField_horizontalMargin
 	rightPadding: Theme.geometry_textField_horizontalMargin
 
-	implicitWidth: contentWidth
+	implicitWidth: Math.max(contentWidth, placeholderText.implicitWidth)
 	implicitHeight: Theme.geometry_textField_height
 
 	horizontalAlignment: Text.AlignHCenter
@@ -32,6 +32,7 @@ CT.TextField {
 		// QTBUG-100490 placeholderText doesn't appear in TextField if inside StackView, so
 		// create our own placeholder here.
 		Label {
+			id: placeholderText
 			anchors {
 				left: parent.left
 				leftMargin: root.leftPadding

--- a/components/listitems/ListTextField.qml
+++ b/components/listitems/ListTextField.qml
@@ -58,9 +58,9 @@ ListItem {
 		property string _textWhenFocused
 		property bool _accepted
 
-		width: Math.max(
-				Theme.geometry_listItem_textField_minimumWidth,
-				Math.min(implicitWidth + leftPadding + rightPadding, Theme.geometry_listItem_textField_maximumWidth))
+		width: Math.max(Theme.geometry_listItem_textField_minimumWidth,
+						Math.min(Theme.geometry_listItem_textField_maximumWidth,
+								 implicitWidth + leftPadding + rightPadding))
 		enabled: root.enabled
 		text: dataItem.isValid ? dataItem.value : ""
 		rightPadding: suffixLabel.text.length ? suffixLabel.implicitWidth : leftPadding


### PR DESCRIPTION
The default size of text field is too small for some placeholder text translations. Truncation was added earlier, but it is better to show the string in full instead (if it still fits in the maximum width limits).

Contributes to #995.