### PR TITLE
Show Grid/Shore first in Overview AC inputs

### DIFF
--- a/data/AcInputs.qml
+++ b/data/AcInputs.qml
@@ -148,6 +148,12 @@ QtObject {
 		}
 	}
 
+	function isGridOrShore(input) {
+		return input
+				&& (input.source === VenusOS.AcInputs_InputSource_Grid
+					|| input.source === VenusOS.AcInputs_InputSource_Shore)
+	}
+
 	function roleName(role) {
 		const match = roles.find(function(r) { return r.role === role })
 		return match ? match.name : "--"

--- a/pages/OverviewPage.qml
+++ b/pages/OverviewPage.qml
@@ -16,8 +16,8 @@ SwipeViewPage {
 	// Preferred order for the input widgets on the left hand side. When placing widgets, avoid / minimize connectors crossing each other.
 	readonly property var _leftWidgetOrder: [
 		// Top widgets: these widgets have to be up the top, as they connect to the 'inverter/charger widget', which is at the top of the center column.
-		VenusOS.OverviewWidget_Type_AcInput1,
-		VenusOS.OverviewWidget_Type_AcInput2,
+		VenusOS.OverviewWidget_Type_AcInputPriority,
+		VenusOS.OverviewWidget_Type_AcInputOther,
 		// End top widgets
 
 		// Middle widgets: these widgets can connect to both the inverter/charger widget and the battery widget in the center column.
@@ -216,8 +216,8 @@ SwipeViewPage {
 
 		let widget = null
 		switch (type) {
-		case VenusOS.OverviewWidget_Type_AcInput1:
-		case VenusOS.OverviewWidget_Type_AcInput2:
+		case VenusOS.OverviewWidget_Type_AcInputPriority:
+		case VenusOS.OverviewWidget_Type_AcInputOther:
 			widget = acInputComponent.createObject(root, args)
 			break
 		case VenusOS.OverviewWidget_Type_Alternator:
@@ -257,9 +257,15 @@ SwipeViewPage {
 
 		// Add AC-in widgets.
 		const acInputConfigs = [
-			{ input: Global.acInputs.input1, widgetType: VenusOS.OverviewWidget_Type_AcInput1 },
-			{ input: Global.acInputs.input2, widgetType: VenusOS.OverviewWidget_Type_AcInput2 },
+			{ input: Global.acInputs.input1, widgetType: VenusOS.OverviewWidget_Type_AcInputPriority },
+			{ input: Global.acInputs.input2, widgetType: VenusOS.OverviewWidget_Type_AcInputOther },
 		]
+		if (Global.acInputs.isGridOrShore(Global.acInputs.input2)
+				&& !Global.acInputs.isGridOrShore(Global.acInputs.input1)) {
+			// Prefer to show the Grid/Shore AC input first, so swap the display order if needed.
+			acInputConfigs[0].widgetType = VenusOS.OverviewWidget_Type_AcInputOther
+			acInputConfigs[1].widgetType = VenusOS.OverviewWidget_Type_AcInputPriority
+		}
 		for (const inputConfig of acInputConfigs) {
 			widget = _createWidget(inputConfig.widgetType)
 			if (!!inputConfig.input) {

--- a/pages/OverviewPage.qml
+++ b/pages/OverviewPage.qml
@@ -36,6 +36,7 @@ SwipeViewPage {
 	// Set a counter that updates whenever the layout should change.
 	// Use a delayed binding to avoid repopulating the model unnecessarily.
 	readonly property int _shouldResetWidgets: Global.dcInputs.model.count
+			+ Global.acInputs.activeInSource
 			+ (Global.acInputs.input1?.operational ? 1 : 0)
 			+ (Global.acInputs.input2?.operational ? 1 : 0)
 			+ (Global.system.showInputLoads ? 1 : 0)

--- a/src/enums.h
+++ b/src/enums.h
@@ -114,8 +114,8 @@ public:
 
 	enum OverviewWidget_Type {
 		OverviewWidget_Type_Unknown,
-		OverviewWidget_Type_AcInput1,
-		OverviewWidget_Type_AcInput2,
+		OverviewWidget_Type_AcInputPriority,
+		OverviewWidget_Type_AcInputOther,
 		OverviewWidget_Type_DcGenerator,
 		OverviewWidget_Type_Alternator,
 		OverviewWidget_Type_FuelCell,


### PR DESCRIPTION
When there is a Grid/Shore input as well as a Generator input, prefer to show the Grid/Shore input first.

Fixes #1716