### PR TITLE
Validate and accept/reject text input when focus is lost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,6 +335,7 @@ set (VENUS_QML_MODULE_SOURCES
     components/listitems/ListAlarm.qml
     components/listitems/ListButton.qml
     components/listitems/ListDateSelector.qml
+    components/listitems/ListIntField.qml
     components/listitems/ListIpAddressField.qml
     components/listitems/ListItem.qml
     components/listitems/ListItemBackground.qml

--- a/Global.qml
+++ b/Global.qml
@@ -71,8 +71,9 @@ QtObject {
 
 	function showToastNotification(category, text, autoCloseInterval = 0) {
 		if (!!notificationLayer) {
-			notificationLayer.showToastNotification(category, text, autoCloseInterval)
+			return notificationLayer.showToastNotification(category, text, autoCloseInterval)
 		}
+		return null
 	}
 
 	function deviceModelsForClass(deviceClass) {

--- a/components/CommonWords.qml
+++ b/components/CommonWords.qml
@@ -161,6 +161,9 @@ QtObject {
 	//% "Error code"
 	readonly property string error_code: qsTrId("common_words_error_code")
 
+	//% "'%1' is not a number."
+	readonly property string error_nan: qsTrId("common_words_error_not_a_number")
+
 	//% "ESS"
 	readonly property string ess: qsTrId("common_words_ess")
 

--- a/components/ToastNotification.qml
+++ b/components/ToastNotification.qml
@@ -17,6 +17,20 @@ Item {
 	property alias text: label.text
 	property alias autoCloseInterval: timer.interval
 
+	property bool _closed
+
+	function close(immediately) {
+		if (_closed) {
+			return
+		}
+		_closed = true
+		if (immediately) {
+			dismissed()
+		} else {
+			dismiss.dismissClicked = true
+		}
+	}
+
 	signal dismissed()
 
 	implicitWidth: parent ? parent.width : 0

--- a/components/controls/TextField.qml
+++ b/components/controls/TextField.qml
@@ -10,6 +10,8 @@ import Victron.VenusOS
 CT.TextField {
 	id: root
 
+	property color borderColor: Theme.color_ok
+
 	font.family: Global.fontFamily
 	font.pixelSize: Theme.font_size_body2
 	passwordCharacter: "\u2022"
@@ -26,7 +28,7 @@ CT.TextField {
 
 	background: Rectangle {
 		color: "transparent"
-		border.color: Theme.color_ok
+		border.color: root.borderColor
 		border.width: Theme.geometry_button_border_width
 		radius: Theme.geometry_button_radius
 

--- a/components/listitems/ListIntField.qml
+++ b/components/listitems/ListIntField.qml
@@ -1,0 +1,33 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+ListTextField {
+	id: root
+
+	property int maximumLength
+
+	readonly property var validateIntInput: function() {
+		const trimmed = textField.text.trim()
+		if (!trimmed.match(/^[0-9]+$/)) {
+			return validationResult(VenusOS.InputValidation_Result_Error, CommonWords.error_nan.arg(textField.text))
+		}
+		if (maximumLength > 0 && trimmed.length > maximumLength) {
+			//% "Use a number with %1 digits or less."
+			return validationResult(VenusOS.InputValidation_Result_Error, qsTrId("number_field_input_too_long").arg(maximumLength))
+		}
+		return validationResult(VenusOS.InputValidation_Result_OK)
+	}
+
+	textField.inputMethodHints: Qt.ImhDigitsOnly
+	validateInput: validateIntInput
+	saveInput: function() {
+		if (dataItem.uid) {
+			dataItem.setValue(parseInt(textField.text))
+		}
+	}
+}

--- a/components/listitems/ListIpAddressField.qml
+++ b/components/listitems/ListIpAddressField.qml
@@ -9,7 +9,35 @@ import Victron.VenusOS
 ListTextField {
 	id: root
 
+	function _isValidIp(text) {
+		// Do a simple IPv4 aaddress validation: 4 groups of 3 digits, separated by a decimal.
+		if (!text.match(/^([0-9]{1,3}\.){3}[0-9]{1,3}$/)) {
+			return false
+		}
+		const groups = text.split(".")
+		for (let i = 0; i < groups.length; ++ i) {
+			const group = parseInt(groups[i])
+			if (group < 0 || group >= 256) {
+				return false
+			}
+		}
+		return true
+	}
+
+	text: CommonWords.ip_address
 	placeholderText: "000.000.000.000"
-	textField.validator: RegularExpressionValidator { regularExpression: /[0-9\.]{1,15}/ }
 	textField.inputMethodHints: Qt.ImhDigitsOnly
+	validateInput: function() {
+		const trimmed = textField.text.trim()
+		if (!_isValidIp(trimmed)) {
+			//% "'%1' is not a valid IP address."
+			return validationResult(VenusOS.InputValidation_Result_Error, qsTrId("ip_address_input_not_valid").arg(trimmed))
+		}
+		return validationResult(VenusOS.InputValidation_Result_OK, "", trimmed)
+	}
+	saveInput: function() {
+		if (dataItem.uid) {
+			dataItem.setValue(textField.text.trim())
+		}
+	}
 }

--- a/components/listitems/ListPortField.qml
+++ b/components/listitems/ListPortField.qml
@@ -6,10 +6,25 @@
 import QtQuick
 import Victron.VenusOS
 
-ListTextField {
+ListIntField {
 	id: root
 
+	//% "Port"
+	text: qsTrId("port_field_title")
 	placeholderText: "80"
-	textField.validator: RegularExpressionValidator { regularExpression: /[0-9]{1,5}/ }
-	textField.inputMethodHints: Qt.ImhDigitsOnly
+	validateInput: function() {
+		// Check whether the input is a number
+		const intValidationResult = validateIntInput()
+		if (intValidationResult.status === VenusOS.InputValidation_Result_Error) {
+			return intValidationResult
+		}
+
+		// Check whether the input is a valid port
+		const valueAsInt = parseInt(textField.text)
+		if (isNaN(valueAsInt) || valueAsInt < 0 || valueAsInt > 65535) {
+			//% "'%1' is not a valid port number. Use a number between 0-65535."
+			return validationResult(VenusOS.InputValidation_Result_Error, qsTrId("port_input_not_valid").arg(textField.text))
+		}
+		return validationResult(VenusOS.InputValidation_Result_OK)
+	}
 }

--- a/components/listitems/ListQuantityField.qml
+++ b/components/listitems/ListQuantityField.qml
@@ -14,10 +14,22 @@ ListTextField {
 	property int decimals: Units.defaultUnitPrecision(unit)
 
 	suffix: Units.defaultUnitString(unit)
-	textField.validator: DoubleValidator {
-		decimals: root.decimals
-		locale: Units.numberFormattingLocaleName
-	}
 	textField.inputMethodHints: Qt.ImhFormattedNumbersOnly
 	textField.text: Units.formatNumber(root.value, root.decimals)
+	validateInput: function() {
+		const numberValue = Units.formattedNumberToReal(textField.text)
+		if (isNaN(numberValue)) {
+		   return validationResult(VenusOS.InputValidation_Result_Error, CommonWords.error_nan.arg(textField.text))
+		}
+
+		// In case the user has entered a number with a greater precision than what is supported,
+		// adjust the precision of the displayed number.
+		const formattedNumber = Units.formatNumber(numberValue, root.decimals)
+		return validationResult(VenusOS.InputValidation_Result_OK, "", formattedNumber)
+	}
+	saveInput: function() {
+		if (dataItem.uid) {
+			dataItem.setValue(Units.formattedNumberToReal(textField.text))
+		}
+	}
 }

--- a/components/listitems/ListRadioButtonGroup.qml
+++ b/components/listitems/ListRadioButtonGroup.qml
@@ -164,20 +164,42 @@ ListNavigationItem {
 								backgroundRect.color: "transparent"
 								Component.onCompleted: allowed = model.index !== root.currentIndex
 
+								validateInput: function() {
+									if (!allowed) {
+										return validationResult(VenusOS.InputValidation_Result_Unknown)
+									}
+									if (textField.text !== bottomContentLoader.password) {
+										//% "%1: Incorrect password"
+										return validationResult(VenusOS.InputValidation_Result_Error, qsTrId("settings_radio_button_incorrect_password").arg(radioButton.text))
+									}
+									return validationResult(VenusOS.InputValidation_Result_OK)
+								}
+								saveInput: function() {
+									if (allowed) {
+										radioButton.select()
+									}
+								}
+
+								onEditingFinished: {
+									allowed = false
+									textField.text = ""
+								}
 								onAccepted: {
 									if (bottomContentLoader.promptPassword) {
 										radioButton.select(textField.text)
 									} else if (textField.text === bottomContentLoader.password) {
 										radioButton.select()
-									} else {
-										//% "Incorrect password"
-										Global.notificationLayer.showToastNotification(VenusOS.Notification_Info,
-												qsTrId("settings_radio_button_incorrect_password"))
 									}
 								}
-								onHasActiveFocusChanged: {
-									if (!hasActiveFocus) {
-										textField.text = ""
+
+								Connections {
+									target: root
+									enabled: passwordField.allowed
+
+									function onOptionClicked(clickedIndex) {
+										if (clickedIndex !== model.index) {
+											passwordField.allowed = false
+										}
 									}
 								}
 							}

--- a/components/listitems/ListRadioButtonGroup.qml
+++ b/components/listitems/ListRadioButtonGroup.qml
@@ -164,10 +164,10 @@ ListNavigationItem {
 								backgroundRect.color: "transparent"
 								Component.onCompleted: allowed = model.index !== root.currentIndex
 
-								onAccepted: function(text) {
+								onAccepted: {
 									if (bottomContentLoader.promptPassword) {
-										radioButton.select(text)
-									} else if (text === bottomContentLoader.password) {
+										radioButton.select(textField.text)
+									} else if (textField.text === bottomContentLoader.password) {
 										radioButton.select()
 									} else {
 										//% "Incorrect password"

--- a/components/listitems/ListTextField.qml
+++ b/components/listitems/ListTextField.qml
@@ -16,15 +16,84 @@ ListItem {
 	property alias placeholderText: textField.placeholderText
 	property string suffix
 	property var flickable: root.ListView ? root.ListView.view : null
-	readonly property bool hasActiveFocus: textField.activeFocus
 
-	signal accepted(text: string)
+	// These are functions that can optionally be overridden.
+	// - validateInput: validates the TextField input, and returns the object provided by
+	//   validationResult() to describe the validation result.
+	// - save: saves the text field input. The default implementation saves the value to the dataItem.
+	//
+	// When the text field loses focus or is accepted, validate is called(); if it returns a result
+	// of InputValidation_Result_OK, then saveInput() is called. validateInput() is also called to check
+	// whether the user has corrected the input to make it valid, if the input was previously found
+	// to be invalid.
+	property var validateInput
+	property var saveInput: function() {
+		if (dataItem.uid) {
+			dataItem.setValue(textField.text)
+		}
+	}
+
 	signal editingFinished()
+	signal accepted()
 
 	function forceActiveFocus() {
 		_aboutToFocus()
 		textField.forceActiveFocus()
 	}
+
+	// Returns an object to return from validateInput(). The status can be:
+	// - InputValidation_Result_Error: the input text is invalid; highlight the input with a red border
+	// - InputValidation_Result_OK: the input text is valid, and can be saved, or red highlight can be removed
+	// - InputValidation_Result_Unknown: the input text should not be saved, but is not invalid, so
+	//   do not highlight with a red border. This is useful when the input string is empty.
+	function validationResult(status, errorText = "", adjustedText = undefined) {
+		return { status: status, errorText = errorText, adjustedText = adjustedText }
+	}
+
+	function runValidation(mode) {
+		const resultStatus = _doValidateInput(mode)
+		if (mode === VenusOS.InputValidation_ValidateAndSave
+				&& resultStatus === VenusOS.InputValidation_Result_OK) {
+			saveInput()
+		}
+		return resultStatus
+	}
+
+	function _doValidateInput(mode) {
+		if (!validateInput) {
+			return VenusOS.InputValidation_Result_OK
+		}
+
+		const result = validateInput()
+		if (!result) {
+			console.warn("validateInput() did not return a valid object!")
+			return VenusOS.InputValidation_Result_Unknown
+		}
+		if (result.status === undefined) {
+			console.warn("validateInput() did not return a valid result status!")
+			return VenusOS.InputValidation_Result_Unknown
+		}
+
+		// If attempting to save, then show any errors and adjust the input text.
+		if (mode === VenusOS.InputValidation_ValidateAndSave) {
+			if (result.status === VenusOS.InputValidation_Result_Error) {
+				let errorText = result.errorText
+				if (errorText.length === 0) {
+					//% "The entered text does not have the correct format. Try again."
+					errorText = qsTrId("text_field_default_error_text")
+				}
+				// TODO if notification is already visible, update the existing notification
+				// and reset the notification timeout.
+				Global.showToastNotification(VenusOS.Notification_Info, errorText, 5000)
+			}
+			if (result.adjustedText != null) {
+				textField.text = result.adjustedText
+			}
+		}
+
+		return result.status
+	}
+
 
 	function _aboutToFocus() {
 		// Intercept the event before the VKB opens and scroll the parent flickable to
@@ -55,8 +124,9 @@ ListItem {
 	property TextField defaultContent: TextField {
 		id: textField
 
-		property string _textWhenFocused
-		property bool _accepted
+		property var currentNotification
+		property bool _showErrorHighlight
+		property bool _validateBeforeSaving
 
 		width: Math.max(Theme.geometry_listItem_textField_minimumWidth,
 						Math.min(Theme.geometry_listItem_textField_maximumWidth,
@@ -65,35 +135,37 @@ ListItem {
 		text: dataItem.isValid ? dataItem.value : ""
 		rightPadding: suffixLabel.text.length ? suffixLabel.implicitWidth : leftPadding
 		horizontalAlignment: root.suffix ? Text.AlignRight : Text.AlignHCenter
+		borderColor: _showErrorHighlight ? Theme.color_red : Theme.color_ok
+
+		onTextEdited: {
+			// When the input is marked as invalid, run the validation again each time the input is
+			// edited. If the result is either OK or unknown, then clear the invalid marker.
+			if (_showErrorHighlight && root.runValidation(VenusOS.InputValidation_ValidateOnly) !== VenusOS.InputValidation_Result_Error) {
+				_showErrorHighlight = false
+				// TODO close the error notification if it is open
+			}
+			_validateBeforeSaving = true
+		}
 
 		onAccepted: {
-			let newValue = text
-			_accepted = true
-			if (dataItem.uid) {
-				dataItem.setValue(newValue)
+			// When input is accepted, validate and remove focus if text is valid.
+			if (_validateBeforeSaving) {
+				_showErrorHighlight = root.runValidation(VenusOS.InputValidation_ValidateAndSave) === VenusOS.InputValidation_Result_Error
+				_validateBeforeSaving = false
 			}
-			textField.focus = false
-			root.accepted(newValue)
+			if (!_showErrorHighlight) {
+				root.accepted()
+				textField.focus = false
+			}
 		}
-
-		onEditingFinished: root.editingFinished()
 
 		onActiveFocusChanged: {
-			if (activeFocus) {
-				_textWhenFocused = text
-				_accepted = false
-			} else if (!_accepted && _textWhenFocused !== text) {
-				text = _textWhenFocused
-				revertedAnimation.to = textField.color
-				revertedAnimation.start()
+			// When focus is lost and the text was changed, validate and save the text.
+			if (_validateBeforeSaving) {
+				_showErrorHighlight = root.runValidation(VenusOS.InputValidation_ValidateAndSave) === VenusOS.InputValidation_Result_Error
+				_validateBeforeSaving = false
 			}
-		}
-
-		ColorAnimation on color {
-			id: revertedAnimation
-
-			from: Theme.color_orange
-			duration: 400
+			root.editingFinished()
 		}
 
 		Label {

--- a/components/listitems/ListTextField.qml
+++ b/components/listitems/ListTextField.qml
@@ -82,9 +82,10 @@ ListItem {
 					//% "The entered text does not have the correct format. Try again."
 					errorText = qsTrId("text_field_default_error_text")
 				}
-				// TODO if notification is already visible, update the existing notification
-				// and reset the notification timeout.
-				Global.showToastNotification(VenusOS.Notification_Info, errorText, 5000)
+				if (textField.currentNotification) {
+					textField.currentNotification.close(true)
+				}
+				textField.currentNotification = Global.showToastNotification(VenusOS.Notification_Info, errorText, 5000)
 			}
 			if (result.adjustedText != null) {
 				textField.text = result.adjustedText
@@ -142,7 +143,11 @@ ListItem {
 			// edited. If the result is either OK or unknown, then clear the invalid marker.
 			if (_showErrorHighlight && root.runValidation(VenusOS.InputValidation_ValidateOnly) !== VenusOS.InputValidation_Result_Error) {
 				_showErrorHighlight = false
-				// TODO close the error notification if it is open
+			}
+			// Close error notification if visible.
+			if (textField.currentNotification) {
+				textField.currentNotification.close(false)
+				textField.currentNotification = null
 			}
 			_validateBeforeSaving = true
 		}

--- a/pages/NotificationLayer.qml
+++ b/pages/NotificationLayer.qml
@@ -14,6 +14,7 @@ Item {
 	function showToastNotification(category, text, autoCloseInterval = 0) {
 		var toast = toaster.createObject(root, { "category": category, "text": text, autoCloseInterval: autoCloseInterval })
 		toastItemsModel.append(toast)
+		return toast
 	}
 
 	function deleteNotification(toast) {
@@ -21,9 +22,10 @@ Item {
 			if (toastItemsModel.get(i) === toast) {
 				toastItemsModel.remove(i, 1)
 				toast.destroy(1000)
-				break
+				return true
 			}
 		}
+		return false
 	}
 
 	ListView {

--- a/pages/NotificationLayer.qml
+++ b/pages/NotificationLayer.qml
@@ -10,6 +10,7 @@ Item {
 	id: root
 
 	anchors.fill: parent
+	anchors.bottomMargin: Qt.inputMethod && Qt.inputMethod.visible ? Qt.inputMethod.keyboardRectangle.height : 0
 
 	function showToastNotification(category, text, autoCloseInterval = 0) {
 		var toast = toaster.createObject(root, { "category": category, "text": text, autoCloseInterval: autoCloseInterval })

--- a/pages/settings/PageGeneratorRuntimeService.qml
+++ b/pages/settings/PageGeneratorRuntimeService.qml
@@ -48,19 +48,18 @@ Page {
 				}
 			}
 
-			ListTextField {
+			ListIntField {
 				id: setTotalRunTime
 
 				//% "Generator total run time (hours)"
 				text: qsTrId("page_settings_generator_total_run_time")
 				secondaryText: Math.round(accumulatedTotalItem.value / 60 / 60) - Math.round(dataItem.value / 60 / 60)
-				textField.inputMethodHints: Qt.ImhDigitsOnly
 				dataItem.uid: settingsBindPrefix + "/AccumulatedTotalOffset"
 				enabled: userHasWriteAccess && state.value === 0
 				allowed: dataItem.isValid
-				textField.maximumLength: 6
-				onAccepted: {
-					dataItem.setValue(accumulatedTotalItem.value - textField.text * 60 * 60)
+				maximumLength: 6
+				saveInput: function() {
+					dataItem.setValue(accumulatedTotalItem.value - parseInt(textField.text, 10) * 60 * 60)
 				}
 
 				VeQuickItem {
@@ -70,18 +69,17 @@ Page {
 				}
 			}
 
-			ListTextField {
+			ListIntField {
 				id: serviceInterval
 
 				//% "Generator service interval (hours)"
 				text: qsTrId("page_settings_generator_service_interval")
 				secondaryText: Math.round(dataItem.value / 60 / 60)
-				textField.inputMethodHints: Qt.ImhDigitsOnly
 				dataItem.uid: settingsBindPrefix + "/ServiceInterval"
-				onAccepted: {
-					dataItem.setValue(textField.text * 60 * 60)
+				saveInput: function() {
+					dataItem.setValue(parseInt(textField.text, 10) * 60 * 60)
 					//% "Service time interval set to %1h. Use the 'Reset service timer' button to reset the service timer."
-					Global.showToastNotification(VenusOS.Notification_Info, qsTrId("page_settings_generator_service_time_interval").arg(hours))
+					Global.showToastNotification(VenusOS.Notification_Info, qsTrId("page_settings_generator_service_time_interval").arg(textField.text))
 				}
 			}
 

--- a/pages/settings/PageGeneratorRuntimeService.qml
+++ b/pages/settings/PageGeneratorRuntimeService.qml
@@ -59,8 +59,8 @@ Page {
 				enabled: userHasWriteAccess && state.value === 0
 				allowed: dataItem.isValid
 				textField.maximumLength: 6
-				onAccepted: function(hours) {
-					dataItem.setValue(accumulatedTotalItem.value - hours * 60 * 60)
+				onAccepted: {
+					dataItem.setValue(accumulatedTotalItem.value - textField.text * 60 * 60)
 				}
 
 				VeQuickItem {
@@ -78,8 +78,8 @@ Page {
 				secondaryText: Math.round(dataItem.value / 60 / 60)
 				textField.inputMethodHints: Qt.ImhDigitsOnly
 				dataItem.uid: settingsBindPrefix + "/ServiceInterval"
-				onAccepted: function(hours) {
-					dataItem.setValue(hours * 60 * 60)
+				onAccepted: {
+					dataItem.setValue(textField.text * 60 * 60)
 					//% "Service time interval set to %1h. Use the 'Reset service timer' button to reset the service timer."
 					Global.showToastNotification(VenusOS.Notification_Info, qsTrId("page_settings_generator_service_time_interval").arg(hours))
 				}

--- a/pages/settings/PageSettingsBatteries.qml
+++ b/pages/settings/PageSettingsBatteries.qml
@@ -102,7 +102,7 @@ Page {
 								placeholderText: qsTrId("settings_batteries_enter_name")
 								dataItem.uid: Global.systemSettings.serviceUid + "/Settings/SystemSetup/Batteries/Configuration/" + batteryMenuItem.configId + "/Name"
 								allowed: dataItem.isValid
-								textField.maximumLength: 32 // TODO can the max be fetched from dbus?
+								textField.maximumLength: 32
 							}
 						}
 					}

--- a/pages/settings/PageSettingsBluetooth.qml
+++ b/pages/settings/PageSettingsBluetooth.qml
@@ -28,7 +28,8 @@ Page {
 				writeAccessLevel: VenusOS.User_AccessType_User
 				textField.maximumLength: 6
 				textField.inputMethodHints: Qt.ImhDigitsOnly
-				onAccepted: {
+				saveInput: function() {
+					dataItem.setValue(textField.text)
 					Global.showToastNotification(VenusOS.Notification_Info,
 						   //% "It might be necessary to remove existing pairing information before connecting."
 						   qsTrId("settings_bluetooth_remove_existing_pairing_info"),

--- a/pages/settings/PageSettingsGeneral.qml
+++ b/pages/settings/PageSettingsGeneral.qml
@@ -205,8 +205,7 @@ Page {
 				//% "Enter password"
 				placeholderText: qsTrId("settings_root_enter_password")
 				textField.echoMode: TextInput.Password
-
-				onAccepted: {
+				saveInput: function() {
 					if (secondaryText.length < 8) {
 						//% "Password needs to be at least 8 characters long"
 						Global.showToastNotification(VenusOS.Notification_Info, qsTrId("settings_root_too_short_password"), 5000)

--- a/pages/settings/PageSettingsTcpIp.qml
+++ b/pages/settings/PageSettingsTcpIp.qml
@@ -153,7 +153,7 @@ Page {
 			allowed: root.ready && root._wifi && root._disconnected
 					 && !service.favorite && service.secured
 			writeAccessLevel: VenusOS.User_AccessType_User
-			onAccepted: {
+			saveInput: function() {
 				var obj = {
 					Service: service.service,
 					Action: "connect",
@@ -248,10 +248,9 @@ Page {
 		}
 
 		ListIpAddressField {
-			text: CommonWords.ip_address
 			enabled: method.userHasWriteAccess && service.manual
 			textField.text: service.ipAddress
-			onAccepted: setServiceProperty("Address", textField.text)
+			saveInput: function() { setServiceProperty("Address", textField.text) }
 		}
 
 		ListIpAddressField {
@@ -259,7 +258,7 @@ Page {
 			text: qsTrId("settings_tcpip_netmask")
 			enabled: method.userHasWriteAccess && service.manual
 			textField.text: service.netmask
-			onAccepted: setServiceProperty("Netmask", textField.text)
+			saveInput: function() { setServiceProperty("Netmask", textField.text) }
 		}
 
 		ListIpAddressField {
@@ -267,7 +266,7 @@ Page {
 			text: qsTrId("settings_tcpip_gateway")
 			enabled: method.userHasWriteAccess && service.manual
 			textField.text: service.gateway
-			onAccepted: setServiceProperty("Gateway", textField.text)
+			saveInput: function() { setServiceProperty("Gateway", textField.text) }
 		}
 
 		ListIpAddressField {
@@ -275,7 +274,7 @@ Page {
 			text: qsTrId("settings_tcpip_dns_server")
 			enabled: method.userHasWriteAccess && service.manual
 			textField.text: service.nameserver
-			onAccepted: setServiceProperty("Nameserver", textField.text)
+			saveInput: function() { setServiceProperty("Nameserver", textField.text) }
 		}
 
 		ListTextItem {

--- a/pages/settings/PageVrmDeviceInstances.qml
+++ b/pages/settings/PageVrmDeviceInstances.qml
@@ -236,11 +236,11 @@ Page {
 			return count
 		}
 
-		function updateSortOrder(index) {
-			const data = get(index)
+		function updateSortOrder(modelIndex) {
+			const data = get(modelIndex)
 			const insertionIndex = findInsertionIndex(data.deviceClass, data.name, data.vrmInstance)
 			if (insertionIndex !== modelIndex) {
-				move(index, insertionIndex, 1)
+				move(modelIndex, insertionIndex, 1)
 			}
 		}
 

--- a/pages/settings/PageVrmDeviceInstances.qml
+++ b/pages/settings/PageVrmDeviceInstances.qml
@@ -259,7 +259,7 @@ Page {
 	GradientListView {
 		model: classAndVrmInstanceModel
 
-		delegate: ListTextField {
+		delegate: ListIntField {
 			id: deviceDelegate
 
 			readonly property int _modelVrmInstance: model.vrmInstance
@@ -277,16 +277,17 @@ Page {
 			textField.inputMethodHints: Qt.ImhDigitsOnly
 			textField.text: model.vrmInstance
 			allowed: model.deviceClass.length > 0 && model.vrmInstance >= 0
-
-			onAccepted: {
+			validateInput: function() {
 				const newVrmInstance = parseInt(textField.text)
 				if (isNaN(newVrmInstance)) {
-					console.warn("Cannot change device instance, bad value:", newVrmInstance)
-					return
+					return validationResult(VenusOS.InputValidation_Result_Error, CommonWords.error_nan.arg(textField.text))
 				}
+				return validationResult(VenusOS.InputValidation_Result_OK, "", newVrmInstance)
+			}
+			saveInput: function() {
+				const newVrmInstance = parseInt(textField.text)
 				root._changeVrmInstance(model.index, newVrmInstance, revertText)
 			}
-
 			on_ModelVrmInstanceChanged: {
 				// If VRM instance is changed in the backend, reset the text.
 				textField.text = _modelVrmInstance

--- a/pages/settings/debug/PageSettingsDemo.qml
+++ b/pages/settings/debug/PageSettingsDemo.qml
@@ -71,7 +71,7 @@ Page {
 					ListElement { display: "Option A"; value: 1 }
 					ListElement { display: "Option B"; value: 2; readOnly: true }
 					ListElement { display: "Option C"; value: 3 }
-					ListElement { display: "Option D"; value: 4 }
+					ListElement { display: "Option D (with password 'AAA')"; value: 4; password: "AAA" }
 					ListElement { display: "Option E"; value: 5 }
 					ListElement { display: "Option F"; value: 6 }
 					ListElement { display: "Option G"; value: 7 }
@@ -156,6 +156,11 @@ Page {
 				placeholderText: "Enter text"
 			}
 
+			ListIntField {
+				text: "Number with 5 digits max"
+				maximumLength: 5
+			}
+
 			ListQuantityField {
 				text: "Quantity input"
 				value: 123.5324
@@ -165,6 +170,7 @@ Page {
 
 			ListIpAddressField {
 				text: "IP address"
+				secondaryText: "12.23.21.4"
 			}
 
 			ListSpinBox {

--- a/src/enums.h
+++ b/src/enums.h
@@ -679,6 +679,19 @@ public:
 		TrackerName_NoDevicePrefix
 	};
 	Q_ENUM(TrackerName_Format)
+
+	enum InputValidation_Result {
+		InputValidation_Result_Unknown,
+		InputValidation_Result_OK,
+		InputValidation_Result_Error,
+	};
+	Q_ENUM(InputValidation_Result)
+
+	enum InputValidation_ValidateMode {
+		InputValidation_ValidateOnly,
+		InputValidation_ValidateAndSave,
+	};
+	Q_ENUM(InputValidation_ValidateMode)
 };
 
 }

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -71,6 +71,13 @@ QString Units::formatNumber(qreal number, int precision) const
 	return formattingLocale()->toString(number, 'f', precision);
 }
 
+qreal Units::formattedNumberToReal(const QString &s) const
+{
+	bool ok = false;
+	const double d = formattingLocale()->toDouble(s, &ok);
+	return ok ? d : qQNaN();
+}
+
 int Units::defaultUnitPrecision(VenusOS::Enums::Units_Type unit) const
 {
 	switch (unit) {

--- a/src/units.h
+++ b/src/units.h
@@ -53,6 +53,7 @@ public:
 
 	QString numberFormattingLocaleName() const;
 	Q_INVOKABLE QString formatNumber(qreal number, int precision = 0) const;
+	Q_INVOKABLE qreal formattedNumberToReal(const QString &s) const;
 
 	Q_INVOKABLE int defaultUnitPrecision(VenusOS::Enums::Units_Type unit) const;
 	Q_INVOKABLE QString defaultUnitString(VenusOS::Enums::Units_Type unit, int formatHints = 0) const;


### PR DESCRIPTION
Align all validation/accept/reject behavior of text fields, so when text field focus is lost:

- Do text validation if required. If it succeeds, save the input; it it fails, highlight the text field and show a toast notification to indicate why the input is invalid.
- If no validation is required, save the input immediately.

Avoid setting a `validator` on the text field, so that text can be freely entered before the input is accepted. 

Text validation can also be forced by pressing Enter/Return, this is not required to save the input.