### PR TITLE
Clear inverter/charger input settings when object becomes invalid

### DIFF
--- a/data/common/InverterCharger.qml
+++ b/data/common/InverterCharger.qml
@@ -80,4 +80,10 @@ Device {
 		}
 		inputSettings.get(inputIndex).inputSettings.setCurrentLimit(currentLimit)
 	}
+
+	onValidChanged: {
+		if (!valid) {
+			inverterCharger.inputSettings.clear()
+		}
+	}
 }


### PR DESCRIPTION
Otherwise, there are stale objects in the input settings model when the object becomes valid again -- for example, if changing the demo mode causes the inverter/charger to be repopulated with different values.

Fixes #1134