### PR TITLE
Solar device list: align solar tracker naming with VRM Portal

### DIFF
--- a/components/SolarHistoryTableView.qml
+++ b/components/SolarHistoryTableView.qml
@@ -117,7 +117,7 @@ Column {
 		]
 		valueForModelIndex: function(trackerIndex, column) {
 			if (column === 0) {
-				return root.solarHistory.trackerName(trackerIndex)
+				return root.solarHistory.trackerName(trackerIndex, VenusOS.TrackerName_NoDevicePrefix)
 			} else if (column === 1) {
 				return root._trackerHistoryTotal("yieldKwh", trackerIndex)
 			} else if (column === 2) {

--- a/data/SolarChargers.qml
+++ b/data/SolarChargers.qml
@@ -26,13 +26,22 @@ QtObject {
 		model.clear()
 	}
 
-	function defaultTrackerName(trackerIndex, totalTrackerCount, deviceName) {
-		if (totalTrackerCount === 1) {
-			return deviceName
+	function formatTrackerName(trackerName, trackerIndex, totalTrackerCount, deviceName, format) {
+		if (format === VenusOS.TrackerName_WithDevicePrefix) {
+			if (trackerName.length > 0) {
+				return "%1-%2".arg(deviceName).arg(trackerName)
+			} else if (totalTrackerCount > 1) {
+				return "%1-#%2".arg(deviceName).arg(trackerIndex + 1)
+			} else {
+				return deviceName
+			}
+		} else {    // format === VenusOS.TrackerName_NoDevicePrefix
+			if (trackerName.length > 0) {
+				return trackerName
+			} else {
+				return "#%2".arg(deviceName).arg(trackerIndex + 1)
+			}
 		}
-		//: Name for a tracker of a solar charger. %1 = solar charger name, %2 = the number of this tracker for the charger
-		//% "%1 (#%2)"
-		return qsTrId("solarcharger_tracker_name").arg(deviceName).arg(trackerIndex + 1)
 	}
 
 	function chargerStateToText(state) {

--- a/data/common/SolarCharger.qml
+++ b/data/common/SolarCharger.qml
@@ -36,9 +36,10 @@ Device {
 		return _history.dailyTrackerHistory(day, trackerIndex)
 	}
 
-	function trackerName(trackerIndex) {
+	function trackerName(trackerIndex, format) {
 		const tracker = _trackerObjects.objectAt(trackerIndex)
-		return tracker ? tracker.name || "" : ""
+		const trackerName = tracker ? tracker.name || "" : ""
+		return Global.solarChargers.formatTrackerName(trackerName, trackerIndex, trackers.count, solarCharger.name, format)
 	}
 
 	//--- internal members below ---
@@ -95,8 +96,7 @@ Device {
 			readonly property real power: solarCharger.trackers.count <= 1 ? solarCharger.power : _power.value || 0
 			readonly property real voltage: _voltage.value || 0
 			readonly property real current: isNaN(power) || isNaN(voltage) || voltage === 0 ? NaN : power / voltage
-
-			readonly property string name: _name.value || Global.solarChargers.defaultTrackerName(model.index, _trackerObjects.count, solarCharger.name)
+			readonly property string name: _name.value || ""
 
 			readonly property VeQuickItem _voltage: VeQuickItem {
 				uid: solarCharger.trackers.count <= 1

--- a/data/common/SolarHistory.qml
+++ b/data/common/SolarHistory.qml
@@ -27,10 +27,10 @@ QtObject {
 		return _historyObjects.dailyTrackerHistory(day, trackerIndex)
 	}
 
-	function trackerName(trackerIndex) {
+	function trackerName(trackerIndex, format) {
 		const nameObject = _trackerNames.objectAt(trackerIndex)
 		const name = nameObject ? nameObject.value || "" : ""
-		return name ? name : Global.solarChargers.defaultTrackerName(trackerIndex, trackerCount, deviceName)
+		return Global.solarChargers.formatTrackerName(name, trackerIndex, trackerCount, deviceName, format)
 	}
 
 	readonly property Instantiator _trackerNames: Instantiator {

--- a/data/mock/SolarChargersImpl.qml
+++ b/data/mock/SolarChargersImpl.qml
@@ -68,7 +68,7 @@ QtObject {
 				if (trackerCount > 1 && Math.random() < 0.5) {
 					const charCode = 'A'.charCodeAt(0)
 					for (trackerIndex = 0; trackerIndex < trackerCount; ++trackerIndex) {
-						const nextTrackerName = "Charger %1 - Tracker %2".arg(root.mockDeviceCount).arg(String.fromCharCode(charCode + trackerIndex))
+						const nextTrackerName = "Tracker %1".arg(String.fromCharCode(charCode + trackerIndex))
 						Global.mockDataSimulator.setMockValue(serviceUid + "/Pv/" + trackerIndex + "/Name", nextTrackerName)
 					}
 				}

--- a/pages/settings/devicelist/rs/PageMultiRs.qml
+++ b/pages/settings/devicelist/rs/PageMultiRs.qml
@@ -234,7 +234,9 @@ Page {
 						valueForModelIndex: function(trackerIndex, column) {
 							const tracker = trackerObjects.objectAt(trackerIndex)
 							if (column === 0) {
-								return tracker.name
+								return Global.solarChargers.formatTrackerName(tracker.name,
+										trackerIndex, root.trackerCount, root.title,
+										VenusOS.TrackerName_NoDevicePrefix)
 							} else if (column === 1) {
 								return tracker.voltage
 							} else if (column === 2) {
@@ -252,7 +254,7 @@ Page {
 								readonly property real power: _power.value === undefined ? NaN : _power.value
 								readonly property real voltage: _voltage.value === undefined ? NaN : _voltage.value
 								readonly property real current: isNaN(power) || isNaN(voltage) || voltage === 0 ? NaN : power / voltage
-								readonly property string name: _name.value || Global.solarChargers.defaultTrackerName(index, root.trackerCount, root.title)
+								readonly property string name: _name.value || ""
 
 								readonly property VeQuickItem _voltage: VeQuickItem { uid: root.bindPrefix + "/Pv/" + index + "/V" }
 								readonly property VeQuickItem _power: VeQuickItem { uid: root.bindPrefix + "/Pv/" + index + "/P" }

--- a/pages/solar/SolarDeviceListPage.qml
+++ b/pages/solar/SolarDeviceListPage.qml
@@ -64,7 +64,7 @@ Page {
 								return historyToday ? historyToday.yieldKwh : NaN
 							}
 
-							text: solarCharger.trackerName(model.index)
+							text: solarCharger.trackerName(model.index, VenusOS.TrackerName_WithDevicePrefix)
 							quantityModel: [
 								{ value: yieldToday, unit: VenusOS.Units_Energy_KiloWattHour },
 								{ value: modelData.voltage, unit: VenusOS.Units_Volt_DC },

--- a/src/enums.h
+++ b/src/enums.h
@@ -628,6 +628,12 @@ public:
 		Alarm_Level_Alarm
 	};
 	Q_ENUM(Alarm_Level)
+
+	enum TrackerName_Format {
+		TrackerName_WithDevicePrefix,
+		TrackerName_NoDevicePrefix
+	};
+	Q_ENUM(TrackerName_Format)
 };
 
 }


### PR DESCRIPTION
In the solar device list shown in the overview drilldowns, align the tracker naming with the naming patterns used in VRM Portal. Prefix each tracker name with the name of its associated solar charger: for example, "My charger-My tracker". If the tracker name is empty, show "My tracker-#1", "My tracker-#2", etc. If the charger does not have multiple trackers, just show the charger name.

In the solar history tables, show the tracker name without the charger name prefix, since the charger name is already shown as the page title.

Fixes #1172