### PR TITLE
Reduce flick decelaration to make flicks less sticky

### DIFF
--- a/components/GradientListView.qml
+++ b/components/GradientListView.qml
@@ -24,6 +24,9 @@ ListView {
 		anchors.bottom: root.bottom
 	}
 
+	maximumFlickVelocity: Theme.geometry_flickable_maximumFlickVelocity
+	flickDeceleration: Theme.geometry_flickable_flickDeceleration
+
 	ScrollBar.vertical: ScrollBar {
 		topPadding: Theme.geometry_gradientList_topMargin
 		bottomPadding: Theme.geometry_gradientList_bottomMargin

--- a/pages/ControlCardsPage.qml
+++ b/pages/ControlCardsPage.qml
@@ -32,6 +32,8 @@ Page {
 		orientation: ListView.Horizontal
 		snapMode: ListView.SnapOneItem
 		boundsBehavior: Flickable.DragOverBounds
+		maximumFlickVelocity: Theme.geometry_flickable_maximumFlickVelocity
+		flickDeceleration: Theme.geometry_flickable_flickDeceleration
 
 		model: ObjectModel {
 			Loader {

--- a/pages/TanksTab.qml
+++ b/pages/TanksTab.qml
@@ -63,6 +63,8 @@ ListView {
 	model: Global.tanks.tankTypes
 	orientation: ListView.Horizontal
 	boundsBehavior: Flickable.StopAtBounds
+	maximumFlickVelocity: Theme.geometry_flickable_maximumFlickVelocity
+	flickDeceleration: Theme.geometry_flickable_flickDeceleration
 
 	delegate: Row {
 		id: tankTypeDelegate

--- a/themes/geometry/FiveInch.json
+++ b/themes/geometry/FiveInch.json
@@ -9,6 +9,9 @@
     "geometry_icon_size_medium": 32,
     "geometry_icon_size_large": 48,
 
+    "geometry_flickable_maximumFlickVelocity": 2500,
+    "geometry_flickable_flickDeceleration": 2500,
+
     "geometry_barGauge_vertical_width_large": 8,
     "geometry_barGauge_vertical_width_small": 4,
     "geometry_barGauge_horizontal_height": 10,

--- a/themes/geometry/SevenInch.json
+++ b/themes/geometry/SevenInch.json
@@ -9,6 +9,9 @@
     "geometry_icon_size_medium": 32,
     "geometry_icon_size_large": 48,
 
+    "geometry_flickable_maximumFlickVelocity": 2500,
+    "geometry_flickable_flickDeceleration": 2500,
+
     "geometry_barGauge_vertical_width_large": 8,
     "geometry_barGauge_vertical_width_small": 4,
     "geometry_barGauge_horizontal_height": 10,


### PR DESCRIPTION
- GX device, WASM build and Linux desktop already had the same flicking parameters
- Keep maximumFlickVelocity, but reduce decelaration from 5000 to 2500
- Could go even further, lightweight flicks are pretty standard in the industry

Fixes #1124.