### PR TITLE
Close side panel when detecting high CPU usage

### DIFF
--- a/pages/BriefPage.qml
+++ b/pages/BriefPage.qml
@@ -461,6 +461,19 @@ SwipeViewPage {
 		}
 	}
 
+	CpuInfo {
+		enabled: root.isCurrentPage && root.state === "panelOpened"
+		upperLimit: 90
+		lowerLimit: 50
+		onOverLimitChanged: {
+			if (overLimit) {
+				//% "System load high, closing the side panel to reduce CPU load"
+				Global.showToastNotification(VenusOS.Notification_Warning, qsTrId("nav_brief_close_side_panel_high_cpu"))
+				root.state = "initialized"
+			}
+		}
+	}
+
 	states: [
 		State {
 			name: "initialized"


### PR DESCRIPTION
Solution proposal: automatically collapse the side panel if CPU utilization goes over 90% and display banner "System load high, closing the side panel to reduce CPU load".

Fixes #1125.