### PR TITLE
Show text validation notification in non-error cases

### DIFF
--- a/components/Utils.js
+++ b/components/Utils.js
@@ -331,6 +331,6 @@ function toHexFormat(n) {
 // - InputValidation_Result_OK: the input text is valid, and can be saved, or red highlight can be removed
 // - InputValidation_Result_Unknown: the input text should not be saved, but is not invalid, so
 //   do not highlight with a red border. This is useful when the input string is empty.
-function validationResult(status, errorText = "", adjustedText = undefined) {
-	return { status: status, errorText: errorText, adjustedText: adjustedText }
+function validationResult(status, notificationText = "", adjustedText = undefined) {
+	return { status: status, notificationText: notificationText, adjustedText: adjustedText }
 }

--- a/components/listitems/ListTextField.qml
+++ b/components/listitems/ListTextField.qml
@@ -67,16 +67,11 @@ ListItem {
 
 		// If attempting to save, then show any errors and adjust the input text.
 		if (mode === VenusOS.InputValidation_ValidateAndSave) {
-			if (result.status === VenusOS.InputValidation_Result_Error) {
-				let errorText = result.errorText
-				if (errorText.length === 0) {
-					//% "The entered text does not have the correct format. Try again."
-					errorText = qsTrId("text_field_default_error_text")
-				}
-				if (textField.currentNotification) {
-					textField.currentNotification.close(true)
-				}
-				textField.currentNotification = Global.showToastNotification(VenusOS.Notification_Info, errorText, 5000)
+			if (textField.currentNotification) {
+				textField.currentNotification.close(true)
+			}
+			if (result.notificationText.length > 0) {
+				textField.currentNotification = Global.showToastNotification(VenusOS.Notification_Info, result.notificationText, 5000)
 			}
 			if (result.adjustedText != null) {
 				textField.text = result.adjustedText

--- a/pages/settings/debug/PageSettingsDemo.qml
+++ b/pages/settings/debug/PageSettingsDemo.qml
@@ -175,6 +175,20 @@ Page {
 				placeholderText: "Enter text"
 			}
 
+			ListTextField {
+				text: "Text input: forced capitalization, numbers disallowed"
+				placeholderText: "Enter text"
+				validateInput: function() {
+					if (textField.text.match(/[0-9]/)) {
+						return Utils.validationResult(VenusOS.InputValidation_Result_Error, "Numbers are not allowed!")
+					} else if (textField.text.match(/[a-z]/)) {
+						return Utils.validationResult(VenusOS.InputValidation_Result_OK, "Characters changed to uppercase", textField.text.toUpperCase())
+					} else {
+						return Utils.validationResult(VenusOS.InputValidation_Result_OK)
+					}
+				}
+			}
+
 			ListIntField {
 				text: "Number with 5 digits max"
 				maximumLength: 5


### PR DESCRIPTION
If notification text is passed to validationResult() when validating text input, then show this notification regardless of whether the validation succeeds or fails, instead of only showing it when validation fails.

This is useful for showing notification text when the input text is adjusted, for example.

Update the demo components page to demonstrate this.