### PR TITLE
Rename ListDvccSwitch.qml to ListSwitchForced.qml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,6 +347,7 @@ set (VENUS_QML_MODULE_SOURCES
     components/listitems/ListSlider.qml
     components/listitems/ListSpinBox.qml
     components/listitems/ListSwitch.qml
+    components/listitems/ListSwitchForced.qml
     components/listitems/ListTemperatureItem.qml
     components/listitems/ListTextField.qml
     components/listitems/ListTextGroup.qml
@@ -362,7 +363,6 @@ set (VENUS_QML_MODULE_SOURCES
     components/settings/ListClearHistoryButton.qml
     components/settings/ListDcInputQuantityGroup.qml
     components/settings/ListDcOutputQuantityGroup.qml
-    components/settings/ListDvccSwitch.qml
     components/settings/ListFirmwareVersionItem.qml
     components/settings/ListRelayState.qml
     components/settings/ListResetHistoryLabel.qml

--- a/components/listitems/ListSwitchForced.qml
+++ b/components/listitems/ListSwitchForced.qml
@@ -9,9 +9,9 @@ import Victron.VenusOS
 ListSwitch {
 	id: root
 
-	readonly property bool _forced: dataItem.value === VenusOS.DVCC_ForcedOff || dataItem.value === VenusOS.DVCC_ForcedOn
+	readonly property bool _forced: dataItem.value === VenusOS.Switch_ForcedOff || dataItem.value === VenusOS.Switch_ForcedOn
 
-	checked: dataItem.value === 1 || dataItem.value === VenusOS.DVCC_ForcedOn
+	checked: dataItem.value === 1 || dataItem.value === VenusOS.Switch_ForcedOn
 	enabled: dataItem.isValid && userHasWriteAccess && !_forced
 
 	secondaryText: _forced && checked

--- a/pages/settings/DvccCommonSettings.qml
+++ b/pages/settings/DvccCommonSettings.qml
@@ -10,7 +10,7 @@ Column {
 	property alias dvccActive: dvccSwitch.checked
 	readonly property alias userHasWriteAccess: dvccSwitch.userHasWriteAccess
 
-	ListDvccSwitch {
+	ListSwitchForced {
 		id: dvccSwitch
 
 		//% "DVCC"

--- a/pages/settings/PageSettingsDvcc.qml
+++ b/pages/settings/PageSettingsDvcc.qml
@@ -58,14 +58,14 @@ Page {
 				stepSize: 0.1
 			}
 
-			ListDvccSwitch {
+			ListSwitchForced {
 				//% "SVS - Shared voltage sense"
 				text: qsTrId("settings_dvcc_shared_voltage_sense")
 				dataItem.uid: Global.systemSettings.serviceUid + "/Settings/SystemSetup/SharedVoltageSense"
 				allowed: defaultAllowed && commonSettings.dvccActive
 			}
 
-			ListDvccSwitch {
+			ListSwitchForced {
 				id: sharedTempSense
 
 				//% "STS - Shared temperature sense"

--- a/src/enums.h
+++ b/src/enums.h
@@ -391,11 +391,11 @@ public:
 	};
 	Q_ENUM(PageManager_InteractionMode)
 
-	enum DVCC_Mode {
-		DVCC_ForcedOff = 2,
-		DVCC_ForcedOn = 3
+	enum Switch_ForcedMode {
+		Switch_ForcedOff = 2,
+		Switch_ForcedOn = 3
 	};
-	Q_ENUM(DVCC_Mode)
+	Q_ENUM(Switch_ForcedMode)
 
 	enum Notification_Type {
 		Notification_Warning,


### PR DESCRIPTION
While this switch is only used in DVCC settings at the moment, it is more generically named in gui-v1, so use similar naming here for parity.