### PR TITLE
Battery list: show values directly from from system /Batteries

### DIFF
--- a/components/QuantityRow.qml
+++ b/components/QuantityRow.qml
@@ -11,6 +11,7 @@ Row {
 
 	property alias model: quantityRepeater.model
 	property alias quantityMetrics: quantityMetrics
+	property bool showFirstSeparator
 
 	// In table mode, items are spaced out without separators between them.
 	// (TODO if not tableMode, then invalid items should be hidden, instead of showing them as "--".)
@@ -40,7 +41,7 @@ Row {
 				height: textLabel.height
 				visible: root._showSeparators
 						&& quantityDelegate.showValue
-						&& model.index !== 0
+						&& (model.index !== 0 || root.showFirstSeparator)
 
 				Rectangle {
 					anchors.horizontalCenter: parent.horizontalCenter

--- a/components/widgets/BatteryWidget.qml
+++ b/components/widgets/BatteryWidget.qml
@@ -182,7 +182,7 @@ OverviewWidget {
 				color: Theme.color_font_secondary
 			}
 			Label {
-				text: Global.batteries.timeToGoText(Global.batteries.system, VenusOS.Battery_TimeToGo_ShortFormat)
+				text: Global.batteries.timeToGoText(Global.batteries.system.timeToGo, VenusOS.Battery_TimeToGo_ShortFormat)
 				color: Theme.color_font_primary
 				width: parent.width
 				elide: Text.ElideRight

--- a/data/Batteries.qml
+++ b/data/Batteries.qml
@@ -27,11 +27,11 @@ QtObject {
 		model.clear()
 	}
 
-	function timeToGoText(battery, format) {
-		if ((battery.timeToGo || 0) <= 0) {
+	function timeToGoText(timeToGo, format) {
+		if ((timeToGo || 0) <= 0) {
 			return ""
 		}
-		const text = Utils.secondsToString(battery.timeToGo)
+		const text = Utils.secondsToString(timeToGo)
 		if (format === VenusOS.Battery_TimeToGo_LongFormat) {
 			//: %1 = time remaining, e.g. '3h 2m'
 			//% "%1 to go"
@@ -41,14 +41,14 @@ QtObject {
 		}
 	}
 
-	function batteryIcon(battery) {
-		return isNaN(battery.power) || battery.power === 0 ? "qrc:/images/icon_battery_24.svg"
-			: (battery.power > 0 ? "qrc:/images/icon_battery_charging_24.svg" : "qrc:/images/icon_battery_discharging_24.svg")
+	function batteryIcon(power) {
+		return isNaN(power) || power === 0 ? "qrc:/images/icon_battery_24.svg"
+			: (power > 0 ? "qrc:/images/icon_battery_charging_24.svg" : "qrc:/images/icon_battery_discharging_24.svg")
 	}
 
-	function batteryMode(battery) {
-		return isNaN(battery.power) || battery.power === 0 ? VenusOS.Battery_Mode_Idle
-			: (battery.power > 0 ? VenusOS.Battery_Mode_Charging : VenusOS.Battery_Mode_Discharging)
+	function batteryMode(power) {
+		return isNaN(power) || power === 0 ? VenusOS.Battery_Mode_Idle
+			: (power > 0 ? VenusOS.Battery_Mode_Charging : VenusOS.Battery_Mode_Discharging)
 	}
 
 	function modeToText(mode) {

--- a/data/common/Battery.qml
+++ b/data/common/Battery.qml
@@ -15,8 +15,8 @@ Device {
 	readonly property real current: _current.isValid ? _current.value : NaN
 	readonly property real temperature: _temperature.isValid ? _temperature.value : NaN
 	readonly property real timeToGo: _timeToGo.isValid ? _timeToGo.value : NaN // in seconds
-	readonly property string icon: !!Global.batteries ? Global.batteries.batteryIcon(battery) : ""
-	readonly property int mode: !!Global.batteries ? Global.batteries.batteryMode(battery) : -1
+	readonly property string icon: !!Global.batteries ? Global.batteries.batteryIcon(power) : ""
+	readonly property int mode: !!Global.batteries ? Global.batteries.batteryMode(power) : -1
 	readonly property bool isParallelBms: _numberOfBmses.isValid
 	readonly property int state: _state.isValid ? _state.value : NaN
 

--- a/data/common/SystemBattery.qml
+++ b/data/common/SystemBattery.qml
@@ -15,8 +15,8 @@ QtObject {
 	readonly property real current: _current.isValid ? _current.value : NaN
 	readonly property real temperature: _temperature.isValid ? _temperature.value : NaN
 	readonly property real timeToGo: _timeToGo.isValid ? _timeToGo.value : NaN
-	readonly property string icon: !!Global.batteries ? Global.batteries.batteryIcon(battery) : ""
-	readonly property int mode: !!Global.batteries ? Global.batteries.batteryMode(battery) : -1
+	readonly property string icon: !!Global.batteries ? Global.batteries.batteryIcon(power) : ""
+	readonly property int mode: !!Global.batteries ? Global.batteries.batteryMode(power) : -1
 
 	readonly property VeQuickItem _stateOfCharge: VeQuickItem {
 		uid: Global.system.serviceUid + "/Dc/Battery/Soc"

--- a/data/mock/BatteriesImpl.qml
+++ b/data/mock/BatteriesImpl.qml
@@ -105,6 +105,33 @@ QtObject {
 		}
 	}
 
+	function updateBatteriesList() {
+		const batteryList = [
+			{
+				// System battery
+				active_battery_service: true,
+				current: dummyBattery.current,
+				id: dummyBattery.serviceUid.substring(BackendConnection.uidPrefix().length + 1),
+				instance: dummyBattery.deviceInstance,
+				name: dummyBattery.name,
+				power: dummyBattery.power,
+				soc: dummyBattery.stateOfCharge,
+				state: dummyBattery.state,
+				temperature: dummyBattery.temperature,
+				timetogo: dummyBattery.timeToGo,
+				voltage: dummyBattery.voltage,
+			},
+			{
+				// Starter battery, which does not have an instance number
+				active_battery_service: false,
+				id: "com.victronenergy.battery.ttyUSB2:1",
+				name: "My starter battery",
+				voltage: 0.029999999329447746
+			}
+		]
+		Global.mockDataSimulator.setMockValue(Global.system.serviceUid + "/Batteries", batteryList)
+	}
+
 	property Battery dummyBattery: Battery {
 		serviceUid: "mock/com.victronenergy.battery.ttyUSB1"
 
@@ -124,12 +151,7 @@ QtObject {
 
 			Global.batteries.system = dummyBattery
 			Global.batteries.addBattery(dummyBattery)
-
-			const batteryList = [{
-				id: "com.victronenergy.battery.ttyUSB1",
-				instance: 1,
-			}]
-			Global.mockDataSimulator.setMockValue(Global.system.serviceUid + "/Batteries", batteryList)
+			root.updateBatteriesList()
 		}
 	}
 
@@ -176,6 +198,7 @@ QtObject {
 					: 0
 			Global.batteries.system._power.setValue(power)
 			Global.batteries.system._current.setValue(power * 0.1)
+			root.updateBatteriesList()
 		}
 	}
 

--- a/pages/BriefPage.qml
+++ b/pages/BriefPage.qml
@@ -181,7 +181,7 @@ SwipeViewPage {
 			voltage: battery.voltage
 			current: battery.current
 			status: Theme.getValueStatus(value, properties.valueType)
-			caption: Global.batteries.timeToGoText(battery, VenusOS.Battery_TimeToGo_LongFormat)
+			caption: Global.batteries.timeToGoText(battery.timeToGo, VenusOS.Battery_TimeToGo_LongFormat)
 			animationEnabled: root.animationEnabled
 			shineAnimationEnabled: battery.mode === VenusOS.Battery_Mode_Charging && root.animationEnabled
 		}

--- a/pages/battery/BatteryListPage.qml
+++ b/pages/battery/BatteryListPage.qml
@@ -76,6 +76,8 @@ Page {
 					QuantityLabel {
 						id: socLabel
 
+						readonly property int statusLevel: Theme.getValueStatus(value, VenusOS.Gauges_ValueType_FallingPercentage)
+
 						width: parent.width
 						height: nameLabel.height
 						alignment: Text.AlignRight
@@ -83,6 +85,14 @@ Page {
 						unit: VenusOS.Units_Percentage
 						font.pixelSize: Theme.font_size_body2
 						visible: !isNaN(batteryDelegate.device.soc)
+						valueColor: batteryDelegate.device.mode === VenusOS.Battery_Mode_Idle ? Theme.color_font_primary
+								: statusLevel === Theme.Critical ? Theme.color_red
+								: statusLevel === Theme.Warning ? Theme.color_orange
+								: Theme.color_green
+						unitColor: batteryDelegate.device.mode === VenusOS.Battery_Mode_Idle ? Theme.color_font_secondary
+								: statusLevel === Theme.Critical ? Theme.color_red
+								: statusLevel === Theme.Warning ? Theme.color_orange
+								: Theme.color_green
 					}
 
 					Label {

--- a/pages/battery/BatteryListPage.qml
+++ b/pages/battery/BatteryListPage.qml
@@ -4,102 +4,114 @@
 */
 
 import QtQuick
+import QtQuick.Layouts
 import QtQuick.Controls.impl as CP
 import Victron.VenusOS
 
 Page {
 	id: root
 
+	//% "Batteries"
+	title: qsTrId("battery_list_page_title")
+
 	GradientListView {
 		model: batteryModel
 		spacing: Theme.geometry_gradientList_spacing
 		delegate: ListItemBackground {
+			id: batteryDelegate
+
+			required property var device
+			readonly property string serviceType: BackendConnection.serviceTypeFromUid(device.serviceUid)
+
 			height: Theme.geometry_batteryListPage_item_height
 
-			Column {
-				anchors {
-					left: parent.left
-					leftMargin: Theme.geometry_listItem_content_horizontalMargin
-					right: arrowIcon.left
-					verticalCenter: parent.verticalCenter
-				}
-				spacing: Theme.geometry_batteryListPage_item_verticalSpacing
+			RowLayout {
+				width: parent.width
+				height: Theme.geometry_batteryListPage_item_height
 
-				Row {
-					id: topRow
-					width: parent.width
+				Column {
+					id: leftColumn
+					Layout.fillWidth: true
+					Layout.leftMargin: Theme.geometry_listItem_content_horizontalMargin
+					spacing: Theme.geometry_batteryListPage_item_verticalSpacing
 
 					Label {
 						id: nameLabel
 
-						width: parent.width - socLabel.width - Theme.geometry_listItem_content_spacing
 						elide: Text.ElideRight
-						text: modelData.name
+						text: batteryDelegate.device.customName
 						font.pixelSize: Theme.font_size_body2
 					}
-
-					QuantityLabel {
-						id: socLabel
-
-						height: nameLabel.height
-						value: modelData.stateOfCharge
-						unit: VenusOS.Units_Percentage
-						font.pixelSize: Theme.font_size_body2
-					}
-				}
-
-				Row {
-					id: bottomRow
-					width: parent.width
 
 					QuantityRow {
 						id: measurementsRow
 
-						anchors.verticalCenter: parent.verticalCenter
-						leftPadding: -(measurementsRow.quantityMetrics.spacing * 2) // align first quantity label with battery name
-						height: parent.height
+						height: nameLabel.height
+						showFirstSeparator: true    // otherwise this row does not align with the battery name
 
 						model: [
-							{ value: modelData.voltage, unit: VenusOS.Units_Volt_DC },
-							{ value: modelData.current, unit: VenusOS.Units_Amp },
-							{ value: modelData.power, unit: VenusOS.Units_Watt },
+							{ value: batteryDelegate.device.voltage, unit: VenusOS.Units_Volt_DC },
+							{ value: batteryDelegate.device.current, unit: VenusOS.Units_Amp, visible: !isNaN(batteryDelegate.device.current) },
+							{ value: batteryDelegate.device.power, unit: VenusOS.Units_Watt, visible: !isNaN(batteryDelegate.device.power) },
 							{
-								value: Global.systemSettings.convertFromCelsius(modelData.temperature),
-								unit: Global.systemSettings.temperatureUnit
+								value: Global.systemSettings.convertFromCelsius(batteryDelegate.device.temperature),
+								unit: Global.systemSettings.temperatureUnit,
+								visible: !isNaN(batteryDelegate.device.temperature)
 							}
 						]
+
+						// Show additional separator at the end, to balance with the first separator.
+						Rectangle {
+							width: Theme.geometry_listItem_separator_width
+							height: nameLabel.height
+							color: Theme.color_listItem_separator
+						}
+					}
+				}
+
+				Column {
+					Layout.fillWidth: true
+					spacing: Theme.geometry_batteryListPage_item_verticalSpacing
+
+					QuantityLabel {
+						id: socLabel
+
+						width: parent.width
+						height: nameLabel.height
+						alignment: Text.AlignRight
+						value: batteryDelegate.device.soc
+						unit: VenusOS.Units_Percentage
+						font.pixelSize: Theme.font_size_body2
+						visible: !isNaN(batteryDelegate.device.soc)
 					}
 
 					Label {
-						anchors.verticalCenter: parent.verticalCenter
-						width: parent.width - measurementsRow.width - Theme.geometry_listItem_content_spacing
+						id: modeLabel
+						width: parent.width
+						horizontalAlignment: Text.AlignRight
 						elide: Text.ElideRight
 						font.pixelSize: Theme.font_size_body2
 						color: Theme.color_listItem_secondaryText
+						visible: !isNaN(batteryDelegate.device.power)
 						text: {
-							const modeText = Global.batteries.modeToText(modelData.mode)
-							if (modelData.mode === VenusOS.Battery_Mode_Discharging) {
-								return modeText + " - " + Global.batteries.timeToGoText(modelData.timeToGo, VenusOS.Battery_TimeToGo_LongFormat)
+							const modeText = Global.batteries.modeToText(batteryDelegate.device.mode)
+							if (batteryDelegate.device.mode === VenusOS.Battery_Mode_Discharging
+									&& batteryDelegate.device.timetogo > 0) {
+								return modeText + " - " + Global.batteries.timeToGoText(batteryDelegate.device.timetogo, VenusOS.Battery_TimeToGo_LongFormat)
+							} else {
+								return modeText
 							}
-							return modeText
 						}
-						horizontalAlignment: Text.AlignRight
 					}
-
 				}
-			}
 
-			CP.ColorImage {
-				id: arrowIcon
-
-				anchors {
-					right: parent.right
-					rightMargin: Theme.geometry_listItem_content_horizontalMargin
-					verticalCenter: parent.verticalCenter
+				CP.ColorImage {
+					Layout.rightMargin: Theme.geometry_listItem_content_horizontalMargin
+					source: "qrc:/images/icon_arrow_32.svg"
+					rotation: 180
+					color: mouseArea.containsPress ? Theme.color_listItem_down_forwardIcon : Theme.color_listItem_forwardIcon
+					opacity: mouseArea.enabled ? 1 : 0
 				}
-				source: "qrc:/images/icon_arrow_32.svg"
-				rotation: 180
-				color: mouseArea.containsPress ? Theme.color_listItem_down_forwardIcon : Theme.color_listItem_forwardIcon
 			}
 
 			ListPressArea {
@@ -107,22 +119,41 @@ Page {
 
 				radius: parent.radius
 				anchors.fill: parent
+				enabled: batteryDelegate.device.instance >= 0
+						&& ["vebus","genset","battery"].indexOf(batteryDelegate.serviceType) >= 0
 				onClicked: {
-					if (BackendConnection.serviceTypeFromUid(modelData.serviceUid) === "vebus") {
-						const deviceIndex = Global.inverterChargers.veBusDevices.indexOf(modelData.serviceUid)
+					// TODO use a generic helper to open a page based on the service type/uid. See issue #1388
+					let deviceIndex
+					if (batteryDelegate.serviceType === "vebus") {
+						deviceIndex = Global.inverterChargers.veBusDevices.indexOf(batteryDelegate.device.serviceUid)
 						if (deviceIndex >= 0) {
 							const veBusDevice = Global.inverterChargers.veBusDevices.deviceAt(deviceIndex)
-							Global.pageManager.pushPage( "/pages/vebusdevice/PageVeBus.qml", {
-								"title": veBusDevice.name,
+							Global.pageManager.pushPage("/pages/vebusdevice/PageVeBus.qml", {
+								"title": Qt.binding(function() { return veBusDevice.name }),
 								"veBusDevice": veBusDevice
 							})
 						}
-						return
+					} else if (batteryDelegate.serviceType === "genset") {
+						Global.pageManager.pushPage("/pages/settings/devicelist/ac-in/PageAcIn.qml", {
+							"title": genericDevice.customName,
+							"bindPrefix": batteryDelegate.device.serviceUid
+						})
+					} else {
+						deviceIndex = Global.batteries.model.indexOf(batteryDelegate.device.serviceUid)
+						if (deviceIndex >= 0) {
+							const batteryDevice = Global.batteries.model.deviceAt(deviceIndex)
+							Global.pageManager.pushPage("/pages/settings/devicelist/battery/PageBattery.qml", {
+								"title": Qt.binding(function() { return batteryDevice.name }),
+								"battery": batteryDevice,
+							})
+						}
 					}
-
-					Global.pageManager.pushPage("/pages/settings/devicelist/battery/PageBattery.qml",
-							{ "title": modelData.name, "battery": modelData })
 				}
+			}
+
+			Device {
+				id: genericDevice
+				serviceUid: batteryDelegate.device.instance >= 0 ? batteryDelegate.device.serviceUid : ""
 			}
 		}
 	}
@@ -132,34 +163,65 @@ Page {
 		id: batteryModel
 	}
 
+	// The battery list is a list of JSON values like this:
+	// [{'active_battery_service': 1,'current': 55,'id': com.victronenergy.battery.ttyO0,'instance': 256,'name': House battery,'power': 1337,'soc': 98.4,'state': 1,'timetogo': 38040,'voltage': 24.3}]
+	// Only 'id', 'name' and 'active_battery_service' are guaranteed to be present for each battery.
 	VeQuickItem {
 		uid: Global.system.serviceUid + "/Batteries"
 		onValueChanged: {
-			let i
 			if (!isValid) {
 				batteryModel.deleteAllAndClear()
 				return
 			}
-			// Value is a list of key-value pairs with info about each battery.
-			const batteryUids = value.map((info) => BackendConnection.serviceUidFromName(info.id, info.instance))
+
+			const batteryList = value
+			const batteryUids = batteryList.map((info) => BackendConnection.serviceUidFromName(info.id, info.instance || 0))
 
 			// Remove batteries that are not in this list
 			batteryModel.intersect(batteryUids)
 
-			// Add new battery objects
-			for (i = 0; i < batteryUids.length; ++i) {
-				if (batteryModel.indexOf(batteryUids[i]) < 0) {
-					batteryComponent.createObject(batteryModel, { serviceUid: batteryUids[i] })
+			// Add new battery objects, or update existing ones in the list.
+			const propertyNames = [ "current", "instance", "power", "soc", "temperature", "timetogo", "voltage" ]
+			for (let i = 0; i < batteryUids.length; ++i) {
+				const batteryInfo = batteryList[i]
+				let batteryObject
+				const batteryIndex = batteryModel.indexOf(batteryUids[i])
+				if (batteryIndex < 0) {
+					batteryObject = batteryComponent.createObject(batteryModel, {
+						serviceUid: batteryUids[i],
+						deviceInstance: batteryInfo.instance || 0,  // always provide an instance so that BaseDevice::valid, so device is added to model
+						customName: batteryInfo.name || "",
+					})
+				} else {
+					batteryObject = batteryModel.deviceAt(batteryIndex)
+				}
+				for (const propertyName of propertyNames) {
+					if (batteryInfo[propertyName] !== undefined) {
+						batteryObject[propertyName] = batteryInfo[propertyName]
+					}
 				}
 			}
 		}
 	}
 
+	component BatteryListDevice : BaseDevice {
+		id: battery
+
+		property real current: NaN
+		property int instance: -1
+		property real power: NaN
+		property real soc: NaN
+		property real temperature: NaN
+		property int timetogo: 0
+		property real voltage: NaN
+		readonly property int mode: Global.batteries.batteryMode(power)
+	}
+
 	Component {
 		id: batteryComponent
 
-		Battery {
-			id: battery
+		BatteryListDevice {
+		   id: battery
 
 			onValidChanged: {
 				if (valid) {

--- a/pages/battery/BatteryListPage.qml
+++ b/pages/battery/BatteryListPage.qml
@@ -79,7 +79,7 @@ Page {
 						text: {
 							const modeText = Global.batteries.modeToText(modelData.mode)
 							if (modelData.mode === VenusOS.Battery_Mode_Discharging) {
-								return modeText + " - " + Global.batteries.timeToGoText(modelData, VenusOS.Battery_TimeToGo_LongFormat)
+								return modeText + " - " + Global.batteries.timeToGoText(modelData.timeToGo, VenusOS.Battery_TimeToGo_LongFormat)
 							}
 							return modeText
 						}


### PR DESCRIPTION
The /Batteries list provides values like "power", "voltage", and "soc", so these can be used to show the values in the battery list. This is better than assuming each /Batteries entry comes from a service that provides paths like /Power, /Voltage, /Soc, etc. and fetching the data values from those paths for each entry.

For example, the /Batteries list may contain a starter battery provided by a genset service, and in this case the voltage is provided by com.victronenergy.genset.*/StarterVoltage instead of /Voltage. The backend uses the /StarterVoltage to set the 'voltage' value for the entry in the /Batteries list, so the UI should show that value, instead of trying to find a /Voltage path that does not exist.

Also rework the UI layout for each delegate in the battery list, since the SOC should be vertically centered if the mode/discharging text is not available.

Fixes #1572
