### PR TITLE
Adjustments to the Overview box sizing

### DIFF
--- a/components/ThreePhaseDisplay.qml
+++ b/components/ThreePhaseDisplay.qml
@@ -64,7 +64,7 @@ Flow {
 				color: quantityLabel.unitColor
 				font.pixelSize: root.widgetSize >= VenusOS.OverviewWidget_Size_L
 						? Theme.font_size_body1
-						: Theme.font_size_phase_small
+						: Theme.font_overviewPage_phase_pixelSize
 			}
 
 			ElectricalQuantityLabel {

--- a/components/widgets/OverviewWidget.qml
+++ b/components/widgets/OverviewWidget.qml
@@ -35,20 +35,22 @@ Rectangle {
 	property list<QtObject> extraContentChildren
 
 	function getCompactHeight(s) {
-		return s === VenusOS.OverviewWidget_Size_XL ? Theme.geometry_overviewPage_widget_compact_xl_height
+		const availableHeight = Theme.geometry_screen_height - Theme.geometry_statusBar_height - Theme.geometry_navigationBar_height
+		return s === VenusOS.OverviewWidget_Size_XL ? availableHeight
 			: s === VenusOS.OverviewWidget_Size_L ? Theme.geometry_overviewPage_widget_compact_l_height
-			: s === VenusOS.OverviewWidget_Size_M ? Theme.geometry_overviewPage_widget_compact_m_height
-			: s === VenusOS.OverviewWidget_Size_S ? Theme.geometry_overviewPage_widget_compact_s_height
-			: s === VenusOS.OverviewWidget_Size_XS ? Theme.geometry_overviewPage_widget_compact_xs_height
+			: s === VenusOS.OverviewWidget_Size_M ? (availableHeight - 2*Theme.geometry_overviewPage_widget_spacing)/3
+			: s === VenusOS.OverviewWidget_Size_S ? (availableHeight - 3*Theme.geometry_overviewPage_widget_spacing)/4
+			: s === VenusOS.OverviewWidget_Size_XS ? (availableHeight - 4*Theme.geometry_overviewPage_widget_spacing)/5
 			: 0
 	}
 
 	function getExpandedHeight(s) {
-		return s === VenusOS.OverviewWidget_Size_XL ? Theme.geometry_overviewPage_widget_expanded_xl_height
+		const availableHeight = Theme.geometry_screen_height - Theme.geometry_statusBar_height - Theme.geometry_overviewPage_layout_expanded_bottomMargin
+		return s === VenusOS.OverviewWidget_Size_XL ? availableHeight
 			: s === VenusOS.OverviewWidget_Size_L ? Theme.geometry_overviewPage_widget_expanded_l_height
-			: s === VenusOS.OverviewWidget_Size_M ? Theme.geometry_overviewPage_widget_expanded_m_height
-			: s === VenusOS.OverviewWidget_Size_S ? Theme.geometry_overviewPage_widget_expanded_s_height
-			: s === VenusOS.OverviewWidget_Size_XS ? Theme.geometry_overviewPage_widget_expanded_xs_height
+			: s === VenusOS.OverviewWidget_Size_M ? (availableHeight - 2*Theme.geometry_overviewPage_widget_spacing)/3
+			: s === VenusOS.OverviewWidget_Size_S ? (availableHeight - 3*Theme.geometry_overviewPage_widget_spacing)/4
+			: s === VenusOS.OverviewWidget_Size_XS ? (availableHeight - 4*Theme.geometry_overviewPage_widget_spacing)/5
 			: 0
 	}
 

--- a/pages/OverviewPage.qml
+++ b/pages/OverviewPage.qml
@@ -166,18 +166,10 @@ SwipeViewPage {
 		const compactPageHeight = Theme.geometry_screen_height
 				- Theme.geometry_statusBar_height
 				- Theme.geometry_navigationBar_height
-
-		if (compactPageHeight !== Theme.geometry_overviewPage_widget_compact_xl_height) {
-			console.log("Warning: theme constants need to be updated.")
-		}
 		const compactWidgetsTopMargin = Math.max(0, (compactPageHeight - compactWidgetHeights) / Math.max(1, widgets.length - 1))
-
 		const expandedPageHeight = Theme.geometry_screen_height
 				- Theme.geometry_statusBar_height
 				- Theme.geometry_overviewPage_layout_expanded_bottomMargin
-		if (expandedPageHeight !== Theme.geometry_overviewPage_widget_expanded_xl_height) {
-			console.log("Warning: theme constants need to be updated.")
-		}
 
 		const expandedWidgetsTopMargin = Math.max(0, (expandedPageHeight - expandedWidgetHeights) / Math.max(1, widgets.length - 1))
 

--- a/pages/OverviewPage.qml
+++ b/pages/OverviewPage.qml
@@ -103,13 +103,13 @@ SwipeViewPage {
 			case 4:
 				// Only one of the widgets can have L size, and the other ones use a reduced size.
 				if (widget === firstLargeWidget) {
-					widget.size = VenusOS.OverviewWidget_Size_L
+					widget.size = VenusOS.OverviewWidget_Size_M
 				} else if (firstLargeWidget != null) {
 					// There is a large widget, so use M or XS size to fit around it
-					widget.size = _leftWidgets.length == 3 ? VenusOS.OverviewWidget_Size_M : VenusOS.OverviewWidget_Size_XS
+					widget.size = VenusOS.OverviewWidget_Size_XS
 				} else {
 					// There are no large widgets; use the same size for all left widgets
-					widget.size = _leftWidgets.length == 3 ? VenusOS.OverviewWidget_Size_M : VenusOS.OverviewWidget_Size_S
+					widget.size = VenusOS.OverviewWidget_Size_S
 				}
 				break
 			default:

--- a/themes/geometry/FiveInch.json
+++ b/themes/geometry/FiveInch.json
@@ -256,16 +256,9 @@
     "geometry_overviewPage_widget_battery_gradient_height": 38,
     "geometry_overviewPage_widget_battery_bottomRow_bottomMargin": 6,
 
-    "geometry_overviewPage_widget_compact_xl_height": 352,
+    "geometry_overviewPage_widget_spacing": 8,
     "geometry_overviewPage_widget_compact_l_height": 152,
-    "geometry_overviewPage_widget_compact_m_height": 114,
-    "geometry_overviewPage_widget_compact_s_height": 80,
-    "geometry_overviewPage_widget_compact_xs_height": 64,
-    "geometry_overviewPage_widget_expanded_xl_height": 400,
     "geometry_overviewPage_widget_expanded_l_height": 176,
-    "geometry_overviewPage_widget_expanded_m_height": 132,
-    "geometry_overviewPage_widget_expanded_s_height": 94,
-    "geometry_overviewPage_widget_expanded_xs_height": 74,
 
     "geometry_overviewPage_connector_line_width": 2,
     "geometry_overviewPage_connector_electron_velocity": 30,

--- a/themes/geometry/SevenInch.json
+++ b/themes/geometry/SevenInch.json
@@ -256,16 +256,9 @@
     "geometry_overviewPage_widget_battery_gradient_height": 48,
     "geometry_overviewPage_widget_battery_bottomRow_bottomMargin": 10,
 
-    "geometry_overviewPage_widget_compact_xl_height": 472,
+    "geometry_overviewPage_widget_spacing": 8,
     "geometry_overviewPage_widget_compact_l_height": 192,
-    "geometry_overviewPage_widget_compact_m_height": 137,
-    "geometry_overviewPage_widget_compact_s_height": 106,
-    "geometry_overviewPage_widget_compact_xs_height": 83,
-    "geometry_overviewPage_widget_expanded_xl_height": 504,
     "geometry_overviewPage_widget_expanded_l_height": 205,
-    "geometry_overviewPage_widget_expanded_m_height": 146,
-    "geometry_overviewPage_widget_expanded_s_height": 113,
-    "geometry_overviewPage_widget_expanded_xs_height": 87,
 
     "geometry_overviewPage_connector_line_width": 2,
     "geometry_overviewPage_connector_electron_velocity": 30,

--- a/themes/typography/FiveInch.json
+++ b/themes/typography/FiveInch.json
@@ -8,5 +8,6 @@
     "font_overviewPage_battery_timeToGo_pixelSize": "font_size_body1",
     "font_overviewPage_widget_quantityLabel_minimumSize": "font_size_body2",
     "font_overviewPage_widget_quantityLabel_maximumSize": "font_size_h1",
+    "font_overviewPage_phase_pixelSize": "font_size_phase_small",
     "font_splashView_progressText_size": "font_size_caption"
 }

--- a/themes/typography/SevenInch.json
+++ b/themes/typography/SevenInch.json
@@ -8,5 +8,6 @@
     "font_overviewPage_battery_timeToGo_pixelSize": "font_size_body2",
     "font_overviewPage_widget_quantityLabel_minimumSize": "font_size_body3",
     "font_overviewPage_widget_quantityLabel_maximumSize": "font_size_h2",
+    "font_overviewPage_phase_pixelSize": "font_size_phase_medium",
     "font_splashView_progressText_size": "font_size_body1"
 }

--- a/themes/typography/TypographyDesign.json
+++ b/themes/typography/TypographyDesign.json
@@ -1,7 +1,8 @@
 {
     "font_size_gsm_icon_caption": 12,
     "font_size_phase_number": 12,
-    "font_size_phase_small": 14,
+    "font_size_phase_small": 13,
+    "font_size_phase_medium": 15,
     "font_size_caption": 16,
     "font_size_body1": 18,
     "font_size_body2": 22,


### PR DESCRIPTION
- Reduce the first widget size if there 4 input widgets. Fixes #1127.
- Simplify Overview widget size category calculations
  * This makes the implementation closer to the design that uses Figma autolayouts
  * Calculating the sizes helps align box spacing between different size categories and between the compact/expanded modes.
  * Aligning spacing between all layout combinations (M+3xXS, L+2xS) is not fully possible unless we make the box heights dynamic so calculating the dimensions from tightest combinations (4xS, 5xXS) to quarantee at least Theme.geometry_overviewPage_widget_spacing spacing
