### PR TITLE
Fix regression in page reloading after firmware update

### DIFF
--- a/Global.qml
+++ b/Global.qml
@@ -60,6 +60,8 @@ QtObject {
 
 	property string firmwareInstalledBuild // don't clear this on UI reload.  it needs to survive reconnection.
 	property bool firmwareInstalledBuildUpdated // as above.
+	property bool needPageReload: Qt.platform.os == "wasm" && firmwareInstalledBuildUpdated // as above.
+
 	property bool isDesktop
 	property bool isGxDevice: Qt.platform.os === "linux" && !isDesktop
 	property real scalingRatio: 1.0

--- a/Main.qml
+++ b/Main.qml
@@ -69,7 +69,7 @@ Window {
 		onConnectionReadyChanged: {
 			if (connectionReady) {
 				active = true
-			} else if (active) {
+			} else if (active && !Global.needPageReload) {
 				root.rebuildUi()
 				active = false
 			}

--- a/pages/DialogLayer.qml
+++ b/pages/DialogLayer.qml
@@ -50,11 +50,11 @@ Item {
 			Timer {
 				running: true
 				interval: 10*1000
-				onTriggered: Qt.quit() // the aboutToQuit handler will trigger page reload.
+				onTriggered: BackendConnection.reloadPage()
 			}
 		}
 	}
 
-	property bool _needPageReload: Qt.platform.os == "wasm" && Global.firmwareInstalledBuildUpdated
+	property bool _needPageReload: Global.needPageReload
 	on_NeedPageReloadChanged: if (_needPageReload) open(_firmwareVersionRestartDialog)
 }

--- a/pages/MainView.qml
+++ b/pages/MainView.qml
@@ -29,7 +29,7 @@ Item {
 
 	property int _loadedPages: 0
 
-	readonly property bool _readyToInit: !!Global.pageManager && Global.dataManagerLoaded
+	readonly property bool _readyToInit: !!Global.pageManager && Global.dataManagerLoaded && !Global.needPageReload
 	on_ReadyToInitChanged: {
 		if (_readyToInit && swipeViewLoader.active == false) {
 			_loadUi()

--- a/src/backendconnection.cpp
+++ b/src/backendconnection.cpp
@@ -182,7 +182,7 @@ void BackendConnection::onReloadPageTimerExpired()
 		mRestartDelayTimer = nullptr;
 	}
 
-	emscripten_run_script("reload();");
+	reloadPage();
 }
 
 // If the wasm itself changed the Security Profile, it should normally be notified
@@ -198,11 +198,17 @@ void BackendConnection::securityProtocolChanged()
 	timer->start(5000);
 }
 
+void BackendConnection::reloadPage()
+{
+	emscripten_run_script("reload();");
+}
+
 #else
 
 void BackendConnection::onNetworkConfigChanged(const QVariant var) { Q_UNUSED(var); }
 void BackendConnection::onReloadPageTimerExpired() {}
 void BackendConnection::securityProtocolChanged() {}
+void BackendConnection::reloadPage() {}
 
 #endif
 

--- a/src/backendconnection.h
+++ b/src/backendconnection.h
@@ -115,6 +115,7 @@ public:
 
 	Q_INVOKABLE void logout();
 	Q_INVOKABLE void securityProtocolChanged();
+	Q_INVOKABLE void reloadPage();
 
 	// Move this to some mock data manager when available
 	Q_INVOKABLE void setMockValue(const QString &uid, const QVariant &value);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -287,11 +287,6 @@ int main(int argc, char *argv[])
 
 	QGuiApplication::styleHints()->setWheelScrollLines(5);
 
-#if defined(VENUS_WEBASSEMBLY_BUILD)
-	QObject::connect(&app, &QGuiApplication::aboutToQuit,
-		&app, [] { emscripten_run_script("location.reload()"); }, Qt::QueuedConnection);
-#endif
-
 	bool enableFpsCounter = false;
 	bool skipSplashScreen = false;
 


### PR DESCRIPTION
We need to prevent rebuildUi() being triggered as a result of the firmware update being detected, otherwise the dialog layer will be destroyed and so the modal dialog which triggers the reload will be destroyed.

Also, with security profile support included, we need to update the method we use to reload the page when a firmware update is detected to ensure that it matches the same reload process used when a change to the security profile is detected.