### PR TITLE
Overview: animate AC Loads -> EVCS connection when loads are combined

### DIFF
--- a/data/mock/EvChargersImpl.qml
+++ b/data/mock/EvChargersImpl.qml
@@ -72,9 +72,9 @@ QtObject {
 				onTriggered: {
 					const zeroPower = Math.random() < 0.2
 					let totalPower = 0
-					for (let i = 0; i < evCharger.phases.count; ++i) {
-						const phasePower = zeroPower ? 0 : Math.random() * 50
-						phases.get(i)._power.setValue(phasePower)
+					for (let i = 0; i < evCharger.phases._phases.count; ++i) {
+						const phasePower = zeroPower ? 0 : 100 + Math.random() * 50
+						phases._phases.objectAt(i)._power.setValue(phasePower)
 						totalPower += phasePower
 					}
 
@@ -182,7 +182,7 @@ QtObject {
 							repeat: true
 							interval: 2000
 							onTriggered: {
-								_power.setValue(Math.random() * 100)
+								_power.setValue(100 + (Math.random() * 100))
 								Qt.callLater(energyMeter.updateTotals)
 							}
 						}

--- a/pages/OverviewPage.qml
+++ b/pages/OverviewPage.qml
@@ -849,9 +849,10 @@ SwipeViewPage {
 			// If splitting loads into (input) AC Loads and (output) Essential Loads:
 			//  - connect to AC Loads, if there are any EV chargers with /Position=1 (AC-In)
 			//  - connect to Essential Loads, if there are any EV chargers with /Position=0 (AC-Out)
-			readonly property bool connectToAcLoads: visible
-					&& (!Global.system.showInputLoads  // AC loads are combined
-						|| Global.evChargers.acInputPositionCount > 0) // AC loads are split, and AC-in position is in use
+			readonly property bool connectToCombinedAcLoads: visible && !Global.system.showInputLoads
+			readonly property bool connectToSplitAcLoads: visible
+					&& Global.system.showInputLoads                 // AC loads are split
+					&& Global.evChargers.acInputPositionCount > 0   // AC-in position is in use
 			readonly property bool connectToEssentialLoads: visible
 					&& Global.system.showInputLoads     // AC loads are split
 					&& Global.system.hasAcOutSystem     // Essential Loads should be visible
@@ -875,18 +876,18 @@ SwipeViewPage {
 				parent: acLoadsWidget
 				location: VenusOS.WidgetConnector_Location_Left
 				offsetY: height + Theme.geometry_overviewPage_connector_anchor_spacing
-				visible: evcsWidget.connectToAcLoads
+				visible: evcsWidget.connectToCombinedAcLoads || evcsWidget.connectToSplitAcLoads
 			}
 			WidgetConnectorAnchor {
 				id: acLoadsToEvcsEndAnchor
 				location: VenusOS.WidgetConnector_Location_Left
 				offsetY: -(height + Theme.geometry_overviewPage_connector_anchor_spacing)
-				visible: evcsWidget.connectToAcLoads
+				visible: evcsWidget.connectToCombinedAcLoads || evcsWidget.connectToSplitAcLoads
 			}
 			WidgetConnector {
 				id: acLoadsToEvcsConnector
 				parent: root
-				visible: evcsWidget.connectToAcLoads
+				visible: evcsWidget.connectToCombinedAcLoads || evcsWidget.connectToSplitAcLoads
 				startWidget: acLoadsWidget
 				startLocation: VenusOS.WidgetConnector_Location_Left
 				startOffsetY: acLoadsToEvcsStartAnchor.offsetY
@@ -898,7 +899,8 @@ SwipeViewPage {
 				animateGeometry: root._animateGeometry
 				animationEnabled: root.animationEnabled
 				animationMode: root.isCurrentPage
-						&& Global.evChargers.acInputPositionPower > Theme.geometry_overviewPage_connector_animationPowerThreshold
+						&& ( (evcsWidget.connectToCombinedAcLoads && Global.evChargers.power > Theme.geometry_overviewPage_connector_animationPowerThreshold)
+						  || (evcsWidget.connectToSplitAcLoads && Global.evChargers.acInputPositionPower > Theme.geometry_overviewPage_connector_animationPowerThreshold) )
 					? VenusOS.WidgetConnector_AnimationMode_StartToEnd
 					: VenusOS.WidgetConnector_AnimationMode_NotAnimated
 			}


### PR DESCRIPTION
a9208f086c73faf36bf37ffb029e2a216afeb292 removed the Inverter/Charger -> EVCS connector, so that the AC Loads -> EVCS connector is used instead when AC loads are combined. However, the AC Loads -> EVCS connector also needs to be updated to animate the connection when needed, i.e. when there is EVCS power for either AC-in or AC-out positions.

The fix restores the connectToInverterCharger that was removed in a9208f086c73faf36bf37ffb029e2a216afeb292 and renames it to connectToCombinedAcLoads, to make the new bindings more clear.

Fixes #1693