### PR TITLE
Fix the tank merge threshold for 7 inch screens

### DIFF
--- a/themes/geometry/SevenInch.json
+++ b/themes/geometry/SevenInch.json
@@ -291,7 +291,7 @@
     "geometry_levelsPage_subgauges_horizontalMargin": 24,
     "geometry_levelsPage_subgauges_bottomMargin": 10,
     "geometry_levelsPage_subgauges_spacing": 8,
-    "geometry_levelsPage_tankMergeThreshold": 8,
+    "geometry_levelsPage_tankMergeThreshold": 7,
     "geometry_levelsPage_tankGauge_radius": 7,
     "geometry_levelsPage_max_tank_count": 6,
 


### PR DESCRIPTION
Fixes #1599

5" screens can fit 5 gauges, 7" screens can fit 6 gauges