### PR TITLE
Do not show battery 'Details' unnecessarily

### DIFF
--- a/pages/settings/devicelist/battery/BatteryDetails.qml
+++ b/pages/settings/devicelist/battery/BatteryDetails.qml
@@ -10,14 +10,6 @@ QtObject {
 	id: root
 
 	property string bindPrefix
-	readonly property bool anyItemValid: {
-		for (let i = 0; i < _dataItems.length; ++i) {
-			if (_dataItems[i].isValid) {
-				return true
-			}
-		}
-		return false
-	}
 
 	readonly property alias modulesOnline: modulesOnline
 	readonly property alias modulesOffline: modulesOffline
@@ -33,6 +25,22 @@ QtObject {
 	readonly property alias maxTemperatureCellId: maxTemperatureCellId
 	readonly property alias installedCapacity: installedCapacity
 	readonly property alias capacity: capacity
+
+	readonly property bool allowsLowestCellVoltage: minCellVoltage.isValid
+	readonly property bool allowsHighestCellVoltage: maxCellVoltage.isValid
+	readonly property bool allowsMinimumCellTemperature: minCellTemperature.isValid
+	readonly property bool allowsMaximumCellTemperature: maxCellTemperature.isValid
+	readonly property bool allowsBatteryModules: modulesOnline.isValid || modulesOffline.isValid
+	readonly property bool allowsNumberOfModulesBlockingChargeDischarge: nrOfModulesBlockingCharge.isValid || nrOfModulesBlockingDischarge.isValid
+	readonly property bool allowsCapacity: installedCapacity.isValid
+
+	readonly property bool hasAllowedItem: allowsLowestCellVoltage
+		|| allowsHighestCellVoltage
+		|| allowsMinimumCellTemperature
+		|| allowsMaximumCellTemperature
+		|| allowsBatteryModules
+		|| allowsNumberOfModulesBlockingChargeDischarge
+		|| allowsCapacity
 
 	readonly property list<VeQuickItem> _dataItems: [
 		VeQuickItem {

--- a/pages/settings/devicelist/battery/PageBattery.qml
+++ b/pages/settings/devicelist/battery/PageBattery.qml
@@ -238,7 +238,7 @@ Page {
 			ListNavigationItem {
 				//% "Details"
 				text: qsTrId("battery_details")
-				allowed: defaultAllowed && batteryDetails.anyItemValid
+				allowed: defaultAllowed && batteryDetails.hasAllowedItem
 				onClicked: {
 					Global.pageManager.pushPage("/pages/settings/devicelist/battery/PageBatteryDetails.qml",
 							{ "title": text, "bindPrefix": root.battery.serviceUid, "details": batteryDetails })

--- a/pages/settings/devicelist/battery/PageBatteryDetails.qml
+++ b/pages/settings/devicelist/battery/PageBatteryDetails.qml
@@ -10,7 +10,7 @@ Page {
 	id: root
 
 	property string bindPrefix
-	property var details
+	property BatteryDetails details
 
 	GradientListView {
 		model: ObjectModel {
@@ -21,7 +21,7 @@ Page {
 					{ value: details.minVoltageCellId.value, visible: details.minVoltageCellId.isValid },
 					{ value: details.minCellVoltage.value, unit: VenusOS.Units_Volt_DC, precision: 3 },
 				]
-				allowed: defaultAllowed && details.minCellVoltage.isValid
+				allowed: defaultAllowed && details.allowsLowestCellVoltage
 			}
 
 			ListQuantityGroup {
@@ -31,7 +31,7 @@ Page {
 					{ value: details.maxVoltageCellId.value, visible: details.maxVoltageCellId.isValid },
 					{ value: details.maxCellVoltage.value, unit: VenusOS.Units_Volt_DC, precision: 3 },
 				]
-				allowed: defaultAllowed && details.maxCellVoltage.isValid
+				allowed: defaultAllowed && details.allowsHighestCellVoltage
 			}
 
 			ListQuantityGroup {
@@ -46,7 +46,7 @@ Page {
 						unit: Global.systemSettings.temperatureUnit
 					}
 				]
-				allowed: defaultAllowed && details.minCellTemperature.isValid
+				allowed: defaultAllowed && details.allowsMinimumCellTemperature
 			}
 
 			ListQuantityGroup {
@@ -61,7 +61,7 @@ Page {
 						unit: Global.systemSettings.temperatureUnit
 					}
 				]
-				allowed: defaultAllowed && details.maxCellTemperature.isValid
+				allowed: defaultAllowed && details.allowsMaximumCellTemperature
 			}
 
 			ListTextGroup {
@@ -75,14 +75,14 @@ Page {
 					//% "%1 offline"
 					details.modulesOffline.value === undefined ? "--" : qsTrId("devicelist_batterydetails_modules_offline").arg(details.modulesOffline.value)
 				]
-				allowed: defaultAllowed && (details.modulesOnline.isValid || details.modulesOffline.isValid)
+				allowed: defaultAllowed && details.allowsBatteryModules
 			}
 
 			ListTextGroup {
 				//% "Number of modules blocking charge / discharge"
 				text: qsTrId("batterydetails_number_of_modules_blocking_charge_discharge")
 				textModel: [ details.nrOfModulesBlockingCharge.value, details.nrOfModulesBlockingDischarge.value ]
-				allowed: defaultAllowed && (details.nrOfModulesBlockingCharge.isValid || details.nrOfModulesBlockingDischarge.isValid)
+				allowed: defaultAllowed && details.allowsNumberOfModulesBlockingChargeDischarge
 			}
 
 			ListQuantityGroup {
@@ -92,7 +92,7 @@ Page {
 					{ value: details.installedCapacity.value, unit: VenusOS.Units_AmpHour },
 					{ value: details.capacity.value, unit: VenusOS.Units_AmpHour }
 				]
-				allowed: defaultAllowed && details.installedCapacity.isValid
+				allowed: defaultAllowed && details.allowsCapacity
 			}
 		}
 	}


### PR DESCRIPTION
The BatteryDetails anyItemValid binding doesn't work anymore for determining whether the details list item should be shown, because some items on the Details page require a test that does not simply test the isValid value. So, add individual properties to check whether each detail would be visible on the Details page.

Fixes #1201