### PR TITLE
Avoid unnecessary DC value separators in Inverter drilldown

### DIFF
--- a/components/CommonWords.qml
+++ b/components/CommonWords.qml
@@ -413,7 +413,7 @@ QtObject {
 	readonly property string signal_strength: qsTrId("common_words_signal_strength");
 
 	//: State of charge (as a percentage). %1 = the SOC value
-	//% "SOC %1%"
+	//% "SOC %1"
 	readonly property string soc_with_prefix: qsTrId("common_words_soc")
 
 	//: A speed measurement value

--- a/pages/invertercharger/OverviewInverterChargerPage.qml
+++ b/pages/invertercharger/OverviewInverterChargerPage.qml
@@ -121,12 +121,33 @@ Page {
 
 			ListQuantityGroup {
 				text: CommonWords.dc
-				textModel: [
-					{ value: dcPower.value, unit: VenusOS.Units_Watt, visible: root.serviceType !== "inverter" },
+
+				readonly property var _socModel: [
+					{ value: CommonWords.soc_with_prefix.arg(stateOfCharge.isValid ? Units.getCombinedDisplayText(VenusOS.Units_Percentage, stateOfCharge.value) : "--") },
+				]
+
+				readonly property var _inverterModel: [
+					{ value: dcVoltage.value, unit: VenusOS.Units_Volt_DC },
+					{ value: dcCurrent.value, unit: VenusOS.Units_Amp }
+				]
+
+				readonly property var _inverterChargerModel: [
+					{ value: dcPower.value, unit: VenusOS.Units_Watt },
 					{ value: dcVoltage.value, unit: VenusOS.Units_Volt_DC },
 					{ value: dcCurrent.value, unit: VenusOS.Units_Amp },
-					{ value: CommonWords.soc_with_prefix.arg(stateOfCharge.isValid ? stateOfCharge.value : "--"), visible: root.serviceType !== "inverter" || isInverterChargerItem.value === 1 },
-				]
+				].concat(_socModel)
+
+				textModel: {
+					if (root.serviceType === "inverter") {
+						if (isInverterChargerItem.value === 1) {
+							return _inverterModel.concat(_socModel)
+						} else {
+							return _inverterModel
+						}
+					} else {
+						return _inverterChargerModel
+					}
+				}
 			}
 
 			ListNavigationItem {


### PR DESCRIPTION
When showing the DC values, only add the necessary values to the quantity model, otherwise the repeater shows separators for values that are not required.

Also, display the SOC with the default percentage precision.