### PR TITLE
generators: add option to skip warm up when start is triggered by inverter overload

### DIFF
--- a/components/PageGensetModel.qml
+++ b/components/PageGensetModel.qml
@@ -74,7 +74,7 @@ ObjectModel {
 
 		VeQuickItem {
 			id: activeCondition
-			uid: root.startStopBindPrefix ? root.startStopBindPrefix + "/RunningByCondition" : ""
+			uid: root.startStopBindPrefix ? root.startStopBindPrefix + "/RunningByConditionCode" : ""
 		}
 
 		VeQuickItem {

--- a/pages/settings/GeneratorCondition.qml
+++ b/pages/settings/GeneratorCondition.qml
@@ -14,6 +14,7 @@ ListNavigationItem {
 	property string timeUnit: "s"
 	property int decimals: 1
 	property bool startValueIsGreater: true
+	property bool supportsWarmup: false
 	property string name: text
 
 	//% "Use %1 value to start/stop"
@@ -130,6 +131,13 @@ ListNavigationItem {
 						allowed: dataItem.isValid
 						dataItem.uid: bindPrefix + "/StopTimer"
 						suffix: root.timeUnit
+					}
+
+					ListSwitch {
+						//% "Skip generator warm-up"
+						text: qsTrId("settings_generator_condition_skip_warmup")
+						dataItem.uid: bindPrefix + "/SkipWarmup"
+						allowed: root.supportsWarmup
 					}
 				}
 			}

--- a/pages/settings/PageGeneratorConditions.qml
+++ b/pages/settings/PageGeneratorConditions.qml
@@ -140,6 +140,7 @@ Page {
 				enableDescription: qsTrId("page_generator_conditions_start_on_overload_warning")
 				startTimeDescription: CommonWords.start_when_warning_is_active_for
 				stopTimeDescription: CommonWords.when_warning_is_cleared_stop_after
+				supportsWarmup: (capabilities.value & 1)
 				bindPrefix: root.bindPrefix + "/InverterOverload"
 			}
 


### PR DESCRIPTION
Also fixes a small bug where the "Control Status" field shows "Stopped" instead of the condition that started the generator. The dbus field `/RunningByConditionCode` must be used to parse the condition name instead of `/RunningByCondition`.