### PR TITLE
Show the custom name on the DeviceList -> details page

### DIFF
--- a/data/common/Tank.qml
+++ b/data/common/Tank.qml
@@ -91,7 +91,7 @@ Device {
 		// This must be a generic Victron tank sensor, where the product name is always "Tank
 		// sensor" and there is no custom name, so use the tank type to provide a meaningful name.
 		? Gauges.tankProperties(type).name
-		: productName || customName
+		: customName || productName
 
 	description: {
 		if (customName.length > 0) {


### PR DESCRIPTION
Fixes #1365

Matthijs asked for this for tank devices, but I have done it for all devices. I can't think of a reason why you wouldn't want the custom name instead of a more generic name.