### PR TITLE
Fix screen unblanking

### DIFF
--- a/ApplicationContent.qml
+++ b/ApplicationContent.qml
@@ -4,6 +4,7 @@
 */
 
 import QtQuick
+import QtQuick.Window
 import QtQuick.Controls as QtQuickControls
 import Victron.VenusOS
 
@@ -43,12 +44,11 @@ Item {
 		Component.onCompleted: Global.firmwareUpdate = firmwareUpdate
 	}
 
-	onWindowChanged: function (window) { screenBlanker.window = window }
-
 	ScreenBlanker {
 		id: screenBlanker
 		enabled: !Global.splashScreenVisible && !(!!Global.pageManager && Global.pageManager.statusBar.notificationButtonVisible)
 		displayOffTime: displayOffItem.isValid ? 1000*displayOffItem.value : 0.0
+		window: root.Window.window
 		property VeQuickItem displayOffItem: VeQuickItem {
 			uid: !!Global.systemSettings ? Global.systemSettings.serviceUid + "/Settings/Gui/DisplayOff" : ""
 		}


### PR DESCRIPTION
Set the window property instead of relying on the windowChanged signal to provide the value. Otherwise, ScreenBlanker::eventFilter() does not receive the touch events as expected.

Fixes #1831