### PR TITLE
CAN Profiles: add the High Voltage CAN bus as an option

### DIFF
--- a/pages/settings/PageSettingsCanbus.qml
+++ b/pages/settings/PageSettingsCanbus.qml
@@ -45,6 +45,12 @@ Page {
 						return profile !== VenusOS.CanBusProfile_Vecan
 					case VenusOS.CanBusConfig_ForcedCanBusBms:
 						return profile !== VenusOS.CanBusProfile_CanBms500
+					// The classic CAN busses don't support CAN fd / CAN XL frames like the HV CAN bus uses.
+					// All other protocols are supported.
+					case VenusOS.CanBusConfig_AnyBus:
+						return profile === VenusOS.CanBusProfile_HighVoltage
+					// These interfaces support all profiles
+					case VenusOS.CanBusConfig_AnyBusAndHv:
 					default:
 						return false
 					}
@@ -76,6 +82,12 @@ Page {
 						display: qsTrId("settings_canbus_bms"),
 						value: VenusOS.CanBusProfile_CanBms500,
 						readOnly: isReadOnly(VenusOS.CanBusProfile_CanBms500)
+					},
+					{
+						//% "HV CAN-bus (500 kbit/s)"
+						display: qsTrId("settings_canbus_high_voltage"),
+						value: VenusOS.CanBusProfile_HighVoltage,
+						readOnly: isReadOnly(VenusOS.CanBusProfile_HighVoltage)
 					},
 					{
 						//% "Oceanvolt (250 kbit/s)"

--- a/pages/settings/PageSettingsCanbus.qml
+++ b/pages/settings/PageSettingsCanbus.qml
@@ -78,13 +78,13 @@ Page {
 						readOnly: isReadOnly(VenusOS.CanBusProfile_VecanAndCanBms)
 					},
 					{
-						//% "CAN-bus BMS (500 kbit/s)"
+						//% "CAN-bus BMS LV (500 kbit/s)"
 						display: qsTrId("settings_canbus_bms"),
 						value: VenusOS.CanBusProfile_CanBms500,
 						readOnly: isReadOnly(VenusOS.CanBusProfile_CanBms500)
 					},
 					{
-						//% "HV CAN-bus (500 kbit/s)"
+						//% "CAN-bus BMS HV (500 kbit/s)"
 						display: qsTrId("settings_canbus_high_voltage"),
 						value: VenusOS.CanBusProfile_HighVoltage,
 						readOnly: isReadOnly(VenusOS.CanBusProfile_HighVoltage)

--- a/src/enums.h
+++ b/src/enums.h
@@ -419,14 +419,22 @@ public:
 		CanBusProfile_CanBms500,
 		CanBusProfile_Oceanvolt,
 		CanBusProfile_None250,
-		CanBusProfile_RvC
+		CanBusProfile_RvC,
+		CanBusProfile_HighVoltage
 	};
 	Q_ENUM(CanBusProfile_Type)
 
 	enum CanBusConfig_Type {
+		// "any" means, any of the for Venus tested protocols, before supporting the
+		// hv-can-bus (CAN-fd). That is classic CAN up to 500 kbit/s.
 		CanBusConfig_AnyBus,
 		CanBusConfig_ForcedCanBusBms,
-		CanBusConfig_ForcedVeCan
+		CanBusConfig_ForcedVeCan,
+		// High Voltage CAN can send CAN fd frames as well. Hence CAN interfaces must
+		// explicitly indicate it is supported, not only that CAN-fd messages are
+		// supported, but also to assure the device can keep up with the higher
+		// througput. The HV protocol uses upto 1Mbit/s at the moment.
+		CanBusConfig_AnyBusAndHv
 	};
 	Q_ENUM(CanBusConfig_Type)
 


### PR DESCRIPTION
WIP. Still need a way to verify this works.

The High Voltage CAN bus requires a CAN bus controller with CAN FD support, hence
only provide this option if the CAN config of the CAN interfaces indicates that it
is capable of handling it.

gui-v1 commit: d21f13064fd0c70a04c5e876114720714fc5490c

Fixes #1084.