### PR TITLE
Ensure disconnected devices are visible in Device List

### DIFF
--- a/pages/settings/devicelist/DeviceListPage.qml
+++ b/pages/settings/devicelist/DeviceListPage.qml
@@ -230,7 +230,7 @@ Page {
 			text: model.cachedDeviceDescription
 			textModel: model.connected && _displayInfo ? _displayInfo.summary || [] : [ CommonWords.not_connected ]
 			down: deviceMouseArea.containsPress
-			allowed: _displayInfo !== null
+			allowed: !model.connected || _displayInfo !== null
 
 			CP.ColorImage {
 				parent: deviceDelegate.content

--- a/src/aggregatedevicemodel.h
+++ b/src/aggregatedevicemodel.h
@@ -59,6 +59,7 @@ private:
 	public:
 		DeviceInfo(BaseDevice *d, BaseDeviceModel *m);
 		~DeviceInfo();
+		bool isConnected() const;
 
 		static QString infoId(BaseDevice *device, BaseDeviceModel *sourceModel);
 
@@ -72,11 +73,11 @@ private:
 	};
 
 	void sourceModelRowsInserted(const QModelIndex &parent, int first, int last);
-	void sourceModelRowsAboutToBeRemoved(const QModelIndex &parent, int first, int last);
 	int indexOf(const QString &deviceInfoId) const;
 	int indexOf(const BaseDevice *device) const;
 	int insertionIndex(BaseDevice *device) const;
 	void deviceDescriptionChanged();
+	void deviceValidChanged();
 	void cleanUp();
 
 	QHash<int, QByteArray> m_roleNames;


### PR DESCRIPTION
In, DeviceListPage.qml, show list entries even if their devices are disconnected.

In aggregatedevicemodel.cpp, consider a device to be disconnected when BaseDevice::isValid() return false (i.e. when it no longer has a device instance, etc.) instead of when it is removed from its source model.

In the long run, the Device List should be generated from com.victronenergy.* or mqtt/* instead of the individual device models, so the sourceModel attributes can be dropped at that point.

Contributes to #1035