### PR TITLE
Add setting to hide input loads on overview

### DIFF
--- a/data/mock/SystemSettingsImpl.qml
+++ b/data/mock/SystemSettingsImpl.qml
@@ -75,6 +75,7 @@ QtObject {
 		setMockSettingValue("System/SecurityProfile", VenusOS.Security_Profile_Secured)
 		setMockSettingValue("SystemSetup/AcInput1", 2)
 		setMockSettingValue("SystemSetup/AcInput2", 3)
+		setMockSettingValue("SystemSetup/HasAcInLoads", 1)
 		setMockSettingValue("Gui/DemoMode", 1)
 
 		setMockSystemValue("AvailableBatteryServices", '{"default": "Automatic", "nobattery": "No battery monitor", "com.victronenergy.vebus/257": "Quattro 24/3000/70-2x50 on VE.Bus", "com.victronenergy.battery/0": "Lynx Smart BMS 500 on VE.Can"}')

--- a/pages/settings/PageSettingsSystem.qml
+++ b/pages/settings/PageSettingsSystem.qml
@@ -84,6 +84,28 @@ Page {
 			}
 
 			ListRadioButtonGroup {
+				//% "Position of AC loads"
+				text: qsTrId("settings_system_ac_position")
+				dataItem.uid: Global.systemSettings.serviceUid + "/Settings/SystemSetup/HasAcInLoads"
+				optionModel: [
+					{
+						//% "AC input & output"
+						display: qsTrId("settings_system_ac_input_and_output"),
+						//% "Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure."
+						caption: qsTrId("settings_system_ac_input_and_output_description"),
+						value: 1
+					},
+					{
+						//% "AC output only"
+						display: qsTrId("settings_system_ac_output_only"),
+						//% "Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger."
+						caption: qsTrId("settings_system_ac_output_only_description"),
+						value: 0
+					},
+				]
+			}
+
+			ListRadioButtonGroup {
 				text: root._isGrid
 					  //% "Monitor for grid failure"
 					? qsTrId("settings_system_monitor_for_grid_failure")


### PR DESCRIPTION
This is to be used in systems with AC-coupled PV on the input, or systems with a grid meter used for energy accounting, but with no actual loads on the input side. It hides the AC input side loads on the overview.

As per 7cecfbf09dd5899bca7a9c76fd16ed12ee55f332 from gui-v1.

Fixes #1460