### PR TITLE
Genset UI: Run time and service changes

### DIFF
--- a/pages/settings/PageGenerator.qml
+++ b/pages/settings/PageGenerator.qml
@@ -48,89 +48,6 @@ Page {
 	ObjectModel {
 		id: startStopModel
 
-		ListTextItem {
-			id: state
-
-			text: CommonWords.state
-			allowed: root.startStopBindPrefix === root.generator0ServiceUid
-			secondaryText: activeCondition.isValid ? Global.generators.stateToText(generatorState.value, activeCondition.value) : '---'
-
-			VeQuickItem {
-				id: activeCondition
-				uid: root.startStopBindPrefix + "/RunningByConditionCode"
-			}
-		}
-
-		ListGeneratorError {
-			allowed: root.startStopBindPrefix === root.generator0ServiceUid
-			dataItem.uid: root.startStopBindPrefix + "/Error"
-		}
-
-		ListTextItem {
-			//% "Run time"
-			text: qsTrId("settings_page_relay_generator_run_time")
-			secondaryText: dataItem.isValid ? Utils.secondsToString(dataItem.value, false) : "0"
-			dataItem.uid: root.startStopBindPrefix + "/Runtime"
-			allowed: generatorState.value in [1, 2, 3] // Running, Warm-up, Cool-down
-		}
-
-		ListTextItem {
-			//% "Total run time"
-			text: qsTrId("settings_page_relay_generator_total_run_time")
-			secondaryText: Utils.secondsToString((accumulatedTotal.value || 0) - (accumulatedTotalOffset.value || 0), false)
-
-			VeQuickItem {
-				id: accumulatedTotal
-				uid: root.settingsBindPrefix + "/AccumulatedTotal"
-			}
-			VeQuickItem {
-				id: accumulatedTotalOffset
-				uid: root.settingsBindPrefix + "/AccumulatedTotalOffset"
-			}
-		}
-
-		ListTextItem {
-			//% "Time to service"
-			text: qsTrId("settings_page_relay_generator_time_to_service")
-			dataItem.uid: root.startStopBindPrefix + "/ServiceCounter"
-			secondaryText: Utils.secondsToString(dataItem.value, false)
-			allowed: defaultAllowed && dataItem.isValid
-		}
-
-		ListTextItem {
-			//% "Accumulated running time since last test run"
-			text: qsTrId("settings_page_relay_generator_accumulated_running_time")
-			showAccessLevel: VenusOS.User_AccessType_Service
-			allowed: defaultAllowed && nextTestRun.allowed
-			secondaryText: Utils.secondsToString(dataItem.value, false)
-			dataItem.uid: root.startStopBindPrefix + "/TestRunIntervalRuntime"
-		}
-
-		ListTextItem {
-			id: nextTestRun
-			//% "Time to next test run"
-			text: qsTrId("settings_page_relay_generator_time_to_next_test_run")
-			secondaryText: ""
-			dataItem.uid: root.startStopBindPrefix + "/NextTestRun"
-			allowed: dataItem.isValid && dataItem.value > 0
-
-			Timer {
-				running: parent.allowed && root.animationEnabled
-				repeat: true
-				interval: 1000
-				onTriggered: {
-					var now = new Date().getTime() / 1000
-					var remainingTime = parent.dataItem.value - now
-					if (remainingTime > 0) {
-						parent.secondaryText = Utils.secondsToString(remainingTime, false)
-						return
-					}
-					//% "Running now"
-					parent.secondaryText = qsTrId("settings_page_relay_generator_running_now")
-				}
-			}
-		}
-
 		ListSwitch {
 			//% "Autostart functionality"
 			text: qsTrId("settings_page_relay_generator_auto_start_enabled")
@@ -149,24 +66,30 @@ Page {
 			]
 		}
 
-		ListNavigationItem {
-			//% "Daily run time"
-			text: qsTrId("settings_page_relay_generator_daily_run_time")
-			onClicked: Global.pageManager.pushPage(dailyRunTimePage, { title: text })
+		ListTextItem {
+			//% "Current run time"
+			text: qsTrId("settings_page_relay_generator_run_time")
+			secondaryText: dataItem.isValid ? Utils.secondsToString(dataItem.value, false) : "0"
+			dataItem.uid: root.startStopBindPrefix + "/Runtime"
+			allowed: generatorState.value >= 1 && generatorState.value <= 3 // Running, Warm-up, Cool-down
+		}
 
-			Component {
-				id: dailyRunTimePage
+		ListTextItem {
+			id: state
 
-				Page {
-					GradientListView {
-						model: _dates
-						delegate: ListTextItem {
-							text: Qt.formatDate(new Date(parseInt(_dates[index]) * 1000), "dd-MM-yyyy") // TODO: locale-specific date format?
-							secondaryText: Utils.secondsToString(JSON.parse(historicalData.value)[_dates[index]], false)
-						}
-					}
-				}
+			text: CommonWords.state
+			allowed: root.startStopBindPrefix === root.generator0ServiceUid
+			secondaryText: activeCondition.isValid ? Global.generators.stateToText(generatorState.value, activeCondition.value) : '---'
+
+			VeQuickItem {
+				id: activeCondition
+				uid: root.startStopBindPrefix + "/RunningByConditionCode"
 			}
+		}
+
+		ListGeneratorError {
+			allowed: root.startStopBindPrefix === root.generator0ServiceUid
+			dataItem.uid: root.startStopBindPrefix + "/Error"
 		}
 
 		ListNavigationItem {
@@ -175,6 +98,17 @@ Page {
 				Global.pageManager.pushPage("/pages/settings/PageSettingsGenerator.qml",
 					{ title: text, settingsBindPrefix: root.settingsBindPrefix, startStopBindPrefix: root.startStopBindPrefix })
 			}
+		}
+
+		ListNavigationItem {
+			//% "Run time and service"
+			text: qsTrId("page_settings_generator_run_time_and_service")
+			onClicked: Global.pageManager.pushPage("/pages/settings/PageGeneratorRuntimeService.qml",
+													{
+														title: text,
+														settingsBindPrefix: root.settingsBindPrefix,
+														startStopBindPrefix: root.startStopBindPrefix
+													})
 		}
 	}
 }

--- a/pages/settings/PageGeneratorRuntimeService.qml
+++ b/pages/settings/PageGeneratorRuntimeService.qml
@@ -18,7 +18,7 @@ Page {
 	VeQuickItem {
 		id: state
 
-		uid: startStopBindPrefix + "/State"
+		uid: root.startStopBindPrefix ? root.startStopBindPrefix + "/State" : ""
 	}
 
 	VeQuickItem {
@@ -109,7 +109,7 @@ Page {
 				//% "Time to next test run"
 				text: qsTrId("settings_page_run_time_and_service_time_to_next_test_run")
 				secondaryText: ""
-				dataItem.uid: root.startStopBindPrefix + "/NextTestRun"
+				dataItem.uid: root.startStopBindPrefix ? root.startStopBindPrefix + "/NextTestRun" : ""
 				allowed: dataItem.isValid && dataItem.value > 0
 
 				Timer {
@@ -135,13 +135,13 @@ Page {
 				showAccessLevel: VenusOS.User_AccessType_Service
 				allowed: defaultAllowed && nextTestRun.allowed
 				secondaryText: Utils.secondsToString(dataItem.value, false)
-				dataItem.uid: root.startStopBindPrefix + "/TestRunIntervalRuntime"
+				dataItem.uid: root.startStopBindPrefix ? root.startStopBindPrefix + "/TestRunIntervalRuntime" : ""
 			}
 
 			ListTextItem {
 				//% "Time to service"
 				text: qsTrId("settings_page_run_time_and_service_time_to_service")
-				dataItem.uid: root.startStopBindPrefix + "/ServiceCounter"
+				dataItem.uid: root.startStopBindPrefix ? root.startStopBindPrefix + "/ServiceCounter" : ""
 				secondaryText: Math.round(dataItem.value / 60 / 60) + "h"
 				allowed: defaultAllowed && dataItem.isValid
 			}
@@ -180,7 +180,7 @@ Page {
 
 				VeQuickItem {
 					id: serviceReset
-					uid: startStopBindPrefix + "/ServiceCounterReset"
+					uid: root.startStopBindPrefix ? startStopBindPrefix + "/ServiceCounterReset" : ""
 				}
 			}
 		}

--- a/pages/settings/PageGeneratorRuntimeService.qml
+++ b/pages/settings/PageGeneratorRuntimeService.qml
@@ -11,6 +11,9 @@ Page {
 
 	property string settingsBindPrefix
 	property string startStopBindPrefix
+	property string gensetBindPrefix: ""
+
+	readonly property var _dates: historicalData.isValid ? Object.keys(JSON.parse(historicalData.value)).reverse() : 0
 
 	VeQuickItem {
 		id: state
@@ -18,14 +21,67 @@ Page {
 		uid: startStopBindPrefix + "/State"
 	}
 
+	VeQuickItem {
+		id: historicalData
+		uid: root.settingsBindPrefix + "/AccumulatedDaily"
+	}
+
+	VeQuickItem {
+		id: accumulatedTotalItem
+
+		uid: settingsBindPrefix + "/AccumulatedTotal"
+	}
+
 	GradientListView {
 		id: settingsListView
 
 		model: ObjectModel {
 
+			ListTextItem {
+				//% "Generator total run time (hours)"
+				text: qsTrId("page_settings_run_time_and_service_total_run_time")
+				allowed: gensetBindPrefix !== ""
+				secondaryText: Math.round(accumulatedTotalItem.value / 60 / 60) + "h"
+			}
+
+			ListIntField {
+				id: setTotalRunTime
+
+				//% "Generator total run time (hours)"
+				text: qsTrId("page_settings_run_time_and_service_total_run_time")
+				secondaryText: Math.round(accumulatedTotalItem.value / 60 / 60) - Math.round(dataItem.value / 60 / 60) + "h"
+				dataItem.uid: settingsBindPrefix + "/AccumulatedTotalOffset"
+				enabled: userHasWriteAccess && state.value === 0
+				allowed: dataItem.isValid && gensetBindPrefix === ""
+				maximumLength: 6
+				saveInput: function() {
+					dataItem.setValue(accumulatedTotalItem.value - parseInt(textField.text, 10) * 60 * 60)
+				}
+			}
+
+			ListNavigationItem {
+				//% "Daily run time"
+				text: qsTrId("settings_page_run_time_and_service_daily_run_time")
+				onClicked: Global.pageManager.pushPage(dailyRunTimePage, { title: text })
+
+				Component {
+					id: dailyRunTimePage
+
+					Page {
+						GradientListView {
+							model: _dates
+							delegate: ListTextItem {
+								text: Qt.formatDate(new Date(parseInt(_dates[index]) * 1000), "dd-MM-yyyy") // TODO: locale-specific date format?
+								secondaryText: Utils.secondsToString(JSON.parse(historicalData.value)[_dates[index]], false)
+							}
+						}
+					}
+				}
+			}
+
 			ListButton {
 				//% "Reset daily run time counters"
-				text: qsTrId("page_settings_generator_reset_daily_run_time_counters")
+				text: qsTrId("page_settings_run_time_and_service_reset_daily_run_time_counters")
 				button.text: CommonWords.press_to_reset
 				onClicked: {
 					if (state.value === 0) {
@@ -34,10 +90,10 @@ Page {
 						var todayInSeconds = today.getTime() / 1000
 						resetDaily.setValue('{"%1" : 0}'.arg(todayInSeconds.toString()))
 						//% "The daily runtime counter has been reset"
-						Global.showToastNotification(VenusOS.Notification_Info, qsTrId("page_settings_generator_runtime_counter_reset"))
+						Global.showToastNotification(VenusOS.Notification_Info, qsTrId("page_settings_run_time_and_service_runtime_counter_reset"))
 					} else if (state.value === 1) {
 						//% "It is not possible to modify the counters while the generator is running"
-						Global.showToastNotification(VenusOS.Notification_Info, qsTrId("page_settings_generator_runtime_counter_cant_reset_while_running"))
+						Global.showToastNotification(VenusOS.Notification_Info, qsTrId("page_settings_run_time_and_service_runtime_counter_cant_reset_while_running"))
 					}
 				}
 
@@ -48,25 +104,46 @@ Page {
 				}
 			}
 
-			ListIntField {
-				id: setTotalRunTime
+			ListTextItem {
+				id: nextTestRun
+				//% "Time to next test run"
+				text: qsTrId("settings_page_run_time_and_service_time_to_next_test_run")
+				secondaryText: ""
+				dataItem.uid: root.startStopBindPrefix + "/NextTestRun"
+				allowed: dataItem.isValid && dataItem.value > 0
 
-				//% "Generator total run time (hours)"
-				text: qsTrId("page_settings_generator_total_run_time")
-				secondaryText: Math.round(accumulatedTotalItem.value / 60 / 60) - Math.round(dataItem.value / 60 / 60)
-				dataItem.uid: settingsBindPrefix + "/AccumulatedTotalOffset"
-				enabled: userHasWriteAccess && state.value === 0
-				allowed: dataItem.isValid
-				maximumLength: 6
-				saveInput: function() {
-					dataItem.setValue(accumulatedTotalItem.value - parseInt(textField.text, 10) * 60 * 60)
+				Timer {
+					running: parent.allowed && root.animationEnabled
+					repeat: true
+					interval: 1000
+					onTriggered: {
+						var now = new Date().getTime() / 1000
+						var remainingTime = parent.dataItem.value - now
+						if (remainingTime > 0) {
+							parent.secondaryText = Utils.secondsToString(remainingTime, false)
+							return
+						}
+						//% "Running now"
+						parent.secondaryText = qsTrId("settings_page_run_time_and_service_running_now")
+					}
 				}
+			}
 
-				VeQuickItem {
-					id: accumulatedTotalItem
+			ListTextItem {
+				//% "Accumulated running time since last test run"
+				text: qsTrId("settings_page_run_time_and_service_accumulated_running_time")
+				showAccessLevel: VenusOS.User_AccessType_Service
+				allowed: defaultAllowed && nextTestRun.allowed
+				secondaryText: Utils.secondsToString(dataItem.value, false)
+				dataItem.uid: root.startStopBindPrefix + "/TestRunIntervalRuntime"
+			}
 
-					uid: settingsBindPrefix + "/AccumulatedTotal"
-				}
+			ListTextItem {
+				//% "Time to service"
+				text: qsTrId("settings_page_run_time_and_service_time_to_service")
+				dataItem.uid: root.startStopBindPrefix + "/ServiceCounter"
+				secondaryText: Math.round(dataItem.value / 60 / 60) + "h"
+				allowed: defaultAllowed && dataItem.isValid
 			}
 
 			ListIntField {
@@ -77,26 +154,32 @@ Page {
 				secondaryText: Math.round(dataItem.value / 60 / 60)
 				dataItem.uid: settingsBindPrefix + "/ServiceInterval"
 				saveInput: function() {
-					dataItem.setValue(parseInt(textField.text, 10) * 60 * 60)
-					//% "Service time interval set to %1h. Use the 'Reset service timer' button to reset the service timer."
-					Global.showToastNotification(VenusOS.Notification_Info, qsTrId("page_settings_generator_service_time_interval").arg(textField.text))
+					var serviceInterval = parseInt(textField.text, 10) * 60 * 60
+					dataItem.setValue(serviceInterval)
+					if (serviceInterval > 0) {
+						//% "Service time interval set to %1h. Use the 'Reset service timer' button to reset the service timer."
+						Global.showToastNotification(VenusOS.Notification_Info, qsTrId("page_settings_run_time_and_service_service_time_interval").arg(textField.text))
+					}
+					else {
+						//% "Service timer disabled."
+						Global.showToastNotification(VenusOS.Notification_Info, qsTrId("page_settings_run_time_and_service_service_time_disabled"))
+					}
 				}
 			}
 
 			ListButton {
 				//% "Reset service timer"
-				text: qsTrId("page_settings_generator_reset_service_timer")
+				text: qsTrId("page_settings_run_time_and_service_reset_service_timer")
 				button.text: CommonWords.press_to_reset
 				allowed: serviceReset.isValid
 				onClicked: {
 					serviceReset.setValue(1)
 					//% "The service timer has been reset"
-					Global.showToastNotification(VenusOS.Notification_Info, qsTrId("page_settings_generator_service_timer_has_been_reset"))
+					Global.showToastNotification(VenusOS.Notification_Info, qsTrId("page_settings_run_time_and_service_service_timer_has_been_reset"))
 				}
 
 				VeQuickItem {
 					id: serviceReset
-
 					uid: startStopBindPrefix + "/ServiceCounterReset"
 				}
 			}

--- a/pages/settings/PageSettingsGenerator.qml
+++ b/pages/settings/PageSettingsGenerator.qml
@@ -152,17 +152,6 @@ Page {
 				allowed: defaultAllowed && quietHours.checked
 				writeAccessLevel: VenusOS.User_AccessType_User
 			}
-
-			ListNavigationItem {
-				//% "Run time and service"
-				text: qsTrId("page_settings_generator_run_time_and_service")
-				onClicked: Global.pageManager.pushPage("/pages/settings/PageGeneratorRuntimeService.qml",
-													   {
-														   title: text,
-														   settingsBindPrefix: root.settingsBindPrefix,
-														   startStopBindPrefix: root.startStopBindPrefix
-													   })
-			}
 		}
 	}
 }

--- a/pages/settings/devicelist/ac-in/PageAcInModelGenset.qml
+++ b/pages/settings/devicelist/ac-in/PageAcInModelGenset.qml
@@ -53,6 +53,14 @@ ObjectModel {
 	}
 
 	ListTextItem {
+		//% "Current run time"
+		text: qsTrId("settings_page_genset_generator_run_time")
+		secondaryText: dataItem.isValid ? Utils.secondsToString(dataItem.value, false) : "0"
+		dataItem.uid: root.startStopBindPrefix + "/Runtime"
+		allowed: generatorState.value >= 1 && generatorState.value <= 3 // Running, Warm-up, Cool-down
+	}
+
+	ListTextItem {
 		//% "Control status"
 		text: qsTrId("ac-in-genset_auto_control_status")
 		secondaryText: activeCondition.isValid ? Global.generators.stateToText(generatorState.value, activeCondition.value) : "--"
@@ -150,19 +158,6 @@ ObjectModel {
 	}
 
 	ListNavigationItem {
-		//% "Auto start/stop"
-		text: qsTrId("ac-in-genset_auto_start_stop")
-		onClicked: {
-			const props = {
-				"title": text,
-				"settingsBindPrefix": root.settingsBindPrefix,
-				"startStopBindPrefix": root.startStopBindPrefix
-			}
-			Global.pageManager.pushPage("/pages/settings/PageGenerator.qml", props)
-		}
-	}
-
-	ListNavigationItem {
 		//% "Engine"
 		text: qsTrId("ac-in-genset_engine")
 		onClicked: {
@@ -228,14 +223,6 @@ ObjectModel {
 							dataItem.uid: root.bindPrefix + "/Engine/WindingTemperature"
 						}
 
-						ListTextItem {
-							//% "Operating time"
-							text: qsTrId("ac-in-genset_operating_time")
-							allowed: defaultAllowed && dataItem.isValid
-							dataItem.uid: root.bindPrefix + "/Engine/OperatingHours"
-							secondaryText: Utils.formatAsHHMM(dataItem.value, true)
-						}
-
 						ListQuantityItem {
 							//% "Starter battery voltage"
 							text: qsTrId("ac-in-genset_starter_battery_voltage")
@@ -255,6 +242,26 @@ ObjectModel {
 			}
 		}
 	}
+
+	ListNavigationItem {
+		text: CommonWords.settings
+			onClicked: {
+				Global.pageManager.pushPage("/pages/settings/PageSettingsGenerator.qml",
+					{ title: text, settingsBindPrefix: root.settingsBindPrefix, startStopBindPrefix: root.startStopBindPrefix })
+			}
+	}
+
+	ListNavigationItem {
+			//% "Run time and service"
+			text: qsTrId("page_settings_generator_run_time_and_service")
+			onClicked: Global.pageManager.pushPage("/pages/settings/PageGeneratorRuntimeService.qml",
+													{
+														title: text,
+														settingsBindPrefix: root.settingsBindPrefix,
+														startStopBindPrefix: root.startStopBindPrefix,
+														gensetBindPrefix: root.bindPrefix
+													})
+		}
 
 	ListNavigationItem {
 		text: CommonWords.device_info_title

--- a/pages/settings/devicelist/ac-in/PageAcInModelGenset.qml
+++ b/pages/settings/devicelist/ac-in/PageAcInModelGenset.qml
@@ -56,7 +56,7 @@ ObjectModel {
 		//% "Current run time"
 		text: qsTrId("settings_page_genset_generator_run_time")
 		secondaryText: dataItem.isValid ? Utils.secondsToString(dataItem.value, false) : "0"
-		dataItem.uid: root.startStopBindPrefix + "/Runtime"
+		dataItem.uid: root.startStopBindPrefix ? root.startStopBindPrefix + "/Runtime" : ""
 		allowed: generatorState.value >= 1 && generatorState.value <= 3 // Running, Warm-up, Cool-down
 	}
 


### PR DESCRIPTION
- Remove Operating time from the Engine page.
- Sync total run time with genset `/Engine/OperatingHours` (dbus_generator)
- Add 'Run time and service' menu at top level
- Remove Total run time from top level since its part of the run time and service menu.
- Change 'Run time' to 'Current run time' on top-level
- Only show 'Current run time' when generator is running, warming up or cooling down.
- Move service interval setting to run time and service menu
- Reordered menu items of generator start stop (relay).
- Changed toast message when disabling the service interval timer.

Fixes #1409