### PR TITLE
Be less restrictive when disallowing mode and current limit changes

### DIFF
--- a/components/CurrentLimitButton.qml
+++ b/components/CurrentLimitButton.qml
@@ -16,7 +16,7 @@ ListItemButton {
 	readonly property string serviceType: BackendConnection.serviceTypeFromUid(serviceUid)
 	readonly property int writeAccessLevel: VenusOS.User_AccessType_User
 	readonly property bool userHasWriteAccess: Global.systemSettings.canAccess(writeAccessLevel)
-	readonly property bool limitAdjustable: currentLimitIsAdjustable.isValid && !!currentLimitIsAdjustable.value
+	readonly property bool limitAdjustable: currentLimitIsAdjustable.value !== 0
 
 	function _currentLimitNotAdjustableText() {
 		if (serviceType !== "acsystem") {

--- a/components/InverterChargerModeButton.qml
+++ b/components/InverterChargerModeButton.qml
@@ -14,7 +14,7 @@ ListItemButton {
 	readonly property string serviceType: BackendConnection.serviceTypeFromUid(serviceUid)
 	readonly property int writeAccessLevel: VenusOS.User_AccessType_User
 	readonly property bool userHasWriteAccess: Global.systemSettings.canAccess(writeAccessLevel)
-	readonly property bool modeAdjustable: modeIsAdjustable.isValid && !!modeIsAdjustable.value
+	readonly property bool modeAdjustable: modeIsAdjustable.value !== 0
 
 	text: serviceType !== "inverter" || isInverterChargerItem.value === 1
 			? Global.inverterChargers.inverterChargerModeToText(modeItem.value)

--- a/data/mock/AcSystemDevicesImpl.qml
+++ b/data/mock/AcSystemDevicesImpl.qml
@@ -73,7 +73,7 @@ Item {
 				acSystem.setMockValue("/Ac/In/1/CurrentLimitIsAdjustable", 1)
 				acSystem.setMockValue("/Ac/In/1/Type", VenusOS.AcInputs_InputSource_Shore)
 				acSystem.setMockValue("/Ac/In/2/CurrentLimit", 20.25)
-				acSystem.setMockValue("/Ac/In/2/CurrentLimitIsAdjustable", 1)
+				acSystem.setMockValue("/Ac/In/2/CurrentLimitIsAdjustable", 0)
 				acSystem.setMockValue("/Ac/In/2/Type", VenusOS.AcInputs_InputSource_Grid)
 				acSystem.setMockValue("/State", Math.floor(Math.random() * VenusOS.System_State_FaultCondition))
 				acSystem.setMockValue("/Mode", VenusOS.Inverter_Mode_Off)


### PR DESCRIPTION
If /ModeIsAdjustable or /CurrentLimitIsAdjustable is not available, then allow the mode or current limit to be adjusted.

Fixes #1637