### PR TITLE
MikeTrahearn/1563 Show Popup for "Detect generator at AC input" setting

### DIFF
--- a/pages/settings/PageSettingsGenerator.qml
+++ b/pages/settings/PageSettingsGenerator.qml
@@ -89,22 +89,27 @@ Page {
 			}
 
 			ListSwitch {
+				id: generatorACInputSwitch
+
 				property bool generatorIsSet: acIn1Source.value === 2 || acIn2Source.value === 2
+				property ToastNotification toast: null
 				//% "Detect generator at AC input"
 				text: qsTrId("page_settings_generator_detect_generator_at_ac_input")
 				dataItem.uid: settingsBindPrefix + "/Alarms/NoGeneratorAtAcIn"
 				interactive: dataItem.isValid && (generatorIsSet || checked)
 				preferredVisible: !noGeneratorAtDcInAlarm.isValid
+
 				onClicked: {
 					if (!checked) {
+						generatorACInputSwitch.toast?.close(true)
 						if (!generatorIsSet) {
 							//% "None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality."
-							Global.showToastNotification(VenusOS.Notification_Info, qsTrId("page_settings_generator_detect_generator_not_set"),
-																	   Theme.animation_generator_detectGeneratorNotSet_toastNotification_autoClose_duration)
+							generatorACInputSwitch.toast = Global.showToastNotification(VenusOS.Notification_Info, qsTrId("page_settings_generator_detect_generator_not_set"),
+																						Theme.animation_generator_detectGeneratorNotSet_toastNotification_autoClose_duration)
 						} else {
 							//% "An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page."
-							Global.showToastNotification(VenusOS.Notification_Info, qsTrId("page_settings_generator_detect_generator_set"),
-																	   Theme.animation_generator_detectGeneratorSet_toastNotification_autoClose_duration)
+							generatorACInputSwitch.toast = Global.showToastNotification(VenusOS.Notification_Info, qsTrId("page_settings_generator_detect_generator_set"),
+																						Theme.animation_generator_detectGeneratorSet_toastNotification_autoClose_duration)
 						}
 					}
 				}
@@ -120,6 +125,13 @@ Page {
 
 					uid: Global.systemSettings.serviceUid + "/Settings/SystemSetup/AcInput2"
 				}
+
+				Connections {
+					target: generatorACInputSwitch.toast
+					function onDismissed() {
+						generatorACInputSwitch.toast = null
+					}
+				}
 			}
 
 			ListSwitch {
@@ -130,9 +142,9 @@ Page {
 				preferredVisible: noGeneratorAtDcInAlarm.isValid
 				onClicked: {
 					if (!checked) {
-							//% "An alarm will be triggered when the DC genset does not reach at least 5A within the first 5 minutes after starting"
-							Global.showToastNotification(VenusOS.Notification_Info, qsTrId("page_settings_generator_detect_at_dc_in_generator_set"),
-																	   Theme.animation_generator_detectGeneratorSet_toastNotification_autoClose_duration)
+						//% "An alarm will be triggered when the DC genset does not reach at least 5A within the first 5 minutes after starting"
+						Global.showToastNotification(VenusOS.Notification_Info, qsTrId("page_settings_generator_detect_at_dc_in_generator_set"),
+													 Theme.animation_generator_detectGeneratorSet_toastNotification_autoClose_duration)
 					}
 				}
 			}
@@ -145,7 +157,7 @@ Page {
 					if (!checked) {
 						//% "An alarm will be triggered when autostart function is left disabled for more than 10 minutes"
 						Global.notificationLayer.showToastNotification(VenusOS.Notification_Info,
-								qsTrId("page_settings_generator_alarm_info"), 12000)
+																	   qsTrId("page_settings_generator_alarm_info"), 12000)
 					}
 				}
 			}
@@ -176,4 +188,3 @@ Page {
 		}
 	}
 }
-


### PR DESCRIPTION
PageSettingsGenerator should correctly shows the existing toast by changing the enabled property to content.enabled so that the button may still be clickable. ListSwitch should be modified to emit its clicked() signal when the content.enabled is false.

Fixes #1563