### PR TITLE
Improve VE.Bus inverter support

### DIFF
--- a/components/VeBusAcIODisplay.qml
+++ b/components/VeBusAcIODisplay.qml
@@ -12,12 +12,18 @@ Loader {
 	property string serviceUid
 
 	width: parent ? parent.width : 0
-	sourceComponent: numberOfPhases.value === 1 ? singlePhaseAcInOut
+	sourceComponent: numberOfAcInputs.value === 0 ? null
+				   : numberOfPhases.value === 1 ? singlePhaseAcInOut
 				   : numberOfPhases.value === 3 ? threePhaseTables : null
 
 	VeQuickItem {
 		id: numberOfPhases
 		uid: root.serviceUid + "/Ac/NumberOfPhases"
+	}
+
+	VeQuickItem {
+		id: numberOfAcInputs
+		uid: root.serviceUid + "/Ac/NumberOfAcInputs"
 	}
 
 	Component {

--- a/pages/vebusdevice/PageVeBus.qml
+++ b/pages/vebusdevice/PageVeBus.qml
@@ -226,6 +226,7 @@ Page {
 			}
 
 			ListQuantity {
+				allowed: defaultAllowed && root.isMulti
 				dataItem.uid: root.bindPrefix + "/Soc"
 				text: CommonWords.state_of_charge
 				unit:VenusOS.Units_Percentage
@@ -238,6 +239,7 @@ Page {
 			}
 
 			ListActiveAcInput {
+				allowed: defaultAllowed && root.isMulti
 				bindPrefix: root.bindPrefix
 			}
 

--- a/pages/vebusdevice/PageVeBusAdvanced.qml
+++ b/pages/vebusdevice/PageVeBusAdvanced.qml
@@ -116,6 +116,7 @@ Page {
 					return qsTrId("vebus_device_press_to_start")
 				}
 				enabled: !isNaN(setChargerState.value) && !isNaN(vebusSubState.value) && !startTimer.running && !interruptTimer.running
+				allowed: defaultAllowed && root.isMulti
 
 				onClicked: {
 					if (firmwareVersion.value < 0x400) {


### PR DESCRIPTION
Some items were visible for inverters while not applicable, such as active input and AC phase data. I copied the behavior mainly from gui-v1.