### PR TITLE
Fix battery paths in AC charger settings

### DIFF
--- a/pages/settings/devicelist/PageAcCharger.qml
+++ b/pages/settings/devicelist/PageAcCharger.qml
@@ -58,12 +58,12 @@ Page {
 
 						VeQuickItem {
 							id: dcVoltage
-							uid: root.bindPrefix + "/Dc/%1/Voltage".arg(model.index + 1)
+							uid: root.bindPrefix + "/Dc/%1/Voltage".arg(model.index)
 						}
 
 						VeQuickItem {
 							id: dcCurrent
-							uid: root.bindPrefix + "/Dc/%1/Current".arg(model.index + 1)
+							uid: root.bindPrefix + "/Dc/%1/Current".arg(model.index)
 						}
 					}
 				}


### PR DESCRIPTION
The voltage/current uid paths start at 0 for the first battery, not 1.

Fixes #1270