### PR TITLE
Fix run-time null error on Brief page for DC Inputs Icon

### DIFF
--- a/pages/BriefPage.qml
+++ b/pages/BriefPage.qml
@@ -14,9 +14,7 @@ SwipeViewPage {
 	property real _gaugeLabelMargin: Theme.geometry_briefPage_edgeGauge_label_initialize_margin
 	property real _gaugeArcOpacity: 0
 	property real _gaugeLabelOpacity: 0
-	readonly property string _dcInputIconSource: Global.dcInputs.model.count === 1
-		 ? Global.dcInputs.inputTypeIcon(Global.dcInputs.model.firstObject.inputType)
-		 : "qrc:/images/icon_dc_24.svg"
+	readonly property string _dcInputIconSource: Global.dcInputs.inputTypeIcon(Global.dcInputs.model.firstObject?.inputType)
 
 	readonly property int _leftGaugeCount: (acInputGauge.active ? 1 : 0) + (dcInputGauge.active ? 1 : 0) + (solarYieldGauge.active ? 1 : 0)
 	readonly property int _rightGaugeCount: dcLoadGauge.active ? 2 : 1  // AC load gauge is always active


### PR DESCRIPTION
Fix that Global.dcInputs.model.firstObject can become null (e.g. if simulator stops) causing the inputType to become inaccessible.
Use optional chaining to return a null into the Global.dcInputs.inputTypeIcon() function which returns the default value "qrc:/images/icon_dc_24.svg" in this case.