### PR TITLE
Don't allow flicking beyond GradientListView bounds

### DIFF
--- a/components/GradientListView.qml
+++ b/components/GradientListView.qml
@@ -15,6 +15,7 @@ ListView {
 	bottomMargin: Theme.geometry_gradientList_bottomMargin
 	leftMargin: Theme.geometry_page_content_horizontalMargin
 	rightMargin: Theme.geometry_page_content_horizontalMargin
+	boundsBehavior: Flickable.DragOverBounds
 
 	// Note: do not set spacing here, as it creates extra spacing if an item has visible=false.
 	// Instead, the spacing is added visually within ListItem's ListItemBackground.


### PR DESCRIPTION
It's disconcerting when a flick makes the view jump around. Restrict the return-to-bounds behavior to dragging.

This is the same as the behavior allowed in the control cards view.