### PR TITLE
Only show onboarding when setting is available

### DIFF
--- a/data/SystemSettings.qml
+++ b/data/SystemSettings.qml
@@ -10,7 +10,7 @@ QtObject {
 	id: root
 
 	readonly property string serviceUid: BackendConnection.serviceUidForType("settings")
-	readonly property bool needsOnboarding: !_onboardingState.done
+	readonly property bool needsOnboarding: _onboardingState.needsOnboarding
 
 	property int electricalQuantity: VenusOS.Units_None
 	property int temperatureUnit: VenusOS.Units_None
@@ -309,10 +309,10 @@ QtObject {
 	}
 
 	readonly property VeQuickItem _onboardingState: VeQuickItem {
-		readonly property bool done: _forceOnboardingDone
-			|| (isValid
-				&& ( (Qt.platform.os === "wasm" && (value & VenusOS.OnboardingState_DoneWasm))
-					|| (Qt.platform.os !== "wasm" && (value & VenusOS.OnboardingState_DoneNative)) ) )
+		readonly property bool needsOnboarding: !_forceOnboardingDone
+			&& isValid
+			&& ( (Qt.platform.os === "wasm" && !(value & VenusOS.OnboardingState_DoneWasm))
+				|| (Qt.platform.os !== "wasm" && !(value & VenusOS.OnboardingState_DoneNative)) )
 
 		property bool _forceOnboardingDone
 


### PR DESCRIPTION
Show the onboarding if the setting indicates it is needed, instead of when it is "not done". This way, the onboarding will not show if the setting is not actually available.