### PR TITLE
Add some parameters specific for Lynx parallel BMS

### DIFF
--- a/data/mock/BatteriesImpl.qml
+++ b/data/mock/BatteriesImpl.qml
@@ -15,6 +15,7 @@ QtObject {
 			"/Balancing": 0,
 			"/Capacity": 200,
 			"/InstalledCapacity": 250,
+			"/NumberOfBmses": 1,
 			"/Connected": 1,
 			"/ConsumedAmphours": 10,
 			"/CustomName": "Lynx Smart BMS HQ21302VUDQ",

--- a/pages/settings/devicelist/battery/PageBattery.qml
+++ b/pages/settings/devicelist/battery/PageBattery.qml
@@ -91,6 +91,22 @@ Page {
 			}
 
 			ListQuantityItem {
+				//% "Total Capacity"
+				text: qsTrId("devicelist_battery_total_capacity")
+				dataItem.uid: root.battery.serviceUid + "/Capacity"
+				allowed: defaultAllowed && numberOfBms.allowed
+				unit: VenusOS.Units_AmpHour
+			}
+
+			ListTextItem {
+				id: numberOfBms
+				//% "Number of BMSes"
+				text: qsTrId("devicelist_battery_number_of_bmses")
+				dataItem.uid: root.battery.serviceUid + "/NumberOfBmses"
+				allowed: defaultAllowed && dataItem.isValid
+			}
+
+			ListQuantityItem {
 				text: CommonWords.state_of_charge
 				value: root.battery.stateOfCharge
 				unit: VenusOS.Units_Percentage


### PR DESCRIPTION
Add Total capacity and number of connected BMSes.

Noticed that the capacity is already shown on the battery details, will still check if the duplication is really wanted.

Fixes #1081.