### PR TITLE
Ensure onboarding/welcome screen cannot get stuck

### DIFF
--- a/components/SplashView.qml
+++ b/components/SplashView.qml
@@ -278,9 +278,7 @@ Rectangle {
 	Loader {
 		id: welcomeLoader
 
-		active: Global.dataManagerLoaded && onboardingState.isValid
-				&& ( (Qt.platform.os === "wasm" && !(onboardingState.value & VenusOS.OnboardingState_DoneWasm))
-				  || (Qt.platform.os !== "wasm" && !(onboardingState.value & VenusOS.OnboardingState_DoneNative)) )
+		active: Global.dataManagerLoaded && Global.systemSettings.needsOnboarding
 		anchors.fill: parent
 		sourceComponent: WelcomeView {
 			anchors.centerIn: parent
@@ -290,10 +288,5 @@ Rectangle {
 			// so that there is a nicer transition from the welcome to the main screen.
 			root.showSplashAnimation = true
 		}
-	}
-
-	VeQuickItem {
-		id: onboardingState
-		uid: Global.dataManagerLoaded ? Global.systemSettings.serviceUid + "/Settings/Gui2/OnBoarding" : ""
 	}
 }

--- a/data/SystemSettings.qml
+++ b/data/SystemSettings.qml
@@ -10,6 +10,7 @@ QtObject {
 	id: root
 
 	readonly property string serviceUid: BackendConnection.serviceUidForType("settings")
+	readonly property bool needsOnboarding: !_onboardingState.done
 
 	property int electricalQuantity: VenusOS.Units_None
 	property int temperatureUnit: VenusOS.Units_None
@@ -105,6 +106,10 @@ QtObject {
 		default:
 			return ""
 		}
+	}
+
+	function setOnboardingDone() {
+		_onboardingState.setDoneFlag()
 	}
 
 	property VeQuickItem accessLevel: VeQuickItem {
@@ -298,6 +303,26 @@ QtObject {
 
 	readonly property VeQuickItem _preventFeedback: VeQuickItem {
 		uid: root.serviceUid + "/Settings/CGwacs/PreventFeedback"
+	}
+
+	readonly property VeQuickItem _onboardingState: VeQuickItem {
+		readonly property bool done: _forceOnboardingDone
+			|| (isValid
+				&& ( (Qt.platform.os === "wasm" && (value & VenusOS.OnboardingState_DoneWasm))
+					|| (Qt.platform.os !== "wasm" && (value & VenusOS.OnboardingState_DoneNative)) ) )
+
+		property bool _forceOnboardingDone
+
+		function setDoneFlag() {
+			_forceOnboardingDone = true
+			if (Qt.platform.os === "wasm") {
+				setValue(value | VenusOS.OnboardingState_DoneWasm)
+			} else {
+				setValue(value | VenusOS.OnboardingState_DoneNative)
+			}
+		}
+
+		uid: root.serviceUid + "/Settings/Gui2/OnBoarding"
 	}
 
 	function reset() {

--- a/pages/welcome/WelcomeView.qml
+++ b/pages/welcome/WelcomeView.qml
@@ -45,7 +45,7 @@ Rectangle {
 			text: qsTrId("welcome_skip")
 			flat: true
 			color: Theme.color_ok
-			onClicked: onboardingState.setDoneFlag()
+			onClicked: Global.systemSettings.setOnboardingDone()
 		}
 
 		ProgressBar {
@@ -145,7 +145,7 @@ Rectangle {
 			}
 			onNextClicked: {
 				if (stackView.depth === welcomePages.count) {
-					onboardingState.setDoneFlag()
+					Global.systemSettings.setOnboardingDone()
 				} else {
 					stackView.push(welcomePages.objectAt(stackView.depth))
 				}
@@ -166,19 +166,5 @@ Rectangle {
 			top: header.bottom
 			bottom: parent.bottom
 		}
-	}
-
-	VeQuickItem {
-		id: onboardingState
-
-		function setDoneFlag() {
-			if (Qt.platform.os === "wasm") {
-				setValue(value | VenusOS.OnboardingState_DoneWasm)
-			} else {
-				setValue(value | VenusOS.OnboardingState_DoneNative)
-			}
-		}
-
-		uid: Global.systemSettings.serviceUid + "/Settings/Gui2/OnBoarding"
 	}
 }


### PR DESCRIPTION
In case a write to /Settings/Gui2/OnBoarding fails, set a bool property that will cause the onboarding/welcome screen to be closed.

Fixes #1601