### PR TITLE
heatpump: show in Device List, and hide from role options

### DIFF
--- a/data/mock/PvInvertersImpl.qml
+++ b/data/mock/PvInvertersImpl.qml
@@ -73,10 +73,21 @@ QtObject {
 				}
 			}
 
+			readonly property VeQuickItem _allowedRoles: VeQuickItem {
+				uid: pvInverter.serviceUid + "/AllowedRoles"
+			}
+
+			readonly property VeQuickItem _role: VeQuickItem {
+				uid: pvInverter.serviceUid + "/Role"
+			}
+
 			Component.onCompleted: {
 				_deviceInstance.setValue(deviceInstance)
 				_customName.setValue("My PV Inverter " + deviceInstance)
 				_statusCode.setValue(Math.random() * VenusOS.PvInverter_StatusCode_Error)
+				_productId.setValue(45058) // dummy value so that ProductId is not invalid, so PageAcIn.qml will show some content
+				_allowedRoles.setValue(Global.acInputs.roles.map((roleInfo) => { return roleInfo.role }))
+				_role.setValue("pvinverter")
 			}
 		}
 	}

--- a/pages/settings/devicelist/DeviceListPage.qml
+++ b/pages/settings/devicelist/DeviceListPage.qml
@@ -117,6 +117,7 @@ Page {
 
 		case "pvinverter":	// deliberate fall through
 		case "grid":		// deliberate fall through
+		case "heatpump":    // deliberate fall through
 		case "acload":
 			url = "/pages/settings/devicelist/ac-in/PageAcIn.qml"
 			params = { "bindPrefix": device.serviceUid }

--- a/pages/settings/devicelist/ac-in/PageAcInSetup.qml
+++ b/pages/settings/devicelist/ac-in/PageAcInSetup.qml
@@ -63,7 +63,9 @@ Page {
 		onValueChanged: {
 			const roles = value
 			role.optionModel = roles ? roles.map(function(v) {
-				return { "display": Global.acInputs.roleName(v), "value": v }
+				// heatpump feature is not properly supported yet. So, hide it unless it is the
+				// currently selected option.
+				return { "display": Global.acInputs.roleName(v), "value": v, "readOnly": v === "heatpump" }
 			}) : []
 		}
 	}


### PR DESCRIPTION
Show heatpump services in the Device List as an AC input service.

Hide it from the role options for now (unless it is already selected as a heatpump) until there is proper support for heat pump services in the UI.

Fixes #1598