### PR TITLE
Commonise GeneratorDisableAutoStartDialog to reduce duplication

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,6 +303,7 @@ set (VENUS_QML_MODULE_SOURCES
     components/dialogs/GeneratorDialog.qml
     components/dialogs/GeneratorStartDialog.qml
     components/dialogs/GeneratorStopDialog.qml
+    components/dialogs/GeneratorDisableAutoStartDialog.qml
     components/dialogs/InverterChargerModeDialog.qml
     components/dialogs/InverterChargerEssModeDialog.qml
     components/dialogs/ModalDialog.qml

--- a/components/PageGensetModel.qml
+++ b/components/PageGensetModel.qml
@@ -73,18 +73,8 @@ ObjectModel {
 		Component {
 			id: confirmationDialogComponent
 
-			ModalWarningDialog {
-				dialogDoneOptions: VenusOS.ModalDialog_DoneOptions_OkAndCancel
-
-				//% "Disable autostart?"
-				title: qsTrId("ac-in-genset_disableautostartdialog_title")
-
-				//% "Autostart will be disabled and the generator won't automatically start based on the configured conditions.\nIf the generator is currently running due to a autostart condition, disabling autostart will also stop it immediately."
-				description: qsTrId("ac-in-genset_disableautostartdialog_description")
-
-				onAccepted: {
-					autostartSwitch.dataItem.setValue(false)
-				}
+			GeneratorDisableAutoStartDialog {
+				onAccepted: autostartSwitch.dataItem.setValue(false)
 			}
 		}
 	}

--- a/components/dialogs/GeneratorDisableAutoStartDialog.qml
+++ b/components/dialogs/GeneratorDisableAutoStartDialog.qml
@@ -1,0 +1,17 @@
+/*
+** Copyright (C) 2023 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+ModalWarningDialog {
+	dialogDoneOptions: VenusOS.ModalDialog_DoneOptions_OkAndCancel
+
+	//% "Disable autostart?"
+	title: qsTrId("ac-in-genset_disableautostartdialog_title")
+
+	//% "Autostart will be disabled and the generator won't automatically start based on the configured conditions.\nIf the generator is currently running due to a autostart condition, disabling autostart will also stop it immediately."
+	description: qsTrId("ac-in-genset_disableautostartdialog_description")
+}

--- a/pages/controlcards/GeneratorCard.qml
+++ b/pages/controlcards/GeneratorCard.qml
@@ -85,18 +85,8 @@ ControlCard {
 		Component {
 			id: confirmationDialogComponent
 
-			ModalWarningDialog {
-				dialogDoneOptions: VenusOS.ModalDialog_DoneOptions_OkAndCancel
-
-				//% "Disable autostart?"
-				title: qsTrId("controlcard_generator_disableautostartdialog_title")
-
-				//% "Autostart will be disabled and the generator won't automatically start based on the configured conditions.\nIf the generator is currently running due to a autostart condition, disabling autostart will also stop it immediately."
-				description: qsTrId("controlcard_generator_disableautostartdialog_description")
-
-				onAccepted: {
-					root.generator.setAutoStart(false)
-				}
+			GeneratorDisableAutoStartDialog {
+				onAccepted: root.generator.setAutoStart(false)
 			}
 		}
 	}


### PR DESCRIPTION
Fixing an outstanding task from PR 1812 to commonise the confirmation dialogs which are otherwise duplicated in PageGensetModel.qml and GeneratorCard.qml
Add a new component GeneratorDisableAutoStartDialog for use in both places.