### PR TITLE
Update AC input details when any system AC info is updated

### DIFF
--- a/data/AcInputs.qml
+++ b/data/AcInputs.qml
@@ -34,11 +34,11 @@ QtObject {
 	// AC input metadata from com.victronenergy.system/Ac/In/<1|2>. There are always two inputs.
 	property AcInputSystemInfo input1Info: AcInputSystemInfo {
 		inputIndex: 0
-		onValidChanged: input1 = root.resetInput(input1, input1Info)
+		onServiceInfoChanged: input1 = root.resetInput(input1, input1Info)
 	}
 	property AcInputSystemInfo input2Info: AcInputSystemInfo {
 		inputIndex: 1
-		onValidChanged: input2 = root.resetInput(input2, input2Info)
+		onServiceInfoChanged: input2 = root.resetInput(input2, input2Info)
 	}
 
 	readonly property Component _acInputComponent: Component {

--- a/data/common/AcInputSystemInfo.qml
+++ b/data/common/AcInputSystemInfo.qml
@@ -24,24 +24,30 @@ QtObject {
 	readonly property real minimumCurrent: _minimumCurrent.isValid ? _minimumCurrent.value : NaN
 	readonly property real maximumCurrent: _maximumCurrent.isValid ? _maximumCurrent.value : NaN
 
+	signal serviceInfoChanged
+
 	readonly property VeQuickItem _connected: VeQuickItem {
 		uid: root.bindPrefix ? root.bindPrefix + "/Connected" : ""
 	}
 
 	readonly property VeQuickItem _deviceInstance: VeQuickItem {
 		uid: root.bindPrefix ? root.bindPrefix + "/DeviceInstance" : ""
+		onValueChanged: Qt.callLater(root.serviceInfoChanged)
 	}
 
 	readonly property VeQuickItem _serviceName: VeQuickItem {
 		uid: root.bindPrefix ? root.bindPrefix + "/ServiceName" : ""
+		onValueChanged: Qt.callLater(root.serviceInfoChanged)
 	}
 
 	readonly property VeQuickItem _serviceType: VeQuickItem {
 		uid: root.bindPrefix ? root.bindPrefix + "/ServiceType" : ""
+		onValueChanged: Qt.callLater(root.serviceInfoChanged)
 	}
 
 	readonly property VeQuickItem _source: VeQuickItem {
 		uid: root.bindPrefix ? root.bindPrefix + "/Source" : ""
+		onValueChanged: Qt.callLater(root.serviceInfoChanged)
 	}
 
 	readonly property VeQuickItem _minimumCurrent: VeQuickItem {


### PR DESCRIPTION
Using onValidChanged to rebuild the AcInput object was incorrect, because this meant the object would not be rebuilt if it changed from e.g. a vebus source to a grid source.

Instead, use onServiceInfoChanged signal to trigger this rebuild, and emit this signal when any of the system input info changes, including the service type and service source.

Issue #1626