### PR TITLE
Use real VeQuickItem values instead of MockDevice

### DIFF
--- a/data/mock/ChargersImpl.qml
+++ b/data/mock/ChargersImpl.qml
@@ -46,6 +46,7 @@ Item {
 				serviceUid = "mock/com.victronenergy.charger.ttyUSB" + deviceInstanceNum
 				_deviceInstance.setValue(deviceInstanceNum)
 				_customName.setValue("AC Charger " + deviceInstanceNum)
+				_productName.setValue("Skylla-i")
 				charger.setMockValue("/Mode", 1)
 				charger.setMockValue("/State", Math.floor(Math.random() * VenusOS.System_State_FaultCondition))
 				charger.setMockValue("/Ac/In/CurrentLimit", Math.random() * 30)

--- a/data/mock/DigitalInputsImpl.qml
+++ b/data/mock/DigitalInputsImpl.qml
@@ -6,8 +6,10 @@
 import QtQuick
 import Victron.VenusOS
 
-Item {
+QtObject {
 	id: root
+
+	property int mockDeviceCount
 
 	function populate() {
 		const inputCount = (Math.random() * 3) + 1
@@ -16,17 +18,20 @@ Item {
 				type: Math.random() * VenusOS.DigitalInput_Type_Generator,
 				state: Math.random() * VenusOS.DigitalInput_State_Stopped
 			})
-			Global.digitalInputs.model.addDevice(inputObj)
 		}
 	}
 
 	property Component inputComponent: Component {
-		MockDevice {
-			property int type
-			property int state
+		DigitalInput {
+			// Set a non-empty uid to avoid bindings to empty serviceUid before Component.onCompleted is called
+			serviceUid: "mock/com.victronenergy.dummy"
 
-			serviceUid: "mock/com.victronenergy.digitalinput.ttyUSB" + deviceInstance
-			name: "DigitalInput" + deviceInstance
+			Component.onCompleted: {
+				const deviceInstanceNum = root.mockDeviceCount++
+				serviceUid = "mock/com.victronenergy.digitalinput.ttyUSB" + deviceInstanceNum
+				_deviceInstance.setValue(deviceInstanceNum)
+				_productName.setValue("Digital input %1".arg(deviceInstanceNum))
+			}
 		}
 	}
 

--- a/data/mock/MeteoDevicesImpl.qml
+++ b/data/mock/MeteoDevicesImpl.qml
@@ -6,19 +6,26 @@
 import QtQuick
 import Victron.VenusOS
 
-Item {
+QtObject {
 	id: root
 
+	property int mockDeviceCount
+
 	function populate() {
-		Global.meteoDevices.model.addDevice(meteoComponent.createObject(root))
+		meteoComponent.createObject(root)
 	}
 
 	property Component meteoComponent: Component {
-		MockDevice {
-			property real irradiance: Math.random() * 500
+		MeteoDevice {
+			// Set a non-empty uid to avoid bindings to empty serviceUid before Component.onCompleted is called
+			serviceUid: "mock/com.victronenergy.dummy"
 
-			serviceUid: "mock/com.victronenergy.meteo.ttyUSB" + deviceInstance
-			name: "meteo" + deviceInstance
+			Component.onCompleted: {
+				const deviceInstanceNum = root.mockDeviceCount++
+				serviceUid = "mock/com.victronenergy.meteo.ttyUSB" + deviceInstanceNum
+				_deviceInstance.setValue(deviceInstanceNum)
+				_productName.setValue("Meteo %1".arg(deviceInstanceNum))
+			}
 		}
 	}
 

--- a/data/mock/MotorDrivesImpl.qml
+++ b/data/mock/MotorDrivesImpl.qml
@@ -6,19 +6,26 @@
 import QtQuick
 import Victron.VenusOS
 
-Item {
+QtObject {
 	id: root
 
+	property int mockDeviceCount
+
 	function populate() {
-		Global.motorDrives.model.addDevice(motorDriveComponent.createObject(root))
+		motorDriveComponent.createObject(root)
 	}
 
 	property Component motorDriveComponent: Component {
-		MockDevice {
-			property real motorRpm: 9000
+		MotorDrive {
+			// Set a non-empty uid to avoid bindings to empty serviceUid before Component.onCompleted is called
+			serviceUid: "mock/com.victronenergy.dummy"
 
-			serviceUid: "mock/com.victronenergy.motordrive.ttyUSB" + deviceInstance
-			name: "MotorDrive" + deviceInstance
+			Component.onCompleted: {
+				const deviceInstanceNum = root.mockDeviceCount++
+				serviceUid = "mock/com.victronenergy.motordrive.ttyUSB" + deviceInstanceNum
+				_deviceInstance.setValue(deviceInstanceNum)
+				_productName.setValue("Meteo %1".arg(deviceInstanceNum))
+			}
 		}
 	}
 

--- a/data/mock/PulseMetersImpl.qml
+++ b/data/mock/PulseMetersImpl.qml
@@ -6,19 +6,26 @@
 import QtQuick
 import Victron.VenusOS
 
-Item {
+QtObject {
 	id: root
 
+	property int mockDeviceCount
+
 	function populate() {
-		Global.pulseMeters.model.addDevice(pulseMeterComponent.createObject(root))
+		pulseMeterComponent.createObject(root)
 	}
 
 	property Component pulseMeterComponent: Component {
-		MockDevice {
-			property real aggregate: 101
+		PulseMeter {
+			// Set a non-empty uid to avoid bindings to empty serviceUid before Component.onCompleted is called
+			serviceUid: "mock/com.victronenergy.dummy"
 
-			serviceUid: "mock/com.victronenergy.pulsemeter.ttyUSB" + deviceInstance
-			name: "PulseMeter" + deviceInstance
+			Component.onCompleted: {
+				const deviceInstanceNum = root.mockDeviceCount++
+				serviceUid = "mock/com.victronenergy.pulsemeter.ttyUSB" + deviceInstanceNum
+				_deviceInstance.setValue(deviceInstanceNum)
+				_productName.setValue("PulseMeter %1".arg(deviceInstanceNum))
+			}
 		}
 	}
 

--- a/data/mock/UnsupportedDevicesImpl.qml
+++ b/data/mock/UnsupportedDevicesImpl.qml
@@ -6,17 +6,26 @@
 import QtQuick
 import Victron.VenusOS
 
-Item {
+QtObject {
 	id: root
 
+	property int mockDeviceCount
+
 	function populate() {
-		Global.unsupportedDevices.model.addDevice(unsupportedComponent.createObject(root))
+		unsupportedComponent.createObject(root)
 	}
 
 	property Component unsupportedComponent: Component {
-		MockDevice {
-			serviceUid: "mock/com.victronenergy.unsupported.ttyUSB" + deviceInstance
-			name: "Unsupported" + deviceInstance
+		UnsupportedDevice {
+			// Set a non-empty uid to avoid bindings to empty serviceUid before Component.onCompleted is called
+			serviceUid: "mock/com.victronenergy.dummy"
+
+			Component.onCompleted: {
+				const deviceInstanceNum = root.mockDeviceCount++
+				serviceUid = "mock/com.victronenergy.unsupported.ttyUSB" + deviceInstanceNum
+				_deviceInstance.setValue(deviceInstanceNum)
+				_productName.setValue("Unsupported %1".arg(deviceInstanceNum))
+			}
 		}
 	}
 


### PR DESCRIPTION
Avoid using MockDevice as it doesn't set real values in the mock backend. There are some uses of MockDevice remaining but those can be removed later.

The change also ensures these devices appear in device list as they now have a ProductName.