### PR TITLE
Prevent dragging/flicking beyond list bounds

### DIFF
--- a/components/GradientListView.qml
+++ b/components/GradientListView.qml
@@ -15,7 +15,7 @@ ListView {
 	bottomMargin: Theme.geometry_gradientList_bottomMargin
 	leftMargin: Theme.geometry_page_content_horizontalMargin
 	rightMargin: Theme.geometry_page_content_horizontalMargin
-	boundsBehavior: Flickable.DragOverBounds
+	boundsBehavior: Flickable.StopAtBounds
 
 	// Note: do not set spacing here, as it creates extra spacing if an item has visible=false.
 	// Instead, the spacing is added visually within ListItem's ListItemBackground.

--- a/pages/ControlCardsPage.qml
+++ b/pages/ControlCardsPage.qml
@@ -31,7 +31,7 @@ Page {
 		}
 		spacing: Theme.geometry_controlCardsPage_spacing
 		orientation: ListView.Horizontal
-		boundsBehavior: Flickable.DragOverBounds
+		boundsBehavior: Flickable.StopAtBounds
 		maximumFlickVelocity: Theme.geometry_flickable_maximumFlickVelocity
 		flickDeceleration: Theme.geometry_flickable_flickDeceleration
 

--- a/pages/settings/PageSettingsGeneral.qml
+++ b/pages/settings/PageSettingsGeneral.qml
@@ -66,6 +66,8 @@ Page {
 	GradientListView {
 		id: settingsListView
 
+		boundsBehavior: Flickable.DragOverBounds
+
 		model: ObjectModel {
 			ListRadioButtonGroup {
 				id: securityProfile


### PR DESCRIPTION
The exception is the General settings page, as this behavior provides a shortcut for access level changes.

Fixes #1363