### PR TITLE
Don't show overview battery temperature when there is none

### DIFF
--- a/components/widgets/BatteryWidget.qml
+++ b/components/widgets/BatteryWidget.qml
@@ -162,6 +162,7 @@ OverviewWidget {
 		unit: Global.systemSettings.temperatureUnit
 		font.pixelSize: Theme.font_size_body2
 		alignment: Qt.AlignRight
+		visible: !isNaN(batteryData.temperature)
 	}
 
 	extraContentChildren: [


### PR DESCRIPTION
Fixes #1362