### PR TITLE
Always calculate average level of multiple tanks if possible

### DIFF
--- a/data/Tanks.qml
+++ b/data/Tanks.qml
@@ -151,19 +151,25 @@ QtObject {
 		let totalLevel = NaN
 		let totalRemaining = NaN
 		let totalCapacity = NaN
+		let requireFallback = false
 		for (let i = 0; i < model.count; ++i) {
 			const tank = model.deviceAt(i)
 			totalRemaining = Units.sumRealNumbers(totalRemaining, tank.remaining)
 			totalCapacity = Units.sumRealNumbers(totalCapacity, tank.capacity)
 			totalLevel = Units.sumRealNumbers(totalLevel, tank.level)
+			requireFallback = requireFallback || isNaN(tank.remaining) || isNaN(tank.capacity)
 		}
-		model.averageLevel = isNaN(totalLevel) || model.count === 0 ? NaN : totalLevel / model.count
+
 		model.totalRemaining = totalRemaining
 		model.totalCapacity = totalCapacity
-
-		// If /Level is not available for the tanks, calculate it from /Remaining and /Capacity.
-		if (isNaN(model.averageLevel) && !isNaN(totalRemaining) && !isNaN(totalCapacity) && totalCapacity > 0) {
+		if (!requireFallback && !isNaN(totalRemaining) && !isNaN(totalCapacity) && totalCapacity > 0) {
+			// if we know all tank capacities and usages,
+			// we can calculate the combined level.
 			model.averageLevel = totalRemaining / totalCapacity * 100
+		} else {
+			// only fall back to a crude average level
+			// if we don't know all tank capacities and usages.
+			model.averageLevel = isNaN(totalLevel) || model.count === 0 ? NaN : totalLevel / model.count
 		}
 	}
 

--- a/data/mock/config/LevelsPageConfig.qml
+++ b/data/mock/config/LevelsPageConfig.qml
@@ -156,6 +156,14 @@ QtObject {
 				{ type: VenusOS.Tank_Type_BlackWater, level: 25, capacity: .2 },
 			]
 		},
+		{
+			// crude average level = 25+75/2 = 50%, but actual combined average = 15.5/22 = 70%
+			name: "Merge 2 Freshwater tanks with vastly different capacities",
+			tanks: [
+				{ type: VenusOS.Tank_Type_FreshWater, level: 25, capacity: 2 },
+				{ type: VenusOS.Tank_Type_FreshWater, level: 75, capacity: 20 },
+			]
+		},
 	]
 
 	property var environmentConfigs: [


### PR DESCRIPTION
If there are two tanks of the same type but vastly different capacities, the combined average level is not the average of their levels, but instead should be calculated based upon their capacities.

Fixes #1208