### PR TITLE
Genset settings: refine "error" setting name

### DIFF
--- a/pages/settings/devicelist/ac-in/PageAcInModelGenset.qml
+++ b/pages/settings/devicelist/ac-in/PageAcInModelGenset.qml
@@ -69,6 +69,8 @@ ObjectModel {
 	}
 
 	ListGeneratorError {
+		//% "Control error code"
+		text: qsTrId("ac-in-genset_control_error_code")
 		allowed: defaultAllowed && dataItem.isValid
 		dataItem.uid: root.startStopBindPrefix ? root.startStopBindPrefix + "/Error" : ""
 	}


### PR DESCRIPTION
Use "Control error code" instead of "Error", to distinguish the display of the control error from that of the genset error.

Contributes to #1220