### PR TITLE
Fix bug in circular gauge arcs when display units change

### DIFF
--- a/components/CircularMultiGauge.qml
+++ b/components/CircularMultiGauge.qml
@@ -35,8 +35,8 @@ Item {
 			width: parent.width
 			delegate: Loader {
 				id: loader
-				property int gaugeStatus: Theme.getValueStatus(model.value, model.valueType)
-				property real value: model.value
+				property int gaugeStatus: Theme.getValueStatus(model.level, model.valueType)
+				property real level: model.level // always draw the tank level (percentage).
 				width: parent.width - (index*_stepSize)
 				height: width
 				anchors.centerIn: parent
@@ -50,7 +50,7 @@ Item {
 						radius: width/2
 						startAngle: 0
 						endAngle: 270
-						value: loader.value
+						value: loader.level
 						progressColor: Theme.color_darkOk,Theme.statusColorValue(loader.gaugeStatus)
 						remainderColor: Theme.color_darkOk,Theme.statusColorValue(loader.gaugeStatus, true)
 						strokeWidth: gauges.strokeWidth
@@ -65,7 +65,7 @@ Item {
 						radius: width/2
 						startAngle: 0
 						endAngle: 270
-						value: loader.value
+						value: loader.level
 						progressColor: Theme.color_darkOk,Theme.statusColorValue(loader.gaugeStatus)
 						remainderColor: Theme.color_darkOk,Theme.statusColorValue(loader.gaugeStatus, true)
 						strokeWidth: gauges.strokeWidth

--- a/components/GaugeModel.qml
+++ b/components/GaugeModel.qml
@@ -41,7 +41,7 @@ ListModel {
 		const value = Global.systemSettings.briefView.unit.value === VenusOS.BriefView_Unit_Percentage || gauge.isBattery ? gauge.tankLevel : gauge.tankRemaining
 
 		insert(_insertionIndex(gauge.tankType, sortedGaugeTypes),
-			   Object.assign({}, Gauges.tankProperties(gauge.tankType), { tankType: gauge.tankType, value: value }))
+			   Object.assign({}, Gauges.tankProperties(gauge.tankType), { tankType: gauge.tankType, level: gauge.tankLevel, value: value }))
 	}
 
 	function findGauge(gauge) {
@@ -57,7 +57,7 @@ ListModel {
 		const gaugeIndex = findGauge(gauge)
 		if (gaugeIndex >= 0) {
 			const value = Global.systemSettings.briefView.unit.value === VenusOS.BriefView_Unit_Percentage || gauge.isBattery ? gauge.tankLevel : gauge.tankRemaining
-			set(gaugeIndex, { name: gauge.tankName, icon: gauge.tankIcon, value: value })
+			set(gaugeIndex, { name: gauge.tankName, icon: gauge.tankIcon, level: gauge.tankLevel, value: value })
 		}
 	}
 
@@ -93,7 +93,7 @@ ListModel {
 					: (tankModel.count === 0 || tankModel.totalCapacity === 0) ? 0
 					: ((Math.min(tankModel.totalRemaining / tankModel.totalCapacity, 1.0) * 100))
 			readonly property real tankRemaining: isBattery ? null
-															: Units.convert(tankModel.totalRemaining, VenusOS.Units_Volume_CubicMeter, Global.systemSettings.volumeUnit);
+					: Units.convert(tankModel.totalRemaining, VenusOS.Units_Volume_CubicMeter, Global.systemSettings.volumeUnit)
 
 			readonly property var _tankProperties: Gauges.tankProperties(tankType)
 


### PR DESCRIPTION
Always provide the tank level (percentage) value in the model. Always draw the arc length based on the level (percentage), and not the remaining capacity (volume) value.

Fixes issue #1527