### PR TITLE
Fix displayed ESS charging duration when > 24 hours

### DIFF
--- a/components/settings/ChargeScheduleItem.qml
+++ b/components/settings/ChargeScheduleItem.qml
@@ -139,8 +139,9 @@ ListNavigationItem {
 					}
 
 					ListTimeSelector {
-						//% "Duration (hh:mm)"
+						//% "Duration"
 						text: qsTrId("cgwacs_battery_schedule_duration")
+						button.text: dataItem.value > 0 ? Utils.secondsToString(dataItem.value) : "--"
 						dataItem.uid: root._scheduleSource + "/Duration"
 						allowed: defaultAllowed && itemEnabled.checked
 						maximumHour: 9999


### PR DESCRIPTION
Format the button text using secondsToString() instead of relying on the default button text from ListTimeSelector, which uses ClockTime.formatTime() and assumes the value is a "time" that is less than 24 hours.

Fixes #1570