### PR TITLE
Fix regression in BatteryWidget animation

### DIFF
--- a/components/widgets/BatteryWidget.qml
+++ b/components/widgets/BatteryWidget.qml
@@ -79,6 +79,7 @@ OverviewWidget {
 			anchors.bottom: parent.bottom
 			visible: batteryData.mode === VenusOS.Battery_Mode_Charging && root._animationReady
 			clip: true
+			z: 6 // greater than the explicit z-order specified in BarGauge.
 
 			SequentialAnimation {
 				property bool startAnimation: root._animationReady


### PR DESCRIPTION
Previous BarGauge fix broke the animation as it set a specific z-order (5) which was higher than zero, thus occluding the animation effect item.