### PR TITLE
Add position setting for energy meters with role evcharger

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,6 +323,7 @@ set (VENUS_QML_MODULE_SOURCES
     components/listitems/ListMqttAccessSwitch.qml
     components/listitems/ListMountStateButton.qml
     components/listitems/ListPvInverterPositionRadioButtonGroup.qml
+    components/listitems/ListEvChargerPositionRadioButtonGroup.qml
     components/listitems/ListRelayState.qml
     components/listitems/ListResetHistory.qml
     components/listitems/ListTemperatureRelay.qml

--- a/components/listitems/ListEvChargerPositionRadioButtonGroup.qml
+++ b/components/listitems/ListEvChargerPositionRadioButtonGroup.qml
@@ -1,0 +1,17 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+ListRadioButtonGroup {
+	//: EVCS AC input/output position
+	//% "Position"
+	text: qsTrId("evcs_ac_position")
+	optionModel: [
+		{ display: CommonWords.acInput(), value: VenusOS.Evcs_Position_ACInput },
+		{ display: CommonWords.ac_output, value: VenusOS.Evcs_Position_ACOutput }
+	]
+}

--- a/pages/evcs/EvChargerSetupPage.qml
+++ b/pages/evcs/EvChargerSetupPage.qml
@@ -14,20 +14,7 @@ Page {
 
 	GradientListView {
 		model: ObjectModel {
-			ListRadioButtonGroup {
-				//: EVCS AC input/output position
-				//% "Position"
-				text: qsTrId("evcs_ac_position")
-				optionModel: [
-					{
-						display: CommonWords.acInput(),
-						value: VenusOS.Evcs_Position_ACInput
-					},
-					{
-						display: CommonWords.ac_output,
-						value: VenusOS.Evcs_Position_ACOutput
-					}
-				]
+			ListEvChargerPositionRadioButtonGroup {
 				dataItem.uid: root.bindPrefix + "/Position"
 			}
 

--- a/pages/settings/devicelist/ac-in/PageAcInSetup.qml
+++ b/pages/settings/devicelist/ac-in/PageAcInSetup.qml
@@ -94,6 +94,11 @@ Page {
 				allowed: role.currentValue === "pvinverter"
 			}
 
+			ListEvChargerPositionRadioButtonGroup {
+				dataItem.uid: root.bindPrefix + "/Position"
+				allowed: role.currentValue === "evcharger"
+			}
+
 			/* EM24 settings */
 
 			ListRadioButtonGroup {


### PR DESCRIPTION
For grid meters proxying for EV chargers, allow setting the position. This also factors out the position selection to a component that is reused in the existing setup page.

https://github.com/victronenergy/venus-private/issues/470