### PR TITLE
Improve battery widget contrast on light style

### DIFF
--- a/themes/color/ColorDesign.json
+++ b/themes/color/ColorDesign.json
@@ -1,5 +1,6 @@
 {
     "color_blue": "#387DC5",
+    "color_lightBlue": "#73A2D3",
     "color_dimBlue": "#B3387DC5",
     "color_darkBlue": "#4D387DC5",
     "color_orange": "#F0962E",

--- a/themes/color/Light.json
+++ b/themes/color/Light.json
@@ -88,7 +88,7 @@
     "color_overviewPage_widget_sideGauge_background": "color_darkOk",
     "color_overviewPage_widget_sideGauge_highlight": "color_ok",
     "color_overviewPage_widget_solar_graph_bar": "color_ok",
-    "color_overviewPage_widget_battery_background": "color_blue",
+    "color_overviewPage_widget_battery_background": "color_lightBlue",
     "color_overviewPage_widget_battery_bubble_background": "#7394bd",
     "color_overviewPage_widget_battery_bubble_border": "#FFFFFF",
 


### PR DESCRIPTION
Serj adjusted the battery background colors.

![image](https://github.com/victronenergy/gui-v2/assets/2203667/07d6d8a5-4bac-4e7a-840a-17b6b9cf0de2)

Fixes #1149.