### PR TITLE
Add configurable "start page"

### DIFF
--- a/ApplicationContent.qml
+++ b/ApplicationContent.qml
@@ -13,9 +13,7 @@ Item {
 
 	property var _inputComponent
 
-	readonly property bool _goToNotifications: !!pageManager.navBar && !!Global.notifications
-			&& Global.notifications.alarm
-			&& !!pageManager.navBar.model && pageManager.navBar.model.count > 0 // if alarm is detected at startup, wait until nav bar is ready
+	readonly property bool _goToNotifications: Global.allPagesLoaded && Global.notifications.alarm
 	on_GoToNotificationsChanged: {
 		if (_goToNotifications) {
 			notificationLayer.popAndGoToNotifications()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,6 +409,7 @@ set (VENUS_QML_MODULE_SOURCES
     data/PulseMeters.qml
     data/PvInverters.qml
     data/SolarChargers.qml
+    data/StartPageConfiguration.qml
     data/System.qml
     data/SystemLoad.qml
     data/SystemSettings.qml
@@ -499,6 +500,7 @@ set (VENUS_QML_MODULE_SOURCES
     pages/settings/PageSettingsDisplayBrief.qml
     pages/settings/PageSettingsDisplayMinMax.qml
     pages/settings/PageSettingsDisplayUnits.qml
+    pages/settings/PageSettingsDisplayStartPage.qml
     pages/settings/PageSettingsDvcc.qml
     pages/settings/PageSettingsDynamicEss.qml
     pages/settings/PageSettingsFirmware.qml

--- a/components/NavBar.qml
+++ b/components/NavBar.qml
@@ -20,10 +20,11 @@ Rectangle {  // Use an opaque background so that page disappears behind nav bar 
 			const url = model.get(i).url
 			if (url.endsWith("/" + pageName)) {
 				_currentIndex = i
-				return
+				return true
 			}
 		}
 		console.warn("setCurrentPage(): cannot find page", pageName)
+		return false
 	}
 
 	function setCurrentIndex(index) {
@@ -35,6 +36,11 @@ Rectangle {  // Use an opaque background so that page disappears behind nav bar 
 			return
 		}
 		_currentIndex = index
+	}
+
+	function getCurrentPage() {
+		const url = model.get(currentIndex).url
+		return url.substring(url.lastIndexOf("/") + 1)
 	}
 
 	width: parent.width

--- a/components/Page.qml
+++ b/components/Page.qml
@@ -12,12 +12,10 @@ FocusScope {
 
 	property string title
 	property color backgroundColor: Theme.color_page_background
-	property bool fullScreenWhenIdle
 	readonly property bool isCurrentPage: !!Global.mainView && Global.mainView.currentPage === root
 	readonly property bool defaultAnimationEnabled: !!Global.mainView && Global.mainView.allowPageAnimations
 			&& !Global.mainView.screenIsBlanked
 	property bool animationEnabled: defaultAnimationEnabled && isCurrentPage
-
 
 	property int topLeftButton: VenusOS.StatusBar_LeftButton_None
 	property int topRightButton: VenusOS.StatusBar_RightButton_None

--- a/components/controls/SwipeView.qml
+++ b/components/controls/SwipeView.qml
@@ -23,6 +23,10 @@ T.SwipeView {
 				|| visibleXEnd >= pageXStart && visibleXEnd <= pageXEnd
 	}
 
+	function getCurrentPage() {
+		return listView.currentItem
+	}
+
 	implicitWidth: Math.max(implicitBackgroundWidth + leftInset + rightInset,
 							contentWidth + leftPadding + rightPadding)
 	implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset,
@@ -46,7 +50,7 @@ T.SwipeView {
 		highlightRangeMode: ListView.StrictlyEnforceRange
 		preferredHighlightBegin: 0
 		preferredHighlightEnd: 0
-		highlightMoveDuration: 250
+		highlightMoveDuration: Global.allPagesLoaded ? 250 : 0 // don't animate when loading initial page
 		maximumFlickVelocity: 4 * (control.orientation === Qt.Horizontal ? width : height)
 
 		Timer {

--- a/data/StartPageConfiguration.qml
+++ b/data/StartPageConfiguration.qml
@@ -1,0 +1,200 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+QtObject {
+	id: root
+
+	required property string systemSettingsUid
+
+	readonly property bool hasStartPage: _startPageName.isValid && _startPageName.value !== ""
+	readonly property bool autoSelect: _startPageMode.value === VenusOS.StartPage_Mode_AutoSelect
+	readonly property int startPageTimeout: _startPageTimeout.value || 0     // in seconds
+	readonly property int autoSelectTimeout: 60 // in seconds
+
+	readonly property var options: [
+		{
+			//: The 'Brief' page
+			//% "Brief"
+			display: qsTrId("startpage_option_brief_without_panel"),
+			value: _jsonStringForType(VenusOS.StartPage_Type_Brief_SidePanelClosed),
+		},
+		{
+			//: The 'Brief' page, with the side panel opened
+			//% "Brief (side panel open)"
+			display: qsTrId("startpage_option_brief_with_panel"),
+			value: _jsonStringForType(VenusOS.StartPage_Type_Brief_SidePanelOpened),
+		},
+		{
+			//: The 'Overview' page
+			//% "Overview"
+			display: qsTrId("startpage_option_overview"),
+			value: _jsonStringForType(VenusOS.StartPage_Type_Overview),
+		},
+		{
+			//: The 'Levels' page, with the "Tanks" section opened
+			//% "Levels (Tanks)"
+			display: qsTrId("startpage_option_levels_tanks"),
+			value: _jsonStringForType(VenusOS.StartPage_Type_Levels_Tanks),
+		},
+		{
+			//: The 'Levels' page, with the "Environment" section opened
+			//% "Levels (Environment)"
+			display: qsTrId("startpage_option_levels_environment"),
+			value: _jsonStringForType(VenusOS.StartPage_Type_Levels_Environment),
+		},
+		{
+			//% "Battery list"
+			display: qsTrId("startpage_option_battery list"),
+			value: _jsonStringForType(VenusOS.StartPage_Type_BatteryList),
+		},
+	]
+
+	// Changes the application view to show the start page.
+	function loadStartPage(swipeView, stackPageUrls) {
+		if (!hasStartPage) {
+			return
+		}
+
+		let config
+		try {
+			config = JSON.parse(_startPageName.value)
+		} catch (e) {
+			console.warn("Unable to parse JSON from:", _startPageName.value, ", exception:", e)
+			return
+		}
+
+		// Load the main page and its properties
+		if (!config.main || !Global.pageManager.navBar.setCurrentPage(config.main.page)) {
+			return
+		}
+		const mainPage = swipeView.getCurrentPage()
+		for (const propertyName in config.main.properties) {
+			if (mainPage.hasOwnProperty(propertyName)) {
+				mainPage[propertyName] = config.main.properties[propertyName]
+			}
+		}
+
+		// Load the required pages onto the stack
+		const stackPages = config.stack || []
+		if (stackPages.length > 0
+				&& stackPageUrls.length > 0
+				&& stackPages[stackPages.length - 1].page === stackPageUrls[stackPageUrls.length - 1]) {
+			// Looks like the stack is already showing the correct page, so there's nothing to do.
+			return
+		}
+		Global.pageManager.popAllPages(PageStack.Immediate)
+		for (let i = 0; i < stackPages.length; ++i) {
+			if (stackPages[i].page) {
+				Global.pageManager.pushPage(stackPages[i].page, stackPages[i].properties || {})
+			}
+		}
+	}
+
+	// Changes the "start page" to be the current visible page, if possible.
+	function autoSelectStartPage(mainPageName, mainPage, stackPageUrls) {
+		if (!autoSelect) {
+			return
+		}
+		if (!mainPageName || !mainPage) {
+			console.warn("autoSelect() failed: mainPageName or mainPage not set")
+			return
+		}
+		const startPageType = _findStartPageTypeForView(mainPageName, mainPage, stackPageUrls)
+		if (startPageType >= 0) {
+			_startPageName.setValue(_jsonStringForType(startPageType))
+		}
+	}
+
+	function _jsonStringForType(startPageType) {
+		switch (startPageType) {
+		case VenusOS.StartPage_Type_Brief_SidePanelClosed:
+			return JSON.stringify({
+				main: { page: "BriefPage.qml", properties: { showSidePanel: false } },
+				stack: [],
+			})
+		case VenusOS.StartPage_Type_Brief_SidePanelOpened:
+			return JSON.stringify({
+				main: { page: "BriefPage.qml", properties: { showSidePanel: true } },
+				stack: [],
+			})
+		case VenusOS.StartPage_Type_Overview:
+			return JSON.stringify({
+				main: { page: "OverviewPage.qml", properties: {} },
+				stack: [],
+			})
+		case VenusOS.StartPage_Type_Levels_Tanks:
+			return JSON.stringify({
+				main: { page: "LevelsPage.qml", properties: { currentTabIndex: 0 } },
+				stack: [],
+			})
+		case VenusOS.StartPage_Type_Levels_Environment:
+			return JSON.stringify({
+				main: { page: "LevelsPage.qml", properties: { currentTabIndex: 1 } },
+				stack: [],
+			})
+		case VenusOS.StartPage_Type_BatteryList:
+			return JSON.stringify({
+				main: { page: "OverviewPage.qml", properties: {} },
+				stack: [{ page: "/pages/battery/BatteryListPage.qml" }],
+			})
+		default:
+			console.warn("Unsupported start page type:", startPageType)
+			return ""
+		}
+	}
+
+	function _findStartPageTypeForView(mainPageName, mainPage, stackPageUrls) {
+		switch (mainPageName) {
+		case "BriefPage.qml":
+			if (stackPageUrls.length === 0) {
+				if (mainPage.showSidePanel === undefined) {
+					console.warn("Error: BriefPage does not have showSidePanel property!")
+				} else {
+					return mainPage.showSidePanel
+							? VenusOS.StartPage_Type_Brief_SidePanelOpened
+							: VenusOS.StartPage_Type_Brief_SidePanelClosed
+				}
+			}
+			break
+		case "OverviewPage.qml":
+			if (stackPageUrls.length === 0) {
+				return VenusOS.StartPage_Type_Overview
+			} else if (stackPageUrls[stackPageUrls.length - 1].endsWith("/BatteryListPage.qml")) {
+				return VenusOS.StartPage_Type_BatteryList
+			}
+			break
+		case "LevelsPage.qml":
+			if (stackPageUrls.length === 0) {
+				if (mainPage.currentTabIndex === undefined) {
+					console.warn("Error: LevelsPage does not have currentTabIndex property!")
+				} else {
+					return mainPage.currentTabIndex === 0
+							? VenusOS.StartPage_Type_Levels_Tanks
+							: VenusOS.StartPage_Type_Levels_Environment
+				}
+			}
+			break
+		}
+		return -1
+	}
+
+	// Whether the start page is enabled. 0 = disabled (i.e. auto-select), 1 = enabled (do not auto-select)
+	readonly property VeQuickItem _startPageMode: VeQuickItem {
+		uid: root.systemSettingsUid + "/Settings/Gui2/StartPage"
+	}
+
+	// JSON string containing the start page configuration.
+	readonly property VeQuickItem _startPageName: VeQuickItem {
+		uid: root.systemSettingsUid + "/Settings/Gui2/StartPageName"
+	}
+
+	// Time to wait (in seconds) when the app is idle, before loading the start page.
+	readonly property VeQuickItem _startPageTimeout: VeQuickItem {
+		uid: root.systemSettingsUid + "/Settings/Gui2/StartPageTimeout"
+	}
+}

--- a/data/SystemSettings.qml
+++ b/data/SystemSettings.qml
@@ -15,6 +15,9 @@ QtObject {
 	property int temperatureUnit: VenusOS.Units_None
 	property string temperatureUnitSuffix
 	property int volumeUnit: VenusOS.Units_None
+	readonly property StartPageConfiguration startPageConfiguration: StartPageConfiguration {
+		systemSettingsUid: root.serviceUid
+	}
 
 	readonly property bool essFeedbackToGridEnabled: _hubSetting.value === VenusOS.System_HubSetting_Ess
 			&& (_overvoltageFeedIn.value === 1 || _preventFeedback.value === 0)

--- a/data/mock/SystemSettingsImpl.qml
+++ b/data/mock/SystemSettingsImpl.qml
@@ -78,6 +78,9 @@ QtObject {
 		setMockSettingValue("SystemSetup/HasAcInLoads", 1)
 		setMockSettingValue("Gui/DemoMode", 1)
 		setMockSettingValue("Gui2/OnBoarding", VenusOS.OnboardingState_DoneNative | VenusOS.OnboardingState_DoneWasm)
+		setMockSettingValue("Gui2/StartPage", VenusOS.StartPage_Mode_AutoSelect)
+		setMockSettingValue("Gui2/StartPageName", "")
+		setMockSettingValue("Gui2/StartPageTimeout", 0)
 
 		setMockSystemValue("AvailableBatteryServices", '{"default": "Automatic", "nobattery": "No battery monitor", "com.victronenergy.vebus/257": "Quattro 24/3000/70-2x50 on VE.Bus", "com.victronenergy.battery/0": "Lynx Smart BMS 500 on VE.Can"}')
 		setMockSystemValue("AutoSelectedBatteryService", "Lynx Smart BMS 500 on VE.Can")

--- a/data/mock/config/MockDataSimulator.qml
+++ b/data/mock/config/MockDataSimulator.qml
@@ -294,6 +294,9 @@ QtObject {
 		case Qt.Key_V:
 			levelsEnabled = !levelsEnabled
 			break
+		case Qt.Key_W:
+			Global.mainView.loadStartPage()
+			break
 		case Qt.Key_Space:
 			Global.splashScreenVisible = false
 			event.accepted = true

--- a/pages/BriefPage.qml
+++ b/pages/BriefPage.qml
@@ -136,7 +136,6 @@ SwipeViewPage {
 	navButtonIcon: "qrc:/images/brief.svg"
 	url: "qrc:/qt/qml/Victron/VenusOS/pages/BriefPage.qml"
 	backgroundColor: Theme.color_briefPage_background
-	fullScreenWhenIdle: true
 	topLeftButton: VenusOS.StatusBar_LeftButton_ControlsInactive
 	topRightButton: sidePanel.active && state !== "panelOpening"
 			? VenusOS.StatusBar_RightButton_SidePanelActive

--- a/pages/LevelsPage.qml
+++ b/pages/LevelsPage.qml
@@ -11,7 +11,6 @@ SwipeViewPage {
 	id: root
 
 	topLeftButton: VenusOS.StatusBar_LeftButton_ControlsInactive
-	fullScreenWhenIdle: true
 	//% "Levels"
 	navButtonText: qsTrId("nav_levels")
 	navButtonIcon: "qrc:/images/levels.svg"

--- a/pages/LevelsPage.qml
+++ b/pages/LevelsPage.qml
@@ -10,6 +10,9 @@ import QtQuick.Controls.impl as CP
 SwipeViewPage {
 	id: root
 
+	// Used by StartPageConfiguration when this is the start page.
+	property alias currentTabIndex: tabBar.currentIndex
+
 	topLeftButton: VenusOS.StatusBar_LeftButton_ControlsInactive
 	//% "Levels"
 	navButtonText: qsTrId("nav_levels")
@@ -22,9 +25,6 @@ SwipeViewPage {
 
 	TabBar {
 		id: tabBar
-
-		// Prefer a tab that is enabled.
-		property int _preferredIndex: model[0].enabled || !model[1].enabled ? 0 : 1
 
 		anchors {
 			top: parent.top
@@ -54,8 +54,8 @@ SwipeViewPage {
 			{ value: qsTrId("levels_page_environment"), enabled: Global.environmentInputs.model.count > 0 }
 		]
 
-		currentIndex: _preferredIndex
-		onCurrentIndexChanged: _preferredIndex = currentIndex   // once user selects a tab, don't use the default index anymore
+		// Prefer a tab that is enabled.
+		currentIndex: model[0].enabled || !model[1].enabled ? 0 : 1
 	}
 
 	TanksTab {

--- a/pages/OverviewPage.qml
+++ b/pages/OverviewPage.qml
@@ -398,7 +398,6 @@ SwipeViewPage {
 	navButtonIcon: "qrc:/images/overview.svg"
 	url: "qrc:/qt/qml/Victron/VenusOS/pages/OverviewPage.qml"
 	topLeftButton: VenusOS.StatusBar_LeftButton_ControlsInactive
-	fullScreenWhenIdle: true
 
 	Component {
 		id: acInputComponent

--- a/pages/PageManager.qml
+++ b/pages/PageManager.qml
@@ -10,9 +10,9 @@ QtObject {
 	id: root
 
 	property QtObject emitter: QtObject {
-		signal pagePushRequested(var obj, var properties)
-		signal pagePopRequested(var toPage)
-		signal popAllPagesRequested()
+		signal pagePushRequested(obj: var, properties: var, operation: int)
+		signal pagePopRequested(toPage: var, operation: int)
+		signal popAllPagesRequested(operation: int)
 	}
 
 	property NavBar navBar
@@ -36,15 +36,15 @@ QtObject {
 		onTriggered: root.interactivity = VenusOS.PageManager_InteractionMode_EnterIdleMode
 	}
 
-	function pushPage(obj, properties) {
-		emitter.pagePushRequested(obj, properties)
+	function pushPage(obj, properties, operation = PageStack.PushTransition) {
+		emitter.pagePushRequested(obj, properties, operation)
 	}
 
-	function popPage(toPage) {
-		emitter.pagePopRequested(toPage)
+	function popPage(toPage, operation = PageStack.PopTransition) {
+		emitter.pagePopRequested(toPage, operation)
 	}
 
-	function popAllPages() {
-		emitter.popAllPagesRequested()
+	function popAllPages(operation = PageStack.PopTransition) {
+		emitter.popAllPagesRequested(operation)
 	}
 }

--- a/pages/PageManager.qml
+++ b/pages/PageManager.qml
@@ -30,8 +30,6 @@ QtObject {
 	property Timer idleModeTimer: Timer {
 		running: !Global.splashScreenVisible
 			&& !!Global.mainView
-			&& Global.mainView.currentPage !== null && Global.mainView.currentPage !== undefined
-			&& Global.mainView.currentPage.fullScreenWhenIdle
 			&& root.interactivity === VenusOS.PageManager_InteractionMode_Interactive
 			&& BackendConnection.applicationVisible
 		interval: Theme.animation_page_idleResize_timeout

--- a/pages/battery/BatteryListPage.qml
+++ b/pages/battery/BatteryListPage.qml
@@ -10,6 +10,9 @@ import Victron.VenusOS
 Page {
 	id: root
 
+	//% "Batteries"
+	title: qsTrId("battery_list_page_title")
+
 	GradientListView {
 		model: batteryModel
 		spacing: Theme.geometry_gradientList_spacing

--- a/pages/settings/PageSettingsDisplay.qml
+++ b/pages/settings/PageSettingsDisplay.qml
@@ -167,6 +167,14 @@ Page {
 				}
 			}
 
+			ListNavigationItem {
+				//% "Start page"
+				text: qsTrId("settings_brief_view_start_page")
+				onClicked: {
+					Global.pageManager.pushPage("/pages/settings/PageSettingsDisplayStartPage.qml", {"title": text})
+				}
+			}
+
 			ListRadioButtonGroup {
 				id: runningVersion
 

--- a/pages/settings/PageSettingsDisplayStartPage.qml
+++ b/pages/settings/PageSettingsDisplayStartPage.qml
@@ -1,0 +1,149 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+Page {
+	id: root
+
+	function _timeoutOptions() {
+		//% "Never"
+		let options = [ { display: qsTrId("settings_startpage_timeout_never"), value: 0 } ]
+		const timeouts = [ 1, 5, 10, 30, 60 ]
+		for (let i = 0; i < timeouts.length; ++i) {
+			const minutes = timeouts[i]
+			//% "After %n minute(s)"
+			options.push({
+				display: qsTrId("settings_startpage_timeout_minutes", minutes),
+				value: minutes * 60
+			})
+		}
+		return options
+	}
+
+	VeQuickItem {
+		id: startPageName
+		uid: Global.systemSettings.serviceUid + "/Settings/Gui2/StartPageName"
+	}
+
+	GradientListView {
+		model: ObjectModel {
+			ListNavigationItem {
+				id: startPageNavigation
+				//% "Start page"
+				text: qsTrId("settings_startpage_name")
+				secondaryText: {
+					const options = Global.systemSettings.startPageConfiguration.options
+					let optionText = ""
+					for (let i = 0; i < options.length; ++i) {
+						if (options[i].value === startPageName.value) {
+							optionText = options[i].display
+							break
+						}
+					}
+					if (optionText.length) {
+						return optionText
+					} else if (Global.systemSettings.startPageConfiguration.autoSelect) {
+						return CommonWords.auto
+					} else {
+						//% "None"
+						return qsTrId("settings_startpage_none")
+					}
+				}
+				bottomContentChildren: [
+					ListLabel {
+						width: Math.min(implicitWidth, startPageNavigation.width)
+						topPadding: 0
+						bottomPadding: 0
+						color: Theme.color_font_secondary
+						//% "Go to this page when the application is inactive."
+						text: qsTrId("settings_startpage_description")
+					}
+				]
+				onClicked: {
+					Global.pageManager.pushPage(startPageOptionsComponent, { title: text })
+				}
+			}
+
+			ListRadioButtonGroup {
+				id: startPageTimeout
+				//% "Timeout"
+				text: qsTrId("settings_startpage_timeout")
+				optionModel: root._timeoutOptions()
+				dataItem.uid: Global.systemSettings.serviceUid + "/Settings/Gui2/StartPageTimeout"
+				bottomContentChildren: [
+					ListLabel {
+						width: Math.min(implicitWidth, startPageTimeout.width)
+						topPadding: 0
+						bottomPadding: 0
+						color: Theme.color_font_secondary
+						//% "Revert to the start page when the application is inactive."
+						text: qsTrId("settings_startpage_timeout_description")
+					}
+				]
+			}
+		}
+	}
+
+	Timer {
+		id: popTimer
+		interval: Theme.animation_settings_radioButtonPage_autoClose_duration
+		onTriggered: Global.pageManager.popPage()
+	}
+
+	Component {
+		id: startPageOptionsComponent
+
+		Page {
+			GradientListView {
+				model: ObjectModel {
+					ListSwitch {
+						id: startPageMode
+						text: CommonWords.auto
+						dataItem.uid: Global.systemSettings.serviceUid + "/Settings/Gui2/StartPage"
+						invertSourceValue: true
+						bottomContentChildren: [
+							ListLabel {
+								width: Math.min(implicitWidth, startPageMode.width)
+								topPadding: 0
+								bottomPadding: 0
+								color: Theme.color_font_secondary
+								//% "After one minute of inactivity, select the current page as the start page, if it is in this list."
+								text: qsTrId("settings_startpage_auto_description")
+							}
+						]
+						onClicked: {
+							popTimer.stop()
+							if (checked) {
+								// Clear the selected start page to indicate that it should now be
+								// auto-selected instead.
+								startPageName.setValue("")
+							}
+						}
+					}
+
+					Column {
+						width: parent ? parent.width : 0
+
+						Repeater {
+							model: Global.systemSettings.startPageConfiguration.options
+							delegate: ListRadioButton {
+								checked: modelData.value === startPageName.value
+								text: modelData.display
+								onClicked: {
+									popTimer.stop()
+									startPageName.setValue(modelData.value)
+									startPageMode.dataItem.setValue(VenusOS.StartPage_Mode_UserSelect)  // disable auto-select switch
+									popTimer.start()
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/enums.h
+++ b/src/enums.h
@@ -717,6 +717,23 @@ public:
 	};
 	Q_ENUM(OnboardingState)
 	Q_DECLARE_FLAGS(OnboardingStateFlag, OnboardingState)
+
+	enum StartPage_Mode {
+		StartPage_Mode_AutoSelect,
+		StartPage_Mode_UserSelect
+	};
+	Q_ENUM(StartPage_Mode)
+
+	enum StartPage_Type {
+		StartPage_Type_None,
+		StartPage_Type_Brief_SidePanelClosed,
+		StartPage_Type_Brief_SidePanelOpened,
+		StartPage_Type_Overview,
+		StartPage_Type_Levels_Tanks,
+		StartPage_Type_Levels_Environment,
+		StartPage_Type_BatteryList
+	};
+	Q_ENUM(StartPage_Type)
 };
 
 }


### PR DESCRIPTION
Allow a "start page" to be configured from Settings > Display & Language > Start Page. This is the page that will be shown:

- on application start-up 
- after the application is idle for a certain time

If the "Auto" option is selected, and a timeout is set, then the start page will be set automatically from the current application page after one minute, if it is one of the available options.

Fixes #1496