### PR TITLE
Handle AC input /Connected value of either 1 or true

### DIFF
--- a/data/common/AcInputSystemInfo.qml
+++ b/data/common/AcInputSystemInfo.qml
@@ -17,7 +17,7 @@ QtObject {
 	property bool isActiveInput
 	readonly property bool valid: deviceInstance >= 0 && serviceType.length && serviceName.length
 
-	readonly property bool connected: _connected.value === 1
+	readonly property bool connected: !!_connected.value
 	readonly property int deviceInstance: _deviceInstance.isValid ? _deviceInstance.value : -1
 	readonly property string serviceType: _serviceType.value || "" // e.g. "vebus"
 	readonly property string serviceName: _serviceName.value || "" // e.g. com.victronenergy.vebus.ttyO, com.victronenergy.grid.ttyO


### PR DESCRIPTION
The backend may publish either 1 or true to indicate /Ac/In/<x>/Connected is set, so allow for either value.

Fixes #1380