### PR TITLE
Overview solar: fix multi-phase display for PV inverters

### DIFF
--- a/data/common/PvInverter.qml
+++ b/data/common/PvInverter.qml
@@ -17,14 +17,14 @@ Device {
 	readonly property real power: _power.isValid ? _power.value : NaN
 	readonly property real voltage: _voltage.isValid ? _voltage.value : NaN
 
-	readonly property QtObject phases: QtObject {
-		property int count
-
+	readonly property PhaseModel phases: PhaseModel {
 		function updateCount(maxPhaseCount) {
-			count = Math.max(count, maxPhaseCount)
+			// pvinverter services do not have /NumberOfPhases, so manually update the phase model
+			// count when phase measurements are detected.
+			phaseCount = Math.max(count, maxPhaseCount)
 		}
 
-		function get(index) {
+		function getPhase(index) {
 			return _phases.objectAt(index)
 		}
 
@@ -43,18 +43,22 @@ Device {
 				readonly property VeQuickItem _phaseEnergy: VeQuickItem {
 					uid: phaseUid + "/Energy/Forward"
 					onIsValidChanged: if (isValid) phases.updateCount(index + 1)
+					onValueChanged: phases.setValue(index, PhaseModel.EnergyRole, value)
 				}
 				readonly property VeQuickItem _phasePower: VeQuickItem {
 					uid: phaseUid + "/Power"
 					onIsValidChanged: if (isValid) phases.updateCount(index + 1)
+					onValueChanged: phases.setValue(index, PhaseModel.PowerRole, value)
 				}
 				readonly property VeQuickItem _phaseCurrent: VeQuickItem {
 					uid: phaseUid + "/Current"
 					onIsValidChanged: if (isValid) phases.updateCount(index + 1)
+					onValueChanged: phases.setValue(index, PhaseModel.CurrentRole, value)
 				}
 				readonly property VeQuickItem _phaseVoltage: VeQuickItem {
 					uid: phaseUid + "/Voltage"
 					onIsValidChanged: if (isValid) phases.updateCount(index + 1)
+					onValueChanged: phases.setValue(index, PhaseModel.VoltageRole, value)
 				}
 			}
 		}

--- a/pages/solar/PvInverterPage.qml
+++ b/pages/solar/PvInverterPage.qml
@@ -69,7 +69,7 @@ Page {
 						{ title: CommonWords.power_watts, unit: VenusOS.Units_Watt }
 					]
 					valueForModelIndex: function(phaseIndex, column) {
-						const phase = root.pvInverter.phases.get(phaseIndex)
+						const phase = root.pvInverter.phases.getPhase(phaseIndex)
 						const columnProperties = ["name", "energy", "voltage", "current", "power"]
 						return phase[columnProperties[column]]
 					}

--- a/src/phasemodel.cpp
+++ b/src/phasemodel.cpp
@@ -66,6 +66,14 @@ void PhaseModel::setValue(int index, Role role, const qreal value)
 		phase.current = value;
 		emit dataChanged(createIndex(index, 0), createIndex(index, 0), { CurrentRole });
 		break;
+	case VoltageRole:
+		phase.voltage = value;
+		emit dataChanged(createIndex(index, 0), createIndex(index, 0), { VoltageRole });
+		break;
+	case EnergyRole:
+		phase.energy = value;
+		emit dataChanged(createIndex(index, 0), createIndex(index, 0), { EnergyRole });
+		break;
 	default:
 		break;
 	}
@@ -101,6 +109,10 @@ QVariant PhaseModel::data(const QModelIndex &index, int role) const
 		return phase.power;
 	case CurrentRole:
 		return phase.current;
+	case VoltageRole:
+		return phase.voltage;
+	case EnergyRole:
+		return phase.energy;
 	default:
 		return QVariant();
 	}
@@ -133,7 +145,9 @@ QHash<int, QByteArray> PhaseModel::roleNames() const
 	static QHash<int, QByteArray> roles = {
 		{ NameRole, "name" },
 		{ PowerRole, "power" },
-		{ CurrentRole, "current" }
+		{ CurrentRole, "current" },
+		{ VoltageRole, "voltage" },
+		{ EnergyRole, "energy" }
 	};
 	return roles;
 }

--- a/src/phasemodel.h
+++ b/src/phasemodel.h
@@ -24,7 +24,9 @@ public:
 	enum Role {
 		NameRole = Qt::UserRole,
 		PowerRole,
-		CurrentRole
+		CurrentRole,
+		VoltageRole,
+		EnergyRole
 	};
 	Q_ENUM(Role)
 
@@ -56,8 +58,10 @@ protected:
 
 private:
 	struct Phase {
-		qreal power = 0;
-		qreal current = 0;
+		qreal power = qQNaN();
+		qreal current = qQNaN();
+		qreal voltage = qQNaN();
+		qreal energy = qQNaN();
 	};
 
 	void resetModel();


### PR DESCRIPTION
There are two use cases for showing PV inverter multi-phase data:

1) Overview SolarYieldWidget, which shows a ThreePhaseDisplay for the PV inverter. ThreePhaseDisplay needs a QAbstractItemModel-based model to create the display delegates using the model roles.

2) PvInverterPage, which needs a QObject for each phase to create a property binding to each phase measurement property (power, current, etc.) so that valueForModelIndex() will be invoked when a measurement value changes.

Change PvInverter to use PhaseModel provide the QAbstractItemModel- based model for case 1, and also provide a getPhase() function for case 2.

QuantityTable could be reworked in future to avoid the need for a valueForModelIndex() function that requires QObject-bindings, thereby removing the need for case 2.

Fixes the regression from a9038b76bfddc53ebc3c3db55061ad4bd671556a. EvCharger does not need a similar fix, since the QAbstractItemModel- based model is not required for current EVCS features in the UI.

Fixes #1654