### PR TITLE
Disable onboarding if touch is disabled

### DIFF
--- a/data/SystemSettings.qml
+++ b/data/SystemSettings.qml
@@ -11,6 +11,8 @@ QtObject {
 
 	readonly property string serviceUid: BackendConnection.serviceUidForType("settings")
 	readonly property bool needsOnboarding: _onboardingState.needsOnboarding
+			// It's hard to skip onboarding without touch, so disable onboarding if touch is disabled.
+			&& _touchEnabled.isValid && _touchEnabled.value !== 0
 
 	property int electricalQuantity: VenusOS.Units_None
 	property int temperatureUnit: VenusOS.Units_None
@@ -311,6 +313,10 @@ QtObject {
 		}
 
 		uid: root.serviceUid + "/Settings/Gui2/OnBoarding"
+	}
+
+	readonly property VeQuickItem _touchEnabled: VeQuickItem {
+		uid: root.serviceUid + "/Settings/Gui/TouchEnabled"
 	}
 
 	function reset() {

--- a/data/mock/SystemSettingsImpl.qml
+++ b/data/mock/SystemSettingsImpl.qml
@@ -79,6 +79,7 @@ QtObject {
 		setMockSettingValue("SystemSetup/AcInput2", 3)
 		setMockSettingValue("SystemSetup/HasAcInLoads", 1)
 		setMockSettingValue("Gui/DemoMode", 1)
+		setMockSettingValue("Gui/TouchEnabled", 1)
 		setMockSettingValue("Gui2/OnBoarding", VenusOS.OnboardingState_DoneNative | VenusOS.OnboardingState_DoneWasm)   // set to 0 to enable onboarding
 		setMockSettingValue("Gui2/StartPage", VenusOS.StartPage_Mode_AutoSelect)
 		setMockSettingValue("Gui2/StartPageName", "")


### PR DESCRIPTION
It's hard to skip onboarding without touch, so disable onboarding if touch is disabled.

Fixes #1660