### PR TITLE
Update device-type pages to provide their own titles

### DIFF
--- a/components/widgets/DcInputWidget.qml
+++ b/components/widgets/DcInputWidget.qml
@@ -36,7 +36,6 @@ OverviewWidget {
 	onClicked: {
 		if (root.inputs.count === 1) {
 			Global.pageManager.pushPage(root.detailUrl, {
-				"title": root.inputs.firstObject.name,
 				"bindPrefix": root.inputs.firstObject.serviceUid
 			})
 		} else {
@@ -83,7 +82,6 @@ OverviewWidget {
 
 					onClicked: {
 						Global.pageManager.pushPage(root.detailUrl, {
-							"title": model.device.name,
 							"bindPrefix": model.device.serviceUid
 						})
 					}

--- a/components/widgets/DcLoadsWidget.qml
+++ b/components/widgets/DcLoadsWidget.qml
@@ -13,10 +13,10 @@ OverviewWidget {
 	function _showSettingsPage(device) {
 		if (BackendConnection.serviceTypeFromUid(device.serviceUid) === "dcdc") {
 			Global.pageManager.pushPage("/pages/settings/devicelist/dc-in/PageDcDcConverter.qml",
-					{ "title": device.name, "bindPrefix": device.serviceUid })
+					{ "bindPrefix": device.serviceUid })
 		} else {
 			  Global.pageManager.pushPage("/pages/settings/devicelist/dc-in/PageDcMeter.qml",
-					{ "title": device.name, "bindPrefix": device.serviceUid })
+					{ "bindPrefix": device.serviceUid })
 		}
 	}
 

--- a/components/widgets/InverterChargerWidget.qml
+++ b/components/widgets/InverterChargerWidget.qml
@@ -20,12 +20,12 @@ OverviewWidget {
 			if (Global.inverterChargers.chargerDevices.count) {
 				const charger = Global.inverterChargers.chargerDevices.firstObject
 				Global.pageManager.pushPage("/pages/settings/devicelist/PageAcCharger.qml",
-						{ "bindPrefix": charger.serviceUid, "title": charger.name })
+						{ "bindPrefix": charger.serviceUid })
 			} else {
 				// Show page for inverter, vebus and acsystem services
 				const device = Global.inverterChargers.firstObject
 				Global.pageManager.pushPage("/pages/invertercharger/OverviewInverterChargerPage.qml",
-						{ "serviceUid": device.serviceUid, "title": device.name })
+						{ "serviceUid": device.serviceUid })
 			}
 		}
 	}

--- a/pages/battery/BatteryListPage.qml
+++ b/pages/battery/BatteryListPage.qml
@@ -139,7 +139,6 @@ Page {
 						})
 					} else if (batteryDelegate.serviceType === "genset") {
 						Global.pageManager.pushPage("/pages/settings/devicelist/ac-in/PageAcIn.qml", {
-							"title": genericDevice.customName,
 							"bindPrefix": batteryDelegate.device.serviceUid
 						})
 					} else {
@@ -148,11 +147,6 @@ Page {
 						})
 					}
 				}
-			}
-
-			Device {
-				id: genericDevice
-				serviceUid: batteryDelegate.device.instance >= 0 ? batteryDelegate.device.serviceUid : ""
 			}
 		}
 	}

--- a/pages/invertercharger/InverterChargerListPage.qml
+++ b/pages/invertercharger/InverterChargerListPage.qml
@@ -30,11 +30,11 @@ Page {
 				// Show page for chargers
 				if (model.device.serviceUid.indexOf('charger') >= 0) {
 					Global.pageManager.pushPage("/pages/settings/devicelist/PageAcCharger.qml",
-							{ "bindPrefix": model.device.serviceUid, "title": model.device.name })
+							{ "bindPrefix": model.device.serviceUid })
 				} else {
 					// Show page for inverter, vebus and acsystem services
 					Global.pageManager.pushPage("/pages/invertercharger/OverviewInverterChargerPage.qml",
-							{ "serviceUid": model.device.serviceUid, "title": model.device.name })
+							{ "serviceUid": model.device.serviceUid })
 				}
 			}
 

--- a/pages/invertercharger/OverviewInverterChargerPage.qml
+++ b/pages/invertercharger/OverviewInverterChargerPage.qml
@@ -13,6 +13,13 @@ Page {
 	property string serviceUid
 	readonly property string serviceType: BackendConnection.serviceTypeFromUid(serviceUid)
 
+	title: device.name
+
+	Device {
+		id: device
+		serviceUid: root.serviceUid
+	}
+
 	VeQuickItem {
 		id: dcCurrent
 

--- a/pages/settings/devicelist/PageAcCharger.qml
+++ b/pages/settings/devicelist/PageAcCharger.qml
@@ -11,6 +11,13 @@ Page {
 
 	property string bindPrefix
 
+	title: device.name
+
+	Device {
+		id: device
+		serviceUid: root.bindPrefix
+	}
+
 	GradientListView {
 		model: ObjectModel {
 			ListSwitch {

--- a/pages/settings/devicelist/PageGenset.qml
+++ b/pages/settings/devicelist/PageGenset.qml
@@ -19,6 +19,13 @@ Page {
 		}
 	}
 
+	title: device.name
+
+	Device {
+		id: device
+		serviceUid: root.bindPrefix
+	}
+
 	VeQuickItem {
 		id: productIdDataItem
 

--- a/pages/settings/devicelist/PageMeteo.qml
+++ b/pages/settings/devicelist/PageMeteo.qml
@@ -12,6 +12,13 @@ Page {
 	property string bindPrefix
 	readonly property string settingsPrefix: Global.systemSettings.serviceUid + "/Settings/Service/meteo/" + deviceInstance.value
 
+	title: device.name
+
+	Device {
+		id: device
+		serviceUid: root.bindPrefix
+	}
+
 	VeQuickItem {
 		id: deviceInstance
 		uid: bindPrefix + "/DeviceInstance"

--- a/pages/settings/devicelist/PageMotorDrive.qml
+++ b/pages/settings/devicelist/PageMotorDrive.qml
@@ -11,6 +11,13 @@ Page {
 
 	property string bindPrefix
 
+	title: device.name
+
+	Device {
+		id: device
+		serviceUid: root.bindPrefix
+	}
+
 	GradientListView {
 		model: ObjectModel {
 			ListQuantity {

--- a/pages/settings/devicelist/ac-in/PageAcInModel.qml
+++ b/pages/settings/devicelist/ac-in/PageAcInModel.qml
@@ -145,7 +145,7 @@ ObjectModel {
 	ListNavigation {
 		text: CommonWords.device_info_title
 		onClicked: {
-			Global.pageManager.pushPage(deviceInfoComponent, { "title": text })
+			Global.pageManager.pushPage(deviceInfoComponent)
 		}
 
 		Component {

--- a/pages/settings/devicelist/dc-in/PageAlternator.qml
+++ b/pages/settings/devicelist/dc-in/PageAlternator.qml
@@ -11,6 +11,13 @@ Page {
 
 	property string bindPrefix
 
+	title: device.name
+
+	Device {
+		id: device
+		serviceUid: root.bindPrefix
+	}
+
 	VeQuickItem {
 		id: productIdDataItem
 

--- a/pages/settings/devicelist/dc-in/PageDcDcConverter.qml
+++ b/pages/settings/devicelist/dc-in/PageDcDcConverter.qml
@@ -11,6 +11,13 @@ Page {
 
 	property string bindPrefix
 
+	title: device.name
+
+	Device {
+		id: device
+		serviceUid: root.bindPrefix
+	}
+
 	GradientListView {
 		model: ObjectModel {
 			ListSwitch {

--- a/pages/settings/devicelist/dc-in/PageDcMeter.qml
+++ b/pages/settings/devicelist/dc-in/PageDcMeter.qml
@@ -11,6 +11,13 @@ Page {
 
 	property alias bindPrefix: dcMeterMode.bindPrefix
 
+	title: device.name
+
+	Device {
+		id: device
+		serviceUid: root.bindPrefix
+	}
+
 	GradientListView {
 		model: PageDcMeterModel {
 			id: dcMeterMode

--- a/pages/settings/devicelist/delegates/DcMeterDeviceListDelegate.qml
+++ b/pages/settings/devicelist/delegates/DcMeterDeviceListDelegate.qml
@@ -17,7 +17,7 @@ DeviceListDelegate {
 
 	onClicked: {
 		Global.pageManager.pushPage("/pages/settings/devicelist/dc-in/PageDcMeter.qml",
-				{ "title": text, bindPrefix : root.device.serviceUid })
+				{ bindPrefix : root.device.serviceUid })
 	}
 
 	VeQuickItem {

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_alternator.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_alternator.qml
@@ -17,7 +17,7 @@ DeviceListDelegate {
 
 	onClicked: {
 		Global.pageManager.pushPage("/pages/settings/devicelist/dc-in/PageAlternator.qml",
-				{ "title": text, bindPrefix : root.device.serviceUid })
+				{ bindPrefix : root.device.serviceUid })
 	}
 
 	VeQuickItem {

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_charger.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_charger.qml
@@ -13,7 +13,7 @@ DeviceListDelegate {
 
 	onClicked: {
 		Global.pageManager.pushPage("/pages/settings/devicelist/PageAcCharger.qml",
-				{ "title": text, bindPrefix : root.device.serviceUid })
+				{ bindPrefix : root.device.serviceUid })
 	}
 
 	VeQuickItem {

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_digitalinput.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_digitalinput.qml
@@ -14,7 +14,7 @@ DeviceListDelegate {
 
 	onClicked: {
 		Global.pageManager.pushPage("/pages/settings/devicelist/PageDigitalInput.qml",
-				{ "title": text, bindPrefix : root.device.serviceUid })
+				{ bindPrefix : root.device.serviceUid })
 	}
 
 	VeQuickItem {

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_meteo.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_meteo.qml
@@ -15,7 +15,7 @@ DeviceListDelegate {
 
 	onClicked: {
 		Global.pageManager.pushPage("/pages/settings/devicelist/PageMeteo.qml",
-				{ "title": text, bindPrefix : root.device.serviceUid })
+				{ bindPrefix : root.device.serviceUid })
 	}
 
 	VeQuickItem {

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_motordrive.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_motordrive.qml
@@ -15,7 +15,7 @@ DeviceListDelegate {
 
 	onClicked: {
 		Global.pageManager.pushPage("/pages/settings/devicelist/PageMotorDrive.qml",
-				{ "title": text, bindPrefix : root.device.serviceUid })
+				{ bindPrefix : root.device.serviceUid })
 	}
 
 	VeQuickItem {

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_pulsemeter.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_pulsemeter.qml
@@ -15,7 +15,7 @@ DeviceListDelegate {
 
 	onClicked: {
 		Global.pageManager.pushPage("/pages/settings/devicelist/pulsemeter/PagePulseCounter.qml",
-				{ "title": text, bindPrefix : root.device.serviceUid })
+				{ bindPrefix : root.device.serviceUid })
 	}
 
 	VeQuickItem {

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_tank.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_tank.qml
@@ -23,7 +23,7 @@ DeviceListDelegate {
 
 	onClicked: {
 		Global.pageManager.pushPage("/pages/settings/devicelist/tank/PageTankSensor.qml",
-				{ "title": text, bindPrefix : root.device.serviceUid })
+				{ bindPrefix : root.device.serviceUid })
 	}
 
 	VeQuickItem {

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_temperature.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_temperature.qml
@@ -22,7 +22,7 @@ DeviceListDelegate {
 
 	onClicked: {
 		Global.pageManager.pushPage("/pages/settings/devicelist/temperature/PageTemperatureSensor.qml",
-				{ "title": text, bindPrefix : root.device.serviceUid })
+				{ bindPrefix : root.device.serviceUid })
 	}
 
 	VeQuickItem {

--- a/pages/settings/devicelist/delegates/GensetDeviceListDelegate.qml
+++ b/pages/settings/devicelist/delegates/GensetDeviceListDelegate.qml
@@ -19,7 +19,7 @@ DeviceListDelegate {
 
 	onClicked: {
 		Global.pageManager.pushPage("/pages/settings/devicelist/PageGenset.qml",
-				{ "title": text, bindPrefix : root.device.serviceUid })
+				{ bindPrefix : root.device.serviceUid })
 	}
 
 	VeQuickItem {

--- a/pages/settings/devicelist/pulsemeter/PagePulseCounter.qml
+++ b/pages/settings/devicelist/pulsemeter/PagePulseCounter.qml
@@ -11,6 +11,13 @@ Page {
 
 	property string bindPrefix
 
+	title: device.name
+
+	Device {
+		id: device
+		serviceUid: root.bindPrefix
+	}
+
 	GradientListView {
 		model: ObjectModel {
 			ListQuantity {

--- a/pages/settings/devicelist/rs/PageMultiRs.qml
+++ b/pages/settings/devicelist/rs/PageMultiRs.qml
@@ -13,6 +13,13 @@ Page {
 	readonly property bool multiPhase: numberOfPhases.isValid && numberOfPhases.value >= 2 && !_phase.isValid
 	readonly property int trackerCount: numberOfTrackers.value || 0
 
+	title: device.name
+
+	Device {
+		id: device
+		serviceUid: root.bindPrefix
+	}
+
 	VeQuickItem {
 		id: numberOfPhases
 		uid: root.bindPrefix + "/Ac/NumberOfPhases"

--- a/pages/settings/devicelist/rs/PageRsSystemDevices.qml
+++ b/pages/settings/devicelist/rs/PageRsSystemDevices.qml
@@ -57,7 +57,7 @@ Page {
 
 			onClicked: {
 				Global.pageManager.pushPage("/pages/settings/devicelist/rs/PageMultiRs.qml",
-						{ "title": text, "bindPrefix": device.serviceUid })
+						{ "bindPrefix": device.serviceUid })
 			}
 		}
 	}

--- a/pages/settings/devicelist/temperature/PageTemperatureSensor.qml
+++ b/pages/settings/devicelist/temperature/PageTemperatureSensor.qml
@@ -11,6 +11,13 @@ Page {
 
 	property string bindPrefix
 
+	title: device.name
+
+	Device {
+		id: device
+		serviceUid: root.bindPrefix
+	}
+
 	VeQuickItem {
 		id: temperatureType
 		uid: bindPrefix + "/TemperatureType"


### PR DESCRIPTION
When pushing a page that uses a device name for the page title, have each page provide this title internally (using the device name) instead of passing the title in as a fixed name.

This way, the page title is updated if the device name changes (e.g. if the custom name changes) and also we don't need to duplicate the code that passes in the page title as a parameter when pushing the page.