### PR TITLE
 Overview page: Grid widget: confusion when some phases in watts and others in kilowatts

### DIFF
--- a/components/QuantityLabel.qml
+++ b/components/QuantityLabel.qml
@@ -14,7 +14,6 @@ Item {
 	property alias font: unitLabel.font
 	property alias valueColor: valueLabel.color
 	property alias unitColor: unitLabel.color
-	property alias unitVisible: unitLabel.visible
 	readonly property alias valueText: valueLabel.text
 	readonly property alias unitText: unitLabel.text
 	property int alignment: Qt.AlignHCenter

--- a/components/ThreePhaseDisplay.qml
+++ b/components/ThreePhaseDisplay.qml
@@ -75,7 +75,6 @@ Flow {
 						: 0
 				dataObject: model
 				font.pixelSize: phaseLabel.font.pixelSize
-				unitVisible: root.widgetSize >= VenusOS.OverviewWidget_Size_M
 				valueColor: phaseDelegate.textColor
 				unitColor: valueColor == Theme.color_font_primary
 						   ? Theme.color_font_secondary

--- a/components/widgets/AcWidget.qml
+++ b/components/widgets/AcWidget.qml
@@ -29,18 +29,24 @@ OverviewWidget {
 		active: root.phaseCount > 1
 		states: [
 			State {
-				name: "small"
-				when: root.size === VenusOS.OverviewWidget_Size_XS || root.size === VenusOS.OverviewWidget_Size_S
+				name: "extrasmall"
+				when: root.size === VenusOS.OverviewWidget_Size_XS
 				PropertyChanges {
 					target: root.quantityLabel
-					visible: !!quantityLabel.dataObject && extraContentLoader.status !== Loader.Ready
+					visible: !!quantityLabel.dataObject && extraContentLoader.status !== Loader.Ready // hide the total power
 					font.pixelSize: Theme.font_overviewPage_widget_quantityLabel_minimumSize
 				}
 				PropertyChanges {
-					target: root
-					secondaryTitle: extraContentLoader.status === Loader.Ready
-									? "(%1)".arg(Units.defaultUnitString(Global.systemSettings.electricalQuantity))
-									: ""
+					target: extraContentLoader
+					anchors.bottomMargin: root.verticalMargin / 3
+				}
+			},
+			State {
+				name: "small"
+				when: root.size === VenusOS.OverviewWidget_Size_S
+				PropertyChanges {
+					target: root.quantityLabel
+					font.pixelSize: Theme.font_overviewPage_widget_quantityLabel_minimumSize
 				}
 				PropertyChanges {
 					target: extraContentLoader
@@ -58,7 +64,7 @@ OverviewWidget {
 				}
 			},
 			State {
-				name: "medium-or-larger"
+				name: "large"
 				when: root.size === VenusOS.OverviewWidget_Size_L || root.size === VenusOS.OverviewWidget_Size_XL
 				PropertyChanges {
 					target: root.quantityLabel


### PR DESCRIPTION
'Small' AcWidgets no longer hide the total power, as there is enough space to show it.
'ExtraSmall' and 'Small' AcWidgets now display units for each phase, eg 'kW', 'W'. 
