### PR TITLE
Improvements for Multi-RS

### DIFF
--- a/pages/invertercharger/OverviewInverterChargerPage.qml
+++ b/pages/invertercharger/OverviewInverterChargerPage.qml
@@ -152,6 +152,15 @@ Page {
 			}
 
 			ListNavigationItem {
+				text: CommonWords.ess
+				allowed: root.serviceType === "acsystem"
+				onClicked: {
+					Global.pageManager.pushPage("/pages/settings/devicelist/rs/PageRsSystemEss.qml",
+							{ "title": text, "bindPrefix": root.serviceUid })
+				}
+			}
+
+			ListNavigationItem {
 				text: CommonWords.product_page
 				onClicked: {
 					if (root.serviceType === "inverter") {

--- a/pages/settings/devicelist/rs/PageRsSystem.qml
+++ b/pages/settings/devicelist/rs/PageRsSystem.qml
@@ -94,14 +94,6 @@ Page {
 			}
 
 			ListNavigationItem {
-				text: CommonWords.ess
-				onClicked: {
-					Global.pageManager.pushPage("/pages/settings/devicelist/rs/PageRsSystemEss.qml",
-							{ "title": text, "bindPrefix": root.bindPrefix })
-				}
-			}
-
-			ListNavigationItem {
 				//% "RS devices"
 				text: qsTrId("settings_rs_devices")
 				onClicked: {

--- a/pages/settings/devicelist/rs/PageRsSystemEss.qml
+++ b/pages/settings/devicelist/rs/PageRsSystemEss.qml
@@ -17,6 +17,11 @@ Page {
 		uid: Global.systemSettings.serviceUid + "/Settings/DynamicEss/Mode"
 	}
 
+	VeQuickItem {
+		id: essMinSocItem
+		uid: bindPrefix + "/Settings/Ess/MinimumSocLimit"
+	}
+
 	GradientListView {
 		model: ObjectModel {
 			ListRadioButtonGroup {
@@ -26,14 +31,20 @@ Page {
 				dataItem.uid: root.bindPrefix + "/Settings/Ess/Mode"
 			}
 
-			ListSpinBox {
+			ListButton {
 				//% "Minimum SOC (unless grid fails)"
 				text: qsTrId("settings_rs_ess_min_soc")
-				allowed: essMode.dataItem.value < 2 // Optimised
-				dataItem.uid: root.bindPrefix + "/Settings/Ess/MinimumSocLimit"
-				suffix: Units.defaultUnitString(VenusOS.Units_Percentage)
-				to: 100
-				stepSize: 5
+				button.text: Units.getCombinedDisplayText(VenusOS.Units_Percentage, essMinSocItem.value)
+				onClicked: Global.dialogLayer.open(minSocDialogComponent)
+
+				Component {
+					id: minSocDialogComponent
+
+					ESSMinimumSOCDialog {
+						minimumStateOfCharge: essMinSocItem.value
+						onAccepted: essMinSocItem.setValue(minimumStateOfCharge)
+					}
+				}
 			}
 
 			ListQuantityItem {

--- a/pages/settings/devicelist/rs/PageRsSystemEss.qml
+++ b/pages/settings/devicelist/rs/PageRsSystemEss.qml
@@ -36,6 +36,15 @@ Page {
 				stepSize: 5
 			}
 
+			ListQuantityItem {
+				//% "Active SOC limit"
+				text: qsTrId("settings_rs_active_soc_limit")
+				allowed: defaultAllowed
+					&& essMode.dataItem.value === VenusOS.Ess_State_OptimizedWithBatteryLife
+				dataItem.uid: root.bindPrefix + "/Ess/ActiveSocLimit"
+				unit: VenusOS.Units_Percentage
+			}
+
 			ListNavigationItem {
 				//% "Dynamic ESS"
 				text: qsTrId("settings_rs_ess_dess")


### PR DESCRIPTION
Some items were duplicated on the product page. Those have been removed.

The ESS menu is moved one up, from the product page to the Inverter/Charger page. Easier for users to reach.

An item was added for the Active SOC limit. This is the battery SOC Limit the RS will maintain when ESS mode is set to optimised with BatteryLife. Therefore it is shown only when in that ESS mode, so that the user will know which MinSoc is being used.