### PR TITLE
Consistently format numbers according to application locale 

### DIFF
--- a/Global.qml
+++ b/Global.qml
@@ -14,7 +14,6 @@ QtObject {
 	property var mainView
 	property var mockDataSimulator    // only valid when mock mode is active
 	property var dataManager
-	property var locale: Qt.locale()  // TODO: read from settings
 	property VeQItemTableModel dataServiceModel: null
 	property var firmwareUpdate
 
@@ -88,7 +87,6 @@ QtObject {
 		mainView = null
 		mockDataSimulator = null
 		dataManager = null
-		locale = Qt.locale()
 		dataServiceModel = null
 		firmwareUpdate = null
 		inputPanel = null

--- a/components/dialogs/NumberSelectorDialog.qml
+++ b/components/dialogs/NumberSelectorDialog.qml
@@ -59,7 +59,7 @@ ModalDialog {
 						? Theme.geometry_spinBox_indicator_minimumWidth
 						: Theme.geometry_spinBox_indicator_maximumWidth
 				textFromValue: function(value, locale) {
-					return Number(value / root._multiplier()).toLocaleString(locale, 'f', root.decimals) + root.suffix
+					return Units.formatNumber(value / root._multiplier(), root.decimals) + root.suffix
 				}
 				from: root.from * root._multiplier()
 				to: root.to * root._multiplier()

--- a/components/listitems/ListQuantityField.qml
+++ b/components/listitems/ListQuantityField.qml
@@ -14,7 +14,10 @@ ListTextField {
 	property int decimals: Units.defaultUnitPrecision(unit)
 
 	suffix: Units.defaultUnitString(unit)
-	textField.validator: DoubleValidator { decimals: root.decimals }
-	textField.inputMethodHints: Qt.ImhDigitsOnly
-	textField.text: Number(value).toFixed(decimals)
+	textField.validator: DoubleValidator {
+		decimals: root.decimals
+		locale: Units.numberFormattingLocaleName
+	}
+	textField.inputMethodHints: Qt.ImhFormattedNumbersOnly
+	textField.text: Units.formatNumber(root.value, root.decimals)
 }

--- a/components/listitems/ListSpinBox.qml
+++ b/components/listitems/ListSpinBox.qml
@@ -24,7 +24,7 @@ ListButton {
 	signal minValueReached()
 	signal selectorAccepted(newValue: var)
 
-	button.text: value === undefined ? "--" : value.toFixed(decimals) + root.suffix
+	button.text: value === undefined ? "--" : Units.formatNumber(value, decimals) + root.suffix
 	enabled: dataItem.uid === "" || dataItem.isValid
 
 	onClicked: Global.dialogLayer.open(numberSelectorComponent, {value: value})

--- a/components/settings/SettingsRangeSlider.qml
+++ b/components/settings/SettingsRangeSlider.qml
@@ -13,8 +13,6 @@ RangeSlider {
 	property string suffix
 	property real labelWidth: Theme.geometry_settings_battery_rangeSlider_labelWidth
 
-	readonly property string _labelPlaceholderText: "" + to.toFixed(decimals) + suffix
-
 	implicitWidth: parent ? parent.width : 0
 	implicitHeight: Theme.geometry_listItem_height
 	stepSize: (to-from) / Theme.geometry_listItem_slider_stepDivsion
@@ -33,7 +31,7 @@ RangeSlider {
 			leftMargin: Theme.geometry_listItem_content_horizontalMargin
 		}
 		width: root.labelWidth
-		text: root.first.value.toFixed(root.decimals) + root.suffix
+		text: Units.formatNumber(root.first.value, root.decimals) + root.suffix
 		horizontalAlignment: Text.AlignRight
 		font.pixelSize: Theme.font_size_body2
 		color: Theme.color_font_secondary
@@ -46,7 +44,7 @@ RangeSlider {
 			rightMargin: Theme.geometry_listItem_content_horizontalMargin
 		}
 		width: root.labelWidth
-		text: root.second.value.toFixed(root.decimals) + root.suffix
+		text: Units.formatNumber(root.second.value, root.decimals) + root.suffix
 		font.pixelSize: Theme.font_size_body2
 		color: Theme.color_font_secondary
 	}

--- a/pages/settings/PageCanbusStatus.qml
+++ b/pages/settings/PageCanbusStatus.qml
@@ -16,7 +16,7 @@ Page {
 			return ""
 		}
 		let perc = count / total * 100
-		return " (" + perc.toFixed(2) + "%)"
+		return " (" + Units.formatNumber(perc, 2) + "%)"
 	}
 
 	VeQuickItem {

--- a/pages/settings/PageChargeCurrentLimits.qml
+++ b/pages/settings/PageChargeCurrentLimits.qml
@@ -74,11 +74,11 @@ Page {
 		delegate: ListTextGroup {
 			readonly property string dcCurrentText: dcCurrent.value === undefined
 				? "--"
-				: dcCurrent.value.toFixed(3) + Units.defaultUnitString(VenusOS.Units_Amp)
+				: Units.formatNumber(dcCurrent.value, 3) + Units.defaultUnitString(VenusOS.Units_Amp)
 			//% "Max: %1"
 			readonly property string maxValueText: maxValue.value === undefined
 				? "-- "
-				: qsTrId("settings_dvcc_max").arg(maxValue.value.toFixed(3))
+				: qsTrId("settings_dvcc_max").arg(Units.formatNumber(maxValue.value, 3))
 
 			width: parent.width
 			text: "[" + (n2kDeviceInstance.value || 0) + "] " + (customName.value || productName.value || "")

--- a/pages/settings/PageGps.qml
+++ b/pages/settings/PageGps.qml
@@ -19,14 +19,17 @@ Page {
 
 		switch (fmt) {
 		case VenusOS.GpsData_Format_DecimalDegrees: // e.g. 52.34489
-			return val.toFixed(6)
+			return Units.formatNumber(val, 6)
 		case VenusOS.GpsData_Format_DegreesMinutes: // e.g. 52° 20.693 N
-			return "%1° %2 %3".arg(Math.floor(degrees).toFixed()).arg(minutes.toFixed(4)).arg(direction)
+			return "%1° %2 %3"
+				.arg(Units.formatNumber(Math.floor(degrees)))
+				.arg(Units.formatNumber(minutes, 4))
+				.arg(direction)
 		default: // VenusOS.GpsData_Format_DegreesMinutesSeconds e.g. 52° 20' 41.6" N
 			return "%1° %2' %3\" %4"
-					.arg(Math.floor(degrees).toFixed())
-					.arg(Math.floor(minutes).toFixed())
-					.arg(seconds.toFixed(1))
+					.arg(Units.formatNumber(Math.floor(degrees)))
+					.arg(Units.formatNumber(Math.floor(minutes)))
+					.arg(Units.formatNumber(seconds, 1))
 					.arg(direction)
 		}
 	}
@@ -73,19 +76,19 @@ Page {
 					if (speedUnit.value === "km/h") {
 						//: GPS speed data, in kilometers per hour
 						//% "%1 km/h"
-						return qsTrId("settings_gps_speed_kmh").arg((dataItem.value * 3.6).toFixed(1))
+						return qsTrId("settings_gps_speed_kmh").arg(Units.formatNumber(dataItem.value * 3.6, 1))
 					} else if (speedUnit.value === "mph") {
 						//: GPS speed data, in miles per hour
 						//% "%1 mph"
-						return qsTrId("settings_gps_speed_mph").arg((dataItem.value * 2.236936).toFixed(1))
+						return qsTrId("settings_gps_speed_mph").arg(Units.formatNumber(dataItem.value * 2.236936, 1))
 					} else if (speedUnit.value === "kt") {
 						//: GPS speed data, in knots
 						//% "%1 kt"
-						return qsTrId("settings_gps_speed_kt").arg((dataItem.value * (3600/1852)).toFixed(1))
+						return qsTrId("settings_gps_speed_kt").arg(Units.formatNumber(dataItem.value * (3600/1852), 1))
 					} else {
 						//: GPS speed data, in meters per second
 						//% "%1 m/s"
-						return qsTrId("settings_gps_speed_ms").arg(dataItem.value.toFixed(2))
+						return qsTrId("settings_gps_speed_ms").arg(Units.formatNumber(dataItem.value, 2))
 					}
 				}
 			}
@@ -94,7 +97,7 @@ Page {
 				//% "Course"
 				text: qsTrId("settings_gps_course")
 				dataItem.uid: bindPrefix + "/Course"
-				secondaryText: dataItem.isValid ? "%1°".arg(dataItem.value.toFixed(1)) : ""
+				secondaryText: dataItem.isValid ? "%1°".arg(Units.formatNumber(dataItem.value, 1)) : ""
 			}
 
 			ListTextItem {

--- a/pages/settings/debug/PagePowerDebug.qml
+++ b/pages/settings/debug/PagePowerDebug.qml
@@ -16,13 +16,13 @@ Page {
 	function powerDiff(a, b) {
 		if (!a.isValid || !b.isValid)
 			return "--"
-		return (a.value - b.value).toFixed(0) + "W"
+		return Units.formatNumber(a.value - b.value) + "W"
 	}
 
 	function apparentPower(V, I) {
 		if (!V.isValid || !I.isValid)
 			return "--"
-		return (V.value * I.value).toFixed(0) + "VA"
+		return Units.formatNumber(V.value * I.value) + "VA"
 	}
 
 	function groupItemWidth(group) {

--- a/pages/settings/debug/PageSettingsDemo.qml
+++ b/pages/settings/debug/PageSettingsDemo.qml
@@ -142,6 +142,7 @@ Page {
 				slider.first.value: 25
 				slider.second.value: 75
 				slider.suffix: "%"
+				slider.decimals: 1
 			}
 
 			ListButton {

--- a/pages/settings/debug/PageSystemData.qml
+++ b/pages/settings/debug/PageSystemData.qml
@@ -10,7 +10,7 @@ Page {
 	id: root
 
 	function _formatValue(value, unit) {
-		return (value == null ? "--" : value.toFixed(2)) + " " + unit
+		return (value == null ? "--" : Units.formatNumber(value, 2)) + " " + unit
 	}
 
 	function _formatPowerValue(value) {

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -33,6 +33,12 @@ Unit::Type unitToVeUnit(Victron::VenusOS::Enums::Units_Type unit)
 	}
 }
 
+const QLocale *formattingLocale()
+{
+	static const QLocale locale = QLocale::c();
+	return &locale;
+}
+
 }
 
 namespace Victron {
@@ -51,6 +57,16 @@ Units::Units(QObject *parent)
 
 Units::~Units()
 {
+}
+
+QString Units::numberFormattingLocaleName() const
+{
+	return formattingLocale()->name();
+}
+
+QString Units::formatNumber(qreal number, int precision) const
+{
+	return formattingLocale()->toString(number, 'f', precision);
 }
 
 int Units::defaultUnitPrecision(VenusOS::Enums::Units_Type unit) const
@@ -299,7 +315,7 @@ quantityInfo Units::getDisplayTextWithHysteresis(VenusOS::Enums::Units_Type unit
 
 		int vFixed = qRound(scaledValue * 10);
 		scaledValue = (1.0*vFixed) / 10.0;
-		quantity.number = QString::number(scaledValue, 'f', 1);
+		quantity.number = formattingLocale()->toString(scaledValue, 'f', 1);
 	} else {
 		// if the value is large (hundreds or thousands) no need to display decimals after the decimal point
 		int digits = numberOfDigits(scaledValue);
@@ -309,10 +325,9 @@ quantityInfo Units::getDisplayTextWithHysteresis(VenusOS::Enums::Units_Type unit
 		const qreal vFixedMultiplier = std::pow(10, precision);
 		int vFixed = qRound(scaledValue * vFixedMultiplier);
 		scaledValue = (1.0*vFixed) / vFixedMultiplier;
-
-		quantity.number = QString::number(scaledValue, 'f', precision);
-
+		quantity.number = formattingLocale()->toString(scaledValue, 'f', precision);
 	}
+
 	return quantity;
 }
 

--- a/src/units.h
+++ b/src/units.h
@@ -37,6 +37,7 @@ class Units : public QObject
 	Q_OBJECT
 	QML_ELEMENT
 	QML_SINGLETON
+	Q_PROPERTY(QString numberFormattingLocaleName READ numberFormattingLocaleName CONSTANT)
 
 public:
 	enum FormatHint {
@@ -49,6 +50,9 @@ public:
 	~Units() override;
 
 	static QObject* instance(QQmlEngine *engine, QJSEngine *);
+
+	QString numberFormattingLocaleName() const;
+	Q_INVOKABLE QString formatNumber(qreal number, int precision = 0) const;
 
 	Q_INVOKABLE int defaultUnitPrecision(VenusOS::Enums::Units_Type unit) const;
 	Q_INVOKABLE QString defaultUnitString(VenusOS::Enums::Units_Type unit, int formatHints = 0) const;

--- a/tests/units/tst_units.qml
+++ b/tests/units/tst_units.qml
@@ -86,8 +86,7 @@ TestCase {
 	}
 
 	function test_precisionOne() {
-		var units = [VenusOS.Units_Volt_DC,
-					 VenusOS.Units_VoltAmpere,
+		var units = [VenusOS.Units_VoltAmpere,
 					 VenusOS.Units_Amp,
 					 VenusOS.Units_Hertz,
 					 VenusOS.Units_AmpHour,
@@ -108,6 +107,36 @@ TestCase {
 
 			if (Units.isScalingSupported(unit)) {
 				expect(unit, 12345, "12.3", "k" + unitString)
+				expect(unit, 123456789, "123", "M" + unitString)
+				expect(unit, 123556789012, "124", "G" + unitString)
+				expect(unit, 123456789012345, "123", "T" + unitString)
+			} else {
+				expect(unit, 12345, "12345", unitString)
+				expect(unit, 123456789, "123456789", unitString)
+			}
+		}
+	}
+
+	function test_precisionTwo() {
+		var units = [
+			VenusOS.Units_Volt_DC
+		]
+
+		for (const unit of units) {
+			const unitString = Units.defaultUnitString(unit)
+
+			expect(unit, NaN, "--", unitString)
+			expect(unit, 0, "0.00", unitString)
+			expect(unit, 0.64, "0.64", unitString)
+			expect(unit, 0.254, "0.25", unitString)
+			expect(unit, 0.255, "0.26", unitString)
+			expect(unit, 14, "14.00", unitString)
+			expect(unit, 15.55, "15.55", unitString)
+			expect(unit, 100, "100", unitString)
+			expect(unit, 1234, "1234", unitString)
+
+			if (Units.isScalingSupported(unit)) {
+				expect(unit, 12345, "12.35", "k" + unitString)
 				expect(unit, 123456789, "123", "M" + unitString)
 				expect(unit, 123556789012, "124", "G" + unitString)
 				expect(unit, 123456789012345, "123", "T" + unitString)


### PR DESCRIPTION
Set application locale and use locale-specific number formatting

Call QLocale::setDefault() when the current language is applied. This allows Qt.locale() to return the locale for the current language, and also this locale will be used as the default locale, e.g. when formatting date/times and floating point numbers for spinboxes and text fields.

In QML, always use toLocaleString() instead of toFixed() to format numbers. The former respects the decimal separator for the locale, while the latter always uses a period as the decimal separator.

In C++, use QLocale::toString() to use the correct locale for number formatting.

Fixes #1108
