### PR TITLE
Set 'layer.enabled' to false wherever text is displayed

### DIFF
--- a/components/SegmentedButtonRow.qml
+++ b/components/SegmentedButtonRow.qml
@@ -6,6 +6,7 @@
 import QtQuick
 import QtQuick.Controls as C
 import QtQuick.Controls.impl as CP
+import QtQuick.Templates as T
 import Victron.VenusOS
 
 Item {
@@ -35,31 +36,36 @@ Item {
 
 			model: null
 
-			delegate: AsymmetricRoundedRectangle {
-				id: buttonDelegate
+			delegate: T.Button {
+				id: mouseArea
 
+				enabled: modelData.enabled !== false
 				width: root.width / buttonRepeater.count
 				height: parent ? parent.height : 0
-				color: modelData.enabled === false && model.index !== root.currentIndex
-					   ? Theme.color_background_disabled
-					   : ((mouseArea.pressed || model.index === root.currentIndex)
-						  ? Theme.color_ok
-						  : Theme.color_darkOk)
-				border.width: Theme.geometry_button_border_width
-				border.color: (modelData.enabled === false && model.index !== root.currentIndex) ? buttonDelegate.color : Theme.color_ok
-				radius: Theme.geometry_button_radius
+				background: AsymmetricRoundedRectangle {
+					id: buttonDelegate
 
-				roundedSide: model.index === 0 ? VenusOS.AsymmetricRoundedRectangle_RoundedSide_Left
-					: model.index === (buttonRepeater.count-1) ? VenusOS.AsymmetricRoundedRectangle_RoundedSide_Right
-					: VenusOS.AsymmetricRoundedRectangle_RoundedSide_NoneHorizontal
-
-				Label {
-					anchors.centerIn: parent
+					width: root.width / buttonRepeater.count
+					height: parent ? parent.height : 0
+					color: modelData.enabled === false && model.index !== root.currentIndex
+						   ? Theme.color_background_disabled
+						   : ((mouseArea.pressed || model.index === root.currentIndex)
+							  ? Theme.color_ok
+							  : Theme.color_darkOk)
+					border.width: Theme.geometry_button_border_width
+					border.color: (modelData.enabled === false && model.index !== root.currentIndex) ? buttonDelegate.color : Theme.color_ok
+					radius: Theme.geometry_button_radius
+					roundedSide: model.index === 0 ? VenusOS.AsymmetricRoundedRectangle_RoundedSide_Left
+							: model.index === (buttonRepeater.count-1) ? VenusOS.AsymmetricRoundedRectangle_RoundedSide_Right
+							: VenusOS.AsymmetricRoundedRectangle_RoundedSide_NoneHorizontal
+				}
+				contentItem: Label {
+					anchors.centerIn: mouseArea
 					font.pixelSize: root.fontPixelSize
 					horizontalAlignment: Text.AlignHCenter
+					verticalAlignment: Text.AlignVCenter
 					x: Theme.geometry_tabBar_horizontalMargin
 					width: parent.width - 2*x
-
 					elide: Text.ElideRight
 					text: modelData.value
 					color: modelData.enabled === false && model.index !== root.currentIndex
@@ -68,17 +74,9 @@ Item {
 							  ? Theme.color_button_down_text
 							  : Theme.color_font_primary)
 				}
-
-				MouseArea {
-					id: mouseArea
-
-					anchors.fill: parent
-					enabled: modelData.enabled !== false
-
-					onClicked: {
-						root.buttonClicked(model.index)
-						root.currentIndex = model.index
-					}
+				onClicked: {
+					root.buttonClicked(model.index)
+					root.currentIndex = model.index
 				}
 			}
 		}

--- a/components/ThreePhaseQuantityTable.qml
+++ b/components/ThreePhaseQuantityTable.qml
@@ -46,6 +46,7 @@ QuantityTable {
 	]
 	labelHorizontalAlignment: Qt.AlignRight
 	headerComponent: AsymmetricRoundedRectangle {
+		layer.enabled: false // if 'layer.enabled' is true, any child text looks rough on wasm builds
 		width: root.width
 		height: Theme.geometry_vebusDeviceListPage_quantityTable_header_height
 		roundedSide: VenusOS.AsymmetricRoundedRectangle_RoundedSide_Top


### PR DESCRIPTION
On wasm builds, text looks rough wherever layer.enabled is true Fixes #1639