### PR TITLE
Add missing ESS Entry to RS System Page

### DIFF
--- a/pages/settings/devicelist/rs/PageRsSystem.qml
+++ b/pages/settings/devicelist/rs/PageRsSystem.qml
@@ -94,6 +94,14 @@ Page {
 			}
 
 			ListNavigation {
+				text: CommonWords.ess
+				onClicked: {
+					Global.pageManager.pushPage("/pages/settings/devicelist/rs/PageRsSystemEss.qml",
+							{ "title": text, "bindPrefix": root.bindPrefix })
+				}
+			}
+
+			ListNavigation {
 				//% "RS devices"
 				text: qsTrId("settings_rs_devices")
 				onClicked: {


### PR DESCRIPTION
- Add the missing entry "ESS" to PageRsSystem.qml that when clicked, loads PageRsSystemEss.qml as per the existing gui-v1 behavior.

Fixes #1829