### PR TITLE
Fix bug in configuring custom tank shapes

### DIFF
--- a/pages/settings/devicelist/tank/PageTankShape.qml
+++ b/pages/settings/devicelist/tank/PageTankShape.qml
@@ -51,8 +51,7 @@ Page {
 			if (_saving) {
 				return
 			}
-
-			if (value === undefined) {
+			if (!value) {
 				pointsListView.model = []
 			} else if (value.length > 0) {
 				// Value is a comma-separated list of "<sensor-level>:<volume>" pairs.


### PR DESCRIPTION
Fixes #1444

A tank with no custom shape defined has a `.../Shape` value of `""`, not `undefined`.