### PR TITLE
Fix SpinBox's up and down indicators to disable when limits are reached

### DIFF
--- a/components/controls/SpinBox.qml
+++ b/components/controls/SpinBox.qml
@@ -85,7 +85,7 @@ CT.SpinBox {
 		implicitWidth: root.indicatorImplicitWidth
 		implicitHeight: Theme.geometry_spinBox_indicator_height
 		radius: Theme.geometry_spinBox_indicator_radius
-		color: root.enabled
+		color: enabled
 			   ? (root.up.pressed ? Theme.color_button_down : Theme.color_button)
 			   : Theme.color_background_disabled
 
@@ -106,7 +106,7 @@ CT.SpinBox {
 		implicitWidth: root.indicatorImplicitWidth
 		implicitHeight: Theme.geometry_spinBox_indicator_height
 		radius: Theme.geometry_spinBox_indicator_radius
-		color: root.enabled
+		color: enabled
 			   ? (root.down.pressed ? Theme.color_button_down : Theme.color_button)
 			   : Theme.color_background_disabled
 		Image {


### PR DESCRIPTION
The overall enabled state of the SpinBox will cascade properly into the up and down indicators, and will take into account the limits being reached automatically due to the SpinBox's internal logic setting the explicit enabled property on the indicators. In so adjusting the color binding from using root.enabled to just the indicator's [effective] enabled we get the correct disabled coloring when the limits are reached.