### PR TITLE
Fix Chinese translations not updating 

### DIFF
--- a/components/dialogs/ESSMinimumSOCDialog.qml
+++ b/components/dialogs/ESSMinimumSOCDialog.qml
@@ -29,7 +29,7 @@ ModalDialog {
 			Label {
 				anchors.horizontalCenter: parent.horizontalCenter
 				font.pixelSize: Theme.font_size_h3
-				text: qsTrId("%1%").arg(root.minimumStateOfCharge)
+				text: "%1%".arg(root.minimumStateOfCharge)
 			}
 
 			Label {

--- a/i18n/venus-gui-v2_zh_CN.ts
+++ b/i18n/venus-gui-v2_zh_CN.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="zh-CN">
+<TS version="2.1" language="zh_CN">
   <context>
     <name></name>
     <message id="ess_card_minimum_soc_value">


### PR DESCRIPTION
After that Chinese version no longer has translation IDs showing on the GUI. There are still 166 translations missing from POEditor, but those are at least autofilled during build.

Fixes #1234