### PR TITLE
Use 0 as default precision for ListTemperatureItem

### DIFF
--- a/components/listitems/ListTemperatureItem.qml
+++ b/components/listitems/ListTemperatureItem.qml
@@ -12,5 +12,4 @@ ListQuantityItem {
 	dataItem.sourceUnit: Units.unitToVeUnit(VenusOS.Units_Temperature_Celsius)
 	dataItem.displayUnit: Units.unitToVeUnit(Global.systemSettings.temperatureUnit)
 	unit: Global.systemSettings.temperatureUnit
-	precision: 1
 }

--- a/pages/settings/devicelist/DeviceListPage.qml
+++ b/pages/settings/devicelist/DeviceListPage.qml
@@ -136,11 +136,11 @@ Page {
 			const inputTemp = Global.systemSettings.convertFromCelsius(device.temperature)
 			if (isNaN(device.humidity)) {
 				summary = [
-					Units.getCombinedDisplayText(Global.systemSettings.temperatureUnit, inputTemp),
+					Units.getCombinedDisplayText(Global.systemSettings.temperatureUnit, inputTemp, 1),
 				]
 			} else {
 				summary = [
-					Units.getCombinedDisplayText(Global.systemSettings.temperatureUnit, inputTemp),
+					Units.getCombinedDisplayText(Global.systemSettings.temperatureUnit, inputTemp, 1),
 					Units.getCombinedDisplayText(VenusOS.Units_Percentage, device.humidity),
 				]
 			}

--- a/pages/settings/devicelist/PageMeteo.qml
+++ b/pages/settings/devicelist/PageMeteo.qml
@@ -35,6 +35,7 @@ Page {
 				//% "Cell temperature"
 				text: qsTrId("page_meteo_cell_temperature")
 				dataItem.uid: bindPrefix + "/CellTemperature"
+				precision: 1
 			}
 
 			ListTemperatureItem {
@@ -44,6 +45,7 @@ Page {
 						  //% "External temperature"
 						  qsTrId("page_meteo_external_temperature")
 				dataItem.uid: bindPrefix + "/ExternalTemperature"
+				precision: 1
 			}
 
 			ListTemperatureItem {
@@ -53,6 +55,7 @@ Page {
 				//% "External temperature (2)"
 				text: qsTrId("page_meteo_external_temperature_2")
 				allowed: dataItem.isValid
+				precision: 1
 			}
 
 			ListQuantityItem {

--- a/pages/settings/devicelist/temperature/PageTemperatureSensor.qml
+++ b/pages/settings/devicelist/temperature/PageTemperatureSensor.qml
@@ -52,6 +52,7 @@ Page {
 			ListTemperatureItem {
 				text: CommonWords.temperature
 				dataItem.uid: bindPrefix + "/Temperature"
+				precision: 1
 			}
 
 			ListQuantityItem {


### PR DESCRIPTION
While temperatures reported by Ruuvi sensors on
com.victronenergy.temperature are accurate and precise enough to show a decimal, temperatures measured by inverters and battery monitors and similar devices are not. So, do not show any precision by default.

Use precision=1 where it is necessary to add precision. This aligns more with the gui-v1 behaviour where temperatures have 0 precision by default.

Fixes #1364