### PR TITLE
PV inverter: make meaning of limiting option clear

### DIFF
--- a/pages/settings/PageSettingsFroniusInverter.qml
+++ b/pages/settings/PageSettingsFroniusInverter.qml
@@ -54,6 +54,7 @@ Page {
 			}
 
 			ListRadioButtonGroupNoYes {
+				id: isActive
 				//% "Show"
 				text: qsTrId("page_settings_fronius_inverter_show")
 				dataItem.uid: bindPrefix + "/IsActive"
@@ -63,10 +64,16 @@ Page {
 				//% "Power limiting"
 				text: qsTrId("page_settings_fronius_inverter_power_limiting")
 				dataItem.uid: bindPrefix + "/EnableLimiter"
-				allowed: limiterSupportedItem.value === 1
+				allowed: isActive.dataItem.value === 1 && limiterSupportedItem.value === 1
 				optionModel: [
 					{ display: CommonWords.disabled, value: 0 },
 					{ display: CommonWords.enabled, value: 1 }
+				]
+				bottomContentChildren: [
+					ListLabel {
+						//% "This PV inverter has support for power limiting. Disable this setting if it interferes with normal operation."
+						text: qsTrId("page_settings_fronius_inverter_power_limiting_label")
+					}
 				]
 			}
 		}


### PR DESCRIPTION
Add some text to indicate what the limiter option is for. It is so a user can disable it where it interferes with normal operation.

Also, hide the limiter option if the PV-inverter is not to be shown to the user, ie if it belongs to another installation and is not used here.