### PR TITLE
Actually ensure heatpump services appear in Device List

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -836,6 +836,7 @@ set(Mock_QML_MODULE_SOURCES
     data/mock/EssImpl.qml
     data/mock/EvChargersImpl.qml
     data/mock/GeneratorsImpl.qml
+    data/mock/HeatPumpsImpl.qml
     data/mock/MeteoDevicesImpl.qml
     data/mock/MockDataManager.qml
     data/mock/MotorDrivesImpl.qml

--- a/components/AllDevicesModel.qml
+++ b/components/AllDevicesModel.qml
@@ -31,6 +31,7 @@ AggregateDeviceModel {
 		gridDeviceModel,
 		gensetDeviceModel,
 		acLoadDeviceModel,
+		heatPumpDeviceModel
 
 	].concat(Global.tanks.allTankModels)
 
@@ -47,5 +48,10 @@ AggregateDeviceModel {
 	readonly property AcInDeviceModel acLoadDeviceModel: AcInDeviceModel {
 		serviceType: "acload"
 		modelId: "acload"
+	}
+
+	readonly property AcInDeviceModel heatPumpDeviceModel: AcInDeviceModel {
+		serviceType: "heatpump"
+		modelId: "heatpump"
 	}
 }

--- a/data/mock/HeatPumpsImpl.qml
+++ b/data/mock/HeatPumpsImpl.qml
@@ -1,0 +1,36 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+QtObject {
+	id: root
+
+	property int mockDeviceCount
+
+	function populate() {
+		const deviceInstanceNum = mockDeviceCount++
+		heatPumpComponent.createObject(root, {
+			serviceUid: "mock/com.victronenergy.heatpump.ttyUSB" + deviceInstanceNum,
+			deviceInstance: deviceInstanceNum,
+		})
+	}
+
+	property Component heatPumpComponent: Component {
+		Device {
+			Component.onCompleted: {
+				_deviceInstance.setValue(deviceInstance)
+				_customName.setValue("Heat Pump %1".arg(deviceInstance))
+				_productId.setValue(0x01) // set a non-empty value so that PageAcIn.qml shows some content
+				BackendConnection.setMockValue(serviceUid + "/Ac/Power", Math.random() * 100)
+			}
+		}
+	}
+
+	Component.onCompleted: {
+		populate()
+	}
+}

--- a/data/mock/MockDataManager.qml
+++ b/data/mock/MockDataManager.qml
@@ -32,6 +32,7 @@ QtObject {
 			property var ess: EssImpl {}
 			property var evChargers: EvChargersImpl {}
 			property var generators: GeneratorsImpl {}
+			property var heatPumps: HeatPumpsImpl { }
 			property var inverterChargers: InverterChargersImpl {}
 			property var meteoDevices: MeteoDevicesImpl { }
 			property var motorDrives: MotorDrivesImpl { }
@@ -44,5 +45,12 @@ QtObject {
 			property var tanks: TanksImpl {}
 			property var unsupportedDevices: UnsupportedDevicesImpl { }
 		}
+	}
+
+	property VeQItemTableModel servicesTableModel: VeQItemTableModel {
+		uids: ["mock"]
+		flags: VeQItemTableModel.AddChildren | VeQItemTableModel.AddNonLeaves | VeQItemTableModel.DontAddItem
+
+		Component.onCompleted: Global.dataServiceModel = servicesTableModel
 	}
 }

--- a/pages/settings/devicelist/AcInDeviceModel.qml
+++ b/pages/settings/devicelist/AcInDeviceModel.qml
@@ -39,24 +39,23 @@ BaseDeviceModel {
 		}
 	}
 
-	property var modelLoader: Loader {
-		sourceComponent: BackendConnection.type === BackendConnection.DBusSource ? dbusModelComponent
-			 : BackendConnection.type === BackendConnection.MqttSource ? mqttModelComponent
-			 : null
+	property Loader modelLoader: Loader {
+		sourceComponent: BackendConnection.type === BackendConnection.MqttSource ? mqttModelComponent
+			 : dbusOrMockModelComponent
 	}
 
-	property var dbusModelComponent: Component {
+	property Component dbusOrMockModelComponent: Component {
 		VeQItemSortTableModel {
 			dynamicSortFilter: true
 			filterRole: VeQItemTableModel.UniqueIdRole
-			filterRegExp: "^dbus/com\.victronenergy\." + root.serviceType + "\."
-			model: BackendConnection.type === BackendConnection.DBusSource ? Global.dataServiceModel : null
+			filterRegExp: "^%1/com\.victronenergy\.%2\.".arg(BackendConnection.uidPrefix()).arg(root.serviceType)
+			model: Global.dataServiceModel
 		}
 	}
 
-	property var mqttModelComponent: Component {
+	property Component mqttModelComponent: Component {
 		VeQItemTableModel {
-			uids: BackendConnection.type === BackendConnection.MqttSource ? ["mqtt/" + root.serviceType ] : []
+			uids: ["mqtt/" + root.serviceType ]
 			flags: VeQItemTableModel.AddChildren | VeQItemTableModel.AddNonLeaves | VeQItemTableModel.DontAddItem
 		}
 	}


### PR DESCRIPTION
65d9b36 is not sufficient; add heatpump services to AllDevicesModel so that these services appear as delegates in the Device List.

It is not necessary to add dbus/HeatPumpsImpl.qml and mqtt/HeatPumpsImpl.qml since the list of heatpump services is only used in AllDevicesModel, and there is no need for an always-present model like Global.heatPumps.

Also update AcInDeviceModel so that it can read mock services as well.

Fixes #1634