### PR TITLE
Avoid unnecessary VeQuickItem::value reads

### DIFF
--- a/components/AcPhase.qml
+++ b/components/AcPhase.qml
@@ -10,14 +10,11 @@ QtObject {
 	id: root
 
 	property string serviceUid
-	readonly property real frequency: _frequency.value === undefined ? NaN : _frequency.value
-	readonly property real current: _current.value === undefined ? NaN : _current.value
-	readonly property real voltage: _voltage.value === undefined ? NaN : _voltage.value
-	readonly property real power: _power.value === undefined ? NaN : _power.value
-	readonly property bool valid: !isNaN(frequency)
-								  && !isNaN(current)
-								  && !isNaN(voltage)
-								  && !isNaN(power)
+	readonly property real frequency: _frequency.isValid ? _frequency.value : NaN
+	readonly property real current: _current.isValid ? _current.value : NaN
+	readonly property real voltage: _voltage.isValid ? _voltage.value : NaN
+	readonly property real power: _power.isValid ? _power.value : NaN
+	readonly property bool valid: _frequency.isValid && _current.isValid && _voltage.isValid && _power.isValid
 
 	readonly property VeQuickItem _frequency: VeQuickItem {
 		uid: serviceUid + "/F"

--- a/components/AcPhase.qml
+++ b/components/AcPhase.qml
@@ -14,7 +14,6 @@ QtObject {
 	readonly property real current: _current.isValid ? _current.value : NaN
 	readonly property real voltage: _voltage.isValid ? _voltage.value : NaN
 	readonly property real power: _power.isValid ? _power.value : NaN
-	readonly property bool valid: _frequency.isValid && _current.isValid && _voltage.isValid && _power.isValid
 
 	readonly property VeQuickItem _frequency: VeQuickItem {
 		uid: serviceUid + "/F"

--- a/components/listitems/ListQuantityItem.qml
+++ b/components/listitems/ListQuantityItem.qml
@@ -20,7 +20,7 @@ ListItem {
 
 			anchors.verticalCenter: parent.verticalCenter
 			font.pixelSize: Theme.font_size_body2
-			value: dataItem.value === undefined ? NaN : dataItem.value
+			value: dataItem.isValid ? dataItem.value : NaN
 		}
 	]
 

--- a/components/listitems/ListTextItem.qml
+++ b/components/listitems/ListTextItem.qml
@@ -16,7 +16,7 @@ ListItem {
 	content.children: [
 		ListTextItemSecondaryLabel {
 			id: secondaryLabel
-			text: dataItem.value === undefined ? "" : dataItem.value
+			text: dataItem.isValid ? dataItem.value : ""
 			width: Math.min(implicitWidth, root.maximumContentWidth)
 			visible: text.length > 0
 		}

--- a/data/DcInputs.qml
+++ b/data/DcInputs.qml
@@ -11,7 +11,7 @@ QtObject {
 
 	property real power: NaN
 	property real current: NaN
-	readonly property real maximumPower: _maximumPower.value === undefined ? NaN : _maximumPower.value
+	readonly property real maximumPower: _maximumPower.isValid ? _maximumPower.value : NaN
 
 	property DeviceModel model: DeviceModel {
 		modelId: "dcInputs"

--- a/data/System.qml
+++ b/data/System.qml
@@ -26,7 +26,7 @@ QtObject {
 		readonly property real power: _dcSystemPower.isValid ? _dcSystemPower.value : NaN
 		readonly property real current: (isNaN(power) || isNaN(voltage) || voltage === 0) ? NaN : power / voltage
 		readonly property real voltage: _dcBatteryVoltage.isValid ? _dcBatteryVoltage.value : NaN
-		readonly property real maximumPower: _maximumDcPower.value === undefined ? NaN : _maximumDcPower.value
+		readonly property real maximumPower: _maximumDcPower.isValid ? _maximumDcPower.value : NaN
 
 		readonly property VeQuickItem _dcSystemPower: VeQuickItem {
 			uid: root.serviceUid + "/Dc/System/Power"
@@ -44,8 +44,8 @@ QtObject {
 	property QtObject solar: QtObject {
 		readonly property real power: Units.sumRealNumbers(acPower, dcPower)
 		property real acPower: _pvMonitor.totalPower
-		property real dcPower: _dcPvPower.value === undefined ? NaN : _dcPvPower.value
-		readonly property real maximumPower: _maximumPower.value === undefined ? NaN : _maximumPower.value
+		property real dcPower: _dcPvPower.isValid ? _dcPvPower.value : NaN
+		readonly property real maximumPower: _maximumPower.isValid ? _maximumPower.value : NaN
 
 		// In cases where the overall current cannot be determined, the value is NaN.
 		readonly property real current: {
@@ -62,7 +62,7 @@ QtObject {
 				}
 				return _pvMonitor.totalCurrent
 			} else if (Global.solarChargers.model.count > 0) {
-				return _dcPvCurrent.value === undefined ? NaN : _dcPvCurrent.value
+				return _dcPvCurrent.isValid ? _dcPvCurrent.value : NaN
 			}
 			return NaN
 		}

--- a/data/common/AcData.qml
+++ b/data/common/AcData.qml
@@ -11,16 +11,16 @@ QtObject {
 
 	property string bindPrefix
 
-	readonly property real voltage: _voltage.value === undefined ? NaN : _voltage.value
-	readonly property real current: _current.value === undefined ? NaN : _current.value
-	readonly property real frequency: _frequency.value === undefined ? NaN : _frequency.value
+	readonly property real voltage: _voltage.isValid ? _voltage.value : NaN
+	readonly property real current: _current.isValid ? _current.value : NaN
+	readonly property real frequency: _frequency.isValid ? _frequency.value : NaN
 
 	// If the power is not reported, calculate the apparent power
-	readonly property real power: _reportedPower.value !== undefined ? _reportedPower.value
-			 : _apparentPower.value !== undefined ? _apparentPower.value
-			 : _voltage.value !== undefined && _current.value !== undefined ? _voltage.value * _current.value
+	readonly property real power: _reportedPower.isValid ? _reportedPower.value
+			 : _apparentPower.isValid ? _apparentPower.value
+			 : _voltage.isValid && _current.isValid ? _voltage.value * _current.value
 			 : NaN
-	readonly property int powerUnit: _reportedPower.value !== undefined ? VenusOS.Units_Watt : VenusOS.Units_VoltAmpere
+	readonly property int powerUnit: _reportedPower.isValid ? VenusOS.Units_Watt : VenusOS.Units_VoltAmpere
 
 	property VeQuickItem _voltage: VeQuickItem {
 		uid: root.bindPrefix ? root.bindPrefix + "/V" : ""

--- a/data/common/AcSystemDevice.qml
+++ b/data/common/AcSystemDevice.qml
@@ -9,7 +9,7 @@ import Victron.VenusOS
 Device {
 	id: acSystemDevice
 
-	readonly property int state: _state.value === undefined ? -1 : _state.value
+	readonly property int state: _state.isValid ? _state.value : -1
 
 	readonly property VeQuickItem _state: VeQuickItem {
 		uid: acSystemDevice.serviceUid + "/State"

--- a/data/common/Battery.qml
+++ b/data/common/Battery.qml
@@ -9,12 +9,12 @@ import Victron.VenusOS
 Device {
 	id: battery
 
-	readonly property real stateOfCharge: _stateOfCharge.value === undefined ? NaN : _stateOfCharge.value
-	readonly property real voltage: _voltage.value === undefined ? NaN : _voltage.value
-	readonly property real power: _power.value === undefined ? NaN : _power.value
-	readonly property real current: _current.value === undefined ? NaN : _current.value
-	readonly property real temperature: _temperature.value === undefined ? NaN : _temperature.value
-	readonly property real timeToGo: _timeToGo.value === undefined ? NaN : _timeToGo.value  // in seconds
+	readonly property real stateOfCharge: _stateOfCharge.isValid ? _stateOfCharge.value : NaN
+	readonly property real voltage: _voltage.isValid ? _voltage.value : NaN
+	readonly property real power: _power.isValid ? _power.value : NaN
+	readonly property real current: _current.isValid ? _current.value : NaN
+	readonly property real temperature: _temperature.isValid ? _temperature.value : NaN
+	readonly property real timeToGo: _timeToGo.isValid ? _timeToGo.value : NaN // in seconds
 	readonly property string icon: !!Global.batteries ? Global.batteries.batteryIcon(battery) : ""
 	readonly property int mode: !!Global.batteries ? Global.batteries.batteryMode(battery) : -1
 	readonly property bool isParallelBms: _numberOfBmses.isValid

--- a/data/common/Charger.qml
+++ b/data/common/Charger.qml
@@ -9,7 +9,7 @@ import Victron.VenusOS
 Device {
 	id: charger
 
-	readonly property int state: _state.value === undefined ? -1 : _state.value
+	readonly property int state: _state.isValid ? _state.value : -1
 
 	readonly property VeQuickItem _state: VeQuickItem {
 		uid: charger.serviceUid + "/State"

--- a/data/common/DcDevice.qml
+++ b/data/common/DcDevice.qml
@@ -9,9 +9,9 @@ import Victron.VenusOS
 Device {
 	id: dcDevice
 
-	readonly property real voltage: _voltage.value === undefined ? NaN : _voltage.value
-	readonly property real current: _current.value === undefined ? NaN : _current.value
-	readonly property real power: _power.value === undefined ? NaN : _power.value
+	readonly property real voltage: _voltage.isValid ? _voltage.value : NaN
+	readonly property real current: _current.isValid ? _current.value : NaN
+	readonly property real power: _power.isValid ? _power.value : NaN
 
 	readonly property VeQuickItem _voltage: VeQuickItem {
 		uid: dcDevice.serviceUid + "/Dc/0/Voltage"

--- a/data/common/DcInput.qml
+++ b/data/common/DcInput.qml
@@ -10,8 +10,8 @@ DcDevice {
 	id: input
 
 	readonly property int inputType: Global.dcInputs.inputType(serviceUid, monitorMode)
-	readonly property real temperature: _temperature.value === undefined ? NaN : _temperature.value
-	readonly property int monitorMode: _monitorMode.value === undefined ? -1 : _monitorMode.value
+	readonly property real temperature: _temperature.isValid ? _temperature.value : NaN
+	readonly property int monitorMode: _monitorMode.isValid ? _monitorMode.value : -1
 
 	property bool _completed
 

--- a/data/common/DigitalInput.qml
+++ b/data/common/DigitalInput.qml
@@ -9,8 +9,8 @@ import Victron.VenusOS
 Device {
 	id: input
 
-	readonly property int type: _type.value === undefined ? -1 : _type.value
-	readonly property int state: _state.value === undefined ? -1 : _state.value
+	readonly property int type: _type.isValid ? _type.value : -1
+	readonly property int state: _state.isValid ? _state.value : -1
 
 	readonly property VeQuickItem _type: VeQuickItem {
 		uid: input.serviceUid + "/Type"

--- a/data/common/EnvironmentInput.qml
+++ b/data/common/EnvironmentInput.qml
@@ -9,9 +9,9 @@ import Victron.VenusOS
 Device {
 	id: input
 
-	readonly property real temperature: _temperature.value === undefined ? NaN : _temperature.value
-	readonly property real humidity: _humidity.value === undefined ? NaN : _humidity.value
-	readonly property int temperatureType: _temperatureType.value === undefined ? -1 : _temperatureType.value
+	readonly property real temperature: _temperature.isValid ? _temperature.value : NaN
+	readonly property real humidity: _humidity.isValid ? _humidity.value : NaN
+	readonly property int temperatureType: _temperatureType.isValid ? _temperatureType.value : -1
 
 	readonly property VeQuickItem _temperature: VeQuickItem {
 		uid: serviceUid + "/Temperature"

--- a/data/common/Generator.qml
+++ b/data/common/Generator.qml
@@ -9,11 +9,11 @@ import Victron.VenusOS
 Device {
 	id: generator
 
-	readonly property int state: _state.value === undefined ? -1 : _state.value
+	readonly property int state: _state.isValid ? _state.value : -1
 	readonly property bool autoStart: _autoStart.value === 1
-	readonly property int manualStartTimer: _manualStartTimer.value === undefined ? -1 : _manualStartTimer.value
+	readonly property int manualStartTimer: _manualStartTimer.isValid ? _manualStartTimer.value : 0
 	readonly property int runtime: _runtime.value || 0
-	readonly property int runningBy: _runningBy.value === undefined ? -1 : _runningBy.value
+	readonly property int runningBy: _runningBy.isValid ? _runningBy.value : 0
 
 	readonly property VeQuickItem _state: VeQuickItem {
 		uid: serviceUid + "/State"

--- a/data/common/Inverter.qml
+++ b/data/common/Inverter.qml
@@ -9,18 +9,18 @@ import Victron.VenusOS
 Device {
 	id: inverter
 
-	readonly property int state: _state.value === undefined ? -1 : _state.value
+	readonly property int state: _state.isValid ? _state.value : -1
 
 	readonly property VeQuickItem _state: VeQuickItem {
 		uid: inverter.serviceUid + "/State"
 	}
 
-	readonly property var currentPhase: acOutL3.bindPrefix !== "" ? acOutL3
+	readonly property AcData currentPhase: acOutL3.bindPrefix !== "" ? acOutL3
 			: acOutL2.bindPrefix !== "" ? acOutL2
 			: acOutL1
 
 	readonly property AcData acOutL1: AcData {
-		bindPrefix: _phase.value === 0 || _phase.value === undefined ? inverter.serviceUid + "/Ac/Out/L1" : ""
+		bindPrefix: _phase.value === 0 || !_phase.isValid ? inverter.serviceUid + "/Ac/Out/L1" : ""
 	}
 	readonly property AcData acOutL2: AcData {
 		bindPrefix:  _phase.value === 1 ? inverter.serviceUid + "/Ac/Out/L2" : ""

--- a/data/common/InverterCharger.qml
+++ b/data/common/InverterCharger.qml
@@ -9,11 +9,11 @@ import Victron.VenusOS
 Device {
 	id: inverterCharger
 
-	readonly property int state: _state.value === undefined ? -1 : _state.value
-	readonly property int mode: _mode.value === undefined ? -1 : _mode.value
-	readonly property real nominalInverterPower: _nominalInverterPower.value === undefined ? NaN : _nominalInverterPower.value
+	readonly property int state: _state.isValid ? _state.value : -1
+	readonly property int mode: _mode.isValid ? _mode.value : -1
+	readonly property real nominalInverterPower: _nominalInverterPower.isValid ? _nominalInverterPower.value : NaN
 
-	readonly property int numberOfAcInputs: _numberOfAcInputs.value === undefined ? NaN : _numberOfAcInputs.value
+	readonly property int numberOfAcInputs: _numberOfAcInputs.isValid ? _numberOfAcInputs.value : NaN
 
 	readonly property VeQuickItem _state: VeQuickItem {
 		uid: inverterCharger.serviceUid + "/State"

--- a/data/common/MeteoDevice.qml
+++ b/data/common/MeteoDevice.qml
@@ -9,7 +9,7 @@ import Victron.VenusOS
 Device {
 	id: meteoDevice
 
-	readonly property real irradiance: _irradiance.value === undefined ? NaN : _irradiance.value
+	readonly property real irradiance: _irradiance.isValid ? _irradiance.value : NaN
 
 	readonly property VeQuickItem _irradiance: VeQuickItem {
 		uid: meteoDevice.serviceUid + "/Irradiance"

--- a/data/common/MotorDrive.qml
+++ b/data/common/MotorDrive.qml
@@ -9,7 +9,7 @@ import Victron.VenusOS
 Device {
 	id: motorDrive
 
-	readonly property real motorRpm: _motorRpm.value === undefined ? NaN : _motorRpm.value
+	readonly property real motorRpm: _motorRpm.isValid ? _motorRpm.value : NaN
 
 	readonly property VeQuickItem _motorRpm: VeQuickItem {
 		uid: motorDrive.serviceUid + "/Motor/RPM"

--- a/data/common/Notification.qml
+++ b/data/common/Notification.qml
@@ -93,8 +93,8 @@ BaseNotification {
 
 	acknowledged: !!_acknowledged.value
 	active: !!_active.value
-	type: _type.value === undefined ? -1 : parseInt(_type.value)
-	dateTime: _dateTime.value === undefined ? _invalidDate : new Date(_dateTime.value * 1000)
+	type: _type.isValid ? parseInt(_type.value) : -1
+	dateTime: _dateTime.isValid ? new Date(_dateTime.value * 1000) : _invalidDate
 	deviceName: _deviceName.value || ""
 	description: _description.value || ""
 	value: _value.value || ""

--- a/data/common/PulseMeter.qml
+++ b/data/common/PulseMeter.qml
@@ -9,7 +9,7 @@ import Victron.VenusOS
 Device {
 	id: pulseMeter
 
-	readonly property real aggregate: _aggregate.value === undefined ? -1 : _aggregate.value
+	readonly property real aggregate: _aggregate.isValid ? _aggregate.value : NaN
 
 	readonly property VeQuickItem _aggregate: VeQuickItem {
 		uid: pulseMeter.serviceUid + "/Aggregate"

--- a/data/common/SolarCharger.qml
+++ b/data/common/SolarCharger.qml
@@ -9,17 +9,17 @@ import Victron.VenusOS
 Device {
 	id: solarCharger
 
-	readonly property int state: _state.value === undefined ? -1 : _state.value
-	readonly property int errorCode: _errorCode.value === undefined ? -1 : _errorCode.value
+	readonly property int state: _state.isValid ? _state.value : -1
+	readonly property int errorCode: _errorCode.isValid ? _errorCode.value : -1
 	readonly property ListModel trackers: ListModel {}
-	readonly property real power: _totalPower.value === undefined ? NaN : _totalPower.value
+	readonly property real power: _totalPower.isValid ? _totalPower.value : NaN
 	readonly property alias history: _history
 
-	readonly property real batteryVoltage: _batteryVoltage.value == undefined ? NaN : _batteryVoltage.value
-	readonly property real batteryCurrent: _batteryCurrent.value == undefined ? NaN : _batteryCurrent.value
-	readonly property real batteryTemperature: _batteryTemperature.value == undefined ? NaN : _batteryTemperature.value
+	readonly property real batteryVoltage: _batteryVoltage.isValid ? _batteryVoltage.value : NaN
+	readonly property real batteryCurrent: _batteryCurrent.isValid ? _batteryCurrent.value : NaN
+	readonly property real batteryTemperature: _batteryTemperature.isValid ? _batteryTemperature.value : NaN
 
-	readonly property bool relayValid: _relay.value !== undefined
+	readonly property bool relayValid: _relay.isValid
 	readonly property bool relayOn: _relay.value === 1
 
 	// This is the overall error history.

--- a/data/common/SystemBattery.qml
+++ b/data/common/SystemBattery.qml
@@ -9,12 +9,12 @@ import Victron.VenusOS
 QtObject {
 	id: battery
 
-	readonly property real stateOfCharge: _stateOfCharge.value === undefined ? NaN : _stateOfCharge.value
-	readonly property real voltage: _voltage.value === undefined ? NaN : _voltage.value
-	readonly property real power: _power.value === undefined ? NaN : _power.value
-	readonly property real current: _current.value === undefined ? NaN : _current.value
-	readonly property real temperature: _temperature.value === undefined ? NaN : _temperature.value
-	readonly property real timeToGo: _timeToGo.value === undefined ? NaN : _timeToGo.value
+	readonly property real stateOfCharge: _stateOfCharge.isValid ? _stateOfCharge.value : NaN
+	readonly property real voltage: _voltage.isValid ? _voltage.value : NaN
+	readonly property real power: _power.isValid ? _power.value : NaN
+	readonly property real current: _current.isValid ? _current.value : NaN
+	readonly property real temperature: _temperature.isValid ? _temperature.value : NaN
+	readonly property real timeToGo: _timeToGo.isValid ? _timeToGo.value : NaN
 	readonly property string icon: !!Global.batteries ? Global.batteries.batteryIcon(battery) : ""
 	readonly property int mode: !!Global.batteries ? Global.batteries.batteryMode(battery) : -1
 

--- a/data/common/Tank.qml
+++ b/data/common/Tank.qml
@@ -10,9 +10,9 @@ import Victron.Gauges
 Device {
 	id: tank
 
-	readonly property int type: _type.value === undefined ? -1 : _type.value
-	readonly property int status: _status.value === undefined ? VenusOS.Tank_Status_Unknown : _status.value
-	readonly property real temperature: _temperature.value === undefined ? NaN : _temperature.value
+	readonly property int type: _type.isValid ? _type.value : -1
+	readonly property int status: _status.isValid ? _status.value : VenusOS.Tank_Status_Unknown
+	readonly property real temperature: _temperature.isValid ? _temperature.value : NaN
 	property real level: NaN
 	property real remaining: NaN
 	property real capacity: NaN
@@ -63,9 +63,9 @@ Device {
 	}
 
 	function _updateMeasurements() {
-		let remainingValue = _remaining.value === undefined ? NaN : _remaining.value
-		let levelValue = _level.value === undefined ? NaN : _level.value    // 0 - 100
-		let capacityValue = _capacity.value === undefined ? NaN : _capacity.value
+		let remainingValue = _remaining.isValid ? _remaining.value : NaN
+		let levelValue = _level.isValid ? _level.value : NaN   // 0 - 100
+		let capacityValue = _capacity.isValid ? _capacity.value : NaN
 
 		// If there is no /Level, calculate it from other values.
 		if (isNaN(levelValue) && !isNaN(capacityValue) && !isNaN(remainingValue)) {

--- a/pages/settings/PageChargeCurrentLimits.qml
+++ b/pages/settings/PageChargeCurrentLimits.qml
@@ -72,12 +72,10 @@ Page {
 		}
 
 		delegate: ListTextGroup {
-			readonly property string dcCurrentText: dcCurrent.value === undefined
-				? "--"
+			readonly property string dcCurrentText: !dcCurrent.isValid ? "--"
 				: Units.formatNumber(dcCurrent.value, 3) + Units.defaultUnitString(VenusOS.Units_Amp)
 			//% "Max: %1"
-			readonly property string maxValueText: maxValue.value === undefined
-				? "-- "
+			readonly property string maxValueText: !maxValue.isValid ? "--"
 				: qsTrId("settings_dvcc_max").arg(Units.formatNumber(maxValue.value, 3))
 
 			width: parent.width

--- a/pages/settings/devicelist/AcInDeviceModel.qml
+++ b/pages/settings/devicelist/AcInDeviceModel.qml
@@ -17,8 +17,8 @@ BaseDeviceModel {
 		delegate: Device {
 			id: device
 
-			readonly property real power: _power.value === undefined ? NaN : _power.value
-			readonly property int gensetStatusCode: _gensetStatusCode.value === undefined ? -1 : _gensetStatusCode.value
+			readonly property real power: _power.isValid ? _power.value : NaN
+			readonly property int gensetStatusCode: _gensetStatusCode.isValid ? _gensetStatusCode.value : -1
 
 			readonly property VeQuickItem _power: VeQuickItem {
 				uid: device.serviceUid + "/Ac/Power"

--- a/pages/settings/devicelist/battery/PageBatteryDetails.qml
+++ b/pages/settings/devicelist/battery/PageBatteryDetails.qml
@@ -70,10 +70,10 @@ Page {
 				textModel: [
 					//: %1 = number of battery modules that are online
 					//% "%1 online"
-					details.modulesOnline.value === undefined ? "--" : qsTrId("devicelist_batterydetails_modules_online").arg(details.modulesOnline.value),
+					details.modulesOnline.isValid ? qsTrId("devicelist_batterydetails_modules_online").arg(details.modulesOnline.value) : "--",
 					//: %1 = number of battery modules that are offline
 					//% "%1 offline"
-					details.modulesOffline.value === undefined ? "--" : qsTrId("devicelist_batterydetails_modules_offline").arg(details.modulesOffline.value)
+					details.modulesOffline.isValid ? qsTrId("devicelist_batterydetails_modules_offline").arg(details.modulesOffline.value) : "--"
 				]
 				allowed: defaultAllowed && details.allowsBatteryModules
 			}

--- a/pages/settings/devicelist/rs/PageMultiRs.qml
+++ b/pages/settings/devicelist/rs/PageMultiRs.qml
@@ -251,9 +251,9 @@ Page {
 							model: root.trackerCount
 							delegate: QtObject {
 								required property int index
-								readonly property real power: _power.value === undefined ? NaN : _power.value
-								readonly property real voltage: _voltage.value === undefined ? NaN : _voltage.value
-								readonly property real current: isNaN(power) || isNaN(voltage) || voltage === 0 ? NaN : power / voltage
+								readonly property real power: _power.isValid ? _power.value : NaN
+								readonly property real voltage: _voltage.isValid ? _voltage.value : NaN
+								readonly property real current: !_power.isValid || !_voltage.isValid || voltage === 0 ? NaN : power / voltage
 								readonly property string name: _name.value || ""
 
 								readonly property VeQuickItem _voltage: VeQuickItem { uid: root.bindPrefix + "/Pv/" + index + "/V" }

--- a/pages/solar/SolarChargerNetworkedOperationPage.qml
+++ b/pages/solar/SolarChargerNetworkedOperationPage.qml
@@ -22,7 +22,7 @@ Page {
 				text: qsTrId("charger_networked")
 				dataItem.uid: root.solarCharger.serviceUid + "/Link/NetworkMode"
 				allowed: dataItem.isValid
-				secondaryText: dataItem.value === undefined ? "" : CommonWords.yesOrNo(dataItem.value & 1)
+				secondaryText: dataItem.isValid ? CommonWords.yesOrNo(dataItem.value & 1) : ""
 			}
 
 			ListTextItem {
@@ -36,7 +36,7 @@ Page {
 				//% "Mode setting"
 				text: qsTrId("charger_mode_setting")
 				secondaryText: {
-					if (dataItem.value === undefined) {
+					if (!dataItem.isValid) {
 						return ""
 					}
 					switch (dataItem.value & 0xE) {
@@ -76,7 +76,7 @@ Page {
 				//% "Master setting"
 				text: qsTrId("charger_master_setting")
 				secondaryText: {
-					if (dataItem.value === undefined) {
+					if (!dataItem.isValid) {
 						return ""
 					}
 					switch (dataItem.value & 0x30) {


### PR DESCRIPTION
If isValid is true, then the value should be usable.