### PR TITLE
Fix DC input names

### DIFF
--- a/components/widgets/AlternatorWidget.qml
+++ b/components/widgets/AlternatorWidget.qml
@@ -9,7 +9,7 @@ import Victron.VenusOS
 DcInputWidget {
 	id: root
 
-	title: VenusOS.digitalInput_typeToText(VenusOS.DcInputs_InputType_Alternator)
+	title: VenusOS.dcInput_typeToText(VenusOS.DcInputs_InputType_Alternator)
 	icon.source: "qrc:/images/alternator.svg"
 	type: VenusOS.OverviewWidget_Type_Alternator
 	detailUrl: "/pages/settings/devicelist/dc-in/PageAlternator.qml"

--- a/components/widgets/DcInputWidget.qml
+++ b/components/widgets/DcInputWidget.qml
@@ -25,7 +25,7 @@ OverviewWidget {
 	}
 
 	title: !inputs.firstObject ? ""
-		   : VenusOS.digitalInput_typeToText(Global.dcInputs.inputType(inputs.firstObject.serviceUid, inputs.firstObject.monitorMode))
+		   : VenusOS.dcInput_typeToText(Global.dcInputs.inputType(inputs.firstObject.serviceUid, inputs.firstObject.monitorMode))
 	quantityLabel.dataObject: QtObject {
 		property real power: NaN
 		property real current: NaN

--- a/data/DcInputs.qml
+++ b/data/DcInputs.qml
@@ -105,38 +105,6 @@ QtObject {
 		}
 	}
 
-	function inputTypeToText(type) {
-		switch (type) {
-		case VenusOS.DcInputs_InputType_AcCharger:
-			//% "AC charger"
-			return qsTrId("dcInputs_ac_charger")
-		case VenusOS.DcInputs_InputType_Alternator:
-			//% "Alternator"
-			return qsTrId("dcInputs_alternator")
-		case VenusOS.DcInputs_InputType_DcCharger:
-			//% "DC charger"
-			return qsTrId("dcInputs_dccharger")
-		case VenusOS.DcInputs_InputType_DcGenerator:
-			//% "DC generator"
-			return qsTrId("dcInputs_dc_generator")
-		case VenusOS.DcInputs_InputType_DcSystem:
-			//% "DC system"
-			return qsTrId("dcInputs_dc_system")
-		case VenusOS.DcInputs_InputType_FuelCell:
-			//% "Fuel cell"
-			return qsTrId("dcInputs_fuelcell")
-		case VenusOS.DcInputs_InputType_ShaftGenerator:
-			//% "Shaft generator"
-			return qsTrId("dcInputs_shaft_generator")
-		case VenusOS.DcInputs_InputType_WaterGenerator:
-			//% "Water generator"
-			return qsTrId("dcInputs_water_generator")
-		case VenusOS.DcInputs_InputType_Wind:
-			//% "Wind charger"
-			return qsTrId("dcInputs_wind_charger")
-		}
-	}
-
 	function inputTypeIcon(type) {
 		switch (type) {
 		case VenusOS.DcInputs_InputType_Alternator:

--- a/pages/BriefSidePanel.qml
+++ b/pages/BriefSidePanel.qml
@@ -208,7 +208,7 @@ exported power v  0.4 |   /
 
 	BriefSidePanelWidget {
 		title: Global.dcInputs.model.count === 1
-				? VenusOS.digitalInput_typeToText(Global.dcInputs.model.firstObject.inputType)
+				? VenusOS.dcInput_typeToText(Global.dcInputs.model.firstObject.inputType)
 				  //% "DC input"
 				: qsTrId("brief_dc_input")
 		icon.source: root.dcInputIconSource

--- a/pages/settings/devicelist/dc-in/PageDcMeterModel.qml
+++ b/pages/settings/devicelist/dc-in/PageDcMeterModel.qml
@@ -22,7 +22,7 @@ ObjectModel {
 	}
 
 	ListDcOutputQuantityGroup {
-		text: VenusOS.digitalInput_typeToText(Global.dcInputs.inputType(root.bindPrefix, monitorMode.value))
+		text: VenusOS.dcInput_typeToText(Global.dcInputs.inputType(root.bindPrefix, monitorMode.value))
 		bindPrefix: root.bindPrefix
 	}
 

--- a/src/enums.cpp
+++ b/src/enums.cpp
@@ -48,6 +48,39 @@ Enums::Battery_Mode Enums::battery_modeFromPower(qreal power) const
 	}
 }
 
+QString Enums::dcInput_typeToText(DcInputs_InputType type) const
+{
+	switch (type) {
+	case DcInputs_InputType_AcCharger:
+		//% "AC charger"
+		return qtTrId("dcInputs_ac_charger");
+	case DcInputs_InputType_Alternator:
+		//% "Alternator"
+		return qtTrId("dcInputs_alternator");
+	case DcInputs_InputType_DcCharger:
+		//% "DC charger"
+		return qtTrId("dcInputs_dccharger");
+	case DcInputs_InputType_DcGenerator:
+		//% "DC generator"
+		return qtTrId("dcInputs_dc_generator");
+	case DcInputs_InputType_DcSystem:
+		//% "DC system"
+		return qtTrId("dcInputs_dc_system");
+	case DcInputs_InputType_FuelCell:
+		//% "Fuel cell"
+		return qtTrId("dcInputs_fuelcell");
+	case DcInputs_InputType_ShaftGenerator:
+		//% "Shaft generator"
+		return qtTrId("dcInputs_shaft_generator");
+	case DcInputs_InputType_WaterGenerator:
+		//% "Water generator"
+		return qtTrId("dcInputs_water_generator");
+	case DcInputs_InputType_Wind:
+		//% "Wind charger"
+		return qtTrId("dcInputs_wind_charger");
+	}
+	return QString();
+}
 
 QString Enums::digitalInput_typeToText(DigitalInput_Type type) const
 {

--- a/src/enums.h
+++ b/src/enums.h
@@ -734,6 +734,8 @@ public:
 	Q_INVOKABLE QString battery_modeToText(Battery_Mode mode) const;
 	Q_INVOKABLE Battery_Mode battery_modeFromPower(qreal power) const;
 
+	Q_INVOKABLE QString dcInput_typeToText(DcInputs_InputType type) const;
+
 	Q_INVOKABLE QString digitalInput_typeToText(DigitalInput_Type type) const;
 	Q_INVOKABLE QString digitalInput_stateToText(DigitalInput_State state) const;
 


### PR DESCRIPTION
Move Global.dcInputs.inputTypeToText() to enums.h to align with other enum-to-text conversion methods.

DC input names should be fetched from this VenusOS.dcInput_typeToText() instead of VenusOS.digitalInput_typeToText().

Fixes #1823