### PR TITLE
Overview: show multi-phase solar total in watts, not amps

### DIFF
--- a/data/System.qml
+++ b/data/System.qml
@@ -62,6 +62,8 @@ QtObject {
 					// cannot be summed across multiple phases.
 					return NaN
 				}
+				// There are one or more PV inverters, which are all single-phase, so it's safe to
+				// return a total current as they should all have the same PV output voltage.
 				return _pvMonitor.totalCurrent
 			} else if (Global.solarChargers.model.count > 0) {
 				return _dcPvCurrent.isValid ? _dcPvCurrent.value : NaN

--- a/data/common/PvMonitor.qml
+++ b/data/common/PvMonitor.qml
@@ -36,6 +36,17 @@ Instantiator {
 		root.totalCurrent = _totalCurrent
 	}
 
+	function _updateMaximumPhaseCount() {
+		let _maxPhaseCount = 0
+		for (let i = 0; i < count; ++i) {
+			const acPvDelegate = root.objectAt(i)
+			if (!!acPvDelegate) {
+				_maxPhaseCount = Math.max(_maxPhaseCount, acPvDelegate.phaseCount)
+			}
+		}
+		root.maxPhaseCount = _maxPhaseCount
+	}
+
 	model: [
 		Global.system.serviceUid + "/Ac/PvOnGrid",
 		Global.system.serviceUid + "/Ac/PvOnGenset",
@@ -46,6 +57,7 @@ Instantiator {
 		id: acPvDelegate
 
 		readonly property string serviceUid: modelData
+		readonly property int phaseCount: vePhaseCount.value || 0
 
 		readonly property VeQuickItem vePhaseCount: VeQuickItem {
 			uid: acPvDelegate.serviceUid + "/NumberOfPhases"
@@ -53,15 +65,7 @@ Instantiator {
 				const phaseCount = value === undefined ? 0 : value
 				if (pvPhases.count !== phaseCount) {
 					pvPhases.model = phaseCount
-
-					let _maxPhaseCount = 0
-					for (let i = 0; i < count; ++i) {
-						const acPvDelegate = root.objectAt(i)
-						if (!!acPvDelegate) {
-							_maxPhaseCount = Math.max(_maxPhaseCount, acPvDelegate.vePhaseCount.value || 0)
-						}
-					}
-					root.maxPhaseCount = _maxPhaseCount
+					Qt.callLater(root._updateMaximumPhaseCount)
 				}
 			}
 		}


### PR DESCRIPTION
PvMonitor maxPhaseCount was incorrect as Instantiator::objectAt() returns an invalid object when the /NumberOfPhases value is initialized on startup. Wait until the end of the event loop to ensure objectAt() returns a valid value.

This fixes the bug where multi-phase solar totals were shown in amps, as the maxPhaseCount is used in System.qml to determine whether there are multi-phase PV inverters on the system.

Fixes #1750