### PR TITLE
BatteryListPage: don't confuse uids of virtual and real batteries

### DIFF
--- a/data/mock/BatteriesImpl.qml
+++ b/data/mock/BatteriesImpl.qml
@@ -106,12 +106,13 @@ QtObject {
 	}
 
 	function updateBatteriesList() {
+		const dummyBatteryServiceName = dummyBattery.serviceUid.substring(BackendConnection.uidPrefix().length + 1)
 		const batteryList = [
 			{
 				// System battery
 				active_battery_service: true,
 				current: dummyBattery.current,
-				id: dummyBattery.serviceUid.substring(BackendConnection.uidPrefix().length + 1),
+				id: dummyBatteryServiceName,
 				instance: dummyBattery.deviceInstance,
 				name: dummyBattery.name,
 				power: dummyBattery.power,
@@ -124,7 +125,7 @@ QtObject {
 			{
 				// Starter battery, which does not have an instance number
 				active_battery_service: false,
-				id: "com.victronenergy.battery.ttyUSB2:1",
+				id: dummyBatteryServiceName + ":1",
 				name: "My starter battery",
 				voltage: 0.029999999329447746
 			}

--- a/pages/battery/BatteryListPage.qml
+++ b/pages/battery/BatteryListPage.qml
@@ -243,6 +243,8 @@ Page {
 		property int timetogo: 0
 		property real voltage: NaN
 		readonly property int mode: Global.batteries.batteryMode(power)
+
+		name: customName
 	}
 
 	Component {


### PR DESCRIPTION
The /Batteries list may have virtual battery entries, with an id like 'com.victronenergy.battery.ttyUSB1:1' and no 'instance' value. For these entries, use the id as the device uid in the device model, instead of assigning a default DeviceInstance=0. Otherwise, it may conflict with the uid of a real battery.

Fixes #1572