### PR TITLE
Sort BaseDeviceModel by device name by default

### DIFF
--- a/data/Generators.qml
+++ b/data/Generators.qml
@@ -11,6 +11,7 @@ QtObject {
 
 	property DeviceModel model: DeviceModel {
 		modelId: "generators"
+		sortBy: BaseDeviceModel.SortByDeviceInstance
 	}
 	property var first: model.firstObject
 

--- a/data/Generators.qml
+++ b/data/Generators.qml
@@ -13,7 +13,6 @@ QtObject {
 		modelId: "generators"
 		sortBy: BaseDeviceModel.SortByDeviceInstance
 	}
-	property var first: model.firstObject
 
 	function addGenerator(generator) {
 		model.addDevice(generator)

--- a/data/InverterChargers.qml
+++ b/data/InverterChargers.qml
@@ -17,6 +17,7 @@ QtObject {
 	// Devices from com.victronenergy.vebus
 	property DeviceModel veBusDevices: DeviceModel {
 		modelId: "veBusDevices"
+		sortBy: BaseDeviceModel.SortByDeviceInstance
 		onCountChanged: {
 			Qt.callLater(root.refreshNominalInverterPower)
 		}
@@ -25,6 +26,7 @@ QtObject {
 	// Devices from com.victronenergy.acsystem
 	property DeviceModel acSystemDevices: DeviceModel {
 		modelId: "acSystemDevices"
+		sortBy: BaseDeviceModel.SortByDeviceInstance
 		onCountChanged: {
 			Qt.callLater(root.refreshNominalInverterPower)
 		}
@@ -34,6 +36,7 @@ QtObject {
 	// (Inverter RS and Phoenix Inverter, which do not have AC inputs)
 	property DeviceModel inverterDevices: DeviceModel {
 		modelId: "inverterDevices"
+		sortBy: BaseDeviceModel.SortByDeviceInstance
 		onCountChanged: {
 			Qt.callLater(root.refreshNominalInverterPower)
 		}

--- a/pages/settings/devicelist/rs/PageRsSystemDevices.qml
+++ b/pages/settings/devicelist/rs/PageRsSystemDevices.qml
@@ -40,17 +40,10 @@ Page {
 		}
 	}
 
-	DeviceModel {
-		id: rsDeviceModel
-		modelId: "multirs"
-	}
 
 	GradientListView {
-		// A model of all the multi RS devices for this AC system, sorted by custom/product name.
-		// Instead of assigning a DeviceModel to the ListView, use AggregateDeviceModel as a
-		// convenience for sorting the model by custom/product name, rather than by device instance.
-		model: AggregateDeviceModel {
-			sourceModels: [ rsDeviceModel ]
+		model: DeviceModel {
+			id: rsDeviceModel
 		}
 
 		delegate: ListNavigationItem {

--- a/src/basedevicemodel.cpp
+++ b/src/basedevicemodel.cpp
@@ -165,6 +165,24 @@ void BaseDeviceModel::setModelId(const QString &modelId)
 	}
 }
 
+void BaseDeviceModel::setSortBy(int sortBy)
+{
+	if (count() > 0) {
+		qmlInfo(this) << "Changing sort order after initialization is not supported";
+		return;
+	}
+
+	if (m_sortBy != sortBy) {
+		m_sortBy = sortBy;
+		emit sortByChanged();
+	}
+}
+
+int BaseDeviceModel::sortBy() const
+{
+	return m_sortBy;
+}
+
 QVariant BaseDeviceModel::data(const QModelIndex &index, int role) const
 {
 	const int row = index.row();
@@ -215,6 +233,8 @@ bool BaseDeviceModel::addDevice(BaseDevice *device)
 	m_devices.insert(index, device);
 	emit endInsertRows();
 	emit countChanged();
+
+	connect(device, &BaseDevice::nameChanged, this, &BaseDeviceModel::deviceNameChanged);
 	refreshFirstObject();
 
 	return true;
@@ -225,7 +245,10 @@ bool BaseDeviceModel::removeDevice(const QString &serviceUid)
 	const int index = indexOf(serviceUid);
 	if (index >= 0) {
 		emit beginRemoveRows(QModelIndex(), index, index);
-		m_devices.removeAt(index);
+		BaseDevice *device = m_devices.takeAt(index);
+		if (device) {
+			device->disconnect(this);
+		}
 		emit endRemoveRows();
 		emit countChanged();
 		refreshFirstObject();
@@ -251,6 +274,11 @@ void BaseDeviceModel::clear()
 		return;
 	}
 	emit beginResetModel();
+	for (int i = 0; i < m_devices.count(); ++i) {
+		if (m_devices[i]) {
+			m_devices[i]->disconnect(this);
+		}
+	}
 	m_devices.clear();
 	emit endResetModel();
 	emit countChanged();
@@ -290,6 +318,64 @@ BaseDevice *BaseDeviceModel::deviceAt(int index) const
 	return m_devices.at(index);
 }
 
+void BaseDeviceModel::deviceNameChanged()
+{
+	BaseDevice *changedDevice = qobject_cast<BaseDevice *>(sender());
+	if (!changedDevice) {
+		qmlInfo(this) << "nameChanged() signal was not from a BaseDevice!";
+		return;
+	}
+
+	const int fromIndex = indexOf(changedDevice->serviceUid());
+	if (fromIndex < 0 || m_devices.count() == 0) {
+		return;
+	}
+
+	// Update the list order if needed
+	int toIndex = count() - 1;
+	for (int i = 0; i < m_devices.count(); ++i) {
+		if (lessThan(changedDevice, m_devices[i])) {
+			if (i > 0 && m_devices[i - 1] == changedDevice) {
+				// The device at the previous index is this changed device, so it is already at
+				// the correct index.
+				return;
+			}
+			// Move the entry to be immediately before this item.
+			toIndex = i > fromIndex ? i - 1 : i;
+			break;
+		}
+	}
+
+	if (fromIndex != toIndex) {
+		const int destIndex = toIndex > fromIndex ? toIndex + 1 : toIndex;
+		beginMoveRows(QModelIndex(), fromIndex, fromIndex, QModelIndex(), destIndex);
+		m_devices.move(fromIndex, toIndex);
+		endMoveRows();
+
+		if (fromIndex == 0 || toIndex == 0) {
+			refreshFirstObject();
+		}
+	}
+}
+
+bool BaseDeviceModel::lessThan(const BaseDevice *deviceA, const BaseDevice *deviceB) const
+{
+	if (!deviceA || !deviceB || deviceA == deviceB) {
+		return false;
+	}
+
+	if (m_sortBy == SortByDeviceName) {
+		if (deviceA->name().localeAwareCompare(deviceB->name()) < 0) {
+			return true;
+		}
+	} else if (m_sortBy == SortByDeviceInstance) {
+		if (deviceA->deviceInstance() < deviceB->deviceInstance()) {
+			return true;
+		}
+	}
+	return false;
+}
+
 int BaseDeviceModel::insertionIndex(const BaseDevice *newDevice) const
 {
 	if (newDevice->deviceInstance() < 0) {
@@ -297,11 +383,11 @@ int BaseDeviceModel::insertionIndex(const BaseDevice *newDevice) const
 		return static_cast<int>(m_devices.count());
 	}
 
-	// Sort device list from lowest to highest deviceInstance.
-	for (int i = 0; i < m_devices.count(); ++i) {
-		BaseDevice *device = m_devices[i];
-		if (device && device->deviceInstance() >= 0 && newDevice->deviceInstance() < device->deviceInstance()) {
-			return i;
+	if (m_sortBy != 0) {
+		for (int i = 0; i < m_devices.count(); ++i) {
+			if (lessThan(newDevice, m_devices[i])) {
+				return i;
+			}
 		}
 	}
 	return static_cast<int>(m_devices.count());

--- a/src/basedevicemodel.h
+++ b/src/basedevicemodel.h
@@ -77,12 +77,12 @@ private:
 	int m_productId = 0;
 };
 
-
 class BaseDeviceModel : public QAbstractListModel
 {
 	Q_OBJECT
 	QML_ELEMENT
 	Q_PROPERTY(int count READ count NOTIFY countChanged)
+	Q_PROPERTY(int sortBy READ sortBy WRITE setSortBy NOTIFY sortByChanged)
 	Q_PROPERTY(QString modelId READ modelId WRITE setModelId NOTIFY modelIdChanged)
 	Q_PROPERTY(BaseDevice *firstObject READ firstObject NOTIFY firstObjectChanged)
 
@@ -91,13 +91,22 @@ public:
 		DeviceRole = Qt::UserRole
 	};
 
+	enum SortBy {
+		SortByDeviceName = 0x1,
+		SortByDeviceInstance = 0x2  // Sort from lowest to highest
+	};
+	Q_ENUM(SortBy)
+
 	explicit BaseDeviceModel(QObject *parent = nullptr);
 
-	BaseDevice *firstObject() const;    // the object with the lowest DeviceInstance
+	BaseDevice *firstObject() const;
 	int count() const;
 
 	QString modelId() const;    // must be unique across all BaseDeviceModel instances
 	void setModelId(const QString &modelId);
+
+	void setSortBy(int sortBy);
+	int sortBy() const;
 
 	int rowCount(const QModelIndex &parent) const override;
 	QVariant data(const QModelIndex& index, int role) const override;
@@ -116,18 +125,22 @@ Q_SIGNALS:
 	void countChanged();
 	void firstObjectChanged();
 	void modelIdChanged();
+	void sortByChanged();
 
 protected:
 	QHash<int, QByteArray> roleNames() const override;
+	void deviceNameChanged();
 
 private:
 	int insertionIndex(const BaseDevice *device) const;
 	void refreshFirstObject();
+	bool lessThan(const BaseDevice *deviceA, const BaseDevice *deviceB) const;
 
 	QHash<int, QByteArray> m_roleNames;
 	QVector<QPointer<BaseDevice> > m_devices;
 	QPointer<BaseDevice> m_firstObject;
 	QString m_modelId;
+	int m_sortBy = SortByDeviceName;
 };
 
 } /* VenusOS */


### PR DESCRIPTION
All models that are used for displaying device lists should be sorted by device name. Only the inverter/charger and generator models need to be sorted solely by device instance, as this is used to determine the "first" or "main" inverter/charger and generator.

Fixes #1299