### PR TITLE
Show custom tank name

### DIFF
--- a/data/common/Tank.qml
+++ b/data/common/Tank.qml
@@ -91,7 +91,7 @@ Device {
 		// This must be a generic Victron tank sensor, where the product name is always "Tank
 		// sensor" and there is no custom name, so use the tank type to provide a meaningful name.
 		? Gauges.tankProperties(type).name
-		: productName || customName
+		: customName || productName
 
 	description: {
 		if (customName.length > 0) {

--- a/pages/TanksTab.qml
+++ b/pages/TanksTab.qml
@@ -108,7 +108,7 @@ ListView {
 
 					PressArea {
 						anchors.fill: parent
-						enabled: tankTypeDelegate.tankModel.count > 1
+						enabled: tankTypeDelegate.mergeTanks
 						radius: gaugeGroup.radius
 						onClicked: {
 							expandedTanksLoader.tankModel = tankTypeDelegate.tankModel


### PR DESCRIPTION
Fix bug in TanksTab. We were enabling the ExpandedTanksView when there was more than 1 tank of a specific type. We should only enable this when there are 'merged' tanks displayed in the delegate.