### PR TITLE
Show all com.victronenergy.battery services in Device List

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -797,6 +797,7 @@ endif()
 # Dbus_QML_MODULE
 set(Dbus_QML_MODULE_SOURCES
     data/dbus/AcSystemDevicesImpl.qml
+    data/dbus/BatteriesImpl.qml
     data/dbus/ChargersImpl.qml
     data/dbus/DBusDataManager.qml
     data/dbus/DcInputsImpl.qml
@@ -926,6 +927,7 @@ endif()
 # Mqtt_QML_MODULE
 set(Mqtt_QML_MODULE_SOURCES
     data/mqtt/AcSystemDevicesImpl.qml
+    data/mqtt/BatteriesImpl.qml
     data/mqtt/ChargersImpl.qml
     data/mqtt/DcInputsImpl.qml
     data/mqtt/DcLoadsImpl.qml

--- a/data/Batteries.qml
+++ b/data/Batteries.qml
@@ -64,43 +64,5 @@ QtObject {
 		}
 	}
 
-	readonly property VeQuickItem _batteries: VeQuickItem {
-		uid: Global.system.serviceUid + "/Batteries"
-		onValueChanged: {
-			let i
-			if (!isValid) {
-				root.model.deleteAllAndClear()
-				return
-			}
-			// Value is a list of key-value pairs with info about each battery.
-			const batteryUids = value.map((info) => BackendConnection.serviceUidFromName(info.id, info.instance))
-
-			// Remove batteries from Global.batteries.model that are not in this list
-			root.model.intersect(batteryUids)
-
-			// Add new entries to Global.batteries.model
-			for (i = 0; i < batteryUids.length; ++i) {
-				if (root.model.indexOf(batteryUids[i]) < 0) {
-					_batteryComponent.createObject(root, { serviceUid: batteryUids[i] })
-				}
-			}
-		}
-	}
-
-	property Component _batteryComponent: Component {
-		Battery {
-			id: battery
-
-			onValidChanged: {
-				if (valid) {
-					root.addBattery(battery)
-				} else {
-					root.removeBattery(battery.serviceUid)
-					battery.destroy()
-				}
-			}
-		}
-	}
-
 	Component.onCompleted: Global.batteries = root
 }

--- a/data/dbus/BatteriesImpl.qml
+++ b/data/dbus/BatteriesImpl.qml
@@ -1,0 +1,33 @@
+/*
+** Copyright (C) 2023 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+QtObject {
+	property Instantiator batteryObjects: Instantiator {
+		model: VeQItemSortTableModel {
+			dynamicSortFilter: true
+			filterRole: VeQItemTableModel.UniqueIdRole
+			filterRegExp: "^dbus/com\.victronenergy\.battery\."
+			model: Global.dataServiceModel
+		}
+
+		delegate: Battery {
+			id: battery
+			serviceUid: model.uid
+
+			onValidChanged: {
+				if (!!Global.batteries) {
+					if (valid) {
+						Global.batteries.addBattery(battery)
+					} else {
+						Global.batteries.removeBattery(battery)
+					}
+				}
+			}
+		}
+	}
+}

--- a/data/dbus/DBusDataManager.qml
+++ b/data/dbus/DBusDataManager.qml
@@ -12,6 +12,7 @@ QtObject {
 
 	property var acSystemDevices: AcSystemDevicesImpl { }
 	property var chargers: ChargersImpl { }
+	property var batteries: BatteriesImpl { }
 	property var dcInputs: DcInputsImpl { }
 	property var dcLoads: DcLoadsImpl { }
 	property var digitalInputs: DigitalInputsImpl {}

--- a/data/mock/BatteriesImpl.qml
+++ b/data/mock/BatteriesImpl.qml
@@ -117,6 +117,7 @@ QtObject {
 			root.initLynxBattery(dummyBattery)
 
 			Global.batteries.system = dummyBattery
+			Global.batteries.addBattery(dummyBattery)
 
 			const batteryList = [{
 				id: "com.victronenergy.battery.ttyUSB1",

--- a/data/mqtt/BatteriesImpl.qml
+++ b/data/mqtt/BatteriesImpl.qml
@@ -1,0 +1,31 @@
+/*
+** Copyright (C) 2023 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+QtObject {
+	property Instantiator batteryObjects: Instantiator {
+		model: VeQItemTableModel {
+			uids: ["mqtt/battery"]
+			flags: VeQItemTableModel.AddChildren | VeQItemTableModel.AddNonLeaves | VeQItemTableModel.DontAddItem
+		}
+
+		delegate: Battery {
+			id: battery
+			serviceUid: model.uid
+
+			onValidChanged: {
+				if (!!Global.batteries) {
+					if (valid) {
+						Global.batteries.addBattery(battery)
+					} else {
+						Global.batteries.removeBattery(battery)
+					}
+				}
+			}
+		}
+	}
+}

--- a/data/mqtt/MqttDataManager.qml
+++ b/data/mqtt/MqttDataManager.qml
@@ -12,6 +12,7 @@ QtObject {
 
 	property var acSystemDevices: AcSystemDevicesImpl { }
 	property var chargers: ChargersImpl { }
+	property var batteries: BatteriesImpl { }
 	property var dcInputs: DcInputsImpl { }
 	property var dcLoads: DcLoadsImpl { }
 	property var digitalInputs: DigitalInputsImpl {}


### PR DESCRIPTION
gui-v2 need two separate battery lists, like this:

- In the Overview Battery drilldown, show all batteries from the list in com.victronenergy.system/Batteries
- In the Device List, show all battery services under com.victronenergy.battery.*

Fix Global.batteries.model to contain all battery services under com.victronenergy.battery.*. The Overview Battery list can be created specifically when requested, when the Battery widget is clicked.

Fixes regression from 5ebe75600bdf7ecacabc480a34fec153642355cf.

Fixes #1357