### PR TITLE
Solar history: only show chart for days that are actually available

### DIFF
--- a/data/common/SolarHistory.qml
+++ b/data/common/SolarHistory.qml
@@ -12,6 +12,7 @@ QtObject {
 	property string bindPrefix
 	property string deviceName
 	property int trackerCount
+	readonly property int daysAvailable: _veHistoryCount.isValid ? _veHistoryCount.value : 0
 	readonly property bool valid: _veHistoryCount.isValid && _veHistoryCount.value > 0
 
 	property SolarHistoryErrorModel errorModel: SolarHistoryErrorModel {

--- a/data/mock/SolarChargersImpl.qml
+++ b/data/mock/SolarChargersImpl.qml
@@ -22,6 +22,10 @@ QtObject {
 				serviceUid: "mock/com.victronenergy.solarcharger.ttyUSB" + deviceInstanceNum,
 				deviceInstance: deviceInstanceNum,
 			})
+			// MPPT chargers connected via VE.CAN only have 2 days of history; add a charger that
+			// simulates this.
+			const historyDaysAvailable = i === 0 ? 2 : 31
+			Global.mockDataSimulator.setMockValue(chargerObj.serviceUid + "/History/Overall/DaysAvailable", historyDaysAvailable)
 			chargerObj.initTrackers(i + 1)
 		}
 	}
@@ -80,8 +84,7 @@ QtObject {
 				randomizeMeasurments()
 
 				// Initialize history values
-				Global.mockDataSimulator.setMockValue(serviceUid + "/History/Overall/DaysAvailable", 30)
-				for (let day = 0; day < 31; ++day) {
+				for (let day = 0; day < solarCharger.history.daysAvailable; ++day) {
 					let dayTotals = []
 					const dayOverallHistoryUid = serviceUid + "/History/Daily/" + day
 					for (trackerIndex = 0; trackerIndex < trackerCount; ++trackerIndex) {

--- a/pages/solar/SolarHistoryPage.qml
+++ b/pages/solar/SolarHistoryPage.qml
@@ -47,14 +47,26 @@ Page {
 			{ text: CommonWords.yesterday, dayRange: [1, 2] }
 		].concat(chartModeOptions)
 
-		readonly property var chartModeOptions: [
-			//% "Last 7 days"
-			{ text: qsTrId("charger_history_last_7_days"), dayRange: [0, 7] },
-			//% "Last 14 days"
-			{ text: qsTrId("charger_history_last_14_days"), dayRange: [0, 14] },
-			//% "Last 30 days"
-			{ text: qsTrId("charger_history_last_30_days"), dayRange: [0, 30] }
-		]
+		readonly property var chartModeOptions: {
+			let options = []
+			if (solarHistory.daysAvailable <= 2) {
+				// MPPT chargers connected via VE.CAN only have 2 days of history (i.e. today and
+				// yesterday), so charts are not available for these devices.
+				return options
+			}
+			const dayRanges = [7, 14, 31]
+			for (let i = 0; i < dayRanges.length; ++i) {
+				const numberOfDays = Math.min(solarHistory.daysAvailable, dayRanges[i])
+				//: %1 = number of days of solar history that will be shown
+				//% "Last %1 days"
+				const optionText = qsTrId("charger_history_last_x_days")
+				options.push({ text: optionText.arg(numberOfDays), dayRange: [0, numberOfDays] })
+				if (numberOfDays >= solarHistory.daysAvailable) {
+					break
+				}
+			}
+			return options
+		}
 
 		anchors {
 			right: parent.right


### PR DESCRIPTION
Use /History/Overall/DaysAvailable to determine the number of days to show in the solar history. Instead of assuming that 30 days of history are available, display [7, 14, 31] days in the combo box dropdown, but only if those days are actually available.

VE.CAN connected MPPTs only have two days of history, so do not show the "Chart" option for these devices.

Fixes #1428