### PR TITLE
Use system /Ac/ActiveIn as primary determinant of highlighted input 

### DIFF
--- a/pages/OverviewPage.qml
+++ b/pages/OverviewPage.qml
@@ -36,6 +36,7 @@ SwipeViewPage {
 	// Set a counter that updates whenever the layout should change.
 	// Use a delayed binding to avoid repopulating the model unnecessarily.
 	readonly property int _shouldResetWidgets: Global.dcInputs.model.count
+			+ Global.acInputs.activeInSource
 			+ (Global.acInputs.input1?.operational ? 1 : 0)
 			+ (Global.acInputs.input2?.operational ? 1 : 0)
 			+ (Global.system.showInputLoads ? 1 : 0)


### PR DESCRIPTION
If system /Ac/ActiveIn/Source or /Ac/ActiveIn/ServiceType is set, then choose the first AC input with a matching source or service type (regardless of the power value, or whether it is a Grid/Shore/Genset).

If neither /Ac/ActiveIn/Source nor /Ac/ActiveIn/ServiceType are set, then choose the first input that is Grid/Shore, or otherwise, any operational input.

Issue #1626