### PR TITLE
miketrahearn/1104 make spinbox number editable

### DIFF
--- a/ApplicationContent.qml
+++ b/ApplicationContent.qml
@@ -4,6 +4,7 @@
 */
 
 import QtQuick
+import QtQuick.Controls as QtQuickControls
 import Victron.VenusOS
 
 Item {
@@ -155,6 +156,8 @@ Item {
 		source: Global.isGxDevice
 				? "qrc:/qt/qml/Victron/VenusOS/components/InputPanel.qml"
 				: "qrc:/qt/qml/Victron/VenusOS/components/WasmVirtualKeyboardHandler.qml"
+		parent: QtQuickControls.Overlay.overlay
+		z: 1
 	}
 
 	// Sometimes, the wasm code may crash. Use a watchdog to detect this and reload the page when necessary.

--- a/components/InputPanel.qml
+++ b/components/InputPanel.qml
@@ -52,7 +52,7 @@ QtVirtualKeyboard.InputPanel {
 
 	states: State {
 		name: "visible"
-		when: Qt.inputMethod.visible
+		when: Qt.inputMethod.visible && !!root.focusedFlickable
 
 		PropertyChanges {
 			target: root.focusedFlickable
@@ -145,6 +145,9 @@ QtVirtualKeyboard.InputPanel {
 
 	onLocaleNameChanged: _setVkbLocale()
 	Component.onCompleted: {
+		// turn off the Virtual Keyboard Text Selection Handles as they don't position properly
+		// under certain circumstances: see https://bugreports.qt.io/browse/QTBUG-114551
+		VirtualKeyboardSettings.inputMethodHints = Qt.ImhNoTextHandles
 		VirtualKeyboardSettings.activeLocales = ["en_US", "cs_CZ", "da_DK", "de_DE", "es_ES", "fr_FR", "it_IT", "nl_NL", "pl_PL", "ru_RU", "ro_RO", "sv_SE", "th_TH", "tr_TR", "uk_UA", "zh_CN", "ar_AR"]
 		_setVkbLocale()
 	}

--- a/components/controls/TextField.qml
+++ b/components/controls/TextField.qml
@@ -26,6 +26,10 @@ CT.TextField {
 	verticalAlignment: Text.AlignVCenter
 	color: Theme.color_font_primary
 
+	selectedTextColor: Theme.color_white
+	selectionColor : Theme.color_blue
+	selectByMouse: !readOnly
+
 	background: Rectangle {
 		color: "transparent"
 		border.color: root.borderColor

--- a/components/dialogs/NumberSelectorDialog.qml
+++ b/components/dialogs/NumberSelectorDialog.qml
@@ -56,15 +56,25 @@ ModalDialog {
 				anchors.horizontalCenter: parent.horizontalCenter
 				width: parent.width - 2*Theme.geometry_modalDialog_content_horizontalMargin
 				height: Theme.geometry_timeSelector_spinBox_height
+				editable: true
 				indicatorImplicitWidth: root.decimals > 0
 						? Theme.geometry_spinBox_indicator_minimumWidth
 						: Theme.geometry_spinBox_indicator_maximumWidth
 				textFromValue: function(value, locale) {
-					return Units.formatNumber(value / root._multiplier(), root.decimals) + root.suffix
+					return Units.formatNumber(value / root._multiplier(), root.decimals)
+				}
+				valueFromText: function(text, locale) {
+					let value = Units.formattedNumberToReal(text) * root._multiplier()
+					if (isNaN(value)) {
+						// don't change the current value
+						value = spinBox.value
+					}
+					return value
 				}
 				from: Math.max(Global.int32Min, root.from * root._multiplier())
 				to: Math.min(Global.int32Max, root.to * root._multiplier())
 				stepSize: root.stepSize * root._multiplier()
+				suffix: root.suffix
 
 				onValueChanged: {
 					if (_initialized) {


### PR DESCRIPTION
Made the SpinBox editable, including enhancing ModalDialog so that it moves to ensure that any text inputs are always shown above the virtual keyboard, which is now shown above all Dialogs where required.

- NumberSelectionDialog is specifically modified to meet the requirements of this ticket.
- Colors used for additional text selection colors are Theme.color_blue and Theme.color_white where non-dark/light theme awareness is required.
- Fixed SpinBox's indicators enabled states on limits.
- Commits comments explain each step of change.

<img width="512" alt="Input Current Limit editable Dark" src="https://github.com/user-attachments/assets/87f55e29-9211-4e9f-916a-933e8364a3c5">
<img width="512" alt="Input Current Limit editable Keys Dark" src="https://github.com/user-attachments/assets/950668fa-26ed-41ab-9b97-6ee32d6ca468">

<img width="512" alt="Input Current Limit editable Light" src="https://github.com/user-attachments/assets/74509080-d2eb-4987-9cf2-937e1e82f5c3">
<img width="512" alt="Input Current Limit editable Keys Light" src="https://github.com/user-attachments/assets/476ebc2e-4e9f-4c0a-921d-fcc47768d215">

<img width="512" alt="Charge Current editable Dark" src="https://github.com/user-attachments/assets/80a70182-47f4-4713-baad-fd448716a334">
<img width="512" alt="Charge Current editable Keys Dark" src="https://github.com/user-attachments/assets/a9c2172a-7132-4767-8b6e-2e2d777bb428">

<img width="512" alt="Charge Current editable Light" src="https://github.com/user-attachments/assets/357f21e3-b4af-4772-a5d9-10f26327351a">
<img width="512" alt="Charge Current editable Keys Light" src="https://github.com/user-attachments/assets/983414e4-1e26-4f3e-85dd-6ab27ae35763">

