### PR TITLE
Overview: allow drilldown on non-active AC input

### DIFF
--- a/components/widgets/AcInputWidget.qml
+++ b/components/widgets/AcInputWidget.qml
@@ -23,7 +23,7 @@ AcWidget {
 	quantityLabel.leftPadding: acInputDirectionIcon.visible ? (acInputDirectionIcon.width + Theme.geometry_acInputDirectionIcon_rightMargin) : 0
 	quantityLabel.acInputMode: true
 	phaseCount: connected ? input.phases.count : 0
-	enabled: !!input
+	enabled: !!inputInfo
 	extraContentLoader.sourceComponent: ThreePhaseDisplay {
 		width: parent.width
 		model: root.input.phases
@@ -32,15 +32,15 @@ AcWidget {
 	}
 
 	onClicked: {
-		if (root.input.serviceType === "acsystem") {
+		const inputServiceUid = BackendConnection.serviceUidFromName(root.inputInfo.serviceName, root.inputInfo.deviceInstance)
+		if (root.inputInfo.serviceType === "acsystem") {
 			Global.pageManager.pushPage("/pages/settings/devicelist/rs/PageRsSystem.qml",
-					{ "title": root.input.name, "bindPrefix": root.input.serviceUid })
-		} else if (root.input.serviceType === "vebus") {
-			const deviceIndex = Global.inverterChargers.veBusDevices.indexOf(root.input.serviceUid)
+					{ "bindPrefix": inputServiceUid })
+		} else if (root.inputInfo.serviceType === "vebus") {
+			const deviceIndex = Global.inverterChargers.veBusDevices.indexOf(inputServiceUid)
 			if (deviceIndex >= 0) {
 				const veBusDevice = Global.inverterChargers.veBusDevices.deviceAt(deviceIndex)
 				Global.pageManager.pushPage( "/pages/vebusdevice/PageVeBus.qml", {
-					"title": veBusDevice.name,
 					"veBusDevice": veBusDevice
 				})
 			}
@@ -49,8 +49,7 @@ AcWidget {
 
 		// Assume this is on a grid/genset service
 		Global.pageManager.pushPage("/pages/settings/devicelist/ac-in/PageAcIn.qml", {
-			"title": root.input.name,
-			"bindPrefix": root.input.serviceUid
+			"bindPrefix": inputServiceUid
 		})
 	}
 

--- a/pages/settings/devicelist/ac-in/PageAcIn.qml
+++ b/pages/settings/devicelist/ac-in/PageAcIn.qml
@@ -11,6 +11,13 @@ Page {
 
 	property string bindPrefix
 
+	title: acInDevice.name
+
+	Device {
+		id: acInDevice
+		serviceUid: root.bindPrefix
+	}
+
 	VeQuickItem {
 		id: productIdDataItem
 

--- a/pages/settings/devicelist/rs/PageRsSystem.qml
+++ b/pages/settings/devicelist/rs/PageRsSystem.qml
@@ -12,9 +12,16 @@ Page {
 	property string bindPrefix
 	readonly property bool multiPhase: numberOfPhases.isValid && numberOfPhases.value > 1
 
+	title: acSystemDevice.name
+
 	VeQuickItem {
 		id: numberOfPhases
 		uid: root.bindPrefix + "/Ac/NumberOfPhases"
+	}
+
+	Device {
+		id: acSystemDevice
+		serviceUid: root.bindPrefix
 	}
 
 	GradientListView {


### PR DESCRIPTION
Any AC input widgets on the Overview page should be clickable and take the user to the drilldown/settings page, even if it is not the currently active AC input.

Also allow PageAcIn.qml and PageRsSystem.qml to provide the device name internally, instead of relying on the launching page to provide the name via the 'title' property.

Fixes #1405