### PR TITLE
Jeroen/move wasm index to cmake

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -109,6 +109,8 @@ jobs:
         mkdir -p artifacts/wasm
         mv build-wasm/venus-gui-v2.{html,js,wasm} build-wasm/qtloader.js images/victronenergy.svg artifacts/wasm/
         mv artifacts/wasm/venus-gui-v2.html artifacts/wasm/index.html
+        grep -q -E '^var createQtAppInstance' artifacts/wasm/venus-gui-v2.js
+        sed -i "s%^var \(createQtAppInstance\)%window.\1%" artifacts/wasm/venus-gui-v2.js
         cp .github/patches/Makefile artifacts/wasm/
         cp LICENSE.txt artifacts/wasm/
         cd artifacts

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -109,9 +109,6 @@ jobs:
         mkdir -p artifacts/wasm
         mv build-wasm/venus-gui-v2.{html,js,wasm} build-wasm/qtloader.js images/victronenergy.svg artifacts/wasm/
         mv artifacts/wasm/venus-gui-v2.html artifacts/wasm/index.html
-        patch artifacts/wasm/index.html < ./.github/patches/index.html.patch
-        grep -q -E '^var createQtAppInstance' artifacts/wasm/venus-gui-v2.js
-        sed -i "s%^var \(createQtAppInstance\)%window.\1%" artifacts/wasm/venus-gui-v2.js
         cp .github/patches/Makefile artifacts/wasm/
         cp LICENSE.txt artifacts/wasm/
         cd artifacts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -981,7 +981,7 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Emscripten")
        COMMAND ${CMAKE_COMMAND} -E copy
             "${CMAKE_CURRENT_SOURCE_DIR}/images/victronenergy.svg"
             "${CMAKE_CURRENT_BINARY_DIR}/victronenergy.svg"
-)
+    )
 
 elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
     list(APPEND venusCompileFlags  ${UNIX_COMPILE_FLAGS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -970,6 +970,19 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Emscripten")
     qt_add_executable(${PROJECT_NAME}
         ${SOURCES}
     )
+
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/wasm/index.html")
+    add_custom_target(WasmFiles SOURCES wasm/index.html)
+    add_custom_command(
+       TARGET ${PROJECT_NAME} POST_BUILD
+       COMMAND ${CMAKE_COMMAND} -E copy
+            "${CMAKE_CURRENT_SOURCE_DIR}/wasm/index.html"
+            "${CMAKE_CURRENT_BINARY_DIR}/venus-gui-v2.html"
+       COMMAND ${CMAKE_COMMAND} -E copy
+            "${CMAKE_CURRENT_SOURCE_DIR}/images/victronenergy.svg"
+            "${CMAKE_CURRENT_BINARY_DIR}/victronenergy.svg"
+)
+
 elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
     list(APPEND venusCompileFlags  ${UNIX_COMPILE_FLAGS})
     qt_add_executable(${PROJECT_NAME}

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -74,7 +74,7 @@
                 status.innerHTML = 'Loading...';
 
                 const instance = await qtLoad({
-                    arguments: ['--mqtt', (location.protocol === 'https:' ? 'wss://' : 'ws://') + document.location.host + '/websocket-mqtt'],
+                    arguments: ['--mqtt', (location.protocol === 'https:' ? 'wss://' : 'ws://') + document.location.host + '/websocket-mqtt'], // delete this line to run wasm builds on the desktop
                     qt: {
                         onLoaded: () => showUi(screen),
                         onExit: exitData =>
@@ -86,7 +86,7 @@
                                 exitData.text !== undefined ? ` (${exitData.text})` : '';
                             showUi(spinner);
                         },
-                        entryFunction: window.venus_gui_v2_entry,
+                        entryFunction: window.venus_gui_v2_entry, // 'venus_gui_v2_entry' comes from CI, see https://github.com/victronenergy/gui-v2/blob/main/.github/workflows/build-wasm.yml#L114
                         containerElements: [screen],
                     }
                 });

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -86,7 +86,7 @@
                                 exitData.text !== undefined ? ` (${exitData.text})` : '';
                             showUi(spinner);
                         },
-                        entryFunction: window.venus_gui_v2_entry, // 'venus_gui_v2_entry' comes from CI, see https://github.com/victronenergy/gui-v2/blob/main/.github/workflows/build-wasm.yml#L114
+                        entryFunction: window.venus_gui_v2_entry, // 'venus_gui_v2_entry' comes from CI, see https://github.com/victronenergy/gui-v2/blob/main/.github/workflows/build-wasm.yml#L113
                         containerElements: [screen],
                     }
                 });
@@ -101,7 +101,7 @@
     <script type="text/javascript">
         var watchdogHit = false // this gets set to 'true' by a timer via BackendConnection::hitWatchdog()
         console.log("starting watchdog timer")
-        setTimeout(function(){ // wait 2 minutes for the page to load, then set a 10 second watchdog timer
+        setTimeout(function() { // wait 2 minutes for the page to load, then set a 10 second watchdog timer
             checkWatchdog()
             setInterval(checkWatchdog, 10000)
         }, 120000)

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -86,7 +86,7 @@
                                 exitData.text !== undefined ? ` (${exitData.text})` : '';
                             showUi(spinner);
                         },
-                        entryFunction: window.createQtAppInstance,
+                        entryFunction: window.venus_gui_v2_entry,
                         containerElements: [screen],
                         
                     }

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -98,5 +98,22 @@
     </script>
     <script src="venus-gui-v2.js"></script>
     <script type="text/javascript" src="qtloader.js"></script>
+    <script type="text/javascript">
+        var watchdogHit = false // this gets set to 'true' by a timer via BackendConnection::hitWatchdog()
+        console.log("starting watchdog timer")
+        setTimeout(function(){ // wait 2 minutes for the page to load, then set a 10 second watchdog timer
+            checkWatchdog()
+            setInterval(checkWatchdog, 10000)
+        }, 120000)
+
+        function checkWatchdog()
+        {
+            if (!watchdogHit) {
+                console.error("Watchdog timer expired - reloading page")
+                location.reload()
+            }
+            watchdogHit = false
+        }
+    </script>
   </body>
 </html>

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+
+    <!--Set visual viewport size for mobile devices to the device size,
+        witch results in a scale of 1 and a 1:1 mapping between CSS pixels
+        and Qt device independent pixels. -->
+    <meta name="viewport" content="width=device-width, height=device-height, user-scalable=0"/>
+
+    <title>venus-gui-v2</title>
+    <style>
+      /* Make the html body cover the entire (visual) viewport with no scroll bars. */
+      html, body { padding: 0; margin: 0; overflow: hidden; height: 100% }
+      #screen { width: 100%; height: 100%; }
+    </style>
+  </head>
+  <body onload="init()">
+    <figure style="overflow:visible;" id="qtspinner">
+      <center style="margin-top:1.5em; line-height:150%">
+        <img src="qtlogo.svg" width="320" height="200" style="display:block"></img>
+        <strong>Qt for WebAssembly: venus-gui-v2</strong>
+        <div id="qtstatus"></div>
+        <noscript>JavaScript is disabled. Please enable JavaScript to use this application.</noscript>
+      </center>
+    </figure>
+    <div id="screen"></div>
+
+    <script type="text/javascript">
+        async function init()
+        {
+            const spinner = document.querySelector('#qtspinner');
+            const screen = document.querySelector('#screen');
+            const status = document.querySelector('#qtstatus');
+
+            const showUi = (ui) => {
+                [spinner, screen].forEach(element => element.style.display = 'none');
+                if (screen === ui)
+                    screen.style.position = 'default';
+                ui.style.display = 'block';
+            }
+
+            try {
+                showUi(spinner);
+                status.innerHTML = 'Loading...';
+
+                const instance = await qtLoad({
+                    qt: {
+                        onLoaded: () => showUi(screen),
+                        onExit: exitData =>
+                        {
+                            status.innerHTML = 'Application exit';
+                            status.innerHTML +=
+                                exitData.code !== undefined ? ` with code ${exitData.code}` : '';
+                            status.innerHTML +=
+                                exitData.text !== undefined ? ` (${exitData.text})` : '';
+                            showUi(spinner);
+                        },
+                        entryFunction: window.venus_gui_v2_entry,
+                        containerElements: [screen],
+                        
+                    }
+                });
+            } catch (e) {
+                console.error(e);
+                console.error(e.stack);
+            }
+        }
+    </script>
+    <script src="venus-gui-v2.js"></script>
+    <script type="text/javascript" src="qtloader.js"></script>
+  </body>
+</html>

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -12,15 +12,18 @@
     <title>venus-gui-v2</title>
     <style>
       /* Make the html body cover the entire (visual) viewport with no scroll bars. */
-      html, body { padding: 0; margin: 0; overflow: hidden; height: 100% }
+      html, body {
+        padding: 0; margin: 0;
+        overflow: hidden; height: 100%;
+        background: #000; color: #fff;
+      }
       #screen { width: 100%; height: 100%; }
     </style>
   </head>
   <body onload="init()">
     <figure style="overflow:visible;" id="qtspinner">
       <center style="margin-top:1.5em; line-height:150%">
-        <img src="qtlogo.svg" width="320" height="200" style="display:block"></img>
-        <strong>Qt for WebAssembly: venus-gui-v2</strong>
+        <img src="victronenergy.svg" width="320" height="200" style="display:block"></img>
         <div id="qtstatus"></div>
         <noscript>JavaScript is disabled. Please enable JavaScript to use this application.</noscript>
       </center>
@@ -28,6 +31,31 @@
     <div id="screen"></div>
 
     <script type="text/javascript">
+        async function check(url, attempt, delay, available, unavailable)
+        {
+           try {
+                const response = await fetch(url, {cache: "no-cache"});
+                if (response.ok) {
+                    available();
+                    return;
+                }
+            } catch (error) {
+            }
+
+            if (attempt == 0 || --attempt == 0) {
+                unavailable();
+                return;
+            }
+
+            setTimeout(check, delay, url, attempt, delay, available, unavailable);
+        }
+
+        // Reload the page and make sure it is available, since the webserver might start up.
+        function reload()
+        {
+            check(location.href, 30, 1000, (function() { location.reload(); }), (function() { console.log("Failed to reload gui-v2: web server unavailable"); }) );
+        }
+
         async function init()
         {
             const spinner = document.querySelector('#qtspinner');
@@ -46,6 +74,7 @@
                 status.innerHTML = 'Loading...';
 
                 const instance = await qtLoad({
+                    arguments: ['--mqtt', (location.protocol === 'https:' ? 'wss://' : 'ws://') + document.location.host + '/websocket-mqtt'],
                     qt: {
                         onLoaded: () => showUi(screen),
                         onExit: exitData =>
@@ -57,7 +86,7 @@
                                 exitData.text !== undefined ? ` (${exitData.text})` : '';
                             showUi(spinner);
                         },
-                        entryFunction: window.venus_gui_v2_entry,
+                        entryFunction: window.createQtAppInstance,
                         containerElements: [screen],
                         
                     }

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -88,7 +88,6 @@
                         },
                         entryFunction: window.venus_gui_v2_entry,
                         containerElements: [screen],
-                        
                     }
                 });
             } catch (e) {


### PR DESCRIPTION
Adjusting / using the customized index.html is cumbersome, since it is a patch as part of the ci. This just adds the index file to the repository and the CMake project instead, so it can be simply adjusted and will be used when running from e.g. QtCreator.