### PR TITLE
dvcc: add setting for control of all multis

### DIFF
--- a/pages/settings/PageSettingsDvcc.qml
+++ b/pages/settings/PageSettingsDvcc.qml
@@ -211,6 +211,31 @@ Page {
 					uid: bmsName.serviceUid ? "%1/CustomName".arg(bmsName.serviceUid) : ""
 				}
 			}
+
+			ListSwitch {
+				//% "Managed battery controls all Multis and Quattros"
+				text: qsTrId("settings_dvcc_control_all_vebus_devices")
+				dataItem.uid: Global.systemSettings.serviceUid + "/Settings/SystemSetup/DvccControlAllMultis"
+				allowed: defaultAllowed && commonSettings.dvccActive &&
+						 nrVebusDevices.isValid && nrVebusDevices.value > 1
+
+				bottomContentChildren: [
+					PrimaryListLabel {
+						topPadding: 0
+						bottomPadding: 0
+						color: Theme.color_font_secondary
+						//% "When enabled, the managed battery controls all Multis and Quattros. "
+						//% "When disabled, only the device on the built-in port is controlled. "
+						//% "See documentation for further information."
+						text: qsTrId("settings_dvcc_control_all_vebus_devices_label")
+					}
+				]
+
+				VeQuickItem {
+					id: nrVebusDevices
+					uid: Global.system.serviceUid + "/Devices/NumberOfVebusDevices"
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Originally DVCC parameters were used only to control one Multi or Quattro. A new feature in systemcalc makes it possible to control all of them, in systems where there may be more than one. To avoid sudden changes in existing systems, it is an option that defaults to off.