### PR TITLE
Fix dbus path in Fronius inverter pages, small cleanup

### DIFF
--- a/pages/settings/PageSettingsFroniusInverter.qml
+++ b/pages/settings/PageSettingsFroniusInverter.qml
@@ -19,12 +19,6 @@ Page {
 	}
 
 	VeQuickItem {
-		id: phaseItem
-
-		uid: bindPrefix + "/Phase"
-	}
-
-	VeQuickItem {
 		id: limiterSupportedItem
 
 		uid: bindPrefix + "/LimiterSupported"

--- a/pages/settings/PageSettingsFroniusInverters.qml
+++ b/pages/settings/PageSettingsFroniusInverters.qml
@@ -14,7 +14,7 @@ Page {
 	GradientListView {
 		model: VeQItemTableModel {
 			uids: BackendConnection.type === BackendConnection.DBusSource
-				  ? ["dbus/" + bindPrefix + "/Inverters"]
+				  ? [bindPrefix + "/Inverters"]
 				  : BackendConnection.type === BackendConnection.MqttSource
 					? ["mqtt/settings/0/Settings/Fronius/Inverters"]
 					: []


### PR DESCRIPTION
The dbus path for Fronius inverters was wrong (it had the dbus/ prefix twice). Also, `phaseItem` was unused.