### PR TITLE
Correctly connect EVCS to AC Loads or Critical Loads

### DIFF
--- a/data/EvChargers.qml
+++ b/data/EvChargers.qml
@@ -57,10 +57,10 @@ QtObject {
 			if (model.count === 1) {
 				overallCurrent = evCharger.current
 			}
-			if (evCharger.position === VenusOS.PvInverter_Position_ACInput) {
+			if (evCharger.position === VenusOS.Evcs_Position_ACInput) {
 				totalInputCount++
 				totalInputPower = Units.sumRealNumbers(totalInputPower, evCharger.power)
-			} else if (evCharger.position === VenusOS.PvInverter_Position_ACOutput) {
+			} else if (evCharger.position === VenusOS.Evcs_Position_ACOutput) {
 				totalOutputCount++
 				totalOutputPower = Units.sumRealNumbers(totalOutputPower, evCharger.power)
 			}

--- a/data/mock/EvChargersImpl.qml
+++ b/data/mock/EvChargersImpl.qml
@@ -14,7 +14,7 @@ QtObject {
 	function populate() {
 		for (let i = 0; i < 3; ++i) {
 			createCharger({
-				position: i % 2 === 0 ? VenusOS.PvInverter_Position_ACInput : VenusOS.PvInverter_Position_ACOutput,
+				position: i % 2 === 0 ? VenusOS.Evcs_Position_ACInput : VenusOS.Evcs_Position_ACOutput,
 				nrOfPhases: i + 1
 			})
 		}

--- a/data/mock/config/BriefAndOverviewPageConfig.qml
+++ b/data/mock/config/BriefAndOverviewPageConfig.qml
@@ -235,7 +235,7 @@ QtObject {
 			system: { showInputLoads: true, hasAcOutSystem: 1, ac: { phaseCount: 1 }, dc: { serviceTypes: ["dcload"] } },
 			evcs: {
 				chargers: [
-					{ status: VenusOS.Evcs_Status_Charging, position: VenusOS.PvInverter_Position_ACInput },
+					{ status: VenusOS.Evcs_Status_Charging, position: VenusOS.Evcs_Position_ACInput },
 				]
 			}
 		},
@@ -244,7 +244,7 @@ QtObject {
 			system: { showInputLoads: true, hasAcOutSystem: 1, ac: {}, dc: { serviceTypes: ["dcload"] } },
 			evcs: {
 				chargers: [
-					{ status: VenusOS.Evcs_Status_Charging, position: VenusOS.PvInverter_Position_ACOutput },
+					{ status: VenusOS.Evcs_Status_Charging, position: VenusOS.Evcs_Position_ACOutput },
 				]
 			}
 		},
@@ -253,8 +253,8 @@ QtObject {
 			system: { showInputLoads: true, hasAcOutSystem: 1, ac: {}, dc: { serviceTypes: ["dcload"] } },
 			evcs: {
 				chargers: [
-					{ status: VenusOS.Evcs_Status_Charging, position: VenusOS.PvInverter_Position_ACInput },
-					{ status: VenusOS.Evcs_Status_Charging, position: VenusOS.PvInverter_Position_ACOutput },
+					{ status: VenusOS.Evcs_Status_Charging, position: VenusOS.Evcs_Position_ACInput },
+					{ status: VenusOS.Evcs_Status_Charging, position: VenusOS.Evcs_Position_ACOutput },
 				]
 			}
 		},
@@ -263,8 +263,8 @@ QtObject {
 			system: { showInputLoads: true, hasAcOutSystem: 0, ac: {}, dc: { serviceTypes: ["dcload"] } },
 			evcs: {
 				chargers: [
-					{ status: VenusOS.Evcs_Status_Charging, position: VenusOS.PvInverter_Position_ACInput },
-					{ status: VenusOS.Evcs_Status_Charging, position: VenusOS.PvInverter_Position_ACOutput },
+					{ status: VenusOS.Evcs_Status_Charging, position: VenusOS.Evcs_Position_ACInput },
+					{ status: VenusOS.Evcs_Status_Charging, position: VenusOS.Evcs_Position_ACOutput },
 				]
 			}
 		},
@@ -273,8 +273,8 @@ QtObject {
 			system: { showInputLoads: false, hasAcOutSystem: 1, ac: {}, dc: { serviceTypes: ["dcload"] } },
 			evcs: {
 				chargers: [
-					{ status: VenusOS.Evcs_Status_Charging, position: VenusOS.PvInverter_Position_ACInput },
-					{ status: VenusOS.Evcs_Status_Charging, position: VenusOS.PvInverter_Position_ACOutput },
+					{ status: VenusOS.Evcs_Status_Charging, position: VenusOS.Evcs_Position_ACInput },
+					{ status: VenusOS.Evcs_Status_Charging, position: VenusOS.Evcs_Position_ACOutput },
 				]
 			}
 		},


### PR DESCRIPTION
Fix the in/out position counters: use the EVCS constants for the in/out position (0 = out, 1 = in), instead of the PV inverter constants (0 = in, 1 = out).