### PR TITLE
Align Overview page AC input title naming with gui v1

### DIFF
--- a/data/AcInputs.qml
+++ b/data/AcInputs.qml
@@ -72,7 +72,13 @@ QtObject {
 	}
 
 	function sourceToText(source) {
+		if (source === undefined) {
+			return CommonWords.acInput()
+		}
 		switch (source) {
+		case VenusOS.AcInputs_InputSource_NotAvailable:
+			//% "Not available"
+			return qsTrId("acInputs_not_available")
 		case VenusOS.AcInputs_InputSource_Grid:
 			return CommonWords.grid
 		case VenusOS.AcInputs_InputSource_Generator:
@@ -80,6 +86,8 @@ QtObject {
 		case VenusOS.AcInputs_InputSource_Shore:
 			//% "Shore"
 			return qsTrId("acInputs_shore")
+		// deliberate fall-through
+		case VenusOS.AcInputs_InputSource_Inverting:
 		default:
 			return ""
 		}


### PR DESCRIPTION
Align sourceToText() in gui-v2/data/AcInputs.qml with getAcSourceName() in gui/qml/OverviewPage.qml

Fixes #1100.