### PR TITLE
Fix EVCS charge current setting

### DIFF
--- a/pages/evcs/EvChargerPage.qml
+++ b/pages/evcs/EvChargerPage.qml
@@ -136,8 +136,9 @@ Page {
 				suffix: Units.defaultUnitString(VenusOS.Units_Amp)
 				from: 0
 				to: root.evCharger.maxCurrent
-				dataItem.uid: root.evCharger.serviceUid + "/Current"
+				dataItem.uid: root.evCharger.serviceUid + "/SetCurrent"
 				allowed: defaultAllowed && dataItem.isValid
+				enabled: chargeMode.value !== VenusOS.Evcs_Mode_Auto
 			}
 
 			ListSwitch {

--- a/pages/evcs/EvChargerPage.qml
+++ b/pages/evcs/EvChargerPage.qml
@@ -138,7 +138,7 @@ Page {
 				to: root.evCharger.maxCurrent
 				dataItem.uid: root.evCharger.serviceUid + "/SetCurrent"
 				allowed: defaultAllowed && dataItem.isValid
-				enabled: chargeMode.value !== VenusOS.Evcs_Mode_Auto
+				enabled: chargeMode.value === VenusOS.Evcs_Mode_Manual
 			}
 
 			ListSwitch {

--- a/pages/evcs/EvChargerSetupPage.qml
+++ b/pages/evcs/EvChargerSetupPage.qml
@@ -14,14 +14,6 @@ Page {
 
 	GradientListView {
 		model: ObjectModel {
-			ListSpinBox {
-				//% "Max charging current"
-				text: qsTrId("evcs_max_charging_current")
-				suffix: Units.defaultUnitString(VenusOS.Units_Amp)
-				dataItem.uid: root.evCharger.serviceUid + "/MaxCurrent"
-				presets: Global.evChargers.maxCurrentPresets
-			}
-
 			ListRadioButtonGroup {
 				//: EVCS AC input/output position
 				//% "Position"


### PR DESCRIPTION
Remove Max charge current from Setup menu
Change path for the setting 'Charge current' to '/SetCurrent'.

Fixes https://github.com/victronenergy/gui-v2/issues/1640
