### PR TITLE
update the UI selection text

### DIFF
--- a/pages/settings/PageSettingsDisplay.qml
+++ b/pages/settings/PageSettingsDisplay.qml
@@ -172,8 +172,11 @@ Page {
 
 				property ModalWarningDialog _restartDialog
 
-				//% "Onscreen UI (GX Touch & Ekrano)"
-				text: qsTrId("settings_display_onscreen_ui")
+				text: onScreenGuiv2Possible.value
+					  //% "User interface"
+					? qsTrId("settings_display_onscreen_ui")
+					  //% "User interface (Remote Console)"
+					: qsTrId("settings_display_remote_console_ui")
 				dataItem.uid: Global.systemSettings.serviceUid + "/Settings/Gui/RunningVersion"
 				writeAccessLevel: VenusOS.User_AccessType_User
 				updateDataOnClick: false
@@ -198,28 +201,37 @@ Page {
 						_restartDialog = restartDialogComponent.createObject(Global.dialogLayer)
 					}
 					_restartDialog.versionName = optionModel[index].display
+					_restartDialog.settingText = runningVersion.text
 					_restartDialog.open()
 					dataItem.setValue(optionModel[index].value)
+				}
+
+				VeQuickItem {
+					id: onScreenGuiv2Possible
+					uid: Global.venusPlatform.serviceUid + "/Gui/OnScreenGuiv2Supported"
 				}
 
 				Component {
 					id: restartDialogComponent
 
 					ModalWarningDialog {
+						property string settingText // "User interface" or "User interface (Remote Console)"
 						property string versionName
 
 						title: BackendConnection.type === BackendConnection.DBusSource
 							  //% "Restarting application..."
 							? qsTrId("settings_restarting_app")
-							  //% "Application restarted"
-							: qsTrId("settings_app_restarted")
+							  //: %1 = The name of the setting being updated
+							  //% "%1 updated"
+							: qsTrId("settings_app_restarted").arg(settingText)
 						description: BackendConnection.type === BackendConnection.DBusSource
 							  //: %1 = the UI version that the system is switching to
-							  //% "Onscreen UI will switch to %1."
+							  //% "User interface will switch to %1."
 							? qsTrId("settings_switch_ui").arg(versionName)
-							   //: %1 = the UI version that the system has switched to.
-							  //% "Onscreen UI has switched to %1."
-							: qsTrId("settings_has_switched_ui").arg(versionName)
+							  //: %1 = The name of the setting being updated
+							  //: %2 = the UI version that the system has switched to.
+							  //% "%1 is set to %2"
+							: qsTrId("settings_has_switched_ui").arg(settingText).arg(versionName)
 
 						dialogDoneOptions: BackendConnection.type === BackendConnection.DBusSource
 								? VenusOS.ModalDialog_DoneOptions_NoOptions


### PR DESCRIPTION
The UI selection now also switches the default index page; remote console or the gui-v2 wasm. What exactly is being switched depends on the device, since not all of them can run gui-v2.

If the device can run gui-v2, the setting is now called 'User interface', otherwise 'User interface (Remote Console)' to make it clear that only remote console will be switched. Remove the Onscreen UI references, since it no longer affects only the Onscreen UI.