### PR TITLE
AcInputs load graph on side panel should be zero-centered

### DIFF
--- a/components/LoadGraph.qml
+++ b/components/LoadGraph.qml
@@ -19,6 +19,7 @@ Item {
 	property color belowThresholdFillColor: Theme.color_blue
 	property color horizontalGradientColor1: Theme.color_briefPage_background
 	property color horizontalGradientColor2: "transparent"
+	property bool zeroCentered
 	property alias active: graphAnimation.running
 
 	signal nextValueRequested()
@@ -84,16 +85,17 @@ Item {
 			height: root.height + 2*strokeWidth
 			width: parent.width + 2*strokeWidth
 			anchors.bottom: parent.bottom
+			zeroCentered: root.zeroCentered
 			offsetFraction: root.offsetFraction
 			fillGradient: LinearGradient {
 				x1: 0; y1: 0
 				x2: 0; y2: height
-				GradientStop { position: 0; color: belowThresholdFillColor }
+				GradientStop { position: 0; color: bluePath.zeroCentered ? "transparent" : belowThresholdFillColor }
 				GradientStop {
 					position: 1 - threshold + (dottedLine.height / height)
-					color: belowThresholdFillColor
+					color: bluePath.zeroCentered ? Qt.rgba(belowThresholdFillColor.r, belowThresholdFillColor.g, belowThresholdFillColor.b, belowThresholdFillColor.a * 0.5) : belowThresholdFillColor
 				}
-				GradientStop { position: 1; color: "transparent" }
+				GradientStop { position: 1; color: bluePath.zeroCentered ? belowThresholdFillColor : "transparent" }
 			}
 		}
 		Row {

--- a/components/LoadGraphShapePath.qml
+++ b/components/LoadGraphShapePath.qml
@@ -19,6 +19,7 @@ Shape {
 	property alias strokeColor: shapePath.strokeColor
 	property alias strokeWidth: shapePath.strokeWidth
 	property alias fillGradient: shapePath.fillGradient
+	property bool zeroCentered
 
 	function calcY(data) { return (1 - (data || 0)) * height }
 
@@ -49,8 +50,8 @@ Shape {
 		PathCubic { x: 11 * segWidth - offset; y: calcY(model[11]); relativeControl1X: rc1x; control1Y: calcY(model[10]); relativeControl2X: rc2x; control2Y: y; }
 
 		PathLine { x: root.width + root.strokeWidth; y: calcY(model[11])}
-		PathLine { x: root.width + root.strokeWidth; y: root.height + root.strokeWidth }
-		PathLine { x: 0 - root.strokeWidth; y: root.height + root.strokeWidth}
+		PathLine { x: root.width + root.strokeWidth; y: root.zeroCentered ? root.height/2 : (root.height + root.strokeWidth) }
+		PathLine { x: 0 - root.strokeWidth; y: root.zeroCentered ? root.height/2 : (root.height + root.strokeWidth) }
 		PathLine { x: 0 - root.strokeWidth; y: shapePath.startY}
 	}
 }

--- a/pages/BriefSidePanel.qml
+++ b/pages/BriefSidePanel.qml
@@ -136,7 +136,8 @@ exported power v  0.4 |   /
 			active: root.animationEnabled
 			aboveThresholdFillColor: Theme.color_blue   // warning color is not needed for inputs
 			belowThresholdFillColor: _graphShowsFeedIn ? Theme.color_green : Theme.color_blue
-			initialModelValue: 0
+			initialModelValue: _graphShowsFeedIn ? 0.5 : 0
+			zeroCentered: _graphShowsFeedIn
 
 			// For a system that only imports, no threshold is required.
 			// For a system that sometimes exports (i.e. can have values below zero), the threshold
@@ -148,7 +149,10 @@ exported power v  0.4 |   /
 				const graphMax = acInputGraphRange.maximumCurrent || 0
 
 				if (_prevGraphMin !== graphMin || _prevGraphMax !== graphMax) {
-					scaleHistoricalData(_prevGraphMin, _prevGraphMax, graphMin, graphMax)
+					// don't scale historical data if the prevMin=prevMax=0 i.e. uninitialized.
+					if (_prevGraphMin !== 0 || _prevGraphMax !== 0) {
+						scaleHistoricalData(_prevGraphMin, _prevGraphMax, graphMin, graphMax)
+					}
 					_prevGraphMin = graphMin
 					_prevGraphMax = graphMax
 				}


### PR DESCRIPTION
Grid draw should be shown in blue above the midpoint (zero amps) dotted line, and grid feed-in should be shown in green below the midpoint dotted line.

Fixes #1073