### PR TITLE
Battery history: Hide menu if history unsupported

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -558,6 +558,7 @@ set (VENUS_QML_MODULE_SOURCES
     pages/settings/devicelist/PageMotorDrive.qml
     pages/settings/devicelist/PageUnsupportedDevice.qml
     pages/settings/devicelist/battery/BatteryDetails.qml
+    pages/settings/devicelist/battery/BatteryHistory.qml
     pages/settings/devicelist/battery/BatterySettingsAlarmModel.qml
     pages/settings/devicelist/battery/BatterySettingsRelayModel.qml
     pages/settings/devicelist/battery/FuseInfo.qml

--- a/pages/settings/devicelist/battery/BatteryHistory.qml
+++ b/pages/settings/devicelist/battery/BatteryHistory.qml
@@ -1,0 +1,133 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+QtObject {
+	id: root
+
+	required property string bindPrefix
+
+	readonly property VeQuickItem deepestDischarge: VeQuickItem {
+		uid: root.bindPrefix + "/History/DeepestDischarge"
+	}
+	readonly property VeQuickItem lastDischarge: VeQuickItem {
+		uid: root.bindPrefix + "/History/LastDischarge"
+	}
+	readonly property VeQuickItem averageDischarge: VeQuickItem {
+		uid: root.bindPrefix + "/History/AverageDischarge"
+	}
+	readonly property VeQuickItem chargeCycles: VeQuickItem {
+		uid: root.bindPrefix + "/History/ChargeCycles"
+	}
+	readonly property VeQuickItem fullDischarges: VeQuickItem {
+		uid: root.bindPrefix + "/History/FullDischarges"
+	}
+	readonly property VeQuickItem totalAhDrawn: VeQuickItem {
+		uid: root.bindPrefix + "/History/TotalAhDrawn"
+	}
+	readonly property VeQuickItem minimumVoltage: VeQuickItem {
+		uid: root.bindPrefix + "/History/MinimumVoltage"
+	}
+	readonly property VeQuickItem maximumVoltage: VeQuickItem {
+		uid: root.bindPrefix + "/History/MaximumVoltage"
+	}
+	readonly property VeQuickItem minimumCellVoltage: VeQuickItem {
+		uid: root.bindPrefix + "/History/MinimumCellVoltage"
+	}
+	readonly property VeQuickItem maximumCellVoltage: VeQuickItem {
+		uid: root.bindPrefix + "/History/MaximumCellVoltage"
+	}
+	readonly property VeQuickItem timeSinceLastFullCharge: VeQuickItem {
+		uid: root.bindPrefix + "/History/TimeSinceLastFullCharge"
+	}
+	readonly property VeQuickItem automaticSyncs: VeQuickItem {
+		uid: root.bindPrefix + "/History/AutomaticSyncs"
+	}
+	readonly property VeQuickItem lowVoltageAlarms: VeQuickItem {
+		uid: root.bindPrefix + "/History/LowVoltageAlarms"
+	}
+	readonly property VeQuickItem highVoltageAlarms: VeQuickItem {
+		uid: root.bindPrefix + "/History/HighVoltageAlarms"
+	}
+	readonly property VeQuickItem lowStarterVoltageAlarms: VeQuickItem {
+		uid: root.bindPrefix + "/History/LowStarterVoltageAlarms"
+	}
+	readonly property VeQuickItem highStarterVoltageAlarms: VeQuickItem {
+		uid: root.bindPrefix + "/History/HighStarterVoltageAlarms"
+	}
+	readonly property VeQuickItem minimumStarterVoltage: VeQuickItem {
+		uid: root.bindPrefix + "/History/MinimumStarterVoltage"
+	}
+	readonly property VeQuickItem maximumStarterVoltage: VeQuickItem {
+		uid: root.bindPrefix + "/History/MaximumStarterVoltage"
+	}
+	readonly property VeQuickItem minimumTemperature: VeQuickItem {
+		uid: root.bindPrefix + "/History/MinimumTemperature"
+	}
+	readonly property VeQuickItem maximumTemperature: VeQuickItem {
+		uid: root.bindPrefix + "/History/MaximumTemperature"
+	}
+	readonly property VeQuickItem dischargedEnergy: VeQuickItem {
+		uid: root.bindPrefix + "/History/DischargedEnergy"
+	}
+	readonly property VeQuickItem chargedEnergy: VeQuickItem {
+		uid: root.bindPrefix + "/History/ChargedEnergy"
+	}
+
+	readonly property VeQuickItem hasStarterVoltage: VeQuickItem {
+		uid: root.bindPrefix + "/Settings/HasStarterVoltage"
+	}
+	readonly property VeQuickItem hasTemperature: VeQuickItem {
+		uid: root.bindPrefix + "/Settings/HasTemperature"
+	}
+
+	readonly property bool allowsDeepestDischarge: deepestDischarge.isValid
+	readonly property bool allowsLastDischarge: lastDischarge.isValid
+	readonly property bool allowsAverageDischarge: averageDischarge.isValid
+	readonly property bool allowsChargeCycles: chargeCycles.isValid
+	readonly property bool allowsFullDischarges: fullDischarges.isValid
+	readonly property bool allowsTotalAhDrawn: totalAhDrawn.isValid
+	readonly property bool allowsMinimumVoltage: minimumVoltage.isValid
+	readonly property bool allowsMaximumVoltage: maximumVoltage.isValid
+	readonly property bool allowsMinimumCellVoltage: minimumCellVoltage.isValid
+	readonly property bool allowsMaximumCellVoltage: maximumCellVoltage.isValid
+	readonly property bool allowsTimeSinceLastFullCharge: timeSinceLastFullCharge.isValid
+	readonly property bool allowsAutomaticSyncs: automaticSyncs.isValid
+	readonly property bool allowsLowVoltageAlarms: lowVoltageAlarms.isValid
+	readonly property bool allowsHighVoltageAlarms: highVoltageAlarms.isValid
+	readonly property bool allowsLowStarterVoltageAlarms: lowStarterVoltageAlarms.isValid && hasStarterVoltage.isValid && hasStarterVoltage.value
+	readonly property bool allowsHighStarterVoltageAlarms: highStarterVoltageAlarms.isValid && hasStarterVoltage.isValid && hasStarterVoltage.value
+	readonly property bool allowsMinimumStarterVoltage: minimumStarterVoltage.isValid && hasStarterVoltage.isValid && hasStarterVoltage.value
+	readonly property bool allowsMaximumStarterVoltage: maximumStarterVoltage.isValid && hasStarterVoltage.isValid && hasStarterVoltage.value
+	readonly property bool allowsMinimumTemperature: minimumTemperature.isValid && hasTemperature.value === 1
+	readonly property bool allowsMaximumTemperature: maximumTemperature.isValid && hasTemperature.value === 1
+	readonly property bool allowsDischargedEnergy: dischargedEnergy.isValid
+	readonly property bool allowsChargedEnergy: chargedEnergy.isValid
+
+	readonly property bool hasAllowedItem: allowsDeepestDischarge
+		|| allowsLastDischarge
+		|| allowsAverageDischarge
+		|| allowsChargeCycles
+		|| allowsFullDischarges
+		|| allowsTotalAhDrawn
+		|| allowsMinimumVoltage
+		|| allowsMaximumVoltage
+		|| allowsMinimumCellVoltage
+		|| allowsMaximumCellVoltage
+		|| allowsTimeSinceLastFullCharge
+		|| allowsAutomaticSyncs
+		|| allowsLowVoltageAlarms
+		|| allowsHighVoltageAlarms
+		|| allowsLowStarterVoltageAlarms
+		|| allowsHighStarterVoltageAlarms
+		|| allowsMinimumStarterVoltage
+		|| allowsMaximumStarterVoltage
+		|| allowsMinimumTemperature
+		|| allowsMaximumTemperature
+		|| allowsDischargedEnergy
+		|| allowsChargedEnergy
+}

--- a/pages/settings/devicelist/battery/PageBattery.qml
+++ b/pages/settings/devicelist/battery/PageBattery.qml
@@ -286,10 +286,15 @@ Page {
 
 			ListNavigationItem {
 				text: CommonWords.history
-				allowed: !isFiamm48TL
+				allowed: !isFiamm48TL && batteryHistory.hasAllowedItem
 				onClicked: {
 					Global.pageManager.pushPage("/pages/settings/devicelist/battery/PageBatteryHistory.qml",
-							{ "title": text, "bindPrefix": root.battery.serviceUid })
+							{ "title": text, "bindPrefix": root.battery.serviceUid, "history": batteryHistory })
+				}
+
+				BatteryHistory {
+					id: batteryHistory
+					bindPrefix: root.battery.serviceUid
 				}
 			}
 

--- a/pages/settings/devicelist/battery/PageBatteryHistory.qml
+++ b/pages/settings/devicelist/battery/PageBatteryHistory.qml
@@ -9,183 +9,171 @@ import Victron.VenusOS
 Page {
 	id: root
 
-	property string bindPrefix
+	required property string bindPrefix
+	required property BatteryHistory history
 
 	GradientListView {
 		model: ObjectModel {
 			ListQuantityItem {
 				//% "Deepest discharge"
 				text: qsTrId("batteryalarms_deepest_discharge")
-				dataItem.uid: root.bindPrefix + "/History/DeepestDischarge"
-				allowed: defaultAllowed && dataItem.isValid
+				allowed: defaultAllowed && root.history.allowsDeepestDischarge
 				unit: VenusOS.Units_AmpHour
+				value: allowed ? root.history.deepestDischarge.value : NaN
 			}
 
 			ListQuantityItem {
 				//% "Last discharge"
 				text: qsTrId("batteryhistory_last_discharge")
-				dataItem.uid: root.bindPrefix + "/History/LastDischarge"
-				allowed: defaultAllowed && dataItem.isValid
+				allowed: defaultAllowed && root.history.allowsLastDischarge
 				unit: VenusOS.Units_AmpHour
+				value: allowed ? root.history.lastDischarge.value : NaN
 			}
 
 			ListQuantityItem {
 				//% "Average discharge"
 				text: qsTrId("batteryhistory_average_discharge")
-				dataItem.uid: root.bindPrefix + "/History/AverageDischarge"
-				allowed: defaultAllowed && dataItem.isValid
+				allowed: defaultAllowed && root.history.allowsAverageDischarge
 				unit: VenusOS.Units_AmpHour
+				value: allowed ? root.history.averageDischarge.value : NaN
 			}
 
 			ListTextItem {
 				//% "Total charge cycles"
 				text: qsTrId("batteryhistory_total_charge_cycles")
-				dataItem.uid: root.bindPrefix + "/History/ChargeCycles"
-				allowed: defaultAllowed && dataItem.isValid
+				allowed: defaultAllowed && root.history.allowsChargeCycles
+				secondaryText: allowed ? root.history.chargeCycles.value : ""
 			}
 
 			ListTextItem {
 				//% "Number of full discharges"
 				text: qsTrId("batteryhistory_number_of_full_discharges")
-				dataItem.uid: root.bindPrefix + "/History/FullDischarges"
-				allowed: defaultAllowed && dataItem.isValid
+				allowed: defaultAllowed && root.history.allowsFullDischarges
+				secondaryText: allowed ? root.history.fullDischarges.value : ""
 			}
 
 			ListQuantityItem {
 				//% "Cumulative Ah drawn"
 				text: qsTrId("batteryhistory_cumulative_ah_drawn")
-				dataItem.uid: root.bindPrefix + "/History/TotalAhDrawn"
-				allowed: defaultAllowed && dataItem.isValid
+				allowed: defaultAllowed && root.history.allowsTotalAhDrawn
 				unit: VenusOS.Units_AmpHour
+				value: allowed ? root.history.totalAhDrawn.value : NaN
 			}
 
 			ListQuantityItem {
 				text: CommonWords.minimum_voltage
-				dataItem.uid: root.bindPrefix + "/History/MinimumVoltage"
-				allowed: defaultAllowed && dataItem.isValid
+				allowed: defaultAllowed && root.history.allowsMinimumVoltage
 				unit: VenusOS.Units_Volt_DC
+				value: allowed ? root.history.minimumVoltage.value : NaN
 			}
 
 			ListQuantityItem {
 				text: CommonWords.maximum_voltage
-				dataItem.uid: root.bindPrefix + "/History/MaximumVoltage"
-				allowed: defaultAllowed && dataItem.isValid
+				allowed: defaultAllowed && root.history.allowsMaximumVoltage
 				unit: VenusOS.Units_Volt_DC
+				value: allowed ? root.history.maximumVoltage.value : NaN
 			}
 
 			ListQuantityItem {
 				//% "Minimum cell voltage"
 				text: qsTrId("batteryhistory_minimum_cell_voltage")
-				dataItem.uid: root.bindPrefix + "/History/MinimumCellVoltage"
-				allowed: defaultAllowed && dataItem.isValid
+				allowed: defaultAllowed && root.history.allowsMinimumCellVoltage
 				unit: VenusOS.Units_Volt_DC
+				value: allowed ? root.history.minimumCellVoltage.value : NaN
 				precision: 3
 			}
 
 			ListQuantityItem {
 				//% "Maximum cell voltage"
 				text: qsTrId("batteryhistory_maximum_cell_voltage")
-				dataItem.uid: root.bindPrefix + "/History/MaximumCellVoltage"
-				allowed: defaultAllowed && dataItem.isValid
+				allowed: defaultAllowed && root.history.allowsMaximumCellVoltage
 				unit: VenusOS.Units_Volt_DC
+				value: allowed ? root.history.maximumCellVoltage.value : NaN
 				precision: 3
 			}
 
 			ListTextItem {
 				//% "Time since last full charge"
 				text: qsTrId("batteryhistory_time_since_last_full_charge")
-				dataItem.uid: root.bindPrefix + "/History/TimeSinceLastFullCharge"
-				allowed: defaultAllowed && dataItem.isValid
-				secondaryText: Utils.secondsToString(dataItem.value)
+				allowed: defaultAllowed && root.history.allowsTimeSinceLastFullCharge
+				secondaryText: allowed ? Utils.secondsToString(root.history.timeSinceLastFullCharge.value) : ""
 			}
 
 			ListTextItem {
 				//% "Synchronisation count"
 				text: qsTrId("batteryhistory_synchronisation_count")
-				dataItem.uid: root.bindPrefix + "/History/AutomaticSyncs"
-				allowed: defaultAllowed && dataItem.isValid
+				allowed: defaultAllowed && root.history.allowsAutomaticSyncs
+				secondaryText: allowed ? root.history.automaticSyncs.value : ""
 			}
 
 			ListTextItem {
 				text: CommonWords.low_voltage_alarms
-				dataItem.uid: root.bindPrefix + "/History/LowVoltageAlarms"
-				allowed: defaultAllowed && dataItem.isValid
+				allowed: defaultAllowed && root.history.allowsLowVoltageAlarms
+				secondaryText: allowed ? root.history.lowVoltageAlarms.value : ""
 			}
 
 			ListTextItem {
 				text: CommonWords.high_voltage_alarms
-				dataItem.uid: root.bindPrefix + "/History/HighVoltageAlarms"
-				allowed: defaultAllowed && dataItem.isValid
+				allowed: defaultAllowed && root.history.allowsHighVoltageAlarms
+				secondaryText: allowed ? root.history.highVoltageAlarms.value : ""
 			}
 
 			ListTextItem {
-				id: lowStarterVoltageAlarm
-
 				//% "Low starter battery voltage alarms"
 				text: qsTrId("batteryhistory_low_starter_bat_voltage_alarms")
-				dataItem.uid: visible ? root.bindPrefix + "/History/LowStarterVoltageAlarms" : ""
-				allowed: defaultAllowed && hasStarterVoltage.isValid && hasStarterVoltage.value
-
-				VeQuickItem {
-					id: hasStarterVoltage
-					uid: root.bindPrefix + "/Settings/HasStarterVoltage"
-				}
+				allowed: defaultAllowed && root.history.allowsLowStarterVoltageAlarms
+				secondaryText: allowed ? root.history.lowStarterVoltageAlarms.value : ""
 			}
 
 			ListTextItem {
-				//% "High starter batttery voltage alarms"
+				//% "High starter battery voltage alarms"
 				text: qsTrId("batteryhistory_high_starter_bat_voltage_alarms")
-				dataItem.uid: visible ? root.bindPrefix + "/History/HighStarterVoltageAlarms" : ""
-				allowed: defaultAllowed && lowStarterVoltageAlarm.visible
+				allowed: defaultAllowed && root.history.allowsHighStarterVoltageAlarms
+				secondaryText: allowed ? root.history.highStarterVoltageAlarms.value : ""
 			}
 
 			ListQuantityItem {
 				//% "Minimum starter battery voltage"
 				text: qsTrId("batteryhistory_minimum_starter_bat_voltage")
-				dataItem.uid: visible ? root.bindPrefix + "/History/MinimumStarterVoltage" : ""
-				allowed: defaultAllowed && lowStarterVoltageAlarm.visible
+				allowed: defaultAllowed && root.history.allowsMinimumStarterVoltage
+				value: allowed ? root.history.minimumStarterVoltage.value : NaN
 				unit: VenusOS.Units_Volt_DC
 			}
 
 			ListQuantityItem {
 				//% "Maximum starter battery voltage"
 				text: qsTrId("batteryhistory_maximum_starter_bat_voltage")
-				dataItem.uid: visible ? root.bindPrefix + "/History/MaximumStarterVoltage" : ""
-				allowed: defaultAllowed && lowStarterVoltageAlarm.visible
+				allowed: defaultAllowed && root.history.allowsMaximumStarterVoltage
+				value: allowed ? root.history.maximumStarterVoltage.value : NaN
 				unit: VenusOS.Units_Volt_DC
 			}
 
 			ListTemperatureItem {
 				text: CommonWords.minimum_temperature
-				allowed: defaultAllowed && hasTemperature.value === 1 && dataItem.isValid
-				dataItem.uid: root.bindPrefix + "/History/MinimumTemperature"
-
-				VeQuickItem {
-					id: hasTemperature
-					uid: root.bindPrefix + "/Settings/HasTemperature"
-				}
+				allowed: defaultAllowed && root.history.allowsMinimumTemperature
+				value: allowed ? root.history.minimumTemperature.value : NaN
 			}
 
 			ListTemperatureItem {
 				text: CommonWords.maximum_temperature
-				allowed: defaultAllowed && hasTemperature.value === 1 && dataItem.isValid
-				dataItem.uid: root.bindPrefix + "/History/MaximumTemperature"
+				allowed: defaultAllowed && root.history.allowsMaximumTemperature
+				value: allowed ? root.history.maximumTemperature.value : NaN
 			}
 
 			ListQuantityItem {
 				//% "Discharged energy"
 				text: qsTrId("batteryhistory_discharged_energy")
-				dataItem.uid: root.bindPrefix + "/History/DischargedEnergy"
-				allowed: defaultAllowed && dataItem.isValid
+				allowed: defaultAllowed && root.history.allowsDischargedEnergy
 				unit: VenusOS.Units_Energy_KiloWattHour
+				value: allowed ? root.history.dischargedEnergy.value : NaN
 			}
 
 			ListQuantityItem {
 				//% "Charged energy"
 				text: qsTrId("batteryhistory_charged_energy")
-				dataItem.uid: root.bindPrefix + "/History/ChargedEnergy"
-				allowed: defaultAllowed && dataItem.isValid
+				allowed: defaultAllowed && root.history.allowsChargedEnergy
 				unit: VenusOS.Units_Energy_KiloWattHour
+				value: allowed ? root.history.chargedEnergy.value : NaN
 			}
 
 			ListResetHistoryLabel {


### PR DESCRIPTION
Hide the battery history submenu if none of the battery history paths are supported.

As per 72dc5627c2c5261145d1060d37abb76447e81cde from gui-v1.

Fixes #1477