### PR TITLE
integrate HasAcOutSystem into system settings

### DIFF
--- a/data/System.qml
+++ b/data/System.qml
@@ -15,6 +15,7 @@ QtObject {
 	readonly property bool hasGridMeter: _gridDeviceType.isValid
 	readonly property bool hasAcOutSystem: _hasAcOutSystem.isValid && _hasAcOutSystem.value === 1
 	readonly property bool hasVebusEss: _systemType.value === "ESS" || _systemType.value === "Hub-4"
+	readonly property bool hasEss: hasVebusEss || _systemType.value === "AC System"
 	readonly property bool showInputLoads: load.acIn.hasPower
 			&& (hasVebusEss ? (hasGridMeter && _withoutGridMeter.value === 0) : hasGridMeter)
 	readonly property bool feedbackEnabled: _feedbackEnabled.value === 1

--- a/pages/settings/PageSettingsHub4.qml
+++ b/pages/settings/PageSettingsHub4.qml
@@ -66,19 +66,11 @@ Page {
 			]
 		}
 
-		ListSwitch {
-			id: acOutInUse
-			//% "Inverter AC output in use"
-			text: qsTrId("settings_ess_inverter_ac_output_in_use")
-			dataItem.uid: Global.systemSettings.serviceUid + "/Settings/SystemSetup/HasAcOutSystem"
-			allowed: defaultAllowed && withoutGridMeter.currentIndex === 0
-		}
-
 		ListRadioButtonGroup {
 			//% "Self-consumption from battery"
 			text: qsTrId("settings_ess_self_consumption_battery")
 			dataItem.uid: Global.systemSettings.serviceUid + "/Settings/CGwacs/BatteryUse"
-			allowed: defaultAllowed && withoutGridMeter.currentIndex === 0 && acOutInUse.checked
+			allowed: defaultAllowed && withoutGridMeter.currentIndex === 0 && hasAcOutSystemItem.value === 1
 			optionModel: [
 				//% "All system loads"
 				{ display: qsTrId("settings_ess_all_system_loads"), value: 0 },
@@ -277,6 +269,11 @@ Page {
 			VeQuickItem {
 				id: scheduleSoc
 				uid: Global.system.serviceUid + "/Control/ScheduledSoc"
+			}
+
+			VeQuickItem {
+				id: hasAcOutSystemItem
+				uid: Global.systemSettings.serviceUid + "/Settings/SystemSetup/HasAcOutSystem"
 			}
 
 			Component {

--- a/pages/settings/PageSettingsSystem.qml
+++ b/pages/settings/PageSettingsSystem.qml
@@ -21,6 +21,18 @@ Page {
 		{ display: qsTrId("settings_system_shore_power"), value: 3 },
 	]
 
+	VeQuickItem {
+		id: hasAcOutLoadsItem
+
+		uid: Global.systemSettings.serviceUid + "/Settings/SystemSetup/HasAcOutSystem"
+	}
+
+	VeQuickItem {
+		id: hasAcInLoadsItem
+
+		uid: Global.systemSettings.serviceUid + "/Settings/SystemSetup/HasAcInLoads"
+	}
+
 	GradientListView {
 		model: ObjectModel {
 
@@ -86,23 +98,35 @@ Page {
 			ListRadioButtonGroup {
 				//% "Position of AC loads"
 				text: qsTrId("settings_system_ac_position")
-				dataItem.uid: Global.systemSettings.serviceUid + "/Settings/SystemSetup/HasAcInLoads"
+				currentIndex: (hasAcInLoadsItem.value === 1 ? 1 : 0) + (
+					hasAcOutLoadsItem.value === 1 ? 2 : 0) - 1
 				optionModel: [
 					{
-						//% "AC input & output"
-						display: qsTrId("settings_system_ac_input_and_output"),
-						//% "Use this option when AC-loads are present on the input of the Inverter/Charger. Use this option if unsure."
-						caption: qsTrId("settings_system_ac_input_and_output_description"),
-						value: 1
+						//% "AC input only"
+						display: qsTrId("settings_system_ac_input_only"),
+						//% "The AC output of the Inverter/Charger is not used."
+						caption: qsTrId("settings_system_ac_input_only_description"),
+						readOnly: !Global.system.hasEss
 					},
 					{
 						//% "AC output only"
 						display: qsTrId("settings_system_ac_output_only"),
-						//% "Use this option when the system uses a grid meter, but all AC-loads are on the output of the Inverter/Charger."
+						//% "All AC loads are on the output of the Inverter/Charger."
 						caption: qsTrId("settings_system_ac_output_only_description"),
-						value: 0
+					},
+					{
+						//% "AC input & output"
+						display: qsTrId("settings_system_ac_input_and_output"),
+						//% "The system will automatically display loads on the input of the Inverter/Charger if a grid meter is present. Loads on the output are always displayed."
+						caption: qsTrId("settings_system_ac_input_and_output_description"),
 					},
 				]
+
+				onOptionClicked: function(index) {
+					index += 1
+					hasAcInLoadsItem.setValue(index & 1)
+					hasAcOutLoadsItem.setValue((index & 2) >> 1)
+				}
 			}
 
 			ListRadioButtonGroup {


### PR DESCRIPTION
HasAcOutSystem used to be an ESS specific setting. With the RS including ESS support internally, make this a system setting.

This also relies on systemcalc v2.201 to detect whether there is any sort of ESS functionality. Loads on the input side (only) makes no sense in a non-ESS system, and therefore that option is hidden.

The text that explains what the settings do are also updated to be more sensible.

https://github.com/victronenergy/venus-private/issues/450