### PR TITLE
MQTT: ensure the portal id parameter is set before connecting

### DIFF
--- a/src/backendconnection.cpp
+++ b/src/backendconnection.cpp
@@ -177,7 +177,6 @@ void BackendConnection::initMqttConnection(const QString &address)
 				// TODO: fetch updated credentials via VRM API if required...
 				producer->setCredentials(m_username, m_password);
 			}
-			producer->setPortalId(m_portalId);
 			producer->continueConnect();
 		}
 	});
@@ -187,6 +186,9 @@ void BackendConnection::initMqttConnection(const QString &address)
 	connect(mqttProducer, &VeQItemMqttProducer::errorChanged,
 		this, &BackendConnection::mqttErrorChanged);
 
+	if (!m_portalId.isEmpty()) {
+		mqttProducer->setPortalId(m_portalId);
+	}
 #if defined(VENUS_WEBASSEMBLY_BUILD)
 	mqttProducer->open(QUrl(address), QMqttClient::MQTT_3_1);
 #else


### PR DESCRIPTION
Previously, it was set after the connection was initiated, but
before the connection was established (i.e. at the same time the
username and password were provided).

Now, it is provided at the very start of the flow, so that the
producer can emit an error if no portal id is provided for
VRM connections.

Also, align the detection of VRM addresses between gui-v2 and
veutil code.

Fixes #1185