### PR TITLE
add text to ess menu about rs settings location

### DIFF
--- a/pages/settings/PageSettingsHub4.qml
+++ b/pages/settings/PageSettingsHub4.qml
@@ -23,6 +23,15 @@ Page {
 		}
 	}
 
+	Component {
+		id: hasAcSystem
+
+		ListLabel {
+			//% "For Multi-RS and HS19 devices, ESS settings are available on the RS System product page."
+			text: qsTrId("settings_ess_rs_information")
+		}
+	}
+
 	ObjectModel {
 		id: essSettings
 
@@ -313,7 +322,7 @@ Page {
 	}
 
 	GradientListView {
-		header: root._valid ? null : noEssHeader
+		header: root._valid ? null : (Global.acSystemDevices.model.count > 0 ? hasAcSystem : noEssHeader)
 		model: root._valid ? essSettings : null
 	}
 


### PR DESCRIPTION
Add text to the ESS menu that shows up if there is an RS system, telling the user that the ESS settings can be accessed from the device list.

https://github.com/victronenergy/gui-v2/issues/1549