### PR TITLE
EvChargerSetupPage: show display lock switch only if available

### DIFF
--- a/pages/evcs/EvChargerSetupPage.qml
+++ b/pages/evcs/EvChargerSetupPage.qml
@@ -50,6 +50,7 @@ Page {
 				text: qsTrId("evcs_lock_charger_display")
 				dataItem.uid: root.evCharger.serviceUid + "/EnableDisplay"
 				invertSourceValue: true
+				allowed: defaultAllowed && dataItem.isValid
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #1486