### PR TITLE
Don't prematurely update the current index in VRM portal options

### DIFF
--- a/pages/settings/PageSettingsLogger.qml
+++ b/pages/settings/PageSettingsLogger.qml
@@ -45,6 +45,7 @@ Page {
 				text: qsTrId("settings_logging_vrm_portal")
 				dataItem.uid: Global.systemSettings.serviceUid + "/Settings/Network/VrmPortal"
 				updateDataOnClick: false
+				updateCurrentIndexOnClick: false // track backend value, set only when confirmation dialog is accepted.
 				popDestination: undefined   // do not automatically pop page when value is selected
 				optionModel: [
 					{ display: CommonWords.off, value: VenusOS.Vrm_PortalMode_Off },


### PR DESCRIPTION
The default behaviour of ListRadioButtonGroup is to set the current index to the clicked option immediately upon click.

In the VRM portal options case, we don't want to do this. Instead, the current index should always track the backend value, and we show the confirmation dialog on click, before attempting to set the backend value.

Thus we need to set the updateCurrentIndexOnClick flag to false.

Fixes issue #1633