### PR TITLE
CAN Profiles: add profile for 500kbit without services

### DIFF
--- a/pages/settings/PageSettingsCanbus.qml
+++ b/pages/settings/PageSettingsCanbus.qml
@@ -106,6 +106,12 @@ Page {
 						display: qsTrId("settings_up_bu_no_services"),
 						value: VenusOS.CanBusProfile_None250,
 						readOnly: true
+					},
+					{
+						//% "Up, but no services (500 kbit/s)"
+						display: qsTrId("settings_up_but_no_services_500"),
+						value: VenusOS.CanBusProfile_None500,
+						readOnly: true
 					}
 				]
 			}

--- a/src/enums.h
+++ b/src/enums.h
@@ -444,7 +444,8 @@ public:
 		CanBusProfile_Oceanvolt,
 		CanBusProfile_None250,
 		CanBusProfile_RvC,
-		CanBusProfile_HighVoltage
+		CanBusProfile_HighVoltage,
+		CanBusProfile_None500
 	};
 	Q_ENUM(CanBusProfile_Type)
 


### PR DESCRIPTION
Copy from gui-v1, [see](https://github.com/victronenergy/gui/commit/93f10e73260dbe47d1a39a30080f03a4de54aee5) here (not in master yet).