### PR TITLE
Show DC flow for Multi RS and Inverter RS

### DIFF
--- a/data/System.qml
+++ b/data/System.qml
@@ -71,11 +71,9 @@ QtObject {
 
 	readonly property QtObject veBus: QtObject {
 		readonly property string serviceUid: BackendConnection.serviceUidFromName(_serviceName.value || "", _deviceInstance.value || 0)
-		readonly property real power: _power.value === undefined ? NaN : _power.value
 
 		readonly property VeQuickItem _serviceName: VeQuickItem { uid: root.serviceUid + "/VebusService" }
 		readonly property VeQuickItem _deviceInstance: VeQuickItem { uid: root.serviceUid + "/VebusInstance" }
-		readonly property VeQuickItem _power: VeQuickItem { uid: veBus.serviceUid ? veBus.serviceUid + "/Dc/0/Power" : "" }
 	}
 
 	function reset() {

--- a/data/mock/InverterChargersImpl.qml
+++ b/data/mock/InverterChargersImpl.qml
@@ -488,6 +488,24 @@ QtObject {
 		}
 	}
 
+	//--- totals
+
+	readonly property VeQuickItem inverterChargerPower: VeQuickItem {
+		uid: Global.system.serviceUid + "/Dc/InverterCharger/Power"
+	}
+
+	readonly property int batteryMode: Global.batteries.system.mode
+	onBatteryModeChanged: {
+		// Positive power when battery is charging, negative power when battery is discharging
+		const randomPower = Math.round(100 + (Math.random() * 600))
+		const batteryMode = Global.batteries.system.mode
+		const power = batteryMode === VenusOS.Battery_Mode_Charging ? randomPower
+				: batteryMode === VenusOS.Battery_Mode_Discharging ? randomPower * -1
+				: 0 // Battery_Mode_Idle
+		root.inverterChargerPower.setValue(power)
+	}
+
+
 	Component.onCompleted: {
 		populateInverterChargers()
 		populateInverters()

--- a/data/mock/SystemImpl.qml
+++ b/data/mock/SystemImpl.qml
@@ -100,9 +100,6 @@ QtObject {
 	readonly property VeQuickItem veBusService: VeQuickItem {
 		uid: Global.system.serviceUid + "/VebusService"
 	}
-	readonly property VeQuickItem veBusPower: VeQuickItem {
-		uid: veBusService.value ? "%1/%2/Dc/0/Power".arg(BackendConnection.uidPrefix()).arg(veBusService.value) : ""
-	}
 
 	property Connections veBusServiceSetup: Connections {
 		target: Global.inverterChargers.veBusDevices
@@ -115,17 +112,6 @@ QtObject {
 			} else {
 				root.veBusService.setValue("")
 			}
-		}
-	}
-
-	property Timer randomizeVeBusValues: Timer {
-		running: Global.mockDataSimulator.timersActive
-		interval: 1000
-		repeat: true
-		triggeredOnStart: true
-
-		onTriggered: {
-			root.veBusPower.setValue(500 + Math.floor(Math.random() * 100))
 		}
 	}
 

--- a/pages/OverviewPage.qml
+++ b/pages/OverviewPage.qml
@@ -692,12 +692,11 @@ SwipeViewPage {
 		animateGeometry: root._animateGeometry
 		animationEnabled: root.animationEnabled
 
-		// If vebus power is positive: battery is charging, so energy flows to battery.
-		// If vebus power is negative: battery is discharging, so energy flows to inverter/charger.
+		// If inverter/charger power is positive: battery is charging, so energy flows to battery.
+		// If inverter/charger power is negative: battery is discharging, so energy flows to inverter/charger.
 		animationMode: root.isCurrentPage
-				&& !isNaN(Global.system.veBus.power)
-				&& Math.abs(Global.system.veBus.power) > Theme.geometry_overviewPage_connector_animationPowerThreshold
-						? (Global.system.veBus.power > 0
+				&& Math.abs(inverterChargerPower.value) > Theme.geometry_overviewPage_connector_animationPowerThreshold
+						? (inverterChargerPower.value > 0
 								? VenusOS.WidgetConnector_AnimationMode_StartToEnd
 								: VenusOS.WidgetConnector_AnimationMode_EndToStart)
 						: VenusOS.WidgetConnector_AnimationMode_NotAnimated
@@ -809,4 +808,8 @@ SwipeViewPage {
 		}
 	}
 
+	VeQuickItem {
+		id: inverterChargerPower
+		uid: Global.system.serviceUid + "/Dc/InverterCharger/Power"
+	}
 }

--- a/pages/settings/debug/HubData.qml
+++ b/pages/settings/debug/HubData.qml
@@ -13,7 +13,6 @@ Page {
 	property alias pvOnAcIn1: _pvOnAcIn1
 	property alias pvOnAcIn2: _pvOnAcIn2
 	property alias pvOnAcOut: _pvOnAcOut
-	property alias vebusAcOut: _vebusAcOut
 	property alias acLoad: _acLoad
 
 	QtObject {
@@ -34,12 +33,6 @@ Page {
 	ObjectAcConnection {
 		id: _pvOnAcIn2
 		bindPrefix: Global.system.serviceUid + "/Ac/PvOnGrid"
-	}
-
-	ObjectAcConnection {
-		id: _vebusAcOut
-		bindPrefix: Global.system.veBus.serviceUid ? Global.system.veBus.serviceUid + "/Ac/Out" : ""
-		powerKey: "P"
 	}
 
 	/*


### PR DESCRIPTION
Animate the flow of energy between the Inverter/Charger and Battery even when there is no VE.Bus inverter.

Use /Dc/InverterCharger/Power rather than the vebus /Dc/0/Power value to animate the flow. The former will be valid even when there is system is using a Multi RS rather than VE.Bus.

Also remove the unused vebus power from HubData.qml, and fix the changes in the mock battery for the power/amp/charging values.

This ports 9e16d73b19154c8638af940beea5ca63965e345b from gui-v1.

Fixes #1083