### PR TITLE
Convert vebus battery temperature to user-preferred unit

### DIFF
--- a/pages/vebusdevice/PageVeBus.qml
+++ b/pages/vebusdevice/PageVeBus.qml
@@ -208,11 +208,10 @@ Page {
 				unit:VenusOS.Units_Percentage
 			}
 
-			ListQuantityItem {
+			ListTemperatureItem {
 				allowed: defaultAllowed && dataItem.isValid && root.isMulti
 				dataItem.uid: veBusDevice.serviceUid + "/Dc/0/Temperature"
 				text: CommonWords.battery_temperature
-				unit: Global.systemSettings.temperatureUnit
 			}
 
 			ActiveAcInputTextItem {


### PR DESCRIPTION
Use ListTemperatureItem, which converts the temperature to the user-preferred unit.

Fixes #1257