### PR TITLE
Fix CI build failure

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -51,7 +51,7 @@ jobs:
         host: 'linux'
         target: 'desktop'
         arch: 'gcc_64'
-        modules: 'qtwebsockets qt5compat qtshadertools'
+        modules: 'qtwebsockets qtshadertools'
         dir: '/opt/hostedtoolcache'
     - name: Install QT ${{env.QT_VERSION}} linux wasm and cmake
       if: steps.cached_qt_emscripten.outputs.cache-hit != 'true'
@@ -62,7 +62,7 @@ jobs:
         host: 'linux'
         target: 'desktop'
         arch: 'wasm_singlethread'
-        modules: 'qtwebsockets qt5compat qtshadertools'
+        modules: 'qtwebsockets qtshadertools'
         tools: 'tools_cmake'
         dir: '/opt/hostedtoolcache'
     - name: patch Qt ${{env.QT_VERSION}}

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -42,9 +42,20 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: 3.x
+    - name: Install Qt ${{env.QT_VERSION}} linux desktop
+      if: steps.cached_qt_emscripten.outputs.cache-hit != 'true'
+      uses: jurplel/install-qt-action@v3
+      with:
+        aqtversion: '==3.1.*'
+        version: "${{env.QT_VERSION}}"
+        host: 'linux'
+        target: 'desktop'
+        arch: 'gcc_64'
+        modules: 'qtwebsockets qt5compat qtshadertools'
+        dir: '/opt/hostedtoolcache'
     - name: Install QT ${{env.QT_VERSION}} linux wasm and cmake
       if: steps.cached_qt_emscripten.outputs.cache-hit != 'true'
-      uses: jurplel/install-qt-action@v4
+      uses: jurplel/install-qt-action@v3
       with:
         aqtversion: '==3.1.*'
         version: "${{env.QT_VERSION}}"


### PR DESCRIPTION
Revert 'jurplel' from v4 back to v3.

I don't really understand why my original Qt6.6.3 changes caused an issue, they built fine on the dev branch, then failed when I merged them to main.

I created this branch from main, then pushed a whitespace change to trigger a CI build, and saw the build issue (shader tools). I pushed the fix, and the following CI build succeeded.

