### PR TITLE
Consider a device valid if it has /CustomName instead of /ProductName

### DIFF
--- a/components/Device.qml
+++ b/components/Device.qml
@@ -9,8 +9,6 @@ import Victron.VenusOS
 BaseDevice {
 	id: root
 
-	readonly property string customName: _customName.value || ""
-
 	readonly property VeQuickItem _deviceInstance: VeQuickItem {
 		uid: root.serviceUid ? root.serviceUid + "/DeviceInstance" : ""
 	}
@@ -30,6 +28,7 @@ BaseDevice {
 	deviceInstance: _deviceInstance.isValid ? _deviceInstance.value : -1
 	productId: _productId.isValid ? _productId.value : 0
 	productName: _productName.value || ""
+	customName: _customName.value || ""
 	name: _customName.value || _productName.value || ""
 	description: name
 }

--- a/data/mock/DcInputsImpl.qml
+++ b/data/mock/DcInputsImpl.qml
@@ -138,7 +138,7 @@ QtObject {
 				const deviceInstanceNum = root.mockDeviceCount++
 				serviceUid = "mock/com.victronenergy." + serviceType + ".ttyUSB" + deviceInstanceNum
 				_deviceInstance.setValue(deviceInstanceNum)
-				_productName.setValue("DC device (%1)".arg(serviceType))
+				_customName.setValue("DC device (%1)".arg(serviceType))
 				setMockValue("/State", 4)
 			}
 		}

--- a/data/mock/DcLoadsImpl.qml
+++ b/data/mock/DcLoadsImpl.qml
@@ -67,7 +67,7 @@ QtObject {
 				const deviceInstanceNum = root.mockDeviceCount++
 				serviceUid = "mock/com.victronenergy." + serviceType + ".ttyUSB" + deviceInstanceNum
 				_deviceInstance.setValue(deviceInstanceNum)
-				_productName.setValue("DC Load (%1)".arg(serviceType))
+				_customName.setValue("DC Load (%1)".arg(serviceType))
 				setMockValue("/Mode", 4)
 				setMockValue("/State", 5)
 				setMockValue("/Error", 0)

--- a/data/mock/DigitalInputsImpl.qml
+++ b/data/mock/DigitalInputsImpl.qml
@@ -30,7 +30,7 @@ QtObject {
 				const deviceInstanceNum = root.mockDeviceCount++
 				serviceUid = "mock/com.victronenergy.digitalinput.ttyUSB" + deviceInstanceNum
 				_deviceInstance.setValue(deviceInstanceNum)
-				_productName.setValue("Digital input %1".arg(deviceInstanceNum))
+				_customName.setValue("Digital input %1".arg(deviceInstanceNum))
 			}
 		}
 	}

--- a/data/mock/GeneratorsImpl.qml
+++ b/data/mock/GeneratorsImpl.qml
@@ -30,7 +30,7 @@ QtObject {
 
 			Component.onCompleted: {
 				_deviceInstance.setValue(0)
-				_productName.setValue("Start/Stop generator")
+				_customName.setValue("Start/Stop generator")
 				_state.setValue(VenusOS.Generators_State_Running)
 				_runningBy.setValue(VenusOS.Generators_RunningBy_Soc)
 				setAutoStart(true)

--- a/data/mock/MeteoDevicesImpl.qml
+++ b/data/mock/MeteoDevicesImpl.qml
@@ -24,7 +24,7 @@ QtObject {
 				const deviceInstanceNum = root.mockDeviceCount++
 				serviceUid = "mock/com.victronenergy.meteo.ttyUSB" + deviceInstanceNum
 				_deviceInstance.setValue(deviceInstanceNum)
-				_productName.setValue("Meteo %1".arg(deviceInstanceNum))
+				_customName.setValue("Meteo %1".arg(deviceInstanceNum))
 			}
 		}
 	}

--- a/data/mock/MotorDrivesImpl.qml
+++ b/data/mock/MotorDrivesImpl.qml
@@ -24,7 +24,7 @@ QtObject {
 				const deviceInstanceNum = root.mockDeviceCount++
 				serviceUid = "mock/com.victronenergy.motordrive.ttyUSB" + deviceInstanceNum
 				_deviceInstance.setValue(deviceInstanceNum)
-				_productName.setValue("Meteo %1".arg(deviceInstanceNum))
+				_customName.setValue("Motor Drive %1".arg(deviceInstanceNum))
 			}
 		}
 	}

--- a/data/mock/PulseMetersImpl.qml
+++ b/data/mock/PulseMetersImpl.qml
@@ -24,7 +24,7 @@ QtObject {
 				const deviceInstanceNum = root.mockDeviceCount++
 				serviceUid = "mock/com.victronenergy.pulsemeter.ttyUSB" + deviceInstanceNum
 				_deviceInstance.setValue(deviceInstanceNum)
-				_productName.setValue("PulseMeter %1".arg(deviceInstanceNum))
+				_customName.setValue("PulseMeter %1".arg(deviceInstanceNum))
 			}
 		}
 	}

--- a/data/mock/PvInvertersImpl.qml
+++ b/data/mock/PvInvertersImpl.qml
@@ -74,7 +74,6 @@ QtObject {
 				const deviceInstanceNum = root.mockDeviceCount++
 				serviceUid = "mock/com.victronenergy.pvinverter.ttyUSB" + deviceInstanceNum
 				_deviceInstance.setValue(deviceInstanceNum)
-				_productName.setValue("PV Inverter")
 				_customName.setValue("My PV Inverter " + deviceInstanceNum)
 				_statusCode.setValue(Math.random() * VenusOS.PvInverter_StatusCode_Error)
 

--- a/data/mock/UnsupportedDevicesImpl.qml
+++ b/data/mock/UnsupportedDevicesImpl.qml
@@ -24,7 +24,7 @@ QtObject {
 				const deviceInstanceNum = root.mockDeviceCount++
 				serviceUid = "mock/com.victronenergy.unsupported.ttyUSB" + deviceInstanceNum
 				_deviceInstance.setValue(deviceInstanceNum)
-				_productName.setValue("Unsupported %1".arg(deviceInstanceNum))
+				_customName.setValue("Unsupported %1".arg(deviceInstanceNum))
 			}
 		}
 	}

--- a/src/basedevicemodel.cpp
+++ b/src/basedevicemodel.cpp
@@ -17,7 +17,7 @@ BaseDevice::BaseDevice(QObject *parent)
 
 bool BaseDevice::isValid() const
 {
-	return !m_serviceUid.isEmpty() && !m_productName.isEmpty() && m_deviceInstance >= 0;
+	return !m_serviceUid.isEmpty() && (!m_productName.isEmpty() || !m_customName.isEmpty()) && m_deviceInstance >= 0;
 }
 
 QString BaseDevice::serviceUid() const
@@ -28,12 +28,10 @@ QString BaseDevice::serviceUid() const
 void BaseDevice::setServiceUid(const QString &serviceUid)
 {
 	if (m_serviceUid != serviceUid) {
-		const bool prevValid = isValid();
-		m_serviceUid = serviceUid;
-		emit serviceUidChanged();
-		if (prevValid != isValid()) {
-			emit validChanged();
-		}
+		maybeEmitValidChanged([=]() {
+			m_serviceUid = serviceUid;
+			emit serviceUidChanged();
+		});
 	}
 }
 
@@ -45,12 +43,10 @@ int BaseDevice::deviceInstance() const
 void BaseDevice::setDeviceInstance(int deviceInstance)
 {
 	if (m_deviceInstance != deviceInstance) {
-		const bool prevValid = isValid();
-		m_deviceInstance = deviceInstance;
-		emit deviceInstanceChanged();
-		if (prevValid != isValid()) {
-			emit validChanged();
-		}
+		maybeEmitValidChanged([=]() {
+			m_deviceInstance = deviceInstance;
+			emit deviceInstanceChanged();
+		});
 	}
 }
 
@@ -75,12 +71,25 @@ QString BaseDevice::productName() const
 void BaseDevice::setProductName(const QString &productName)
 {
 	if (m_productName != productName) {
-		const bool prevValid = isValid();
-		m_productName = productName;
-		emit productNameChanged();
-		if (prevValid != isValid()) {
-			emit validChanged();
-		}
+		maybeEmitValidChanged([=]() {
+			m_productName = productName;
+			emit productNameChanged();
+		});
+	}
+}
+
+QString BaseDevice::customName() const
+{
+	return m_customName;
+}
+
+void BaseDevice::setCustomName(const QString &customName)
+{
+	if (m_customName != customName) {
+		maybeEmitValidChanged([=]() {
+			m_customName = customName;
+			emit customNameChanged();
+		});
 	}
 }
 
@@ -107,6 +116,15 @@ void BaseDevice::setDescription(const QString &description)
 	if (m_description != description) {
 		m_description = description;
 		emit descriptionChanged();
+	}
+}
+
+void BaseDevice::maybeEmitValidChanged(const std::function<void ()> &propertyChangeFunc)
+{
+	const bool prevValid = isValid();
+	propertyChangeFunc();
+	if (prevValid != isValid()) {
+		emit validChanged();
 	}
 }
 

--- a/src/basedevicemodel.h
+++ b/src/basedevicemodel.h
@@ -11,6 +11,8 @@
 #include <QAbstractListModel>
 #include <qqmlintegration.h>
 
+#include <functional>
+
 namespace Victron {
 namespace VenusOS {
 
@@ -23,6 +25,7 @@ class BaseDevice : public QObject
 	Q_PROPERTY(int deviceInstance READ deviceInstance WRITE setDeviceInstance NOTIFY deviceInstanceChanged)
 	Q_PROPERTY(int productId READ productId WRITE setProductId NOTIFY productIdChanged)
 	Q_PROPERTY(QString productName READ productName WRITE setProductName NOTIFY productNameChanged)
+	Q_PROPERTY(QString customName READ customName WRITE setCustomName NOTIFY customNameChanged)
 	Q_PROPERTY(QString name READ name WRITE setName NOTIFY nameChanged)
 	Q_PROPERTY(QString description READ description WRITE setDescription NOTIFY descriptionChanged)
 
@@ -43,6 +46,9 @@ public:
 	QString productName() const;
 	void setProductName(const QString &productName);
 
+	QString customName() const;
+	void setCustomName(const QString &customName);
+
 	QString name() const;
 	void setName(const QString &name);
 
@@ -54,15 +60,19 @@ Q_SIGNALS:
 	void serviceUidChanged();
 	void deviceInstanceChanged();
 	void productNameChanged();
+	void customNameChanged();
 	void productIdChanged();
 	void nameChanged();
 	void descriptionChanged();
 
 private:
+	void maybeEmitValidChanged(const std::function<void()>& propertyChangeFunc);
+
 	QString m_serviceUid;
 	QString m_name;
 	QString m_description;
 	QString m_productName;
+	QString m_customName;
 	int m_deviceInstance = -1;
 	int m_productId = 0;
 };


### PR DESCRIPTION
Some valid devices do not set /ProductName, but they do have a valid /CustomName, so consider a device valid if either of these are set.

To check this in mock data, set /CustomName instead of /ProductName where the name is not a proper product name.

Fixes #1296, #1233