### PR TITLE
Fix position of "connected" icon in Wi-Fi networks list

### DIFF
--- a/pages/settings/PageSettingsWifi.qml
+++ b/pages/settings/PageSettingsWifi.qml
@@ -84,9 +84,10 @@ Page {
 			primaryLabel.leftPadding: Theme.geometry_icon_size_medium + Theme.geometry_listItem_content_spacing
 
 			CP.ColorImage {
+				parent: delagate.primaryLabel
 				anchors {
-					left: delagate.primaryLabel.left
-					verticalCenter: delagate.primaryLabel.verticalCenter
+					left: parent.left
+					verticalCenter: parent.verticalCenter
 				}
 				source: "qrc:/images/icon_checkmark_32.svg"
 				color: Theme.color_green

--- a/pages/settings/PageSettingsWifi.qml
+++ b/pages/settings/PageSettingsWifi.qml
@@ -76,7 +76,7 @@ Page {
 		}
 
 		delegate: ListNavigation {
-			id: delagate
+			id: accessPointDelegate
 
 			//% "[Hidden]"
 			text: model.network ? model.network : qsTrId("settings_tcpip_hidden")
@@ -84,7 +84,7 @@ Page {
 			primaryLabel.leftPadding: Theme.geometry_icon_size_medium + Theme.geometry_listItem_content_spacing
 
 			CP.ColorImage {
-				parent: delagate.primaryLabel
+				parent: accessPointDelegate.primaryLabel
 				anchors {
 					left: parent.left
 					verticalCenter: parent.verticalCenter
@@ -100,7 +100,7 @@ Page {
 				id: wifiPointComponent
 
 				PageSettingsTcpIp {
-					title: delagate.text
+					title: accessPointDelegate.text
 					service: model.service
 					network: model.network
 					tech: "wifi"


### PR DESCRIPTION
This also avoids the warning "Cannot anchor to an item that isn't a parent or sibling" when opening PageSettingsWifi.qml.