### PR TITLE
Use shorter title for history page

### DIFF
--- a/pages/settings/devicelist/rs/PageMultiRs.qml
+++ b/pages/settings/devicelist/rs/PageMultiRs.qml
@@ -116,11 +116,8 @@ Page {
 				text: CommonWords.daily_history
 				preferredVisible: root.trackerCount > 0
 				onClicked: {
-					//: Multi RS historic PV data information. %1 = Multi RS name
-					//% "%1 History"
-					const title = qsTrId("settings_multirs_history_name").arg(root.title)
 					Global.pageManager.pushPage("/pages/solar/SolarHistoryPage.qml",
-							{ "title": title, "solarHistory": solarHistory })
+							{ "solarHistory": solarHistory })
 				}
 
 				SolarHistory {

--- a/pages/solar/SolarChargerPage.qml
+++ b/pages/solar/SolarChargerPage.qml
@@ -184,11 +184,8 @@ Page {
 				text: CommonWords.history
 				preferredVisible: root.solarCharger.history.valid
 				onClicked: {
-					//: Solar charger historic data information. %1 = charger name
-					//% "%1 History"
-					const title = qsTrId("charger_history_name").arg(root.solarCharger.name)
 					Global.pageManager.pushPage("/pages/solar/SolarHistoryPage.qml",
-							{ "title": title, "solarHistory": root.solarCharger.history })
+							{ "solarHistory": root.solarCharger.history })
 				}
 			}
 

--- a/pages/solar/SolarHistoryPage.qml
+++ b/pages/solar/SolarHistoryPage.qml
@@ -12,7 +12,7 @@ Page {
 
 	property SolarHistory solarHistory
 
-	title: solarHistory.deviceName
+	title: CommonWords.history
 
 	TabBar {
 		id: tabBar


### PR DESCRIPTION
This avoids redundancy in the breadcrumbs where the device name is repeated.