### PR TITLE
Fix tank and environment input object cleanup in mock mode

### DIFF
--- a/data/common/Tank.qml
+++ b/data/common/Tank.qml
@@ -45,7 +45,7 @@ Device {
 	}
 
 	onValidChanged: Qt.callLater(tank._updateModel)
-	onTypeChanged: Qt.callLater(tank._updateModel)
+	onTypeChanged: Qt.callLater(tank._updateModel) // if type changes, move tank to the correct model
 
 	function _updateModel() {
 		if (valid && type >= 0) {

--- a/data/mock/EnvironmentInputsImpl.qml
+++ b/data/mock/EnvironmentInputsImpl.qml
@@ -85,7 +85,7 @@ Item {
 			const hasCreatedObjects = _createdObjects.length > 0
 			while (_createdObjects.length > 1) {
 				let obj = _createdObjects.pop()
-				obj._deviceInstance.setValue(-1)
+				obj.deviceInstance = -1
 				obj.destroy()
 			}
 
@@ -97,7 +97,7 @@ Item {
 
 			if (hasCreatedObjects) {
 				let lastObject = _createdObjects.shift()
-				lastObject._deviceInstance.setValue(-1)
+				lastObject.deviceInstance = -1
 				lastObject.destroy()
 			}
 		}

--- a/data/mock/TanksImpl.qml
+++ b/data/mock/TanksImpl.qml
@@ -91,7 +91,7 @@ QtObject {
 			const hasCreatedObjects = _createdObjects.length > 0
 			while (_createdObjects.length > 1) {
 				let obj = _createdObjects.pop()
-				obj._deviceInstance.setValue(-1)
+				obj.deviceInstance = -1
 				obj.destroy()
 			}
 
@@ -103,7 +103,7 @@ QtObject {
 
 			if (hasCreatedObjects) {
 				let lastObject = _createdObjects.shift()
-				lastObject._deviceInstance.setValue(-1)
+				lastObject.deviceInstance = -1
 				lastObject.destroy()
 			}
 		}
@@ -132,7 +132,7 @@ QtObject {
 			} else {
 				// remove a tank
 				const index = Math.floor(Math.random() * _createdObjects.length)
-				_createdObjects[index]._deviceInstance.setValue(-1) // causes tank to remove itself from model
+				_createdObjects[index].deviceInstance = -1 // causes tank to remove itself from model
 				_createdObjects.splice(index, 1)
 			}
 		}
@@ -155,7 +155,7 @@ QtObject {
 			root.addTank(tankProperties)
 		} else {
 			for (var i = 0; i < _createdObjects.length; ++i) {
-				_createdObjects[i]._deviceInstance.setValue(-1) // causes tank to remove itself from model
+				_createdObjects[i].deviceInstance = -1 // causes tank to remove itself from model
 			}
 
 			_createdObjects = []


### PR DESCRIPTION
Set the deviceInstance property value directly, instead of calling _deviceInstance.setValue(), so that BaseDevice::setDeviceInstance() is called and BaseDevice::validChanged is emitted when the device instance is set to -1. This ensures the clean up handlers in Tank.qml and EnvironmentInput.qml are triggered.

Also clean up Tank.qml to use a single signal handler to check whether the tank needs to be added/removed to/from the tank models.