### PR TITLE
Add support for the SolarSense 750 irradiance sensor

### DIFF
--- a/pages/settings/devicelist/PageMeteo.qml
+++ b/pages/settings/devicelist/PageMeteo.qml
@@ -74,6 +74,14 @@ Page {
 			}
 
 			ListQuantityItem {
+				dataItem.uid: bindPrefix + "/WindDirection"
+				//% "Wind direction"
+				text: qsTrId("page_meteo_wind_direction")
+				allowed: dataItem.isValid
+				unit: VenusOS.Units_CardinalDirection
+			}
+
+			ListQuantityItem {
 				dataItem.uid: bindPrefix + "/InstallationPower"
 				//% "Installation Power"
 				text: qsTrId("page_meteo_installation_power")

--- a/pages/settings/devicelist/PageMeteo.qml
+++ b/pages/settings/devicelist/PageMeteo.qml
@@ -14,8 +14,12 @@ Page {
 
 	VeQuickItem {
 		id: deviceInstance
-
 		uid: bindPrefix + "/DeviceInstance"
+	}
+
+	VeQuickItem {
+		id: productId
+		uid: root.bindPrefix + "/ProductId"
 	}
 
 	GradientListView {
@@ -34,16 +38,18 @@ Page {
 			ListTemperatureItem {
 				//% "Cell temperature"
 				text: qsTrId("page_meteo_cell_temperature")
+				allowed: dataItem.isValid
 				dataItem.uid: bindPrefix + "/CellTemperature"
 				precision: 1
 			}
 
 			ListTemperatureItem {
-				text: sensor2.dataItem.isValid ?
-						  //% "External temperature (1)"
-						  qsTrId("page_meteo_external_temperature_1") :
-						  //% "External temperature"
-						  qsTrId("page_meteo_external_temperature")
+				text: sensor2.dataItem.isValid
+					//% "External temperature (1)"
+					? qsTrId("page_meteo_external_temperature_1")
+					//% "External temperature"
+					: qsTrId("page_meteo_external_temperature")
+				allowed: dataItem.isValid
 				dataItem.uid: bindPrefix + "/ExternalTemperature"
 				precision: 1
 			}
@@ -67,6 +73,67 @@ Page {
 				precision: 1
 			}
 
+			ListQuantityItem {
+				dataItem.uid: bindPrefix + "/InstallationPower"
+				//% "Installation Power"
+				text: qsTrId("page_meteo_installation_power")
+				allowed: dataItem.isValid
+				unit: VenusOS.Units_Watt
+				precision: 1
+			}
+
+			ListQuantityItem {
+				dataItem.uid: bindPrefix + "/TodaysYield"
+				//% "Today's yield"
+				text: qsTrId("page_meteo_daily_yield")
+				allowed: dataItem.isValid
+				unit: VenusOS.Units_Energy_KiloWattHour
+				precision: 1
+			}
+
+			ListItem {
+				id: sensorBattery
+
+				//% "Sensor battery"
+				text: qsTrId("page_meteo_battery_voltage")
+				allowed: defaultAllowed && batteryVoltage.isValid
+
+				content.children: [
+					QuantityLabel {
+						id: batteryVoltageLabel
+						anchors.verticalCenter: parent.verticalCenter
+						font.pixelSize: Theme.font_size_body2
+						value: batteryVoltage.value === undefined ? NaN : batteryVoltage.value
+						unit: VenusOS.Units_Volt_DC
+						VeQuickItem {
+							id: batteryVoltage
+							uid: bindPrefix + "/BatteryVoltage"
+						}
+					},
+					Label {
+						anchors.verticalCenter: parent.verticalCenter
+						text: {
+							if (lowBattery.isValid) {
+								const low = lowBattery.value === 1
+								//% "Low"
+								return low ? qsTrId("meteo_sensor_battery_status_low")
+													: CommonWords.ok
+							} else {
+								return ""
+							}
+						}
+						color: lowBattery.value === 1 ? Theme.color_red : Theme.color_green
+						font.pixelSize: Theme.font_size_body2
+						verticalAlignment: Text.AlignVCenter
+
+						VeQuickItem {
+							id: lowBattery
+							uid:  bindPrefix + "/Alarms/LowBattery"
+						}
+					}
+				]
+			}
+
 			ListNavigationItem {
 				id: settingsMenu
 
@@ -75,6 +142,15 @@ Page {
 														   "title": CommonWords.settings,
 														   meteoSettingsPrefix: root.settingsPrefix
 													   })
+				allowed: productId.value === ProductInfo.ProductId_MeteoSensor_Imt
+			}
+
+			ListNavigationItem {
+				text: CommonWords.device_info_title
+				onClicked: {
+					Global.pageManager.pushPage("/pages/settings/PageDeviceInfo.qml",
+									{ "title": text, "bindPrefix": root.bindPrefix })
+				}
 			}
 		}
 	}

--- a/src/enums.h
+++ b/src/enums.h
@@ -83,6 +83,7 @@ public:
 		Units_Speed_MetresPerSecond,
 		Units_Hectopascal,
 		Units_Kilopascal,
+		Units_CardinalDirection,
 	};
 	Q_ENUM(Units_Type)
 

--- a/src/productinfo.h
+++ b/src/productinfo.h
@@ -56,6 +56,7 @@ public:
 		ProductId_PowerBox_Smappee = 0xB018,
 		ProductId_PvInverter_Fronius = 0xA142, // VE_PROD_ID_PV_INVERTER_FRONIUS
 		ProductId_TankSensor_Generic = 0xA160,
+		ProductId_MeteoSensor_Imt = 0xB030, // VE_PROD_ID_IMT_SI_RS485_SOLAR_IRRADIANCE_SENSOR
 	};
 	Q_ENUM(ProductId_Misc)
 

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -94,7 +94,9 @@ int Units::defaultUnitPrecision(VenusOS::Enums::Units_Type unit) const
 	case VenusOS::Enums::Units_Temperature_Celsius:    // fall through
 	case VenusOS::Enums::Units_Temperature_Fahrenheit: // fall through
 	case VenusOS::Enums::Units_Temperature_Kelvin:     // fall through
-	case VenusOS::Enums::Units_RevolutionsPerMinute: return 0;
+	case VenusOS::Enums::Units_RevolutionsPerMinute:   // fall through
+	case VenusOS::Enums::Units_CardinalDirection:      // fall through
+		return 0;
 	default:
 		// VoltAmpere
 		// Amp
@@ -150,6 +152,8 @@ QString Units::defaultUnitString(VenusOS::Enums::Units_Type unit, int formatHint
 		return QStringLiteral("hPa");
 	case VenusOS::Enums::Units_Kilopascal:
 		return QStringLiteral("kPa");
+	case VenusOS::Enums::Units_CardinalDirection:
+		return DegreesSymbol;
 	default:
 		qWarning() << "No unit label known for unit:" << unit;
 		return QString();
@@ -197,6 +201,7 @@ bool Units::isScalingSupported(VenusOS::Enums::Units_Type unit) const
 	case VenusOS::Enums::Units_Temperature_Kelvin:
 	case VenusOS::Enums::Units_Hectopascal:
 	case VenusOS::Enums::Units_Kilopascal:
+	case VenusOS::Enums::Units_CardinalDirection:
 	default:
 		return false;
 	}
@@ -255,6 +260,11 @@ quantityInfo Units::getDisplayTextWithHysteresis(VenusOS::Enums::Units_Type unit
 			? formattingLocale()->toString(99.0, 'f', 0)
 			: formattingLocale()->toString(100.0, 'f', 0);
 		return quantity;
+	}
+
+	if (unit == VenusOS::Enums::Units_CardinalDirection) {
+		value = fmod(value + 360, 360);
+		quantity.unit += " " + formatWindDirection(static_cast<int>(value));
 	}
 
 	qreal scaledValue = value;
@@ -427,6 +437,29 @@ qreal Units::sumRealNumbersList(const QList<qreal> &numbers) const
 int Units::unitToVeUnit(VenusOS::Enums::Units_Type unit) const
 {
 	return static_cast<int>(::unitToVeUnit(unit));
+}
+
+QString Units::formatWindDirection(int degrees) const {
+	const QString directions[] = {
+		//% "N"
+		qtTrId("direction_north"),
+		//% "NE"
+		qtTrId("direction_northeast"),
+		//% "E"
+		qtTrId("direction_east"),
+		//% "SE"
+		qtTrId("direction_southeast"),
+		//% "S"
+		qtTrId("direction_south"),
+		//% "SW"
+		qtTrId("direction_southwest"),
+		//% "W"
+		qtTrId("direction_west"),
+		//% "NW"
+		qtTrId("direction_northwest")
+	};
+	const int index = static_cast<int>((degrees + 22.5) / 45.0) % 8;
+	return directions[index];
 }
 
 } // Units

--- a/src/units.h
+++ b/src/units.h
@@ -98,6 +98,9 @@ public:
 		qreal normalized = qMax(fromMin, qMin(fromMax, n));
 		return qFuzzyIsNull(fromRange) ? 0.0 : ((((normalized - fromMin) / fromRange) * toRange) + toMin);
 	}
+
+private:
+	QString formatWindDirection(int degrees) const;
 };
 
 }

--- a/tests/units/tst_units.qml
+++ b/tests/units/tst_units.qml
@@ -45,6 +45,22 @@ TestCase {
 		expect(VenusOS.Units_Percentage, 100, "100", "%")
 	}
 
+	function test_windDirection() {
+		expect(VenusOS.Units_CardinalDirection, NaN, "--", "°")
+		expect(VenusOS.Units_CardinalDirection, 0, "0", "° direction_north")
+		expect(VenusOS.Units_CardinalDirection, 45, "45", "° direction_northeast")
+		expect(VenusOS.Units_CardinalDirection, 90, "90", "° direction_east")
+		expect(VenusOS.Units_CardinalDirection, 135, "135", "° direction_southeast")
+		expect(VenusOS.Units_CardinalDirection, 180, "180", "° direction_south")
+		expect(VenusOS.Units_CardinalDirection, 215, "215", "° direction_southwest")
+		expect(VenusOS.Units_CardinalDirection, 270, "270", "° direction_west")
+		expect(VenusOS.Units_CardinalDirection, 315, "315", "° direction_northwest")
+		expect(VenusOS.Units_CardinalDirection, 360, "0", "° direction_north")
+		expect(VenusOS.Units_CardinalDirection, -23, "337", "° direction_northwest")
+		expect(VenusOS.Units_CardinalDirection, 400, "40", "° direction_northeast")
+		expect(VenusOS.Units_CardinalDirection, 23.6, "24", "° direction_northeast")
+	}
+
 	function test_precisionZero() {
 		var units = [VenusOS.Units_Volume_Liter,
 					 VenusOS.Units_Volume_GallonImperial,


### PR DESCRIPTION
Add support for the bluetooth SolarSense 750 irradiance sensor.

Tested on https://vrm.victronenergy.com/installation/348124/dashboard and working as intended. One of the things to notice is that the device is currently only visible on the dbus when there is irradiance, so during our daytime. 