### PR TITLE
Fix SettingsPage's GradientListView to add clipping

### DIFF
--- a/pages/SettingsPage.qml
+++ b/pages/SettingsPage.qml
@@ -23,6 +23,8 @@ SwipeViewPage {
 	GradientListView {
 		id: settingsListView
 
+		clip: true
+
 		model: [
 			{
 				//% "Device list"


### PR DESCRIPTION
Clip the GradientListView to prevent delegates that extend beyond the ListView's top and bottom edges from being clickable outside of those boundaries.

This was reproduced and the root cause discovered.

Tested the fix on Desktop, WASM and Cerbo as "can no longer reproduce".

Fixes #1714