### PR TITLE
Be more explicit about tank gauge delegate sizing

### DIFF
--- a/components/TankGaugeGroup.qml
+++ b/components/TankGaugeGroup.qml
@@ -33,25 +33,29 @@ TankItem {
 	gauge: Row {
 		id: subgauges // contains 1 or more gauges of a single type
 
-		spacing: Theme.geometry_levelsPage_subgauges_spacing
+		height: parent.height
+		spacing: root.mergeTanks ? Theme.geometry_levelsPage_subgauges_spacing : 0
 
 		Repeater {
 			model: root.gaugeTanks
 			delegate: Loader {
 				active: model.index === 0 || root.mergeTanks
-				sourceComponent: TankGauge {
-					expanded: root.expanded
-					animationEnabled: root.animationEnabled
-					width: {
+				width: {
+					if (active) {
 						const availableSpace = root.width - 2*Theme.geometry_levelsPage_subgauges_horizontalMargin
 						if (root.mergeTanks) {
 							return (availableSpace - (gaugeTanks.count - 1) * subgauges.spacing)/gaugeTanks.count
 						} else {
 							return availableSpace
 						}
+					} else {
+						return 0
 					}
-
-					height: subgauges.height
+				}
+				height: subgauges.height
+				sourceComponent: TankGauge {
+					expanded: root.expanded
+					animationEnabled: root.animationEnabled
 					valueType: root.tankProperties.valueType
 					value: (root.mergeTanks ? model.device.level : root.level) / 100
 					isGrouped: root.mergeTanks


### PR DESCRIPTION
In TankGaugeGroup there is a Row populated by a Repeater whose delegate is a Loader.  The geometry of the Loader isn't explicitly defined, so will be inherited from its item if the Loader is active.  If a particular Loader is active, its geometry will be set; if that Loader then becomes inactive, it's possible that the geometry of that loader is being "stuck" at the old item's width, rather than being reset to zero.

This commit ensures that the width of the loader is explicitly set to the width of the item if active, otherwise zero.

It also makes various spacings and data bindings much more explicit for maintainability purposes.

A mock config is added which was intended to test the error case, although I was unable to reproduce using the mock backend.

Contributes to #1017