### PR TITLE
Remove redundant value setting

### DIFF
--- a/data/mock/MeteoDevicesImpl.qml
+++ b/data/mock/MeteoDevicesImpl.qml
@@ -24,6 +24,7 @@ QtObject {
 			Component.onCompleted: {
 				_deviceInstance.setValue(deviceInstance)
 				_customName.setValue("Meteo %1".arg(deviceInstance))
+				_irradiance.setValue(Math.random() * 100)
 			}
 		}
 	}

--- a/pages/settings/devicelist/PageMeteo.qml
+++ b/pages/settings/devicelist/PageMeteo.qml
@@ -63,7 +63,6 @@ Page {
 				//% "Wind speed"
 				text: qsTrId("page_meteo_wind_speed")
 				allowed: dataItem.isValid
-				value: dataItem.value
 				unit: VenusOS.Units_Speed_MetresPerSecond
 				precision: 1
 			}


### PR DESCRIPTION
The value will already be set to the dataItem.value.

Also add a dummy irradiance value so that the mock Meteo object has a value in the Device List.