### PR TITLE
Device List: rework to load per-service delegate files 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,6 +214,7 @@ set (VENUS_QML_MODULE_SOURCES
     components/CurrentLimitButton.qml
     components/DateSelector.qml
     components/Device.qml
+    components/DeviceListDelegate.qml
     components/DynamicValueRange.qml
     components/ElectricalQuantityLabel.qml
     components/EnvironmentGauge.qml
@@ -588,6 +589,37 @@ set (VENUS_QML_MODULE_SOURCES
     pages/settings/devicelist/dc-in/PageDcMeterModel.qml
     pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml
     pages/settings/devicelist/dc-in/PageDcMeterHistory.qml
+    pages/settings/devicelist/delegates/AcInDeviceListDelegate.qml
+    pages/settings/devicelist/delegates/DcMeterDeviceListDelegate.qml
+    pages/settings/devicelist/delegates/DeviceListDelegate_acload.qml
+    pages/settings/devicelist/delegates/DeviceListDelegate_acsystem.qml
+    pages/settings/devicelist/delegates/DeviceListDelegate_alternator.qml
+    pages/settings/devicelist/delegates/DeviceListDelegate_battery.qml
+    pages/settings/devicelist/delegates/DeviceListDelegate_charger.qml
+    pages/settings/devicelist/delegates/DeviceListDelegate_dcdc.qml
+    pages/settings/devicelist/delegates/DeviceListDelegate_dcgenset.qml
+    pages/settings/devicelist/delegates/DeviceListDelegate_dcload.qml
+    pages/settings/devicelist/delegates/DeviceListDelegate_dcsource.qml
+    pages/settings/devicelist/delegates/DeviceListDelegate_dcsystem.qml
+    pages/settings/devicelist/delegates/DeviceListDelegate_digitalinput.qml
+    pages/settings/devicelist/delegates/DeviceListDelegate_evcharger.qml
+    pages/settings/devicelist/delegates/DeviceListDelegate_fuelcell.qml
+    pages/settings/devicelist/delegates/DeviceListDelegate_genset.qml
+    pages/settings/devicelist/delegates/DeviceListDelegate_grid.qml
+    pages/settings/devicelist/delegates/DeviceListDelegate_heatpump.qml
+    pages/settings/devicelist/delegates/DeviceListDelegate_inverter.qml
+    pages/settings/devicelist/delegates/DeviceListDelegate_meteo.qml
+    pages/settings/devicelist/delegates/DeviceListDelegate_motordrive.qml
+    pages/settings/devicelist/delegates/DeviceListDelegate_multi.qml
+    pages/settings/devicelist/delegates/DeviceListDelegate_pulsemeter.qml
+    pages/settings/devicelist/delegates/DeviceListDelegate_pvinverter.qml
+    pages/settings/devicelist/delegates/DeviceListDelegate_solarcharger.qml
+    pages/settings/devicelist/delegates/DeviceListDelegate_tank.qml
+    pages/settings/devicelist/delegates/DeviceListDelegate_temperature.qml
+    pages/settings/devicelist/delegates/DeviceListDelegate_unsupported.qml
+    pages/settings/devicelist/delegates/DeviceListDelegate_vebus.qml
+    pages/settings/devicelist/delegates/DisconnectedDeviceListDelegate.qml
+    pages/settings/devicelist/delegates/GensetDeviceListDelegate.qml
     pages/settings/devicelist/inverter/PageInverter.qml
     pages/settings/devicelist/inverter/PageSolarStats.qml
     pages/settings/devicelist/rs/PageMultiRs.qml

--- a/components/DeviceListDelegate.qml
+++ b/components/DeviceListDelegate.qml
@@ -1,0 +1,16 @@
+/*
+** Copyright (C) 2023 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+ListQuantityGroupNavigationItem {
+	id: root
+
+	property BaseDevice device
+	property BaseDeviceModel sourceModel
+
+	text: device.name
+}

--- a/components/listitems/ListItem.qml
+++ b/components/listitems/ListItem.qml
@@ -83,7 +83,7 @@ Item {
 		}
 		font.pixelSize: flat ? Theme.font_size_body1 : Theme.font_size_body2
 		wrapMode: Text.Wrap
-		width: root.availableWidth - content.width
+		width: root.availableWidth - content.width - Theme.geometry_listItem_content_spacing
 	}
 
 	Row {

--- a/data/mock/DigitalInputsImpl.qml
+++ b/data/mock/DigitalInputsImpl.qml
@@ -18,8 +18,6 @@ QtObject {
 			const inputObj = inputComponent.createObject(root, {
 				serviceUid: "mock/com.victronenergy.digitalinput.ttyUSB" + deviceInstanceNum,
 				deviceInstance: deviceInstanceNum,
-				type: Math.random() * VenusOS.DigitalInput_Type_Generator,
-				state: Math.random() * VenusOS.DigitalInput_State_Stopped
 			})
 		}
 	}
@@ -29,6 +27,8 @@ QtObject {
 			Component.onCompleted: {
 				_deviceInstance.setValue(deviceInstance)
 				_customName.setValue("Digital input %1".arg(deviceInstance))
+				Global.mockDataSimulator.setMockValue(serviceUid + "/Type", Math.floor(Math.random() * VenusOS.DigitalInput_Type_Generator))
+				Global.mockDataSimulator.setMockValue(serviceUid + "/State", Math.floor(Math.random() * VenusOS.DigitalInput_State_Stopped))
 			}
 		}
 	}

--- a/data/mock/EvChargersImpl.qml
+++ b/data/mock/EvChargersImpl.qml
@@ -15,7 +15,9 @@ QtObject {
 		for (let i = 0; i < 3; ++i) {
 			createCharger({
 				position: i % 2 === 0 ? VenusOS.Evcs_Position_ACInput : VenusOS.Evcs_Position_ACOutput,
-				nrOfPhases: i + 1
+				nrOfPhases: i + 1,
+				status: Math.floor(Math.random() * VenusOS.Evcs_Status_Charged),
+				mode: Math.floor(Math.random() * VenusOS.Evcs_Mode_Scheduled),
 			})
 		}
 		createEnergyMeter()
@@ -91,7 +93,7 @@ QtObject {
 				interval: 3000
 
 				onTriggered: {
-					evCharger._status.setValue(Math.random() * VenusOS.Evcs_Status_OverheatingDetected)
+					evCharger._status.setValue(Math.floor(Math.random() * VenusOS.Evcs_Status_OverheatingDetected))
 				}
 			}
 

--- a/data/mock/PulseMetersImpl.qml
+++ b/data/mock/PulseMetersImpl.qml
@@ -24,6 +24,7 @@ QtObject {
 			Component.onCompleted: {
 				_deviceInstance.setValue(deviceInstance)
 				_customName.setValue("PulseMeter %1".arg(deviceInstance))
+				Global.mockDataSimulator.setMockValue(serviceUid + "/Aggregate", Math.random() * 100)
 			}
 		}
 	}

--- a/data/mock/SolarChargersImpl.qml
+++ b/data/mock/SolarChargersImpl.qml
@@ -172,7 +172,7 @@ QtObject {
 				_productName.setValue("SmartSolar Charger MPPT 100/50")
 				_customName.setValue("My Solar Charger " + deviceInstance)
 				_state.setValue(VenusOS.SolarCharger_State_ExternalControl)
-				_errorCode.setValue(Math.floor(Math.random() * 30))
+				_errorCode.setValue(Math.random() < 0.4 ? Math.floor(Math.random() * 30) : 0)
 				root.setRandomErrors(serviceUid + "/History/Overall")
 			}
 		}

--- a/pages/settings/devicelist/DeviceListPage.qml
+++ b/pages/settings/devicelist/DeviceListPage.qml
@@ -3,230 +3,56 @@
 ** See LICENSE.txt for license information.
 */
 
-/*
- * These settings are regularly brought up to date with the settings from gui-v1.
- * Currently up to date with gui-v1 v5.6.6.
- */
-
 import QtQuick
-import QtQuick.Controls.impl as CP
 import Victron.VenusOS
 
 Page {
 	id: root
 
-	function _deviceDisplayInfo(serviceType, device, sourceModel) {
-		let summary = []
-		let url = ""
-		let params = ""
-
-		if (!serviceType || !device || !sourceModel) {
-			return null
-		}
-
-		switch(serviceType) {
-		case "acsystem":
-			url = "/pages/settings/devicelist/rs/PageRsSystem.qml"
-			params = { "bindPrefix" : device.serviceUid }
-			summary = [ Global.system.systemStateToText(device.state) ]
-			break;
-
-		case "vebus":
-			// vebus devices may also show up as AC inputs or batteries, so ensure they do not
-			// appear multiple times in the list.
-			if (sourceModel !== Global.inverterChargers.veBusDevices) {
-				return null
-			} else {
-				url = "/pages/vebusdevice/PageVeBus.qml"
-				params = { "veBusDevice" : device }
-				summary = [ Global.system.systemStateToText(device.state) ]
-			}
-			break;
-
-		case "multi":
-			// multi devices are not shown in the Device List; they are shown as part of the
-			// "Devices" list in the acsystem page (PageRsSystem) instead.
-			return null
-
-		case "battery":
-			url = "/pages/settings/devicelist/battery/PageBattery.qml"
-			params = { "battery" : device }
-			summary = (!device.isParallelBms && device.state === VenusOS.Battery_State_Pending)
-					? [
-						  CommonWords.pending,
-						  Units.getCombinedDisplayText(VenusOS.Units_Volt_DC, device.voltage),
-						  Units.getCombinedDisplayText(VenusOS.Units_Percentage, device.stateOfCharge)
-					  ]
-					: [
-						  Units.getCombinedDisplayText(VenusOS.Units_Percentage, device.stateOfCharge),
-						  Units.getCombinedDisplayText(VenusOS.Units_Volt_DC, device.voltage),
-						  Units.getCombinedDisplayText(VenusOS.Units_Amp, device.current),
-					  ]
-			break;
-
-		case "solarcharger":
-			url = "/pages/solar/SolarChargerPage.qml"
-			params = { "solarCharger" : device }
-			summary = [
-				device.errorCode <= 0
-						? Units.getCombinedDisplayText(VenusOS.Units_Watt, device.power)
-						  //: %1 = error number
-						  //% "Error: #%1"
-						: qsTrId("devicelist_solarcharger_error").arg(device.errorCode)
-			]
-			break;
-
-		case "charger":
-			url = "/pages/settings/devicelist/PageAcCharger.qml"
-			params = { "bindPrefix" : device.serviceUid }
-			summary = [ Global.system.systemStateToText(device.state) ]
-			break;
-
-		case "tank":
-			url = "/pages/settings/devicelist/tank/PageTankSensor.qml"
-			params = { "bindPrefix" : device.serviceUid }
-
-			if (isNaN(device.level)) {
-				summary = [ device.status === VenusOS.Tank_Status_Unknown ? "--" : Global.tanks.statusToText(device.status) ]
-			} else {
-				const levelText = Units.getCombinedDisplayText(VenusOS.Units_Percentage, device.level)
-				if (isNaN(device.temperature)) {
-					summary = [ levelText ]
-				} else {
-					const tankTemp = Global.systemSettings.convertFromCelsius(device.temperature)
-					summary = [
-						Units.getCombinedDisplayText(Global.systemSettings.temperatureUnit, tankTemp),
-						levelText
-					]
-				}
-			}
-			break;
-
-		case "genset":		// deliberate fall through
-		case "dcgenset":
-			url = "/pages/settings/devicelist/PageGenset.qml"
-			params = { "bindPrefix": device.serviceUid }
-
-			const gensetPowerText = Units.getCombinedDisplayText(VenusOS.Units_Watt, device.power)
-			if (device.gensetStatusCode >= 0) {
-				summary = [ Global.acInputs.gensetStatusCodeToText(device.gensetStatusCode), gensetPowerText ]
-			} else {
-				summary = [ gensetPowerText ]
-			}
-			break;
-
-		case "pvinverter":	// deliberate fall through
-		case "grid":		// deliberate fall through
-		case "heatpump":    // deliberate fall through
-		case "acload":
-			url = "/pages/settings/devicelist/ac-in/PageAcIn.qml"
-			params = { "bindPrefix": device.serviceUid }
-
-			const acInputPowerText = Units.getCombinedDisplayText(VenusOS.Units_Watt, device.power)
-			if (device.gensetStatusCode >= 0) {
-				summary = [ Global.acInputs.gensetStatusCodeToText(device.gensetStatusCode), acInputPowerText ]
-			} else {
-				summary = [ acInputPowerText ]
-			}
-			break;
-
-		case "motordrive":
-			url = "/pages/settings/devicelist/PageMotorDrive.qml"
-			params = { "bindPrefix" : device.serviceUid }
-			summary = [ Units.getCombinedDisplayText(VenusOS.Units_RevolutionsPerMinute, device.motorRpm) ]
-			break;
-
-		case "inverter":
-			url = "/pages/settings/devicelist/inverter/PageInverter.qml"
-			params = { "bindPrefix" : device.serviceUid }
-			summary = [ Units.getCombinedDisplayText(device.currentPhase.powerUnit, device.currentPhase.power) ]
-			break;
-
-		case "temperature":
-			url = "/pages/settings/devicelist/temperature/PageTemperatureSensor.qml"
-			params = { "bindPrefix" : device.serviceUid }
-
-			const inputTemp = Global.systemSettings.convertFromCelsius(device.temperature)
-			if (isNaN(device.humidity)) {
-				summary = [
-					Units.getCombinedDisplayText(Global.systemSettings.temperatureUnit, inputTemp, 0),
-				]
-			} else {
-				summary = [
-					Units.getCombinedDisplayText(Global.systemSettings.temperatureUnit, inputTemp, 0),
-					Units.getCombinedDisplayText(VenusOS.Units_Percentage, device.humidity),
-				]
-			}
-			break;
-
-		case "digitalinput":
-			url = "/pages/settings/devicelist/PageDigitalInput.qml"
-			params = {"bindPrefix": device.serviceUid }
-			summary = [ Global.digitalInputs.inputStateToText(device.state) ]
-			break;
-
-		case "evcharger":
-			url = "/pages/evcs/EvChargerPage.qml"
-			params = { "evCharger" : device }
-
-			const evChargerModeText = Global.evChargers.chargerModeToText(device.mode)
-			if (device.mode < 0) {
-				summary = [ Units.getCombinedDisplayText(VenusOS.Units_Watt, device.power) ]
-			} else if (device.status === VenusOS.Evcs_Status_Charging) {
-				summary = [ evChargerModeText, Units.getCombinedDisplayText(VenusOS.Units_Watt, device.power) ]
-			} else if (device.status >= 0) {
-				summary = [ evChargerModeText, Global.evChargers.chargerStatusToText(device.status) ]
-			} else {
-				summary = [ evChargerModeText ]
-			}
-			break;
-
-		case "fuelcell":	// deliberate fall through
-		case "dcsource":	// deliberate fall through
-		case "dcload":		// deliberate fall through
-		case "dcsystem":	// deliberate fall through
-		case "dcdc":        // deliberate fall through
-		case "alternator":
-			url = serviceType === "alternator" ? "/pages/settings/devicelist/dc-in/PageAlternator.qml"
-					: "/pages/settings/devicelist/dc-in/PageDcMeter.qml"
-			params = {"bindPrefix": device.serviceUid }
-			summary = [
-				Units.getCombinedDisplayText(VenusOS.Units_Volt_DC, device.voltage),
-				Units.getCombinedDisplayText(VenusOS.Units_Amp, device.current),
-				Units.getCombinedDisplayText(VenusOS.Units_Watt, device.power),
-			]
-			break;
-
-		case "pulsemeter":
-			url = "/pages/settings/devicelist/pulsemeter/PagePulseCounter.qml"
-			params = {"bindPrefix": device.serviceUid }
-			summary = [ Units.getCombinedDisplayText(Global.systemSettings.volumeUnit, device.aggregate) ]
-			break;
-
-		case "unsupported":
-			//: Device is not supported
-			//% "Unsupported"
-			summary = [ qsTrId("devicelist_unsupported") ]
-			url = "/pages/settings/devicelist/PageUnsupportedDevice.qml"
-			params = { "bindPrefix": device.serviceUid }
-			break;
-
-		case "meteo":
-			url = "/pages/settings/devicelist/PageMeteo.qml"
-			params = {"bindPrefix": device.serviceUid }
-			summary = [ Units.getCombinedDisplayText(VenusOS.Units_WattsPerSquareMeter, device.irradiance) ]
-			break;
-
-		default:
-			return null
-		}
-		params.title = Qt.binding(function(){ return device.name })
-
-		return { "summary": summary, "url": url, "params": params }
-	}
-
 	GradientListView {
 		model: Global.allDevicesModel
+
+		delegate: Loader {
+			id: delegateLoader
+
+			required property bool connected
+			required property BaseDevice device
+			required property BaseDeviceModel sourceModel
+			required property string cachedDeviceName
+
+			readonly property bool _loadCustomDelegate: connected && !!device
+
+			// Only set width; height is sized to the loaded item, in case allowed=false and the
+			// item should not be visible.
+			width: parent ? parent.width : 0
+
+			on_LoadCustomDelegateChanged: {
+				let delegateUri
+				if (_loadCustomDelegate) {
+					const serviceType = BackendConnection.serviceTypeFromUid(device.serviceUid)
+					if (!serviceType) {
+						console.warn("DeviceList: cannot load delegate, cannot read service type from serviceUid:", device.serviceUid)
+						return
+					}
+					setSource("delegates/DeviceListDelegate_%1.qml".arg(serviceType), {
+						device: Qt.binding(function() { return delegateLoader.device }),
+						sourceModel: Qt.binding(function() { return delegateLoader.sourceModel }),
+					})
+				} else {
+					setSource("delegates/DisconnectedDeviceListDelegate.qml", {
+						cachedDeviceName: Qt.binding(function() { return delegateLoader.cachedDeviceName }),
+					})
+				}
+			}
+
+			onStatusChanged: {
+				if (status === Loader.Error) {
+					console.log("Failed to load Device List delegate for '%1' service from file: %2"
+						.arg(BackendConnection.serviceTypeFromUid(device.serviceUid))
+						.arg(source))
+				}
+			}
+		}
 
 		footer: ListButton {
 			//% "Remove disconnected devices"
@@ -237,47 +63,5 @@ Page {
 				Global.allDevicesModel.removeDisconnectedDevices()
 			}
 		}
-
-		delegate: ListTextGroup {
-			id: deviceDelegate
-
-			readonly property string _serviceType: model.device
-					? BackendConnection.type === BackendConnection.MqttSource
-						? model.device.serviceUid.split("/")[1] || ""    // serviceUid = mqtt/<serviceType>/<path>
-						: model.device.serviceUid.split(".")[2] || ""    // serviceUid = dbus/com.victronenergy.<serviceType>[.suffix]/<path>
-					: ""
-			readonly property var _displayInfo: model.connected
-					? root._deviceDisplayInfo(_serviceType, model.device, model.sourceModel)
-					: null
-
-			text: model.cachedDeviceName
-			textModel: model.connected && _displayInfo ? _displayInfo.summary || [] : [ CommonWords.not_connected ]
-			down: deviceMouseArea.containsPress
-			allowed: !model.connected || _displayInfo !== null
-
-			CP.ColorImage {
-				parent: deviceDelegate.content
-				anchors.verticalCenter: parent.verticalCenter
-				source: "qrc:/images/icon_arrow_32.svg"
-				rotation: 180
-				color: deviceMouseArea.containsPress ? Theme.color_listItem_down_forwardIcon : Theme.color_listItem_forwardIcon
-				visible: deviceMouseArea.enabled
-			}
-
-			ListPressArea {
-				id: deviceMouseArea
-
-				anchors {
-					fill: parent
-					bottomMargin: deviceDelegate.spacing
-				}
-				radius: deviceDelegate.backgroundRect.radius
-				enabled: !!_displayInfo && _displayInfo.url.length > 0
-				onClicked: {
-					Global.pageManager.pushPage(_displayInfo.url, _displayInfo.params)
-				}
-			}
-		}
 	}
 }
-

--- a/pages/settings/devicelist/delegates/AcInDeviceListDelegate.qml
+++ b/pages/settings/devicelist/delegates/AcInDeviceListDelegate.qml
@@ -1,0 +1,29 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+DeviceListDelegate {
+	id: root
+
+	secondaryText: connected.value === 1 ? "" : CommonWords.not_connected
+	quantityModel: connected.value === 1 ? [ { value: totalPower.value, unit: VenusOS.Units_Watt } ] : null
+
+	onClicked: {
+		Global.pageManager.pushPage("/pages/settings/devicelist/ac-in/PageAcIn.qml",
+				{ bindPrefix : root.device.serviceUid })
+	}
+
+	VeQuickItem {
+		id: connected
+		uid: root.device.serviceUid + "/Connected"
+	}
+
+	VeQuickItem {
+		id: totalPower
+		uid: root.device.serviceUid + "/Ac/Power"
+	}
+}

--- a/pages/settings/devicelist/delegates/DcMeterDeviceListDelegate.qml
+++ b/pages/settings/devicelist/delegates/DcMeterDeviceListDelegate.qml
@@ -1,0 +1,37 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+DeviceListDelegate {
+	id: root
+
+	quantityModel: [
+		{ unit: VenusOS.Units_Volt_DC, value: voltage.value },
+		{ unit: VenusOS.Units_Amp, value: current.value },
+		{ unit: VenusOS.Units_Watt, value: power.value }
+	]
+
+	onClicked: {
+		Global.pageManager.pushPage("/pages/settings/devicelist/dc-in/PageDcMeter.qml",
+				{ bindPrefix : root.device.serviceUid })
+	}
+
+	VeQuickItem {
+		id: voltage
+		uid: root.device.serviceUid + "/Dc/0/Voltage"
+	}
+
+	VeQuickItem {
+		id: current
+		uid: root.device.serviceUid + "/Dc/0/Current"
+	}
+
+	VeQuickItem {
+		id: power
+		uid: root.device.serviceUid + "/Dc/0/Power"
+	}
+}

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_acload.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_acload.qml
@@ -1,0 +1,10 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+AcInDeviceListDelegate {
+}

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_acsystem.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_acsystem.qml
@@ -1,0 +1,23 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+DeviceListDelegate {
+	id: root
+
+	secondaryText: Global.system.systemStateToText(state.value)
+
+	onClicked: {
+		Global.pageManager.pushPage("/pages/settings/devicelist/rs/PageRsSystem.qml",
+				{ bindPrefix : root.device.serviceUid })
+	}
+
+	VeQuickItem {
+		id: state
+		uid: root.device.serviceUid + "/State"
+	}
+}

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_alternator.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_alternator.qml
@@ -1,0 +1,37 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+DeviceListDelegate {
+	id: root
+
+	quantityModel: [
+		{ unit: VenusOS.Units_Volt_DC, value: voltage.value },
+		{ unit: VenusOS.Units_Amp, value: current.value },
+		{ unit: VenusOS.Units_Watt, value: power.value }
+	]
+
+	onClicked: {
+		Global.pageManager.pushPage("/pages/settings/devicelist/dc-in/PageAlternator.qml",
+				{ bindPrefix : root.device.serviceUid })
+	}
+
+	VeQuickItem {
+		id: voltage
+		uid: root.device.serviceUid + "/Dc/0/Voltage"
+	}
+
+	VeQuickItem {
+		id: current
+		uid: root.device.serviceUid + "/Dc/0/Current"
+	}
+
+	VeQuickItem {
+		id: power
+		uid: root.device.serviceUid + "/Dc/0/Power"
+	}
+}

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_battery.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_battery.qml
@@ -1,0 +1,60 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+DeviceListDelegate {
+	id: root
+
+	readonly property bool isParallelBms: numberOfBmses.isValid
+
+	readonly property var _pendingModel: [
+		{ unit: VenusOS.Units_None, value: CommonWords.pending },
+		{ unit: VenusOS.Units_Volt_DC, value: voltage.value },
+		{ unit: VenusOS.Units_Percentage, value: soc.value },
+	]
+
+	readonly property var _defaultModel: [
+		{ unit: VenusOS.Units_Percentage, value: soc.value },
+		{ unit: VenusOS.Units_Volt_DC, value: voltage.value },
+		{ unit: VenusOS.Units_Amp, value: current.value },
+	]
+
+	quantityModel: !root.isParallelBms && state.isValid && state.value === VenusOS.Battery_State_Pending
+		   ? _pendingModel
+		   : _defaultModel
+
+	onClicked: {
+		const battery = sourceModel.deviceAt(sourceModel.indexOf(root.device.serviceUid))
+		Global.pageManager.pushPage("/pages/settings/devicelist/battery/PageBattery.qml",
+				{ battery: battery })
+	}
+
+	VeQuickItem {
+		id: numberOfBmses
+		uid: root.device.serviceUid + "/NumberOfBmses"
+	}
+
+	VeQuickItem {
+		id: state
+		uid: root.device.serviceUid + "/State"
+	}
+
+	VeQuickItem {
+		id: voltage
+		uid: root.device.serviceUid + "/Dc/0/Voltage"
+	}
+
+	VeQuickItem {
+		id: soc
+		uid: root.device.serviceUid + "/Soc"
+	}
+
+	VeQuickItem {
+		id: current
+		uid: root.device.serviceUid + "/Dc/0/Current"
+	}
+}

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_charger.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_charger.qml
@@ -1,0 +1,23 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+DeviceListDelegate {
+	id: root
+
+	secondaryText: Global.system.systemStateToText(state.value)
+
+	onClicked: {
+		Global.pageManager.pushPage("/pages/settings/devicelist/PageAcCharger.qml",
+				{ bindPrefix : root.device.serviceUid })
+	}
+
+	VeQuickItem {
+		id: state
+		uid: root.device.serviceUid + "/State"
+	}
+}

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_dcdc.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_dcdc.qml
@@ -1,0 +1,11 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+DcMeterDeviceListDelegate {
+}
+

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_dcgenset.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_dcgenset.qml
@@ -1,0 +1,10 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+GensetDeviceListDelegate {
+}

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_dcload.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_dcload.qml
@@ -1,0 +1,11 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+DcMeterDeviceListDelegate {
+}
+

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_dcsource.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_dcsource.qml
@@ -1,0 +1,11 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+DcMeterDeviceListDelegate {
+}
+

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_dcsystem.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_dcsystem.qml
@@ -1,0 +1,11 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+DcMeterDeviceListDelegate {
+}
+

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_digitalinput.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_digitalinput.qml
@@ -1,0 +1,23 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+DeviceListDelegate {
+	id: root
+
+	secondaryText: Global.digitalInputs.inputStateToText(state.value)
+
+	onClicked: {
+		Global.pageManager.pushPage("/pages/settings/devicelist/PageDigitalInput.qml",
+				{ bindPrefix : root.device.serviceUid })
+	}
+
+	VeQuickItem {
+		id: state
+		uid: root.device.serviceUid + "/State"
+	}
+}

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_evcharger.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_evcharger.qml
@@ -1,0 +1,45 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+DeviceListDelegate {
+	id: root
+
+	readonly property var _powerModel: [ { unit: VenusOS.Units_Watt, value: power.value } ]
+	readonly property var _statusModel: [ { unit: VenusOS.Units_None, value: Global.evChargers.chargerStatusToText(status.value) } ]
+	readonly property var _modeModel: [ { unit: VenusOS.Units_None, value: Global.evChargers.chargerModeToText(mode.value) } ]
+
+	quantityModel: {
+		let secondaryInfo = []
+		if (!mode.isValid || status.value === VenusOS.Evcs_Status_Charging) {
+			secondaryInfo = [ { unit: VenusOS.Units_Watt, value: power.value } ]
+		} else if (status.isValid) {
+			secondaryInfo = [ { unit: VenusOS.Units_None, value: Global.evChargers.chargerStatusToText(status.value) } ]
+		}
+		return mode.isValid ? _modeModel.concat(secondaryInfo) : secondaryInfo
+	}
+
+	onClicked: {
+		const evCharger = sourceModel.deviceAt(sourceModel.indexOf(root.device.serviceUid))
+		Global.pageManager.pushPage("/pages/evcs/EvChargerPage.qml", { evCharger : evCharger })
+	}
+
+	VeQuickItem {
+		id: mode
+		uid: root.device.serviceUid + "/Mode"
+	}
+
+	VeQuickItem {
+		id: status
+		uid: root.device.serviceUid + "/Status"
+	}
+
+	VeQuickItem {
+		id: power
+		uid: root.device.serviceUid + "/Ac/Power"
+	}
+}

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_fuelcell.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_fuelcell.qml
@@ -1,0 +1,10 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+DcMeterDeviceListDelegate {
+}

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_genset.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_genset.qml
@@ -1,0 +1,10 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+GensetDeviceListDelegate {
+}

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_grid.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_grid.qml
@@ -1,0 +1,10 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+AcInDeviceListDelegate {
+}

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_heatpump.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_heatpump.qml
@@ -1,0 +1,10 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+AcInDeviceListDelegate {
+}

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_inverter.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_inverter.qml
@@ -1,0 +1,25 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+DeviceListDelegate {
+	id: root
+
+	quantityModel: [
+		{ value: inverter.currentPhase.power, unit: inverter.currentPhase.powerUnit }
+	]
+
+	onClicked: {
+		Global.pageManager.pushPage("/pages/settings/devicelist/inverter/PageInverter.qml",
+				{ bindPrefix : root.device.serviceUid })
+	}
+
+	Inverter {
+		id: inverter
+		serviceUid: root.device.serviceUid
+	}
+}

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_meteo.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_meteo.qml
@@ -1,0 +1,25 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+DeviceListDelegate {
+	id: root
+
+	quantityModel: [
+		{ value: irradiance.value, unit: VenusOS.Units_WattsPerSquareMeter }
+	]
+
+	onClicked: {
+		Global.pageManager.pushPage("/pages/settings/devicelist/PageMeteo.qml",
+				{ bindPrefix : root.device.serviceUid })
+	}
+
+	VeQuickItem {
+		id: irradiance
+		uid: root.device.serviceUid + "/Irradiance"
+	}
+}

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_motordrive.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_motordrive.qml
@@ -1,0 +1,25 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+DeviceListDelegate {
+	id: root
+
+	quantityModel: [
+		{ unit: VenusOS.Units_RevolutionsPerMinute, value: motorRpm.value }
+	]
+
+	onClicked: {
+		Global.pageManager.pushPage("/pages/settings/devicelist/PageMotorDrive.qml",
+				{ bindPrefix : root.device.serviceUid })
+	}
+
+	VeQuickItem {
+		id: motorRpm
+		uid: root.device.serviceUid + "/Motor/RPM"
+	}
+}

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_multi.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_multi.qml
@@ -1,0 +1,13 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+DeviceListDelegate {
+	// multi devices are not shown in the Device List; they are shown as part of the
+	// "Devices" list in the acsystem page (PageRsSystem) instead.
+	allowed: false
+}

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_pulsemeter.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_pulsemeter.qml
@@ -1,0 +1,25 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+DeviceListDelegate {
+	id: root
+
+	quantityModel: [
+		{ value: aggregate.value, unit: Global.systemSettings.volumeUnit }
+	]
+
+	onClicked: {
+		Global.pageManager.pushPage("/pages/settings/devicelist/pulsemeter/PagePulseCounter.qml",
+				{ bindPrefix : root.device.serviceUid })
+	}
+
+	VeQuickItem {
+		id: aggregate
+		uid: root.device.serviceUid + "/Aggregate"
+	}
+}

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_pvinverter.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_pvinverter.qml
@@ -1,0 +1,10 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+AcInDeviceListDelegate {
+}

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_solarcharger.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_solarcharger.qml
@@ -1,0 +1,38 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+DeviceListDelegate {
+	id: root
+
+	readonly property var _errorModel: [
+		//: %1 = error number
+		//% "Error: #%1"
+		{ unit: VenusOS.Units_None, value: qsTrId("devicelist_solarcharger_error").arg(errorCode.value) }
+	]
+
+	readonly property var _powerModel: [
+		{ value: power.value, unit: VenusOS.Units_Watt }
+	]
+
+	quantityModel: errorCode.isValid && errorCode.value > 0 ? _errorModel : _powerModel
+
+	onClicked: {
+		const solarCharger = sourceModel.deviceAt(sourceModel.indexOf(root.device.serviceUid))
+		Global.pageManager.pushPage("/pages/solar/SolarChargerPage.qml", { solarCharger : solarCharger })
+	}
+
+	VeQuickItem {
+		id: power
+		uid: root.device.serviceUid + "/Yield/Power"
+	}
+
+	VeQuickItem {
+		id: errorCode
+		uid: root.device.serviceUid + "/ErrorCode"
+	}
+}

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_tank.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_tank.qml
@@ -1,0 +1,45 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+DeviceListDelegate {
+	id: root
+
+	readonly property var _temperatureAndLevelModel: [
+		{ unit: Global.systemSettings.temperatureUnit, value: temperature.value },
+		{ unit: VenusOS.Units_Percentage, value: level.value },
+	]
+
+	readonly property var _levelModel: [
+		{ unit: VenusOS.Units_Percentage, value: level.value },
+	]
+
+	secondaryText: level.isValid ? "" : (status.isValid ? Global.tanks.statusToText(status.value) : "--")
+	quantityModel: level.isValid ? (temperature.isValid ? _temperatureAndLevelModel : _levelModel) : null
+
+	onClicked: {
+		Global.pageManager.pushPage("/pages/settings/devicelist/tank/PageTankSensor.qml",
+				{ bindPrefix : root.device.serviceUid })
+	}
+
+	VeQuickItem {
+		id: temperature
+		uid: root.device.serviceUid + "/Temperature"
+		sourceUnit: Units.unitToVeUnit(VenusOS.Units_Temperature_Celsius)
+		displayUnit: Units.unitToVeUnit(Global.systemSettings.temperatureUnit)
+	}
+
+	VeQuickItem {
+		id: level
+		uid: root.device.serviceUid + "/Level"
+	}
+
+	VeQuickItem {
+		id: status
+		uid: root.device.serviceUid + "/Status"
+	}
+}

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_temperature.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_temperature.qml
@@ -1,0 +1,39 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+DeviceListDelegate {
+	id: root
+
+	readonly property var _temperatureAndHumidityModel: [
+		{ unit: Global.systemSettings.temperatureUnit, value: temperature.value },
+		{ unit: VenusOS.Units_Percentage, value: humidity.value },
+	]
+
+	readonly property var _temperatureModel: [
+		{ unit: Global.systemSettings.temperatureUnit, value: temperature.value },
+	]
+
+	quantityModel: humidity.isValid ? _temperatureAndHumidityModel : _temperatureModel
+
+	onClicked: {
+		Global.pageManager.pushPage("/pages/settings/devicelist/temperature/PageTemperatureSensor.qml",
+				{ bindPrefix : root.device.serviceUid })
+	}
+
+	VeQuickItem {
+		id: temperature
+		uid: root.device.serviceUid + "/Temperature"
+		sourceUnit: Units.unitToVeUnit(VenusOS.Units_Temperature_Celsius)
+		displayUnit: Units.unitToVeUnit(Global.systemSettings.temperatureUnit)
+	}
+
+	VeQuickItem {
+		id: humidity
+		uid: root.device.serviceUid + "/Humidity"
+	}
+}

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_unsupported.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_unsupported.qml
@@ -1,0 +1,20 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+DeviceListDelegate {
+	id: root
+
+	//: Device is not supported
+	//% "Unsupported"
+	secondaryText: qsTrId("devicelist_unsupported")
+
+	onClicked: {
+		Global.pageManager.pushPage("/pages/settings/devicelist/PageUnsupportedDevice.qml",
+				{ bindPrefix : root.device.serviceUid })
+	}
+}

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_vebus.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_vebus.qml
@@ -1,0 +1,26 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+DeviceListDelegate {
+	id: root
+
+	// vebus devices may also show up as AC inputs or batteries, so ensure they do not
+	// appear multiple times in the list.
+	allowed: sourceModel === Global.inverterChargers.veBusDevices
+	secondaryText: Global.system.systemStateToText(state.value)
+
+	onClicked: {
+		const veBusDevice = sourceModel.deviceAt(sourceModel.indexOf(root.device.serviceUid))
+		Global.pageManager.pushPage("/pages/vebusdevice/PageVeBus.qml", { veBusDevice : veBusDevice })
+	}
+
+	VeQuickItem {
+		id: state
+		uid: root.device.serviceUid + "/State"
+	}
+}

--- a/pages/settings/devicelist/delegates/DisconnectedDeviceListDelegate.qml
+++ b/pages/settings/devicelist/delegates/DisconnectedDeviceListDelegate.qml
@@ -1,0 +1,14 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+ListTextItem {
+	property string cachedDeviceName
+
+	text: cachedDeviceName
+	secondaryText: CommonWords.not_connected
+}

--- a/pages/settings/devicelist/delegates/GensetDeviceListDelegate.qml
+++ b/pages/settings/devicelist/delegates/GensetDeviceListDelegate.qml
@@ -1,0 +1,29 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+DeviceListDelegate {
+	id: root
+
+	secondaryText: statusCode.isValid ? "" : CommonWords.not_connected
+	quantityModel: statusCode.isValid
+		? [
+			  { unit: VenusOS.Units_None, value: Global.acInputs.gensetStatusCodeToText(statusCode.value) },
+			  { value: power.value, unit: VenusOS.Units_Watt },
+		  ]
+		: null
+
+	onClicked: {
+		Global.pageManager.pushPage("/pages/settings/devicelist/PageGenset.qml",
+				{ bindPrefix : root.device.serviceUid })
+	}
+
+	VeQuickItem {
+		id: statusCode
+		uid: root.device.serviceUid + "/StatusCode"
+	}
+}


### PR DESCRIPTION
The _deviceDisplayInfo() in DeviceListPage is problematic as it causes binding updates to all delegates whenever any of the displayed delegate values change. 

Instead of using this single gigantic function to configure delegates, load per-service QML files that define their own delegate UIs. This improvement also means that custom list items can be provided for individual services, instead of requiring all services to use a similar delegate UI.

All delegates should have the same appearance as before, except for the Inverter delegate, which has been fixed to only show the power for the currently active phase.

Issue #1338

(This only reworks the UI delegates; the second part of the task is to rework the model loading, which will be done separately.)