### PR TITLE
DeviceList: avoid duplicate tanks after changing fluid type

### DIFF
--- a/src/aggregatedevicemodel.h
+++ b/src/aggregatedevicemodel.h
@@ -73,6 +73,7 @@ private:
 	};
 
 	void sourceModelRowsInserted(const QModelIndex &parent, int first, int last);
+	void sourceModelRowsAboutToBeRemoved(const QModelIndex &parent, int first, int last);
 	int indexOf(const QString &deviceInfoId) const;
 	int indexOf(const BaseDevice *device) const;
 	int insertionIndex(BaseDevice *device) const;


### PR DESCRIPTION
If a tank moves from one tank model to another, due to changing its fluid type, then AggregateDeviceModel must remove the tank from the old model.

Normally AggregateDeviceModel does not remove device entries because they are typically only removed from their source models when they are disconnected, and in that case, the AggregateDeviceModel just shows them as "Not connected" instead of removing them. However, in this case, the devices should be removed from AggregateDeviceModel, as they are still valid and not disconnected.

Fixes #1631