### PR TITLE
Use more meaningful names for Victron tank sensors

### DIFF
--- a/data/common/Tank.qml
+++ b/data/common/Tank.qml
@@ -87,6 +87,12 @@ Device {
 		}
 	}
 
+	name: productId === 0xA160
+		// This must be a generic Victron tank sensor, where the product name is always "Tank
+		// sensor" and there is no custom name, so use the tank type to provide a meaningful name.
+		? Gauges.tankProperties(type).name
+		: productName || customName
+
 	description: {
 		if (customName.length > 0) {
 			return customName


### PR DESCRIPTION
Use the tank type name instead of "Tank sensor" as the name.

Fixes #1258