### PR TITLE
Handle invalid state changes in FirmwareUpdate

### DIFF
--- a/components/FirmwareUpdate.qml
+++ b/components/FirmwareUpdate.qml
@@ -28,9 +28,13 @@ QtObject {
 
 		// Make sure notificationLayer is ready before reading the firmware state,
 		// otherwise Global.showToastNotification() call inside onValueChanged signal handler will fail.
-		uid: !!Global.notificationLayer ? Global.venusPlatform.serviceUid + "/Firmware/State" : ""
+		uid: (Global.allPagesLoaded && !!Global.notificationLayer) ? Global.venusPlatform.serviceUid + "/Firmware/State" : ""
 
 		onValueChanged: {
+			if (uid === "" || !isValid) {
+				return
+			}
+
 			let msg = ""
 			switch (value) {
 			case FirmwareUpdater.Idle: // fall through

--- a/data/DataManager.qml
+++ b/data/DataManager.qml
@@ -129,6 +129,6 @@ Item {
 		active: false
 		asynchronous: true
 		onStatusChanged: if (status === Loader.Error) console.warn("Unable to load data manager:", source)
-		onLoaded: Global.dataManagerLoaded = true
+		onLoaded: Qt.callLater(function() { Global.dataManagerLoaded = true })
 	}
 }

--- a/pages/MainView.qml
+++ b/pages/MainView.qml
@@ -79,7 +79,7 @@ Item {
 			anchors.fill: parent
 			onCurrentIndexChanged: navBar.setCurrentIndex(currentIndex)
 			contentChildren: swipePageModel.children
-			Component.onCompleted: Global.allPagesLoaded = true
+			Component.onCompleted: Qt.callLater(function() { Global.allPagesLoaded = true })
 		}
 	}
 


### PR DESCRIPTION
Ensure that we don't raise spurious notifications for invalid state values.

Also, perform some global state transitions asynchronously to avoid potential issues with synchronous data accesses in bindings which depend on Global.dataManagerLoaded or Global.allPagesLoaded.

Contributes to issue #1447