### PR TITLE
Set different onboarding 'completed' states for wasm vs device

### DIFF
--- a/components/SplashView.qml
+++ b/components/SplashView.qml
@@ -278,7 +278,9 @@ Rectangle {
 	Loader {
 		id: welcomeLoader
 
-		active: Global.dataManagerLoaded && (onboardingDone.isValid && onboardingDone.value !== 1)
+		active: Global.dataManagerLoaded && onboardingState.isValid
+				&& ( (Qt.platform.os === "wasm" && !(onboardingState.value & VenusOS.OnboardingState_DoneWasm))
+				  || (Qt.platform.os !== "wasm" && !(onboardingState.value & VenusOS.OnboardingState_DoneNative)) )
 		anchors.fill: parent
 		sourceComponent: WelcomeView {
 			anchors.centerIn: parent
@@ -291,7 +293,7 @@ Rectangle {
 	}
 
 	VeQuickItem {
-		id: onboardingDone
+		id: onboardingState
 		uid: Global.dataManagerLoaded ? Global.systemSettings.serviceUid + "/Settings/Gui2/OnBoarding" : ""
 	}
 }

--- a/data/mock/SystemSettingsImpl.qml
+++ b/data/mock/SystemSettingsImpl.qml
@@ -77,7 +77,7 @@ QtObject {
 		setMockSettingValue("SystemSetup/AcInput2", 3)
 		setMockSettingValue("SystemSetup/HasAcInLoads", 1)
 		setMockSettingValue("Gui/DemoMode", 1)
-		setMockSettingValue("Gui2/OnBoarding", 1)
+		setMockSettingValue("Gui2/OnBoarding", VenusOS.OnboardingState_DoneNative | VenusOS.OnboardingState_DoneWasm)
 
 		setMockSystemValue("AvailableBatteryServices", '{"default": "Automatic", "nobattery": "No battery monitor", "com.victronenergy.vebus/257": "Quattro 24/3000/70-2x50 on VE.Bus", "com.victronenergy.battery/0": "Lynx Smart BMS 500 on VE.Can"}')
 		setMockSystemValue("AutoSelectedBatteryService", "Lynx Smart BMS 500 on VE.Can")

--- a/pages/welcome/WelcomeView.qml
+++ b/pages/welcome/WelcomeView.qml
@@ -45,7 +45,7 @@ Rectangle {
 			text: qsTrId("welcome_skip")
 			flat: true
 			color: Theme.color_ok
-			onClicked: onboardingDone.setValue(1)
+			onClicked: onboardingState.setDoneFlag()
 		}
 
 		ProgressBar {
@@ -145,7 +145,7 @@ Rectangle {
 			}
 			onNextClicked: {
 				if (stackView.depth === welcomePages.count) {
-					onboardingDone.setValue(1)
+					onboardingState.setDoneFlag()
 				} else {
 					stackView.push(welcomePages.objectAt(stackView.depth))
 				}
@@ -169,7 +169,16 @@ Rectangle {
 	}
 
 	VeQuickItem {
-		id: onboardingDone
+		id: onboardingState
+
+		function setDoneFlag() {
+			if (Qt.platform.os === "wasm") {
+				setValue(value | VenusOS.OnboardingState_DoneWasm)
+			} else {
+				setValue(value | VenusOS.OnboardingState_DoneNative)
+			}
+		}
+
 		uid: Global.systemSettings.serviceUid + "/Settings/Gui2/OnBoarding"
 	}
 }

--- a/src/enums.h
+++ b/src/enums.h
@@ -709,9 +709,19 @@ public:
 		InputValidation_ValidateAndSave,
 	};
 	Q_ENUM(InputValidation_ValidateMode)
+
+	enum OnboardingState {
+		OnboardingState_NotDone,
+		OnboardingState_DoneNative = 0x01,
+		OnboardingState_DoneWasm = 0x02
+	};
+	Q_ENUM(OnboardingState)
+	Q_DECLARE_FLAGS(OnboardingStateFlag, OnboardingState)
 };
 
 }
 }
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(Victron::VenusOS::Enums::OnboardingStateFlag)
 
 #endif // VICTRON_VENUSOS_GUI_V2_ENUMS_H


### PR DESCRIPTION
This allows the onboarding/welcome screen to be shown on the device, even if it was previously shown on wasm, and vice-versa.

Contributes to #1441