### PR TITLE
Show updated device name when it is changed by user

### DIFF
--- a/pages/settings/devicelist/DeviceListPage.qml
+++ b/pages/settings/devicelist/DeviceListPage.qml
@@ -219,7 +219,7 @@ Page {
 		default:
 			return null
 		}
-		params.title = device.name
+		params.title = Qt.binding(function(){ return device.name })
 
 		return { "summary": summary, "url": url, "params": params }
 	}


### PR DESCRIPTION
From the Device List, if you open a device page and then open the "Device" sub-page and change its custom name, then step back to the device page, the page should show the updated device name.

Fixes #1249