### PR TITLE
Change tank/temp error "disconnected" to "open circuit"

### DIFF
--- a/components/CommonWords.qml
+++ b/components/CommonWords.qml
@@ -332,6 +332,9 @@ QtObject {
 	//% "Open"
 	readonly property string open_status: qsTrId("common_words_open_status");
 
+	//% "Open circuit"
+	readonly property string open_circuit: qsTrId("common_words_open_circuit");
+
 	//% "Overall history"
 	readonly property string overall_history: qsTrId("common_words_overall_history")
 

--- a/data/Tanks.qml
+++ b/data/Tanks.qml
@@ -125,8 +125,8 @@ QtObject {
 		switch (status) {
 		case VenusOS.Tank_Status_Ok:
 			return CommonWords.ok
-		case VenusOS.Tank_Status_Disconnected:
-			return CommonWords.disconnected
+		case VenusOS.Tank_Status_Open_Circuit:
+			return CommonWords.open_circuit
 		case VenusOS.Tank_Status_ShortCircuited:
 			//% "Short circuited"
 			return qsTrId("tank_status_short_circuited")

--- a/pages/settings/devicelist/temperature/PageTemperatureSensor.qml
+++ b/pages/settings/devicelist/temperature/PageTemperatureSensor.qml
@@ -32,7 +32,7 @@ Page {
 					case 0:
 						return CommonWords.ok
 					case 1:
-						return CommonWords.disconnected
+						return CommonWords.open_circuit
 					case 2:
 						//% "Short circuited"
 						return qsTrId("temperature_short_circuited")

--- a/src/enums.h
+++ b/src/enums.h
@@ -373,7 +373,7 @@ public:
 
 	enum Tank_Status {
 		Tank_Status_Ok = 0,
-		Tank_Status_Disconnected,
+		Tank_Status_Open_Circuit,
 		Tank_Status_ShortCircuited,
 		Tank_Status_ReversePolarity,
 		Tank_Status_Unknown,


### PR DESCRIPTION
Port of 403b535e460d54c77474ff4766c703e2d3ade4ba from gui-v1.

When tank sensor is absent, show "Open circuit" instead of "Disconnected". The latter former means the sensor is absent, while the latter means that the dbus service for a device has vanished.

Fixes #1238