### PR TITLE
Alternator: Added support for Utilization

### DIFF
--- a/pages/settings/devicelist/dc-in/PageAlternatorModel.qml
+++ b/pages/settings/devicelist/dc-in/PageAlternatorModel.qml
@@ -71,6 +71,14 @@ ObjectModel {
 	}
 
 	ListQuantityItem {
+		//% "Utilization"
+		text: qsTrId("alternator_wakespeed_utilization")
+		dataItem.uid: root.bindPrefix + "/Utilization"
+		unit: VenusOS.Units_Percentage
+		allowed: defaultAllowed && dataItem.isValid
+	}
+
+	ListQuantityItem {
 		text: CommonWords.speed
 		dataItem.uid: root.bindPrefix + "/Speed"
 		unit: VenusOS.Units_RevolutionsPerMinute


### PR DESCRIPTION
As part of integrating the Wakesopeed with VenusOS via RV-C a utilisation field has been added to dBus.