### PR TITLE
Add controls for the RS to the Inverter Charger card

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,6 +311,7 @@ set (VENUS_QML_MODULE_SOURCES
     components/dialogs/GeneratorStartDialog.qml
     components/dialogs/GeneratorStopDialog.qml
     components/dialogs/InverterChargerModeDialog.qml
+    components/dialogs/InverterChargerEssModeDialog.qml
     components/dialogs/ModalDialog.qml
     components/dialogs/ModalWarningDialog.qml
     components/dialogs/NumberSelectorDialog.qml

--- a/components/dialogs/ESSMinimumSOCDialog.qml
+++ b/components/dialogs/ESSMinimumSOCDialog.qml
@@ -11,14 +11,6 @@ ModalDialog {
 
 	property int minimumStateOfCharge
 
-	onAboutToShow: {
-		minimumStateOfCharge = Global.ess.minimumStateOfCharge
-	}
-
-	onAccepted: {
-		Global.ess.setMinimumStateOfChargeRequested(minimumStateOfCharge)
-	}
-
 	//% "Minimum SOC"
 	title: qsTrId("ess_card_minimum_soc")
 

--- a/components/dialogs/InverterChargerEssModeDialog.qml
+++ b/components/dialogs/InverterChargerEssModeDialog.qml
@@ -1,0 +1,39 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+// Dialog for changing the ESS mode on acsystem services, that is Multi-RS
+// and HS-19 systems.
+
+ModalDialog {
+	id: root
+
+	property int essMode
+
+	//% "ESS mode"
+	title: qsTrId("controlcard_inverter_charger_ess_mode")
+	contentItem: Column {
+		Repeater {
+			id: repeater
+			model: Global.ess.stateModel
+			delegate: Component {
+				Column {
+					width: parent.width
+
+					ListRadioButton {
+						flat: true
+						checked: modelData.value === root.essMode
+						text: modelData.display
+						onClicked: root.essMode = modelData.value
+					}
+
+					SeparatorBar { visible: model.index !== repeater.count - 1 }
+				}
+			}
+		}
+	}
+}

--- a/data/Ess.qml
+++ b/data/Ess.qml
@@ -28,14 +28,32 @@ QtObject {
 	}
 
 	readonly property var stateModel: [
-		//% "Optimized with battery life"
-		{ display: qsTrId("ess_state_optimized_with_battery_life"), value: VenusOS.Ess_State_OptimizedWithBatteryLife },
-		//% "Optimized without battery life"
-		{ display: qsTrId("ess_state_optimized_without_battery_life"), value: VenusOS.Ess_State_OptimizedWithoutBatteryLife },
-		//% "Keep batteries charged"
-		{ display: qsTrId("ess_state_keep_batteries_charged"), value: VenusOS.Ess_State_KeepBatteriesCharged },
-		//% "External control"
-		{ display: qsTrId("ess_state_external_control"), value: VenusOS.Ess_State_ExternalControl },
+		{
+			//% "Optimized with battery life"
+			display: qsTrId("ess_state_optimized_with_battery_life"),
+			//% "Optimized + battery life"
+			buttonText: qsTrId("ess_state_optimized_with_battery_life_button"),
+			value: VenusOS.Ess_State_OptimizedWithBatteryLife
+		},
+		{
+			//% "Optimized without battery life"
+			display: qsTrId("ess_state_optimized_without_battery_life"),
+			//% "Optimized"
+			buttonText: qsTrId("ess_state_optimized_without_battery_life_button"),
+			value: VenusOS.Ess_State_OptimizedWithoutBatteryLife
+		},
+		{
+			//% "Keep batteries charged"
+			display: qsTrId("ess_state_keep_batteries_charged"),
+			//% "Keep charged"
+			buttonText: qsTrId("ess_state_keep_batteries_charged_button"),
+			value: VenusOS.Ess_State_KeepBatteriesCharged
+		},
+		{
+			//% "External control"
+			display: qsTrId("ess_state_external_control"),
+			value: VenusOS.Ess_State_ExternalControl
+		}
 	]
 
 	function essStateToText(s) {
@@ -43,6 +61,16 @@ QtObject {
 			const row = stateModel[i]
 			if (row.value === s) {
 				return row.display
+			}
+		}
+		return ""
+	}
+
+	function essStateToButtonText(s) {
+		for (let i = 0; i < stateModel.length; ++i) {
+			const row = stateModel[i]
+			if (row.value === s) {
+				return (row.buttonText === undefined) ? row.display : row.buttonText
 			}
 		}
 		return ""

--- a/pages/controlcards/ESSCard.qml
+++ b/pages/controlcards/ESSCard.qml
@@ -55,7 +55,10 @@ ControlCard {
 			Component {
 				id: minSocDialogComponent
 
-				ESSMinimumSOCDialog { }
+				ESSMinimumSOCDialog {
+					minimumStateOfCharge: Global.ess.minimumStateOfCharge
+					onAccepted: Global.ess.setMinimumStateOfChargeRequested(minimumStateOfCharge)
+				}
 			}
 		}
 

--- a/pages/controlcards/InverterChargerCard.qml
+++ b/pages/controlcards/InverterChargerCard.qml
@@ -12,6 +12,8 @@ ControlCard {
 	property string serviceUid
 	property string name
 	readonly property string serviceType: BackendConnection.serviceTypeFromUid(serviceUid)
+	readonly property int writeAccessLevel: VenusOS.User_AccessType_User
+	readonly property bool userHasWriteAccess: Global.systemSettings.canAccess(writeAccessLevel)
 
 	icon.source: "qrc:/images/inverter_charger.svg"
 	title.text: serviceType === "inverter"
@@ -27,6 +29,11 @@ ControlCard {
 	VeQuickItem {
 		id: stateItem
 		uid: root.serviceUid + "/State"
+	}
+
+	VeQuickItem {
+		id: essModeItem
+		uid: root.serviceUid + "/Settings/Ess/Mode"
 	}
 
 	Column {
@@ -67,6 +74,32 @@ ControlCard {
 					serviceUid: root.serviceUid
 				}
 			]
+		}
+
+		FlatListItemSeparator {}
+
+		ListItem {
+			text: CommonWords.ess
+			flat: true
+			allowed: essModeItem.isValid
+			content.children: [
+				ListItemButton {
+					font.pixelSize: Theme.font_size_body1
+					text: Global.ess.essStateToButtonText(essModeItem.value)
+					enabled: userHasWriteAccess
+					onClicked: {
+						Global.dialogLayer.open(essModeDialogComponent, { essMode: essModeItem.value })
+					}
+				}
+			]
+		}
+	}
+
+	Component {
+		id: essModeDialogComponent
+
+		InverterChargerEssModeDialog {
+			onAccepted: essModeItem.setValue(essMode)
 		}
 	}
 }

--- a/pages/controlcards/InverterChargerCard.qml
+++ b/pages/controlcards/InverterChargerCard.qml
@@ -36,6 +36,11 @@ ControlCard {
 		uid: root.serviceUid + "/Settings/Ess/Mode"
 	}
 
+	VeQuickItem {
+		id: essMinSocItem
+		uid: root.serviceUid + "/Settings/Ess/MinimumSocLimit"
+	}
+
 	Column {
 		anchors {
 			top: parent.status.bottom
@@ -93,6 +98,15 @@ ControlCard {
 				}
 			]
 		}
+
+		ListButton {
+			//% "Minimum SOC"
+			text: qsTrId("controlcard_inverter_charger_ess_minimum_soc")
+			flat: true
+			allowed: essMinSocItem.isValid
+			button.text: Units.getCombinedDisplayText(VenusOS.Units_Percentage, essMinSocItem.value)
+			onClicked: Global.dialogLayer.open(essMinSocDialogComponent)
+		}
 	}
 
 	Component {
@@ -100,6 +114,15 @@ ControlCard {
 
 		InverterChargerEssModeDialog {
 			onAccepted: essModeItem.setValue(essMode)
+		}
+	}
+
+	Component {
+		id: essMinSocDialogComponent
+
+		ESSMinimumSOCDialog {
+			minimumStateOfCharge: essMinSocItem.value
+			onAccepted: essMinSocItem.setValue(minimumStateOfCharge)
 		}
 	}
 }

--- a/pages/controlcards/InverterChargerCard.qml
+++ b/pages/controlcards/InverterChargerCard.qml
@@ -103,7 +103,9 @@ ControlCard {
 			//% "Minimum SOC"
 			text: qsTrId("controlcard_inverter_charger_ess_minimum_soc")
 			flat: true
-			allowed: essMinSocItem.isValid
+			allowed: essMinSocItem.isValid && [
+				VenusOS.Ess_State_OptimizedWithBatteryLife,
+				VenusOS.Ess_State_OptimizedWithoutBatteryLife].includes(essModeItem.value)
 			button.text: Units.getCombinedDisplayText(VenusOS.Units_Percentage, essMinSocItem.value)
 			onClicked: Global.dialogLayer.open(essMinSocDialogComponent)
 		}

--- a/pages/settings/PageSettingsHub4.qml
+++ b/pages/settings/PageSettingsHub4.qml
@@ -127,7 +127,10 @@ Page {
 			Component {
 				id: minSocDialogComponent
 
-				ESSMinimumSOCDialog { }
+				ESSMinimumSOCDialog {
+					minimumStateOfCharge: Global.ess.minimumStateOfCharge
+					onAccepted: Global.ess.setMinimumStateOfChargeRequested(minimumStateOfCharge)
+				}
 			}
 		}
 


### PR DESCRIPTION
The RS (and HS19) have internal ESS functionality. This adds the basic ESS settings to the Inverter/Charger card, but in a way that it is hidden for VE.Bus Multis and Quattros.

I have indeed redefined the ESS modes yet again, because I wanted to shorten the names for display on the button. I'm open to alternatives. The idea was to work sparingly with the available space.

This also refactors the ESSMinimumSOC dialog so that it can be reused for the RS.