### PR TITLE
Rename "Relay controlled genset" to "Genset start/stop"

### DIFF
--- a/pages/settings/PageSettingsRelay.qml
+++ b/pages/settings/PageSettingsRelay.qml
@@ -24,8 +24,8 @@ Page {
 				optionModel: [
 					//% "Alarm relay"
 					{ display: qsTrId("settings_relay_alarm_relay"), value: VenusOS.Relay_Function_Alarm },
-					//% "Relay controlled genset"
-					{ display: qsTrId("settings_relay_generator_start_stop"), value: VenusOS.Relay_Function_GeneratorStartStop },
+					//% "Genset start/stop"
+					{ display: qsTrId("settings_relay_genset_start_stop"), value: VenusOS.Relay_Function_GeneratorStartStop },
 					//% "Connected genset helper relay"
 					{ display: qsTrId("settings_relay_genset_helper_relay"), value: VenusOS.Relay_Function_GensetHelperRelay },
 					//% "Tank pump"


### PR DESCRIPTION
As per gui-v1 commit bbb36d0e37f4826f325ea00438e2a69f4b68d3ca

Fixes #1557