### PR TITLE
Fix manual control button and dialog

### DIFF
--- a/components/GeneratorManualControlButton.qml
+++ b/components/GeneratorManualControlButton.qml
@@ -25,9 +25,9 @@ ListItemButton {
 	// state at the time dialog was opened. This avoid changing the color of the button
 	// when it is visible below the open start/stop dialogs.
 	checked: _generatorStateBeforeDialogOpen < 0
-			 ? _state.value === VenusOS.Generators_State_Running
-			   || _state.value === VenusOS.Generators_State_WarmUp
-			 : _generatorStateBeforeDialogOpen === VenusOS.Generators_State_Running
+			 ? _runningByConditionCode.value === VenusOS.Generators_RunningBy_Manual
+			 : _generatorStateBeforeDialogOpen === VenusOS.Generators_State_Running 
+			   && _runningByConditionCode.value === VenusOS.Generators_RunningBy_Manual
 
 	text: checked
 			//% "Manual Stop"
@@ -48,8 +48,7 @@ ListItemButton {
 			return
 		}
 
-		if (_state.value === VenusOS.Generators_State_Running
-				|| _state.value === VenusOS.Generators_State_WarmUp) {
+		if (_runningByConditionCode.value === VenusOS.Generators_RunningBy_Manual) {
 			Global.dialogLayer.open(generatorStopDialogComponent)
 		} else {
 			Global.dialogLayer.open(generatorStartDialogComponent)
@@ -59,6 +58,11 @@ ListItemButton {
 	VeQuickItem {
 		id: _state
 		uid: root.generatorUid ? root.generatorUid + "/State" : ""
+	}
+
+	VeQuickItem {
+		id: _runningByConditionCode
+		uid: root.generatorUid ? root.generatorUid + "/RunningByConditionCode" : ""
 	}
 
 	VeQuickItem {

--- a/components/dialogs/GeneratorDialog.qml
+++ b/components/dialogs/GeneratorDialog.qml
@@ -31,6 +31,7 @@ ModalDialog {
 
 	readonly property Generator generator: Generator { serviceUid: root.generatorUid }
 	readonly property int generatorState: generator ? generator.state : VenusOS.Generators_State_Stopped
+	readonly property int generatorRunningBy: generator ? generator.runningBy : VenusOS.Generators_RunningBy_NotRunning
 	property var runGeneratorAction
 
 	title: CommonWords.generator

--- a/components/dialogs/GeneratorStartDialog.qml
+++ b/components/dialogs/GeneratorStartDialog.qml
@@ -13,10 +13,9 @@ GeneratorDialog {
 	acceptText: qsTrId("controlcard_generator_startdialog_start_now")
 	secondaryTitle: CommonWords.manual_start
 
-	onGeneratorStateChanged: {
+	onGeneratorRunningByChanged: {
 		if (root.open) {
-			if (generatorState == VenusOS.Generators_State_Running
-					|| generatorState == VenusOS.Generators_State_WarmUp) {
+			if (generatorRunningBy == VenusOS.Generators_RunningBy_Manual) {
 				root.accept()
 			}
 		}

--- a/components/dialogs/GeneratorStopDialog.qml
+++ b/components/dialogs/GeneratorStopDialog.qml
@@ -23,6 +23,15 @@ GeneratorDialog {
 		}
 	}
 
+	// Invoked when manually starting generator while it was already running due to a condition.
+	onGeneratorRunningByChanged: {
+		if (root.open) {
+			if (generatorRunningBy != VenusOS.Generators_RunningBy_Manual) {
+				root.accept()
+			}
+		}
+	}
+
 	runGeneratorAction: function() {
 		root.generator.stop()
 	}


### PR DESCRIPTION
Synchronize the behavior with gui-v1.
Only show the "Manual stop" button when the generator is actually running due to a manual start.
Also allows to manually start the generator while
it was already running due to a condition.

https://github.com/victronenergy/gui-v2/issues/1564