### PR TITLE
Allow generator auto-start to be toggled while generator is running

### DIFF
--- a/pages/controlcards/GeneratorCard.qml
+++ b/pages/controlcards/GeneratorCard.qml
@@ -39,7 +39,6 @@ ControlCard {
 		//% "Autostart"
 		text: qsTrId("controlcard_generator_label_autostart")
 		checked: root.generator.autoStart
-		enabled: root.generator.state !== VenusOS.Generators_State_Running
 		flat: true
 		bottomContent.children: [
 			ListLabel {


### PR DESCRIPTION
If the auto-start switch is disabled while the generator is running, then it is not possible to stop the generator if it started due to auto-start conditions.

This also aligns with the gui-v1 behavior, which allows this toggle to be changed while the generator is running.