### PR TITLE
Add support for Zuid-Afrikaans

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1134,7 +1134,7 @@ qt_add_resources(${PROJECT_NAME} "${PROJECT_NAME}_large_resources"
         themes/typography/TypographyDesign.json
 )
 
-list(APPEND TS_CODES "ar" "cs" "da" "de" "es" "fr" "it" "nl" "pl" "ro" "ru" "sv" "th" "tr" "uk" "zh_CN")
+list(APPEND TS_CODES "af" "ar" "cs" "da" "de" "es" "fr" "it" "nl" "pl" "ro" "ru" "sv" "th" "tr" "uk" "zh_CN")
 list(APPEND TS_FILES ${TS_CODES})
 list(TRANSFORM TS_FILES PREPEND "i18n/${PROJECT_NAME}_")
 list(TRANSFORM TS_FILES APPEND ".ts")

--- a/components/InputPanel.qml
+++ b/components/InputPanel.qml
@@ -148,7 +148,7 @@ QtVirtualKeyboard.InputPanel {
 		// turn off the Virtual Keyboard Text Selection Handles as they don't position properly
 		// under certain circumstances: see https://bugreports.qt.io/browse/QTBUG-114551
 		VirtualKeyboardSettings.inputMethodHints = Qt.ImhNoTextHandles
-		VirtualKeyboardSettings.activeLocales = ["en_US", "cs_CZ", "da_DK", "de_DE", "es_ES", "fr_FR", "it_IT", "nl_NL", "pl_PL", "ru_RU", "ro_RO", "sv_SE", "th_TH", "tr_TR", "uk_UA", "zh_CN", "ar_AR"]
+		VirtualKeyboardSettings.activeLocales = ["en_US", "af_ZA", "cs_CZ", "da_DK", "de_DE", "es_ES", "fr_FR", "it_IT", "nl_NL", "pl_PL", "ru_RU", "ro_RO", "sv_SE", "th_TH", "tr_TR", "uk_UA", "zh_CN", "ar_AR"]
 		_setVkbLocale()
 	}
 }

--- a/i18n/venus-gui-v2_af.ts
+++ b/i18n/venus-gui-v2_af.ts
@@ -1,0 +1,10526 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="af">
+  <context>
+    <name></name>
+    <message id="settings_tailscale_disabled">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="118"/>
+      <source>Disabled</source>
+      <translation type="unfinished">Ontsluit</translation>
+    </message>
+    <message id="common_words_inverter_overload">
+      <location filename="../../components/CommonWords.qml" line="225"/>
+      <source>Inverter overload</source>
+      <translation>Omsetter oorlading</translation>
+    </message>
+    <message id="common_words_power_watts">
+      <location filename="../../components/CommonWords.qml" line="352"/>
+      <source>Power</source>
+      <extracomment>Electric power, as measured in Watts</extracomment>
+      <translation>Krag</translation>
+    </message>
+    <message id="solarchargers_state_off">
+      <location filename="../../src/enums.cpp" line="196"/>
+      <source>Off</source>
+      <translation>Af</translation>
+    </message>
+    <message id="common_words_auto">
+      <location filename="../../components/CommonWords.qml" line="74"/>
+      <source>Auto</source>
+      <translation>Outo</translation>
+    </message>
+    <message id="common_words_high_battery_voltage">
+      <location filename="../../components/CommonWords.qml" line="186"/>
+      <source>High battery voltage</source>
+      <translation>Hoë batteryspanning</translation>
+    </message>
+    <message id="overview_widget_inverter_title">
+      <location filename="../../components/widgets/InverterChargerWidget.qml" line="34"/>
+      <source>Inverter / Charger</source>
+      <translation>Omsetter/laaier</translation>
+    </message>
+    <message id="common_words_low_battery_voltage">
+      <location filename="../../components/CommonWords.qml" line="234"/>
+      <source>Low battery voltage</source>
+      <translation>Lae batteryspanning</translation>
+    </message>
+    <message id="common_words_manual">
+      <location filename="../../components/CommonWords.qml" line="253"/>
+      <source>Manual</source>
+      <translation>Handleiding</translation>
+    </message>
+    <message id="settings_startpage_none">
+      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
+      <source>None</source>
+      <extracomment>Indicates no phase</extracomment>
+      <translation>Geen</translation>
+    </message>
+    <message id="common_words_position_ac">
+      <location filename="../../components/CommonWords.qml" line="359"/>
+      <source>Position</source>
+      <extracomment>EVCS AC input/output position</extracomment>
+      <translation>Posisie</translation>
+    </message>
+    <message id="common_words_speed">
+      <location filename="../../components/CommonWords.qml" line="421"/>
+      <source>Speed</source>
+      <extracomment>A speed measurement value</extracomment>
+      <translation>Spoed</translation>
+    </message>
+    <message id="common_words_state">
+      <location filename="../../components/CommonWords.qml" line="439"/>
+      <source>State</source>
+      <translation>Toestand</translation>
+    </message>
+    <message id="settings_firmware_installing">
+      <location filename="../../components/FirmwareUpdate.qml" line="67"/>
+      <source>Installing %1...</source>
+      <extracomment>%1 = firmware version</extracomment>
+      <translation>Installeer tans %1...</translation>
+    </message>
+    <message id="splash_view_unknown_error">
+      <location filename="../../components/SplashView.qml" line="271"/>
+      <source>Unknown error</source>
+      <translation>Onbekende fout</translation>
+    </message>
+    <message id="controlcard_inverter_charger_ess_minimum_soc">
+      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="104"/>
+      <source>Minimum SOC</source>
+      <translation type="unfinished">Minimum SOC</translation>
+    </message>
+    <message id="settings_radio_button_enter_password">
+      <location filename="../../components/listitems/core/ListRadioButtonGroup.qml" line="175"/>
+      <source>Enter password</source>
+      <translation>Sleutel wagwoord in</translation>
+    </message>
+    <message id="settings_firmware_press_to_check">
+      <location filename="../../components/listitems/ListFirmwareCheckButton.qml" line="18"/>
+      <source>Press to check</source>
+      <translation>Druk om na te gaan</translation>
+    </message>
+    <message id="common_words_grid">
+      <location filename="../../components/CommonWords.qml" line="180"/>
+      <source>Grid</source>
+      <translation>Rooster</translation>
+    </message>
+    <message id="overview_widget_solaryield_title">
+      <location filename="../../components/widgets/SolarYieldWidget.qml" line="26"/>
+      <source>Solar yield</source>
+      <translation>Sonopbrengs</translation>
+    </message>
+    <message id="inverters_state_externalccontrol">
+      <location filename="../../data/System.qml" line="188"/>
+      <source>External control</source>
+      <translation>Eksterne beheer</translation>
+    </message>
+    <message id="levels_page_tanks">
+      <location filename="../../pages/LevelsPage.qml" line="53"/>
+      <source>Tanks</source>
+      <translation>Tenks</translation>
+    </message>
+    <message id="levels_page_environment">
+      <location filename="../../pages/LevelsPage.qml" line="55"/>
+      <source>Environment</source>
+      <translation>Omgewing</translation>
+    </message>
+    <message id="notifications_no_current_alerts">
+      <location filename="../../pages/NotificationsPage.qml" line="145"/>
+      <source>No current alerts</source>
+      <translation>Geen huidige waarskuwings nie</translation>
+    </message>
+    <message id="settings_bluetooth">
+      <location filename="../../pages/SettingsPage.qml" line="110"/>
+      <source>Bluetooth</source>
+      <translation>Bluetooth</translation>
+    </message>
+    <message id="settings_general">
+      <location filename="../../pages/SettingsPage.qml" line="36"/>
+      <source>General</source>
+      <translation>Algemeen</translation>
+    </message>
+    <message id="settings_firmware">
+      <location filename="../../pages/SettingsPage.qml" line="41"/>
+      <source>Firmware</source>
+      <translation type="unfinished">Firmware</translation>
+    </message>
+    <message id="settings_date_and_time">
+      <location filename="../../pages/SettingsPage.qml" line="46"/>
+      <source>Date &amp; Time</source>
+      <translation>Datum en Tyd</translation>
+    </message>
+    <message id="settings_system_setup">
+      <location filename="../../pages/SettingsPage.qml" line="51"/>
+      <source>System setup</source>
+      <translation>Stelsel opstelling</translation>
+    </message>
+    <message id="settings_system_dvcc">
+      <location filename="../../pages/SettingsPage.qml" line="56"/>
+      <source>DVCC</source>
+      <translation type="unfinished">VVSB - Verspreide Volt en Spannings Beheer</translation>
+    </message>
+    <message id="settings_display_and_language">
+      <location filename="../../pages/SettingsPage.qml" line="61"/>
+      <source>Display &amp; Language</source>
+      <translation>Vertoon en taal</translation>
+    </message>
+    <message id="common_words_ess">
+      <location filename="../../components/CommonWords.qml" line="171"/>
+      <source>ESS</source>
+      <extracomment>ESS  - meaning uncertain to translate</extracomment>
+      <translation type="unfinished">ESS</translation>
+    </message>
+    <message id="settings_energy_meters">
+      <location filename="../../pages/SettingsPage.qml" line="75"/>
+      <source>Energy meters</source>
+      <translation>Energie meters</translation>
+    </message>
+    <message id="settings_pv_inverters">
+      <location filename="../../pages/SettingsPage.qml" line="80"/>
+      <source>PV inverters</source>
+      <translation>PV Omsetters</translation>
+    </message>
+    <message id="settings_tailscale_ethernet">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="103"/>
+      <source>Ethernet</source>
+      <translation type="unfinished">Ethernet</translation>
+    </message>
+    <message id="settings_wifi">
+      <location filename="../../pages/SettingsPage.qml" line="95"/>
+      <source>Wi-Fi</source>
+      <translation>Wi-Fi</translation>
+    </message>
+    <message id="settings_gsm_modem">
+      <location filename="../../pages/SettingsPage.qml" line="100"/>
+      <source>GSM modem</source>
+      <translation>GSM modem</translation>
+    </message>
+    <message id="settings_gps">
+      <location filename="../../pages/SettingsPage.qml" line="105"/>
+      <source>GPS</source>
+      <translation>GPS</translation>
+    </message>
+    <message id="settings_generator_start_stop">
+      <location filename="../../pages/SettingsPage.qml" line="116"/>
+      <source>Generator start/stop</source>
+      <translation>Opwekker begin/eindig</translation>
+    </message>
+    <message id="settings_tank_pump">
+      <location filename="../../pages/SettingsPage.qml" line="122"/>
+      <source>Tank pump</source>
+      <translation>Tenkpomp</translation>
+    </message>
+    <message id="settings_services">
+      <location filename="../../pages/SettingsPage.qml" line="132"/>
+      <source>Services</source>
+      <translation>Dienste</translation>
+    </message>
+    <message id="settings_io">
+      <location filename="../../pages/SettingsPage.qml" line="137"/>
+      <source>I/O</source>
+      <translation type="unfinished">I/O</translation>
+    </message>
+    <message id="settings_venus_os_large_features">
+      <location filename="../../pages/SettingsPage.qml" line="142"/>
+      <source>Venus OS Large features</source>
+      <translation type="unfinished">Venus OS Hoofkenmerke</translation>
+    </message>
+    <message id="ess_battery_life_limit">
+      <location filename="../../pages/controlcards/ESSCard.qml" line="72"/>
+      <source>Battery life limit: %1%</source>
+      <translation>Batteryleeftydperk: %1%</translation>
+    </message>
+    <message id="controlcard_generator_disableautostartdialog_description">
+      <location filename="../../pages/controlcards/GeneratorCard.qml" line="94"/>
+      <source>Autostart will be disabled and the generator won't automatically start based on the configured conditions.</source>
+      <translation>Outobegin sal gedeaktiveer word en die kragopwekker sal nie outomaties begin op grond van die gekonfigureerde toestande nie.</translation>
+    </message>
+    <message id="controlcard_generator_subcard_button_manual_stop">
+      <location filename="../../components/GeneratorManualControlButton.qml" line="34"/>
+      <source>Manual Stop</source>
+      <translation>Handmatige stop</translation>
+    </message>
+    <message id="controlcard_generator_subcard_button_manual_start">
+      <location filename="../../components/GeneratorManualControlButton.qml" line="37"/>
+      <source>Manual Start</source>
+      <translation>Handmatige begin</translation>
+    </message>
+    <message id="evcs_autostart">
+      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="23"/>
+      <source>Autostart</source>
+      <translation>Outomatiese begin</translation>
+    </message>
+    <message id="controlcard_switches">
+      <location filename="../../pages/controlcards/SwitchesCard.qml" line="16"/>
+      <source>Switches</source>
+      <translation>Skakelaars</translation>
+    </message>
+    <message id="settings_access_level">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="75"/>
+      <source>Access level</source>
+      <translation>Toegangsvlak</translation>
+    </message>
+    <message id="settings_access_user">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="80"/>
+      <source>User</source>
+      <translation>Gebruiker</translation>
+    </message>
+    <message id="settings_access_user_installer">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="82"/>
+      <source>User &amp; Installer</source>
+      <translation>Gebruiker en installeerder</translation>
+    </message>
+    <message id="settings_access_superuser">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="84"/>
+      <source>Superuser</source>
+      <translation>Supergebruiker</translation>
+    </message>
+    <message id="settings_access_service">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="86"/>
+      <source>Service</source>
+      <translation>Diens</translation>
+    </message>
+    <message id="settings_dvcc_switch_reset_vebus_after_disabling_dvcc">
+      <location filename="../../pages/settings/DvccCommonSettings.qml" line="23"/>
+      <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
+      <translation>Maak seker dat jy ook die VE.Bus-stelsel terugstel nadat jy DVCC gedeaktiveer het</translation>
+    </message>
+    <message id="settings_dvcc_limit_charge_current">
+      <location filename="../../pages/settings/DvccCommonSettings.qml" line="32"/>
+      <source>Limit charge current</source>
+      <translation>Beperk ladingstroom</translation>
+    </message>
+    <message id="settings_dvcc_max_charge_current">
+      <location filename="../../pages/settings/DvccCommonSettings.qml" line="44"/>
+      <source>Maximum charge current</source>
+      <translation>Maksimum stroomlading</translation>
+    </message>
+    <message id="generator_condition_use_value_to_start_stop">
+      <location filename="../../pages/settings/GeneratorCondition.qml" line="21"/>
+      <source>Use %1 value to start/stop</source>
+      <translation>Gebruik %1 waarde om te begin/stop</translation>
+    </message>
+    <message id="generator_condition_start_when_property_is_higher_than">
+      <location filename="../../pages/settings/GeneratorCondition.qml" line="24"/>
+      <source>Start when %1 is higher than</source>
+      <translation>Begin wanneer %1 hoër is as</translation>
+    </message>
+    <message id="generator_condition_start_when_property_is_lower_than">
+      <location filename="../../pages/settings/GeneratorCondition.qml" line="27"/>
+      <source>Start when %1 is lower than</source>
+      <translation>Begin wanneer %1 laer is as</translation>
+    </message>
+    <message id="generator_condition_stop_when_property_is_higher_than">
+      <location filename="../../pages/settings/GeneratorCondition.qml" line="32"/>
+      <source>Stop when %1 is higher than</source>
+      <translation>Stop wanneer %1 hoër is as</translation>
+    </message>
+    <message id="generator_condition_stop_when_property_is_lower_than">
+      <location filename="../../pages/settings/GeneratorCondition.qml" line="35"/>
+      <source>Stop when %1 is lower than</source>
+      <translation>Stop wanneer %1 laer is as</translation>
+    </message>
+    <message id="settings_fronius_remove_ip_address">
+      <location filename="../../pages/settings/IpAddressListView.qml" line="53"/>
+      <source>Remove IP address?</source>
+      <extracomment>IP -Identiteit Protokol</extracomment>
+      <translation>Verwyder IP-adres?</translation>
+    </message>
+    <message id="settings_dvcc_max">
+      <location filename="../../pages/settings/PageChargeCurrentLimits.qml" line="79"/>
+      <source>Max: %1</source>
+      <translation>Maks: 1%</translation>
+    </message>
+    <message id="settings_deviceinfo_connection">
+      <location filename="../../pages/settings/PageDeviceInfo.qml" line="22"/>
+      <source>Connection</source>
+      <translation>Verbinding</translation>
+    </message>
+    <message id="settings_deviceinfo_product">
+      <location filename="../../pages/settings/PageDeviceInfo.qml" line="29"/>
+      <source>Product</source>
+      <translation>Produk</translation>
+    </message>
+    <message id="settings_tcpip_name">
+      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="141"/>
+      <source>Name</source>
+      <translation>Naam</translation>
+    </message>
+    <message id="settings_deviceinfo_product_id">
+      <location filename="../../pages/settings/PageDeviceInfo.qml" line="46"/>
+      <source>Product ID</source>
+      <translation>Produk ID</translation>
+    </message>
+    <message id="settings_deviceinfo_hardware_version">
+      <location filename="../../pages/settings/PageDeviceInfo.qml" line="59"/>
+      <source>Hardware version</source>
+      <translation>Hardeware weergawe</translation>
+    </message>
+    <message id="settings_deviceinfo_device_name">
+      <location filename="../../pages/settings/PageDeviceInfo.qml" line="80"/>
+      <source>Device name</source>
+      <translation>Toestel naam</translation>
+    </message>
+    <message id="settings_remote_switch_control_disabled">
+      <location filename="../../components/listitems/ListGeneratorError.qml" line="17"/>
+      <source>Remote switch control disabled</source>
+      <translation>Afstandskakelaarbeheer gedeaktiveer</translation>
+    </message>
+    <message id="settings_generator_in_fault_condition">
+      <location filename="../../components/listitems/ListGeneratorError.qml" line="19"/>
+      <source>Generator in fault condition</source>
+      <translation>Kragopwekker in fout toestand</translation>
+    </message>
+    <message id="settings_generator_not_detected">
+      <location filename="../../components/listitems/ListGeneratorError.qml" line="21"/>
+      <source>Generator not detected at AC input</source>
+      <translation>Generator nie by Wisselstroom-invoer bespeur nie</translation>
+    </message>
+    <message id="settings_page_run_time_and_service_accumulated_running_time">
+      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="140"/>
+      <source>Accumulated running time since last test run</source>
+      <translation>Opgehoopte looptyd sedert laaste toetslopie</translation>
+    </message>
+    <message id="settings_page_run_time_and_service_time_to_next_test_run">
+      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="116"/>
+      <source>Time to next test run</source>
+      <translation>Tyd voor volgende toetslopie</translation>
+    </message>
+    <message id="settings_page_run_time_and_service_running_now">
+      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="133"/>
+      <source>Running now</source>
+      <translation>Nou in bedryf</translation>
+    </message>
+    <message id="common_words_manual_start">
+      <location filename="../../components/CommonWords.qml" line="259"/>
+      <source>Manual start</source>
+      <translation>Handmatige begin</translation>
+    </message>
+    <message id="page_generator_conditions_start_generator">
+      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="74"/>
+      <source>Start generator</source>
+      <translation>Begin kragopwekker</translation>
+    </message>
+    <message id="settings_page_run_time_and_service_daily_run_time">
+      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
+      <source>Daily run time</source>
+      <translation>Daaglikse looptyd</translation>
+    </message>
+    <message id="value_must_be_greater_than_stop_value">
+      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="17"/>
+      <source>Value must be greater than stop value</source>
+      <translation>Waarde moet groter as stopwaarde wees</translation>
+    </message>
+    <message id="value_must_be_lower_than_start_value">
+      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="24"/>
+      <source>Value must be lower than start value</source>
+      <translation>Waarde moet laer as beginwaarde wees</translation>
+    </message>
+    <message id="settings_minmax_acout_max_power">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="123"/>
+      <source>AC output</source>
+      <translation>Wisselstroom uitset</translation>
+    </message>
+    <message id="page_generator_ac_load_use_ac_load">
+      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
+      <source>Use AC Load to start/stop</source>
+      <translation>Gebruik wisselstroomlading om te begin/stop</translation>
+    </message>
+    <message id="page_generator_ac_load_measurement">
+      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="45"/>
+      <source>Measurement</source>
+      <translation>Meting</translation>
+    </message>
+    <message id="total_consumption">
+      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="49"/>
+      <source>Total consumption</source>
+      <translation>Totale verbruik</translation>
+    </message>
+    <message id="total_ac_out">
+      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="51"/>
+      <source>Inverter total AC out</source>
+      <translation>Omgeskakelde totale wisselstroom uitset</translation>
+    </message>
+    <message id="ac_out_highest_phase">
+      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="53"/>
+      <source>Inverter AC out highest phase</source>
+      <translation>Omgeskakelde wisselstroom uit hoogste fase</translation>
+    </message>
+    <message id="start_when_power_is_higher_than">
+      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="60"/>
+      <source>Start when power is higher than</source>
+      <translation>Begin wanneer krag hoër is as</translation>
+    </message>
+    <message id="stop_when_power_is_lower_than">
+      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="92"/>
+      <source>Stop when power is lower than</source>
+      <translation>Stop wanneer krag laer is as</translation>
+    </message>
+    <message id="settings_system_battery_monitor">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="150"/>
+      <source>Battery monitor</source>
+      <translation>Battery monitor</translation>
+    </message>
+    <message id="settings_system_unavailable_monitor">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="153"/>
+      <source>Unavailable monitor, set another</source>
+      <translation>Monitor nie-beskikbaar, skakel oor na 'n ander</translation>
+    </message>
+    <message id="page_generator_conditions_on_loss_of_communication">
+      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="68"/>
+      <source>On loss of communication</source>
+      <translation>Met verlies van kommunikasie</translation>
+    </message>
+    <message id="page_generator_conditions_stop_generator">
+      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="72"/>
+      <source>Stop generator</source>
+      <translation>Stop kragopwekker</translation>
+    </message>
+    <message id="page_generator_conditions_keep_generator_running">
+      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="76"/>
+      <source>Keep generator running</source>
+      <translation>Hou kragopwekker aan die gang</translation>
+    </message>
+    <message id="page_generator_conditions_stop_generator_when_ac_input_available">
+      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="82"/>
+      <source>Stop generator when AC-input is available</source>
+      <translation>Stop kragopwekking wanneer wisselstroom inset beskikbaar is</translation>
+    </message>
+    <message id="page_generator_conditions_battery_soc">
+      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="105"/>
+      <source>Battery SOC</source>
+      <translation type="unfinished">Battery SBS - Sekuriteits Bedryfs Sentrum</translation>
+    </message>
+    <message id="settings_inverter_high_temperature">
+      <location filename="../../data/Generators.qml" line="91"/>
+      <source>Inverter high temperature</source>
+      <translation>Omskakelaar hoë temperatuur</translation>
+    </message>
+    <message id="page_generator_conditions_start_on_high_temperature_warning">
+      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="141"/>
+      <source>Start on high temperature warning</source>
+      <translation>Begin op hoë temperatuur waarskuwing</translation>
+    </message>
+    <message id="page_generator_conditions_start_on_overload_warning">
+      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="150"/>
+      <source>Start on overload warning</source>
+      <translation>Begin op oorladingswaarskuwing</translation>
+    </message>
+    <message id="generator_periodic_run">
+      <location filename="../../data/Generators.qml" line="73"/>
+      <source>Periodic run</source>
+      <translation>Periodieke bedryf</translation>
+    </message>
+    <message id="run_interval">
+      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="25"/>
+      <source>Run interval</source>
+      <translation>Bedryfs interval</translation>
+    </message>
+    <message id="page_generator_test_run_days">
+      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="28"/>
+      <source>%1 day(s)</source>
+      <translation>%1 dag(e)</translation>
+    </message>
+    <message id="page_generator_test_run_skip_run">
+      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="36"/>
+      <source>Skip run if has been running for</source>
+      <translation>Slaan bedryf oor as al in bedryf was vir</translation>
+    </message>
+    <message id="page_generator_test_run_start_always">
+      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="40"/>
+      <source>Start always</source>
+      <translation>Skakel altyd aan</translation>
+    </message>
+    <message id="page_generator_test_run_run_interval_start_date">
+      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="52"/>
+      <source>Run interval start date</source>
+      <translation>Bedryfs interval begin datum</translation>
+    </message>
+    <message id="page_generator_test_run_run_duration">
+      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="63"/>
+      <source>Run duration (hh:mm)</source>
+      <translation>Bedryfs duur (uu:mm)</translation>
+    </message>
+    <message id="page_generator_test_run_run_until_fully_charged">
+      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="72"/>
+      <source>Run until battery is fully charged</source>
+      <translation>Bly aan bedryf totdat batterye ten volle gelaai is</translation>
+    </message>
+    <message id="settings_gps_ok_fix">
+      <location filename="../../pages/settings/PageGps.qml" line="45"/>
+      <source>GPS OK (fix)</source>
+      <translation>GPS gereed (herstel)</translation>
+    </message>
+    <message id="settings_gps_ok_no_fix">
+      <location filename="../../pages/settings/PageGps.qml" line="48"/>
+      <source>GPS connected, but no GPS fix</source>
+      <translation>GPS gekoppel, maar geen GPS-oplossing nie</translation>
+    </message>
+    <message id="settings_gps_not_connected">
+      <location filename="../../pages/settings/PageGps.qml" line="51"/>
+      <source>No GPS connected</source>
+      <translation>Geen GPS gekoppel nie</translation>
+    </message>
+    <message id="settings_gps_latitude">
+      <location filename="../../pages/settings/PageGps.qml" line="57"/>
+      <source>Latitude</source>
+      <translation>Breedtegraad</translation>
+    </message>
+    <message id="settings_gps_longitude">
+      <location filename="../../pages/settings/PageGps.qml" line="64"/>
+      <source>Longitude</source>
+      <translation>Lengtegraad</translation>
+    </message>
+    <message id="settings_gps_speed_kmh">
+      <location filename="../../pages/settings/PageGps.qml" line="79"/>
+      <source>%1 km/h</source>
+      <extracomment>GPS speed data, in kilometers per hour</extracomment>
+      <translation>%1 km/u</translation>
+    </message>
+    <message id="settings_gps_speed_mph">
+      <location filename="../../pages/settings/PageGps.qml" line="83"/>
+      <source>%1 mph</source>
+      <extracomment>GPS speed data, in miles per hour</extracomment>
+      <translation>%1 mpu</translation>
+    </message>
+    <message id="settings_gps_speed_kt">
+      <location filename="../../pages/settings/PageGps.qml" line="87"/>
+      <source>%1 kt</source>
+      <extracomment>GPS speed data, in knots</extracomment>
+      <translation type="unfinished">%1 kt</translation>
+    </message>
+    <message id="settings_gps_speed_ms">
+      <location filename="../../pages/settings/PageGps.qml" line="91"/>
+      <source>%1 m/s</source>
+      <extracomment>GPS speed data, in meters per second</extracomment>
+      <translation>%1 m/s</translation>
+    </message>
+    <message id="settings_gps_course">
+      <location filename="../../pages/settings/PageGps.qml" line="98"/>
+      <source>Course</source>
+      <translation>Kursus</translation>
+    </message>
+    <message id="settings_gps_altitude">
+      <location filename="../../pages/settings/PageGps.qml" line="105"/>
+      <source>Altitude</source>
+      <translation>Hoogte</translation>
+    </message>
+    <message id="settings_gps_num_satellites">
+      <location filename="../../pages/settings/PageGps.qml" line="111"/>
+      <source>Number of satellites</source>
+      <translation>Aantal satelliete</translation>
+    </message>
+    <message id="settings_ess_debug_grid_setpoint">
+      <location filename="../../pages/settings/PageHub4Debug.qml" line="15"/>
+      <source>Grid Setpoint</source>
+      <translation>Roosterstelpunt</translation>
+    </message>
+    <message id="settings_ess_debug_ac_in_setpoint">
+      <location filename="../../pages/settings/PageHub4Debug.qml" line="49"/>
+      <source>AC-In setpoint</source>
+      <translation>Wisselstroom-in stelpunt</translation>
+    </message>
+    <message id="settings_ess_debug_battery_current">
+      <location filename="../../pages/settings/PageHub4Debug.qml" line="58"/>
+      <source>Current: %1</source>
+      <extracomment>Battery current, in amps</extracomment>
+      <translation>Huidig: %1</translation>
+    </message>
+    <message id="settings_ess_debug_battery_voltage">
+      <location filename="../../pages/settings/PageHub4Debug.qml" line="61"/>
+      <source>Voltage: %1</source>
+      <extracomment>Battery voltage, in volts</extracomment>
+      <translation>Spanning: %1</translation>
+    </message>
+    <message id="settings_ess_debug_limits_i">
+      <location filename="../../pages/settings/PageHub4Debug.qml" line="77"/>
+      <source>Limits (I)</source>
+      <translation>Limiete (I)</translation>
+    </message>
+    <message id="settings_ess_debug_battery_charge">
+      <location filename="../../pages/settings/PageHub4Debug.qml" line="80"/>
+      <location filename="../../pages/settings/PageHub4Debug.qml" line="101"/>
+      <source>Charge: %1</source>
+      <translation>Laai: %1</translation>
+    </message>
+    <message id="settings_ess_debug_battery_discharge">
+      <location filename="../../pages/settings/PageHub4Debug.qml" line="82"/>
+      <location filename="../../pages/settings/PageHub4Debug.qml" line="103"/>
+      <source>Discharge: %1</source>
+      <translation>Ontlading: %1</translation>
+    </message>
+    <message id="settings_ess_debug_limits_p">
+      <location filename="../../pages/settings/PageHub4Debug.qml" line="98"/>
+      <source>Limits (P)</source>
+      <translation>Limiete (P)</translation>
+    </message>
+    <message id="settings_batteries_battery_visible">
+      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="15"/>
+      <source>Visible</source>
+      <translation>Sigbaar</translation>
+    </message>
+    <message id="settings_batteries_battery_hidden">
+      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="17"/>
+      <source>Hidden</source>
+      <translation>Versteek</translation>
+    </message>
+    <message id="settings_batteries_battery_auxiliary_measurement">
+      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="62"/>
+      <source>%1 (Auxiliary measurement)</source>
+      <translation>%1 (Bystandsmeting)</translation>
+    </message>
+    <message id="settings_batteries_battery_output">
+      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="64"/>
+      <source>%1 (Output %2)</source>
+      <translation>%1 (Uitset %2)</translation>
+    </message>
+    <message id="settings_batteries_active_battery_monitor">
+      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="88"/>
+      <source>Active battery monitor</source>
+      <translation>Aktiewe batterymonitor</translation>
+    </message>
+    <message id="settings_system_enter_user_defined_name">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="74"/>
+      <source>Enter name</source>
+      <translation>Voer naam in</translation>
+    </message>
+    <message id="settings_continuous_scan">
+      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="46"/>
+      <source>Continuous scanning</source>
+      <translation>Deurlopende skandering</translation>
+    </message>
+    <message id="settings_io_bluetooth_adapters">
+      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="59"/>
+      <source>Bluetooth adapters</source>
+      <translation>Bluetooth koppelstukke</translation>
+    </message>
+    <message id="settings_pincode">
+      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="25"/>
+      <source>Pincode</source>
+      <translation>Geheime kode</translation>
+    </message>
+    <message id="settings_bluetooth_remove_existing_pairing_info">
+      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="35"/>
+      <source>It might be necessary to remove existing pairing information before connecting.</source>
+      <translation>Dit kan nodig wees om bestaande saambindinligsinligting te verwyder voordat u koppel.</translation>
+    </message>
+    <message id="settings_cgwacs_phase_type">
+      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="63"/>
+      <source>Phase type</source>
+      <translation>Fase tipe</translation>
+    </message>
+    <message id="settings_single_phase">
+      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="68"/>
+      <source>Single phase</source>
+      <translation>Enkelfase</translation>
+    </message>
+    <message id="settings_multi_phase">
+      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="70"/>
+      <source>Multi phase</source>
+      <translation>Meervoudige fase</translation>
+    </message>
+    <message id="settings_pv_inverter_on_phase_2">
+      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="77"/>
+      <source>PV inverter on phase 2</source>
+      <translation>PV-omsetter op fase 2</translation>
+    </message>
+    <message id="settings_cgwacs_pv_inverter_l2_position">
+      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="87"/>
+      <source>PV inverter on phase 2 Position</source>
+      <translation>PV-omsetter op fase 2 posisie</translation>
+    </message>
+    <message id="settings_canbus_profile">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="60"/>
+      <source>CAN-bus profile</source>
+      <translation type="unfinished">CAN-bus profiel  - CAN meaning uncertain</translation>
+    </message>
+    <message id="settings_canbus_vecan_lynx_ion_bms">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="70"/>
+      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
+      <translation type="unfinished">VE.Can &amp; Lynx Ion BMS (250 kbit/s)</translation>
+    </message>
+    <message id="settings_canbus_vecan_and_can_bus_bms">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="76"/>
+      <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
+      <translation type="unfinished">VE.Can &amp; CAN-bus BMS (250 kbit/s)</translation>
+    </message>
+    <message id="settings_oceanvolt">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="94"/>
+      <source>Oceanvolt (250 kbit/s)</source>
+      <translation>Oseaanvolt (250 kbit/s)</translation>
+    </message>
+    <message id="settings_rvc">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="100"/>
+      <source>RV-C (250 kbit/s)</source>
+      <translation type="unfinished">RV-C (250 kbit/s)</translation>
+    </message>
+    <message id="settings_up_bu_no_services">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="106"/>
+      <source>Up, but no services (250 kbit/s)</source>
+      <translation>Op, maar geen dienslewering (250 kbit/s)</translation>
+    </message>
+    <message id="settings_devices">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="121"/>
+      <source>Devices</source>
+      <translation>Toestelle</translation>
+    </message>
+    <message id="settings_canbus_nmea2000out">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="136"/>
+      <source>NMEA2000-out</source>
+      <translation type="unfinished">NMEA2000-uit</translation>
+    </message>
+    <message id="settings_canbus_unique_id_select">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="143"/>
+      <source>Unique identity number selector</source>
+      <translation>Unieke identiteitsnommerversteller</translation>
+    </message>
+    <message id="settings_canbus_unique_id_wait">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="161"/>
+      <source>Please wait, changing and checking the unique number takes a while</source>
+      <translation>Wag asseblief, dit neem 'n rukkie om die unieke nommer te verander en na te gaan</translation>
+    </message>
+    <message id="settings_canbus_unique_id_vecan_description">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="152"/>
+      <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
+      <translation>Bogenoemde versteller stel watter  unieke blok identiteitsnommers om te gebruik vir die NAAM Unieke Identiteitsnommers in die PGN 60928 NAAM-veld. Verander slegs wanneer verskeie GX-toestelle in een VE.Can-netwerk gebruik word.</translation>
+    </message>
+    <message id="settings_canbus_unique_id_rvc_description">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="155"/>
+      <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
+      <translation>Bogenoemde versteller stel watter blok unieke identiteitsnommers om te gebruik vir die reeksnommer in die DGN 60928 ADDRESS_CLAIM veld. Verander slegs wanneer verskeie GX-toestelle in een RV-C-netwerk gebruik word.</translation>
+    </message>
+    <message id="settings_canbus_unique_id_choose">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="178"/>
+      <source>Check Unique id numbers</source>
+      <translation>Gaan Unieke ID-nommers na</translation>
+    </message>
+    <message id="settings_canbus_unique_id_conflict">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="196"/>
+      <source>There is another device connected with this unique number, please select a new number.</source>
+      <translation>Daar is 'n ander toestel wat met hierdie unieke nommer gekoppel is, kies asseblief 'n nuwe nommer.</translation>
+    </message>
+    <message id="settings_canbus_unique_id_ok">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="204"/>
+      <source>OK: No other device is connected with this unique number.</source>
+      <translation>REG: Geen ander toestel is met hierdie unieke nommer gekoppel nie.</translation>
+    </message>
+    <message id="common_words_network_status">
+      <location filename="../../components/CommonWords.qml" line="295"/>
+      <source>Network status</source>
+      <translation>Netwerk status</translation>
+    </message>
+    <message id="settings_adaptive_brightness">
+      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="20"/>
+      <source>Adaptive brightness</source>
+      <translation>Aanpasbare helderheid</translation>
+    </message>
+    <message id="settings_brightness">
+      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="27"/>
+      <source>Brightness</source>
+      <translation>Helderheid</translation>
+    </message>
+    <message id="settings_display_off_time">
+      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="35"/>
+      <source>Display off time</source>
+      <translation>Wys aftyd</translation>
+    </message>
+    <message id="settings_displayoff_10sec">
+      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="41"/>
+      <source>10 sec</source>
+      <translation>10 sek</translation>
+    </message>
+    <message id="settings_displayoff_30sec">
+      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="43"/>
+      <source>30 sec</source>
+      <translation>30 sek</translation>
+    </message>
+    <message id="settings_1_min">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="95"/>
+      <source>1 min</source>
+      <translation>1 min</translation>
+    </message>
+    <message id="settings_10_min">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="99"/>
+      <source>10 min</source>
+      <translation>10 min</translation>
+    </message>
+    <message id="settings_30_min">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="103"/>
+      <source>30 min</source>
+      <translation>30 min</translation>
+    </message>
+    <message id="settings_startpage_timeout_never">
+      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
+      <source>Never</source>
+      <translation>Nooit nie</translation>
+    </message>
+    <message id="settings_display_color_mode">
+      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="58"/>
+      <source>Display mode</source>
+      <translation>Vertoonmodus</translation>
+    </message>
+    <message id="settings_display_dark_mode">
+      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="62"/>
+      <source>Dark</source>
+      <extracomment>Dark colors mode</extracomment>
+      <translation>Donker</translation>
+    </message>
+    <message id="settings_display_light_mode">
+      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="65"/>
+      <source>Light</source>
+      <extracomment>Light colors mode</extracomment>
+      <translation>Lig</translation>
+    </message>
+    <message id="settings_brief_view_levels">
+      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="76"/>
+      <source>Brief view levels</source>
+      <translation>Kort aansigvlakke</translation>
+    </message>
+    <message id="settings_language">
+      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="84"/>
+      <source>Language</source>
+      <translation>Taal</translation>
+    </message>
+    <message id="settings_language_changing_language">
+      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="136"/>
+      <source>Changing language</source>
+      <translation>Veranderende taal</translation>
+    </message>
+    <message id="settings_units_energy">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="18"/>
+      <source>Electrical power display</source>
+      <translation>Elektriese krag vertoon</translation>
+    </message>
+    <message id="settings_units_watts">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="22"/>
+      <source>Power (Watts)</source>
+      <translation>Krag (Watt)</translation>
+    </message>
+    <message id="settings_units_amps">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="25"/>
+      <source>Current (Amps)</source>
+      <translation>Stroom (ampère)</translation>
+    </message>
+    <message id="settings_units">
+      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="156"/>
+      <source>Units</source>
+      <translation>Eenhede</translation>
+    </message>
+    <message id="settings_briefview_level">
+      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="33"/>
+      <source>Level %1</source>
+      <extracomment>Level number</extracomment>
+      <translation>Vlak 1</translation>
+    </message>
+    <message id="settings_units_celsius">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="42"/>
+      <source>Celsius</source>
+      <translation>Celsius</translation>
+    </message>
+    <message id="settings_units_fahrenheit">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
+      <source>Fahrenheit</source>
+      <translation>Fahrenheit</translation>
+    </message>
+    <message id="settings_dvcc_instructions">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="19"/>
+      <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
+      <translation>&lt;b&gt;WAARSKUWING:&lt;/b&gt; Lees die handleiding voordat jy verstel.</translation>
+    </message>
+    <message id="settings_dvcc_limit_managed_battery_charge_voltage">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="40"/>
+      <source>Limit managed battery charge voltage</source>
+      <translation>Beperk bestuurde batterylaaispanning</translation>
+    </message>
+    <message id="settings_dvcc_max_charge_voltage">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="52"/>
+      <source>Maximum charge voltage</source>
+      <translation>Maksimum laaispanning</translation>
+    </message>
+    <message id="settings_dvcc_shared_voltage_sense">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="62"/>
+      <source>SVS - Shared voltage sense</source>
+      <translation>SVS - Gedeelde spanningswaarde</translation>
+    </message>
+    <message id="settings_dvcc_shared_temp_sense">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="71"/>
+      <source>STS - Shared temperature sense</source>
+      <translation>STS - Gedeelde temperatuurwaarde</translation>
+    </message>
+    <message id="settings_tank_unavailable_sensor">
+      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="70"/>
+      <source>Unavailable sensor, set another</source>
+      <translation>Onbeskikbare sensor, stel 'n ander</translation>
+    </message>
+    <message id="settings_dvcc_used_sensor">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="103"/>
+      <source>Used sensor</source>
+      <translation>Gebruikte sensor</translation>
+    </message>
+    <message id="settings_dvcc_shared_current_sense">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="115"/>
+      <source>SCS - Shared current sense</source>
+      <translation>SCS - Gedeelde stroomsin</translation>
+    </message>
+    <message id="settings_dvcc_scs_status">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="122"/>
+      <source>SCS status</source>
+      <translation>SCS status</translation>
+    </message>
+    <message id="settings_dvcc_scs_disabled_external_control">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="130"/>
+      <source>Disabled (external control)</source>
+      <translation>Gedeaktiveer (eksterne beheer)</translation>
+    </message>
+    <message id="settings_dvcc_scs_disabled_no_chargers">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="132"/>
+      <source>Disabled (no chargers)</source>
+      <translation>Gedeaktiveer (geen laaiers)</translation>
+    </message>
+    <message id="settings_dvcc_scs_disabled_no_battery_monitor">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="134"/>
+      <source>Disabled (no battery monitor)</source>
+      <translation>Gedeaktiveer (geen batterymonitor nie)</translation>
+    </message>
+    <message id="settings_dvcc_auto_selection">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="144"/>
+      <source>Automatic selection</source>
+      <translation>Outomatiese keuse</translation>
+    </message>
+    <message id="settings_dvcc_no_bms_control">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="146"/>
+      <source>No BMS control</source>
+      <translation>Geen BMS beheer nie</translation>
+    </message>
+    <message id="settings_dvcc_controlling_bms">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="150"/>
+      <source>Controlling BMS</source>
+      <translation>Beheer BMS</translation>
+    </message>
+    <message id="settings_dvcc_unavailable_bms">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="156"/>
+      <source>Unavailable, set another</source>
+      <extracomment>Shown when BMS instance is invalid</extracomment>
+      <translation>Onbeskikbaar, stel 'n ander</translation>
+    </message>
+    <message id="settings_dvcc_auto_selected">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="186"/>
+      <source>Auto selected</source>
+      <translation>Outo gekies</translation>
+    </message>
+    <message id="settings_build_date_time">
+      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
+      <source>Build date/time</source>
+      <translation>Bou datum/tyd</translation>
+    </message>
+    <message id="settings_online_updates">
+      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="33"/>
+      <source>Online updates</source>
+      <translation>Aanlyn opdaterings</translation>
+    </message>
+    <message id="settings_install_firmware_from_sd_usb">
+      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="41"/>
+      <source>Install firmware from SD/USB</source>
+      <translation type="unfinished">Installeer firmware vanaf SD/USB</translation>
+    </message>
+    <message id="settings_stored_backup_firmware">
+      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="49"/>
+      <source>Stored backup firmware</source>
+      <translation type="unfinished">Gestoorde rugsteunfirmware</translation>
+    </message>
+    <message id="settings_firmware_check_for_updates_on_sd_usb">
+      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
+      <source>Check for updates on SD/USB</source>
+      <translation type="unfinished">Kyk vir opdaterings op SD/USB</translation>
+    </message>
+    <message id="settings_firmware_found">
+      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
+      <source>Firmware found</source>
+      <translation type="unfinished">Firmware gevind</translation>
+    </message>
+    <message id="settings_firmware_offline_installing">
+      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
+      <source>Installing %1</source>
+      <extracomment>%1 = firmware version</extracomment>
+      <translation>Installeer tans %1</translation>
+    </message>
+    <message id="settings_firmware_online_press_to_update_to">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="93"/>
+      <source>Press to update to %1</source>
+      <extracomment>%1 = firmware version</extracomment>
+      <translation>Druk om op te dateer na %1</translation>
+    </message>
+    <message id="settings_firmware_build_date_time">
+      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
+      <source>Firmware build date/time</source>
+      <translation type="unfinished">Firmware bou datum/tyd</translation>
+    </message>
+    <message id="settings_auto_update">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
+      <source>Auto update</source>
+      <translation>Outo-opdatering</translation>
+    </message>
+    <message id="settings_firmware_check_only">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
+      <source>Check only</source>
+      <translation>Kontroleer slegs</translation>
+    </message>
+    <message id="settings_firmware_check_and_download_only">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
+      <source>Check and download only</source>
+      <translation>Kontroleer en laai slegs af</translation>
+    </message>
+    <message id="settings_firmware_check_and_update">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
+      <source>Check and update</source>
+      <translation>Kontroleer en opdateer</translation>
+    </message>
+    <message id="settings_update_feed">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
+      <source>Update feed</source>
+      <translation>Inset opdateer</translation>
+    </message>
+    <message id="settings_firmware_image_type">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="53"/>
+      <source>Image type</source>
+      <translation>Tipe beeld</translation>
+    </message>
+    <message id="settings_firmware_normal">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="58"/>
+      <source>Normal</source>
+      <translation>Normaal</translation>
+    </message>
+    <message id="settings_firmware_large">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="60"/>
+      <source>Large</source>
+      <translation>Groot</translation>
+    </message>
+    <message id="settings_firmware_check_for_updates">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="71"/>
+      <source>Check for updates</source>
+      <translation>Kyk vir opdaterings</translation>
+    </message>
+    <message id="settings_firmware_update_available">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="79"/>
+      <source>Update available</source>
+      <translation>Opdatering beskikbaar</translation>
+    </message>
+    <message id="settings_firmware_online_installing_progress">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="85"/>
+      <source>Installing %1 %2%</source>
+      <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
+      <translation>Installeer tans %1 %2%</translation>
+    </message>
+    <message id="settings_firmware_update_build_date_time">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="112"/>
+      <source>Update build date/time</source>
+      <translation type="unfinished">Opdateer bou-datum/-tyd op</translation>
+    </message>
+    <message id="page_settings_fronius_inverters">
+      <location filename="../../pages/settings/PageSettingsFronius.qml" line="30"/>
+      <source>Inverters</source>
+      <translation>Omsetters</translation>
+    </message>
+    <message id="page_settings_fronius_find_pv_inverters">
+      <location filename="../../pages/settings/PageSettingsFronius.qml" line="36"/>
+      <source>Find PV inverters</source>
+      <translation>Soek PV-omsetters</translation>
+    </message>
+    <message id="page_settings_fronius_detected_ip_addresses">
+      <location filename="../../pages/settings/PageSettingsFronius.qml" line="43"/>
+      <source>Detected IP addresses</source>
+      <translation>Bespeur IP-adresse</translation>
+    </message>
+    <message id="page_settings_fronius_add_ip_address_manually">
+      <location filename="../../pages/settings/PageSettingsFronius.qml" line="49"/>
+      <source>Add IP address manually</source>
+      <translation>Voeg IP-adres handmatig by</translation>
+    </message>
+    <message id="page_settings_fronius_tcp_port">
+      <location filename="../../pages/settings/PageSettingsFronius.qml" line="55"/>
+      <source>TCP port</source>
+      <translation>TCP-poort</translation>
+    </message>
+    <message id="page_settings_fronius_inverter_multiphase">
+      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
+      <source>Multiphase</source>
+      <translation>Meerfasig</translation>
+    </message>
+    <message id="page_settings_fronius_inverter_l1">
+      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
+      <source>L1</source>
+      <translation>L1</translation>
+    </message>
+    <message id="page_settings_fronius_inverter_l2">
+      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="48"/>
+      <source>L2</source>
+      <translation>L2</translation>
+    </message>
+    <message id="page_settings_fronius_inverter_l3">
+      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="50"/>
+      <source>L3</source>
+      <translation>L3</translation>
+    </message>
+    <message id="page_settings_fronius_inverter_split_phase">
+      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="52"/>
+      <source>Split-phase (L1+L2)</source>
+      <translation>Gesplete fase (L1+L2)</translation>
+    </message>
+    <message id="page_settings_fronius_inverter_show">
+      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="59"/>
+      <source>Show</source>
+      <translation>Wys</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_mp">
+      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="39"/>
+      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="95"/>
+      <source>AC-In1 MP</source>
+      <translation type="unfinished">WS-In1 MP</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_l1">
+      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="101"/>
+      <source>AC-In1 L%1</source>
+      <translation type="unfinished">WS-In1 L%1</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_unknown">
+      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="105"/>
+      <source>AC-In1 --</source>
+      <translation type="unfinished">WS-In1 --</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_out_mp">
+      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="57"/>
+      <source>AC-Out MP</source>
+      <translation type="unfinished">WS-Uit MP</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_out_l">
+      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="63"/>
+      <source>AC-Out L%1</source>
+      <translation type="unfinished">WS-Uit L%1</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_out_phase_unknown">
+      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="67"/>
+      <source>AC-Out --</source>
+      <translation>WS-Uit-</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in2_mp">
+      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="76"/>
+      <source>AC-In2 MP</source>
+      <translation type="unfinished">WS-In2 MP</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in2_l1">
+      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="82"/>
+      <source>AC-In2 L%1</source>
+      <translation type="unfinished">WS-In2 L%1</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in2_phase_unknown">
+      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="86"/>
+      <source>AC-In2 --</source>
+      <translation type="unfinished">WS-In2 --</translation>
+    </message>
+    <message id="settings_fronius_rescan_title">
+      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="40"/>
+      <source>Rescan for IP addresses?</source>
+      <translation>Herskandeer vir IP-adresse?</translation>
+    </message>
+    <message id="settings_fronius_rescan">
+      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="42"/>
+      <source>Rescan</source>
+      <translation>Skandeer weer/Herskandeer</translation>
+    </message>
+    <message id="settings_ssh_on_lan">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="240"/>
+      <source>SSH on LAN</source>
+      <translation type="unfinished">SSH op LAN</translation>
+    </message>
+    <message id="settings_remote_support">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="249"/>
+      <source>Remote support</source>
+      <translation>Afstandsondersteuning</translation>
+    </message>
+    <message id="settings_remote_support_tunnel">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="255"/>
+      <source>Remote support tunnel</source>
+      <translation>Afgeleë ondersteuningstonnel</translation>
+    </message>
+    <message id="settings_remote_ip_and_support">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="264"/>
+      <source>Remote support IP and port</source>
+      <translation>Afgeleë ondersteuning IP en poort</translation>
+    </message>
+    <message id="settings_reboot_now">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="300"/>
+      <source>Reboot now</source>
+      <translation>Herlaai nou</translation>
+    </message>
+    <message id="settings_audible_alarm">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="340"/>
+      <source>Audible alarm</source>
+      <translation>Hoorbare alarm</translation>
+    </message>
+    <message id="settings_demo_mode">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="359"/>
+      <source>Demo mode</source>
+      <translation>Demo-modus</translation>
+    </message>
+    <message id="page_settings_demo_ess">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="368"/>
+      <source>ESS demo</source>
+      <translation>ESS demo</translation>
+    </message>
+    <message id="page_settings_demo_1">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="370"/>
+      <source>Boat/Motorhome demo 1</source>
+      <translation>Boot/motorhuis demo 1</translation>
+    </message>
+    <message id="page_settings_demo_2">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="372"/>
+      <source>Boat/Motorhome demo 2</source>
+      <translation>Boot/motorhuis demo 2</translation>
+    </message>
+    <message id="settings_demo_mode_caption">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="382"/>
+      <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
+      <translation>As u demo-modus begin, sal sommige instellings verander en die gebruikerskoppelvlak sal vir 'n oomblik nie reageer nie.</translation>
+    </message>
+    <message id="page_settings_generator_conditions">
+      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="29"/>
+      <source>Conditions</source>
+      <translation>Voorwaardes</translation>
+    </message>
+    <message id="page_settings_generator_minimum_run_time">
+      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="35"/>
+      <source>Minimum run time</source>
+      <translation>Minimum looptyd</translation>
+    </message>
+    <message id="page_settings_generator_warm_up_time">
+      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="56"/>
+      <source>Warm-up time</source>
+      <translation>Opwarmingstyd</translation>
+    </message>
+    <message id="page_settings_generator_cool_down_time">
+      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="65"/>
+      <source>Cool-down time</source>
+      <translation>Afkoeltyd</translation>
+    </message>
+    <message id="page_settings_generator_detect_generator_at_ac_input">
+      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="89"/>
+      <source>Detect generator at AC input</source>
+      <translation>Bespeur kragopwekker by WS-invoer</translation>
+    </message>
+    <message id="page_settings_generator_detect_generator_not_set">
+      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="96"/>
+      <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
+      <translation>Nie een van die WS-insette is op kragopwekker ingestel nie. Gaan na die instellingsbladsy en stel die korrekte WS-invoer na kragopwekker om hierdie funksionaliteit te aktiveer.</translation>
+    </message>
+    <message id="page_settings_generator_detect_generator_set">
+      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="100"/>
+      <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
+      <translation>'n Alarm sal geaktiveer word wanneer geen krag van die kragopwekker by die wisselsetter se wisselstroom-ingang bespeur word nie. Maak seker dat die korrekte WS-inset ingestel is na die opwekker op die stelselopstellingsbladsy</translation>
+    </message>
+    <message id="page_settings_generator_quiet_hours_start_time">
+      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="142"/>
+      <source>Quiet hours start time</source>
+      <translation>Stil-ure begin tyd</translation>
+    </message>
+    <message id="page_settings_generator_quiet_hours_end_time">
+      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="150"/>
+      <source>Quiet hours end time</source>
+      <translation>Stil-ure eindtyd</translation>
+    </message>
+    <message id="page_settings_generator_run_time_and_service">
+      <location filename="../../components/PageGensetModel.qml" line="293"/>
+      <location filename="../../pages/settings/PageGenerator.qml" line="110"/>
+      <source>Run time and service</source>
+      <translation>Looptyd en diens</translation>
+    </message>
+    <message id="page_settings_run_time_and_service_reset_daily_run_time_counters">
+      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
+      <source>Reset daily run time counters</source>
+      <translation>Stel daaglikse looptydtellers terug</translation>
+    </message>
+    <message id="page_settings_run_time_and_service_runtime_counter_reset">
+      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="99"/>
+      <source>The daily runtime counter has been reset</source>
+      <translation>Die daaglikse looptydteller is teruggestel</translation>
+    </message>
+    <message id="page_settings_run_time_and_service_runtime_counter_cant_reset_while_running">
+      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="102"/>
+      <source>It is not possible to modify the counters while the generator is running</source>
+      <translation>Dit is nie moontlik om die tellers te verander terwyl die kragopwekker aan die gang is nie</translation>
+    </message>
+    <message id="page_settings_generator_service_interval">
+      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="159"/>
+      <source>Generator service interval (hours)</source>
+      <translation>Opwekker diens interval (ure)</translation>
+    </message>
+    <message id="page_settings_run_time_and_service_service_time_interval">
+      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="167"/>
+      <source>Service time interval set to %1h. Use the 'Reset service timer' button to reset the service timer.</source>
+      <translation>Dienstydinterval gestel op %1h. Gebruik die 'Herstel dienstydteller'-knoppie om die dienstydteller terug te stel.</translation>
+    </message>
+    <message id="page_settings_run_time_and_service_reset_service_timer">
+      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="178"/>
+      <source>Reset service timer</source>
+      <translation>Stel dienstydteller terug</translation>
+    </message>
+    <message id="settings_gps_settings">
+      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="67"/>
+      <source>GPS Settings</source>
+      <translation>GPS-instellings</translation>
+    </message>
+    <message id="settings_gps_format">
+      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="81"/>
+      <source>Format</source>
+      <extracomment>Format of reported GPS data</extracomment>
+      <translation>Formaat</translation>
+    </message>
+    <message id="settings_gps_format_dms_example">
+      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="86"/>
+      <source>52° 20' 41.6" N, 5° 13' 12.3" E</source>
+      <extracomment>Example of GPS data in the 'Degrees, Minutes, Seconds' format</extracomment>
+      <translation>52° 20' 41.6" N, 5° 13' 12.3" O</translation>
+    </message>
+    <message id="settings_gps_format_dd_example">
+      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="89"/>
+      <source>52.34489, 5.22008</source>
+      <extracomment>Example of GPS data in the 'Decimal Degrees' format</extracomment>
+      <translation>52.34489, 5.22008</translation>
+    </message>
+    <message id="settings_gps_format_dm_example">
+      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="92"/>
+      <source>52° 20.693 N, 5° 13.205 E</source>
+      <extracomment>Example of GPS data in the 'Degrees Minutes' format</extracomment>
+      <translation>52° 20.693 N, 5° 13.205 O</translation>
+    </message>
+    <message id="settings_gps_speed_unit">
+      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="99"/>
+      <source>Speed Unit</source>
+      <extracomment>Speed unit for reported GPS data</extracomment>
+      <translation>Eenheid van spoed</translation>
+    </message>
+    <message id="settings_gps_format_kmh">
+      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="103"/>
+      <source>Kilometers per hour</source>
+      <translation>Kilometer per uur</translation>
+    </message>
+    <message id="settings_gps_format_ms">
+      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="105"/>
+      <source>Meters per second</source>
+      <translation>Meter per sekonde</translation>
+    </message>
+    <message id="settings_gps_format_mph">
+      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="107"/>
+      <source>Miles per hour</source>
+      <translation>Myl per uur</translation>
+    </message>
+    <message id="settings_gps_format_kt">
+      <location filename="../../pages/settings/PageSettingsGpsList.qml" line="109"/>
+      <source>Knots</source>
+      <translation>Knope</translation>
+    </message>
+    <message id="page_settings_no_gsm_modem_connected">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="40"/>
+      <source>No GSM modem connected</source>
+      <translation>Geen GSM-modem gekoppel nie</translation>
+    </message>
+    <message id="page_settings_gsm_internet">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="51"/>
+      <source>Internet</source>
+      <translation>Internet</translation>
+    </message>
+    <message id="page_settings_gsm_carrier">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="60"/>
+      <source>Carrier</source>
+      <translation>Draer</translation>
+    </message>
+    <message id="page_settings_gsm_error_message">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="86"/>
+      <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
+If that doesn't work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
+      <translation>Dit mag nodig wees om die APN-instellings hieronder op hierdie bladsy op te stel, kontak jou operateur vir besonderhede.
+As dit nie werk nie, gaan sim-kaart in 'n foon na om seker te maak dat daar krediet is en/of dit is geregistreer om vir data gebruik te word.</translation>
+    </message>
+    <message id="page_settings_gsm_allow_roaming">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="92"/>
+      <source>Allow roaming</source>
+      <translation>Laat rondswerf toe</translation>
+    </message>
+    <message id="page_settings_gsm_sim_status">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="99"/>
+      <source>Sim status</source>
+      <extracomment>SIM in Afrikaans is; Intekenaar Identiteits Modum - IIM</extracomment>
+      <translation type="unfinished">IIM status</translation>
+    </message>
+    <message id="page_settings_gsm_sim_not_inserted">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="104"/>
+      <source>SIM not inserted</source>
+      <translation type="unfinished">IIM nie ingesit nie</translation>
+    </message>
+    <message id="page_settings_gsm_pin_required">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="107"/>
+      <source>PIN required</source>
+      <translation>PIN vereis</translation>
+    </message>
+    <message id="page_settings_gsm_puk_required">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="110"/>
+      <source>PUK required</source>
+      <extracomment>Persoonlike Ontblokkings Kode</extracomment>
+      <translation type="unfinished">POK vereis</translation>
+    </message>
+    <message id="page_settings_gsm_sim_failure">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="113"/>
+      <source>SIM failure</source>
+      <translation type="unfinished">IIM-fout</translation>
+    </message>
+    <message id="page_settings_gsm_sim_busy">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="116"/>
+      <source>SIM busy</source>
+      <translation type="unfinished">IIM besig</translation>
+    </message>
+    <message id="page_settings_gsm_wrong_sim">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="119"/>
+      <source>Wrong SIM</source>
+      <translation type="unfinished">Verkeerde IIM</translation>
+    </message>
+    <message id="page_settings_gsm_wrong_pin">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="122"/>
+      <source>Wrong PIN</source>
+      <translation>Verkeerde PIN</translation>
+    </message>
+    <message id="page_settings_gsm_ready">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
+      <source>Ready</source>
+      <translation>Gereed</translation>
+    </message>
+    <message id="page_settings_gsm_pin">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="136"/>
+      <source>PIN</source>
+      <translation>PIN - Persoonlike Identifikasie Nommer</translation>
+    </message>
+    <message id="page_settings_gsm_apn">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="152"/>
+      <source>APN</source>
+      <translation type="unfinished">TPN - Toegangspunt Naam</translation>
+    </message>
+    <message id="page_settings_gsm_default">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="154"/>
+      <source>Default</source>
+      <translation>Verstek</translation>
+    </message>
+    <message id="page_settings_gsm_use_default_apn">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="168"/>
+      <source>Use default APN</source>
+      <translation type="unfinished">Gebruik verstek TPN</translation>
+    </message>
+    <message id="page_settings_gsm_apn_name">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="180"/>
+      <source>APN name</source>
+      <translation type="unfinished">TPN naam</translation>
+    </message>
+    <message id="page_settings_gsm_use_authentication">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="194"/>
+      <source>Use authentication</source>
+      <translation>Gebruik verifikasie</translation>
+    </message>
+    <message id="page_settings_gsm_user_name">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="209"/>
+      <source>User name</source>
+      <translation>Gebruikersnaam</translation>
+    </message>
+    <message id="page_settings_gsm_imei">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="224"/>
+      <source>IMEI</source>
+      <translation type="unfinished">IMTI - Internationale Mobiele Toerusing Identiteit</translation>
+    </message>
+    <message id="settings_ess_battery_life_self_consumption">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="15"/>
+      <source>Self-consumption</source>
+      <translation>Selfverbruik</translation>
+    </message>
+    <message id="settings_ess_no_ess_assistant">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="22"/>
+      <source>No ESS Assistant found</source>
+      <extracomment>Werker Self Diens</extracomment>
+      <translation type="unfinished">Geen WSD-assistent gevind nie</translation>
+    </message>
+    <message id="settings_ess_grid_metering">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="58"/>
+      <source>Grid metering</source>
+      <translation>Roostermeting</translation>
+    </message>
+    <message id="settings_ess_external_meter">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
+      <source>External meter</source>
+      <translation>Eksterne meter</translation>
+    </message>
+    <message id="settings_ess_inverter_charger">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
+      <source>Inverter/Charger</source>
+      <translation>Omsetter/laaier</translation>
+    </message>
+    <message id="settings_ess_multiphase_regulation">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
+      <source>Multiphase regulation</source>
+      <translation>Multifase regulering</translation>
+    </message>
+    <message id="settings_ess_phase_compensation">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="92"/>
+      <source>Total of all phases</source>
+      <translation>Totaal van alle fases</translation>
+    </message>
+    <message id="settings_ess_individual_phase">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="94"/>
+      <source>Individual phase</source>
+      <translation>Individuele fase</translation>
+    </message>
+    <message id="settings_ess_multiphase_split_notif">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="100"/>
+      <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
+
+CAUTION: Use only if required by the utility provider.</source>
+      <translation>Elke fase word gereguleer om individueel die roosterstelpunt te bereik (stelseldoeltreffendheid word verminder).
+
+WAARSKUWING: Gebruik slegs indien dit deur die diensteverskaffer vereis word.</translation>
+    </message>
+    <message id="settings_ess_multiphase_total_notif">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="103"/>
+      <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
+
+Use unless prohibited by the utility provider.</source>
+      <translation>Die totaal van alle fases word intelligent gereguleer om die roosterstelpunt te bereik (stelseldoeltreffendheid is geoptimaliseer).
+
+Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
+    </message>
+    <message id="settings_rs_ess_min_soc">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="40"/>
+      <source>Minimum SOC (unless grid fails)</source>
+      <extracomment>Sekuriteits Bedryfs Sentrum</extracomment>
+      <translation type="unfinished">Minimum SBS (tensy rooster misluk)</translation>
+    </message>
+    <message id="settings_rs_active_soc_limit">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="57"/>
+      <source>Active SOC limit</source>
+      <translation type="unfinished">Aktiewe SBS limiet</translation>
+    </message>
+    <message id="settings_ess_peak_shaving">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="251"/>
+      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
+      <source>Peak shaving</source>
+      <translation type="unfinished">Piek skeer</translation>
+    </message>
+    <message id="settings_ess_above_minimum_soc_only">
+      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
+      <source>Above minimum SOC only</source>
+      <translation type="unfinished">Slegs bo die minimum SBS</translation>
+    </message>
+    <message id="settings_ess_always">
+      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="60"/>
+      <source>Always</source>
+      <translation>Altyd</translation>
+    </message>
+    <message id="settings_ess_battery_life_discharge_disabled">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
+      <source>Discharge disabled</source>
+      <translation>Ontlading gedeaktiveer</translation>
+    </message>
+    <message id="settings_ess_battery_life_slow_charge">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="157"/>
+      <source>Slow charge</source>
+      <translation>Stadige lading</translation>
+    </message>
+    <message id="inverters_state_system_sustain">
+      <location filename="../../data/System.qml" line="194"/>
+      <source>Sustain</source>
+      <translation>Onderhou</translation>
+    </message>
+    <message id="inverters_state_recharge">
+      <location filename="../../data/System.qml" line="197"/>
+      <source>Recharge</source>
+      <translation>Herlaai</translation>
+    </message>
+    <message id="settings_ess_limit_charge_power">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="169"/>
+      <source>Limit charge power</source>
+      <translation>Beperk laaikrag</translation>
+    </message>
+    <message id="settings_ess_max_charge_power">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="188"/>
+      <source>Maximum charge power</source>
+      <translation>Maksimum laaikrag</translation>
+    </message>
+    <message id="settings_ess_limit_inverter_power">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="201"/>
+      <source>Limit inverter power</source>
+      <translation>Beperk Omsetter krag </translation>
+    </message>
+    <message id="settings_ess_max_inverter_power">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="220"/>
+      <source>Maximum inverter power</source>
+      <translation>Maksimum Omsetter krag</translation>
+    </message>
+    <message id="settings_ess_grid_setpoint">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="231"/>
+      <source>Grid setpoint</source>
+      <translation>Rooster stelpunt</translation>
+    </message>
+    <message id="settings_ess_grid_feed_in">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="240"/>
+      <source>Grid feed-in</source>
+      <translation>Roosterinvoer</translation>
+    </message>
+    <message id="settings_ess_ac_coupled_pv">
+      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
+      <source>AC-coupled PV - feed in excess</source>
+      <translation>WS-gekoppelde PV - voer in oormaat</translation>
+    </message>
+    <message id="settings_ess_dc_coupled_pv">
+      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
+      <source>DC-coupled PV - feed in excess</source>
+      <translation>DS-gekoppelde PV - voer in oormaat</translation>
+    </message>
+    <message id="settings_ess_limit_system_feed_in">
+      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="46"/>
+      <source>Limit system feed-in</source>
+      <translation>Beperk stelseltoevoer</translation>
+    </message>
+    <message id="settings_ess_max_feed_in">
+      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="62"/>
+      <source>Maximum feed-in</source>
+      <translation>Maksimum toevoer</translation>
+    </message>
+    <message id="settings_ess_feed_in_limiting_active">
+      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
+      <source>Feed-in limiting active</source>
+      <translation>Invoerbeperking aktief</translation>
+    </message>
+    <message id="settings_io_analog_inputs">
+      <location filename="../../pages/settings/PageSettingsIo.qml" line="32"/>
+      <source>Analog inputs</source>
+      <translation>Analoog insette</translation>
+    </message>
+    <message id="settings_io_digital_inputs">
+      <location filename="../../pages/settings/PageSettingsIo.qml" line="60"/>
+      <source>Digital inputs</source>
+      <translation>Digitale insette</translation>
+    </message>
+    <message id="settings_io_digital_input">
+      <location filename="../../pages/settings/PageSettingsIo.qml" line="90"/>
+      <source>Digital input %1</source>
+      <extracomment>%1 = number of the digital input</extracomment>
+      <translation>Digitale invoer %1</translation>
+    </message>
+    <message id="digitalinputs_type_pulsemeter">
+      <location filename="../../src/enums.cpp" line="60"/>
+      <source>Pulse meter</source>
+      <translation>Pulsmeter</translation>
+    </message>
+    <message id="digitalinputs_type_dooralarm">
+      <location filename="../../src/enums.cpp" line="63"/>
+      <source>Door alarm</source>
+      <translation>Deur alarm</translation>
+    </message>
+    <message id="digitalinputs_type_bilgepump">
+      <location filename="../../src/enums.cpp" line="66"/>
+      <source>Bilge pump</source>
+      <translation type="unfinished">Lenspomp</translation>
+    </message>
+    <message id="digitalinputs_type_bilgealarm">
+      <location filename="../../src/enums.cpp" line="69"/>
+      <source>Bilge alarm</source>
+      <translation type="unfinished">Bilge alarm</translation>
+    </message>
+    <message id="digitalinputs_type_burglaralarm">
+      <location filename="../../src/enums.cpp" line="72"/>
+      <source>Burglar alarm</source>
+      <translation>Diefwering</translation>
+    </message>
+    <message id="digitalinputs_type_smokealarm">
+      <location filename="../../src/enums.cpp" line="75"/>
+      <source>Smoke alarm</source>
+      <translation>Rookalarm</translation>
+    </message>
+    <message id="digitalinputs_type_firealarm">
+      <location filename="../../src/enums.cpp" line="78"/>
+      <source>Fire alarm</source>
+      <translation>Brandalarm</translation>
+    </message>
+    <message id="digitalinputs_type_co2alarm">
+      <location filename="../../src/enums.cpp" line="81"/>
+      <source>CO2 alarm</source>
+      <translation>CO2 alarm</translation>
+    </message>
+    <message id="settings_io_bt_sensors">
+      <location filename="../../pages/settings/PageSettingsIo.qml" line="101"/>
+      <source>Bluetooth sensors</source>
+      <translation>Bluetooth-sensors</translation>
+    </message>
+    <message id="settings_large_features_not_offically_supported">
+      <location filename="../../pages/settings/PageSettingsLarge.qml" line="16"/>
+      <source>Note that these features are not officially supported by Victron. Please turn to community.victronenergy.com for questions.
+
+Documentation at https://ve3.nl/vol</source>
+      <translation>Let daarop dat hierdie kenmerke nie amptelik deur Victron ondersteun word nie. Draai asseblief na community.victronenergy.com vir vrae.
+
+Dokumentasie by https://ve3.nl/vol</translation>
+    </message>
+    <message id="settings_large_signal_k">
+      <location filename="../../pages/settings/PageSettingsLarge.qml" line="23"/>
+      <source>Signal K</source>
+      <translation>Sein K</translation>
+    </message>
+    <message id="settings_large_node_red">
+      <location filename="../../pages/settings/PageSettingsLarge.qml" line="38"/>
+      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
+      <source>Node-RED</source>
+      <translation>Node-ROOI</translation>
+    </message>
+    <message id="settings_large_enabled_safe_mode">
+      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="24"/>
+      <source>Enabled (safe mode)</source>
+      <translation>Geaktiveer (veilige modus)</translation>
+    </message>
+    <message id="settings_logging_time_ago_deferred">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="22"/>
+      <source>Deferred by %1s</source>
+      <extracomment>%1 = number of seconds</extracomment>
+      <translation>Uitgestel met %1s</translation>
+    </message>
+    <message id="settings_vrm_portal_id">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="86"/>
+      <source>VRM Portal ID</source>
+      <extracomment>Volt Regulerings Mode</extracomment>
+      <translation>VRM Portaal ID</translation>
+    </message>
+    <message id="settings_log_interval">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="92"/>
+      <source>Log interval</source>
+      <translation>Log interval</translation>
+    </message>
+    <message id="settings_5_min">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="97"/>
+      <source>5 min</source>
+      <translation>5 min</translation>
+    </message>
+    <message id="settings_15_min">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="101"/>
+      <source>15 min</source>
+      <translation>15 min</translation>
+    </message>
+    <message id="settings_1_hr">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="105"/>
+      <source>1 hour</source>
+      <translation>1 uur</translation>
+    </message>
+    <message id="settings_2_hr">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="107"/>
+      <source>2 hours</source>
+      <translation>2 ure</translation>
+    </message>
+    <message id="settings_4_hr">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="109"/>
+      <source>4 hours</source>
+      <translation>4 ure</translation>
+    </message>
+    <message id="settings_12_hr">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="111"/>
+      <source>12 hours</source>
+      <translation>12 uur</translation>
+    </message>
+    <message id="settings_1_day">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="113"/>
+      <source>1 day</source>
+      <translation>1 dag</translation>
+    </message>
+    <message id="settings_https_enabled">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="123"/>
+      <source>Use secure connection (HTTPS)</source>
+      <translation type="unfinished">Gebruik veilige verbinding (HTTPS)</translation>
+    </message>
+    <message id="settings_last_contact">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="135"/>
+      <source>Last contact</source>
+      <translation>Laaste kontak</translation>
+    </message>
+    <message id="settings_connection_error_150">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="191"/>
+      <source>#150 Unexpected response text</source>
+      <translation>#150 Onverwagse reaksieteks</translation>
+    </message>
+    <message id="settings_connection_error_151">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="194"/>
+      <source>#151 Unexpected HTTP response</source>
+      <translation>#151 Onverwagte HTTP-reaksie</translation>
+    </message>
+    <message id="settings_connection_error_152">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="197"/>
+      <source>#152 Connection timeout</source>
+      <translation>#152 Verbinding uitteltyd</translation>
+    </message>
+    <message id="settings_connection_error_153">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="200"/>
+      <source>#153 Connection error</source>
+      <translation>#153 Verbindingsfout</translation>
+    </message>
+    <message id="settings_connection_error_154">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="203"/>
+      <source>#154 DNS failure</source>
+      <translation>#154 DNS-fout</translation>
+    </message>
+    <message id="settings_connection_error_155">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="206"/>
+      <source>#155 Routing error</source>
+      <translation>#155 Routing fout</translation>
+    </message>
+    <message id="settings_connection_error_156">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="209"/>
+      <source>#156 VRM unavailable</source>
+      <translation>#156 VRM nie beskikbaar nie</translation>
+    </message>
+    <message id="settings_connection_error_157">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="212"/>
+      <source>#159 Unknown error</source>
+      <translation>#159 Onbekende fout</translation>
+    </message>
+    <message id="settings_vrm_error_message">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="229"/>
+      <source>Error message: 
+%1</source>
+      <translation>Foutboodskap:
+%1</translation>
+    </message>
+    <message id="settings_no_contact_reboot">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="254"/>
+      <source>Reboot device when no contact</source>
+      <translation>Herlaai toestel wanneer geen kontak nie</translation>
+    </message>
+    <message id="settings_vrm_no_contact_reset_delay">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="264"/>
+      <source>No contact reset delay (hh:mm)</source>
+      <translation>Geen kontak-terugstelling vertraging (uu:mm)</translation>
+    </message>
+    <message id="settings_vrm_storage_location">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="270"/>
+      <source>Storage location</source>
+      <translation>Bergingsplek</translation>
+    </message>
+    <message id="settings_vrm_no_buffer_active">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="272"/>
+      <source>No buffer active</source>
+      <translation>Geen buffer aktief nie</translation>
+    </message>
+    <message id="settings_vrm_internal_storage">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="275"/>
+      <source>Internal storage</source>
+      <translation>Interne bergplek</translation>
+    </message>
+    <message id="settings_vrm_transferring">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="277"/>
+      <source>Transferring</source>
+      <translation>Oordrag</translation>
+    </message>
+    <message id="settings_vrm_external_storage">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="279"/>
+      <source>External storage</source>
+      <translation>Eksterne berging</translation>
+    </message>
+    <message id="settings_vrm_no_error">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="291"/>
+      <source>No Error</source>
+      <translation>Geen fout nie</translation>
+    </message>
+    <message id="settings_vrm_no_space_error">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="293"/>
+      <source>No space left on storage</source>
+      <translation>Geen spasie oor op berging nie</translation>
+    </message>
+    <message id="settings_vrm_io_error">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="295"/>
+      <source>IO error</source>
+      <translation>IO fout</translation>
+    </message>
+    <message id="settings_vrm_mount_error">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="297"/>
+      <source>Mount error</source>
+      <translation>Monteer fout</translation>
+    </message>
+    <message id="settings_vrm_storage_contains_firmware_error">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="299"/>
+      <source>Contains firmware image. Not using.</source>
+      <translation>Bevat firmware-beeld. Gebruik nie.</translation>
+    </message>
+    <message id="settings_vrm_storage_not_writable_error">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="301"/>
+      <source>SD card / USB stick not writable</source>
+      <translation>SD-kaart / USB-stok nie skryfbaar nie</translation>
+    </message>
+    <message id="settings_vrm_free_disk_space">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="310"/>
+      <source>Free disk space</source>
+      <translation>Vrye skyfspasie</translation>
+    </message>
+    <message id="settings_vrm_byte">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="313"/>
+      <source>byte</source>
+      <translation>greep</translation>
+    </message>
+    <message id="settings_vrm_bytes">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="315"/>
+      <source>bytes</source>
+      <translation>grepe</translation>
+    </message>
+    <message id="settings_vrm_stored_records">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="323"/>
+      <source>Stored records</source>
+      <translation>Gestoorde rekords</translation>
+    </message>
+    <message id="settings_vrm_records_count">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="326"/>
+      <source>%1 records</source>
+      <translation>%1 rekords</translation>
+    </message>
+    <message id="settings_vrm_oldest_record_age">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="334"/>
+      <source>Oldest record age</source>
+      <translation>Oudste rekord ouderdom</translation>
+    </message>
+    <message id="settings_modbus_enable_modbus_tcp">
+      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
+      <source>Enable Modbus/TCP</source>
+      <translation type="unfinished">Aktiveer Modbus/TCP</translation>
+    </message>
+    <message id="settings_modbus_no_errors">
+      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
+      <source>No errors reported</source>
+      <translation>Geen foute gerapporteer nie</translation>
+    </message>
+    <message id="settings_modbus_time_of_last_error">
+      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
+      <source>Time of last error</source>
+      <translation>Tyd van laaste fout</translation>
+    </message>
+    <message id="settings_modbus_available_services">
+      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="60"/>
+      <source>Available services</source>
+      <translation>Beskikbare dienste</translation>
+    </message>
+    <message id="settings_modbus_unit_id">
+      <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
+      <source>Unit ID: %1</source>
+      <translation>Eenheid-ID: %1</translation>
+    </message>
+    <message id="settings_relay_function_relay1">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="20"/>
+      <source>Function (Relay 1)</source>
+      <translation>Funksie (aflos 1)</translation>
+    </message>
+    <message id="settings_relay_function">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="22"/>
+      <source>Function</source>
+      <translation>Funksie</translation>
+    </message>
+    <message id="settings_relay_alarm_relay">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="26"/>
+      <source>Alarm relay</source>
+      <translation>Alarm weerstand</translation>
+    </message>
+    <message id="settings_relay_alarm_polarity">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="43"/>
+      <source>Alarm relay polarity</source>
+      <translation>Alarm weerstand polariteit</translation>
+    </message>
+    <message id="settings_relay_normally_open">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="48"/>
+      <source>Normally open</source>
+      <translation>Normaal oop</translation>
+    </message>
+    <message id="settings_relay_normally_closed">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="50"/>
+      <source>Normally closed</source>
+      <translation>Normaal toe</translation>
+    </message>
+    <message id="settings_relay_relay1on">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="59"/>
+      <source>Relay 1 on</source>
+      <translation>Weerstand 1 aan</translation>
+    </message>
+    <message id="settings_relay_on">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="61"/>
+      <source>Relay on</source>
+      <translation>Weerstand aan</translation>
+    </message>
+    <message id="settings_relay_function_relay2">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="70"/>
+      <source>Function (Relay 2)</source>
+      <translation>Funksie (Weerstand 2)</translation>
+    </message>
+    <message id="settings_relay_relay2on">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="84"/>
+      <source>Relay 2 on</source>
+      <translation>Weerstand 2 aan</translation>
+    </message>
+    <message id="settings_relay_temp_control_rules">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="92"/>
+      <source>Temperature control rules</source>
+      <translation>Temperatuurbeheerreëls</translation>
+    </message>
+    <message id="settings_relay_activate_on_temp">
+      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="97"/>
+      <source>Relay activation on temperature</source>
+      <translation>Weerstand aktivering op temperatuur</translation>
+    </message>
+    <message id="settings_relay_no_temperature_relay">
+      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="121"/>
+      <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to "Temperature".</source>
+      <translation>Geen weerstand is gekonfigureer om deur temperatuur geaktiveer te word nie. Gaan na die aflosinstellingsbladsy wat in die hoofinstellingskieslys geleë is en stel die weerstandsfunksie op "Temperatuur".</translation>
+    </message>
+    <message id="settings_firmware_version_switch_option">
+      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
+      <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
+      <translation>Hierdie opsie laat jou toe om te wissel tussen die huidige en die vorige firmware weergawe. Geen internet of standaarddeviasiekaart nodig nie.</translation>
+    </message>
+    <message id="settings_firmware_current_version">
+      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
+      <source>Firmware %1 (%2)</source>
+      <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
+      <translation>Fermware %1 (%2)</translation>
+    </message>
+    <message id="settings_firmware_press_to_boot">
+      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
+      <source>Press to boot</source>
+      <translation>Druk om te begin</translation>
+    </message>
+    <message id="settings_firmware_rebooting_to">
+      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
+      <source>Rebooting to %1</source>
+      <extracomment>%1 = backup version</extracomment>
+      <translation>Herbegin tans na %1</translation>
+    </message>
+    <message id="settings_firmware_switching_not_possible">
+      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
+      <source>Switching firmware version is not possible when auto update is set to "Check and update". Set auto update to "Disabled" or "Check only" to enable this option.</source>
+      <translation>Verandering van firmware-weergawe is nie moontlik wanneer outomatiese opdatering op "Kontroleer en werk op" gestel is nie. Stel outomatiese opdatering op "Gedeaktiveer" of "Slegs kontroleer" om hierdie opsie te aktiveer.</translation>
+    </message>
+    <message id="settings_firmware_backup_not_available">
+      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
+      <source>Backup firmware not available</source>
+      <translation>Rugsteun-firmware nie beskikbaar nie</translation>
+    </message>
+    <message id="settings_services_modbus_tcp">
+      <location filename="../../pages/settings/PageSettingsServices.qml" line="16"/>
+      <source>Modbus TCP</source>
+      <translation type="unfinished">Modbus TCP</translation>
+    </message>
+    <message id="settings_services_canbus_over_tcpip_debug">
+      <location filename="../../pages/settings/PageSettingsServices.qml" line="76"/>
+      <source>CAN-bus over TCP/IP (Debug)</source>
+      <translation>CAN-bus oor TCP/IP (Ontfout)</translation>
+    </message>
+    <message id="settings_system_shore_power">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
+      <source>Shore power</source>
+      <translation type="unfinished">Oewer krag</translation>
+    </message>
+    <message id="settings_system_name_vehicle">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="43"/>
+      <source>Vehicle</source>
+      <translation>Voertuig</translation>
+    </message>
+    <message id="settings_system_name_boat">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="45"/>
+      <source>Boat</source>
+      <translation>Boot</translation>
+    </message>
+    <message id="settings_system_name">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="50"/>
+      <source>System name</source>
+      <translation>Stelsel naam</translation>
+    </message>
+    <message id="settings_tcpip_auto">
+      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="225"/>
+      <source>Automatic</source>
+      <translation>Outomatiese</translation>
+    </message>
+    <message id="settings_system_name_user_defined">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="65"/>
+      <source>User defined</source>
+      <translation>Gebruiker gedefinieerd</translation>
+    </message>
+    <message id="settings_system_user_defined_name">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="72"/>
+      <source>User-defined name</source>
+      <translation>Gebruiker-gedefinieerde naam</translation>
+    </message>
+    <message id="settings_system_ac_input_1">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="84"/>
+      <source>AC input 1</source>
+      <translation>WS-invoer 1</translation>
+    </message>
+    <message id="settings_system_ac_input_2">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="93"/>
+      <source>AC input 2</source>
+      <translation>WS-invoer 2</translation>
+    </message>
+    <message id="settings_system_monitor_for_grid_failure">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="135"/>
+      <source>Monitor for grid failure</source>
+      <translation>Monitor vir rooster mislukking</translation>
+    </message>
+    <message id="settings_system_monitor_for_shore_disconnect">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="137"/>
+      <source>Monitor for shore disconnect</source>
+      <translation type="unfinished">Monitor vir wal ontkoppel</translation>
+    </message>
+    <message id="settings_system_auto_selected">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="175"/>
+      <source>Auto-selected</source>
+      <translation>Outo-geselekteer</translation>
+    </message>
+    <message id="settings_system_has_dc_system">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="184"/>
+      <source>Has DC system</source>
+      <translation>Het DS-stelsel</translation>
+    </message>
+    <message id="settings_system_status_sync_vebus_soc_with_battery">
+      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
+      <source>Synchronize VE.Bus SOC with battery</source>
+      <translation>Sinchroniseer VE.Bus SBS met battery</translation>
+    </message>
+    <message id="settings_system_status_solar_charger_vebus">
+      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
+      <source>Use solar charger current to improve VE.Bus SOC</source>
+      <translation>Gebruik sonkraglaaierstroom om VE.Bus SBS te verbeter</translation>
+    </message>
+    <message id="settings_system_status_solar_charger_voltage_control">
+      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
+      <source>Solar charger voltage control</source>
+      <translation>Sonkraglaaier spanningsbeheer</translation>
+    </message>
+    <message id="settings_system_status_solar_charger_current_control">
+      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
+      <source>Solar charger current control</source>
+      <translation>Sonkraglaaier stroombeheer</translation>
+    </message>
+    <message id="charger_network_bms_control">
+      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="128"/>
+      <source>BMS control</source>
+      <oldsource>BMS Control</oldsource>
+      <translation type="unfinished">BMS beheer</translation>
+    </message>
+    <message id="settings_pump_function_not_enabled">
+      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="38"/>
+      <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to "Tank pump".</source>
+      <translation>Tenkpomp begin/stop-funksie is nie geaktiveer nie. Gaan na weerstandinstellings en stel funksie op "Tankpomp".</translation>
+    </message>
+    <message id="settings_pump_state">
+      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
+      <source>Pump state</source>
+      <translation>Pomp toestand</translation>
+    </message>
+    <message id="settings_tank_sensor">
+      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
+      <source>Tank sensor</source>
+      <translation>Tenk sensor</translation>
+    </message>
+    <message id="settings_tank_start_level">
+      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="90"/>
+      <source>Start level</source>
+      <translation>Begin vlak</translation>
+    </message>
+    <message id="settings_tank_stop_level">
+      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="99"/>
+      <source>Stop level</source>
+      <translation>Stop vlak</translation>
+    </message>
+    <message id="settings_tcpip_connection_lost">
+      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="125"/>
+      <source>Connection lost</source>
+      <translation>Konneksie verlore</translation>
+    </message>
+    <message id="settings_tcpip_connection_unplugged">
+      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="127"/>
+      <source>Unplugged</source>
+      <translation>Ontkoppel</translation>
+    </message>
+    <message id="settings_tcpip_hidden">
+      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="146"/>
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="82"/>
+      <source>[Hidden]</source>
+      <translation>[Versteek]</translation>
+    </message>
+    <message id="settings_tcpip_connect_to_network">
+      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="169"/>
+      <source>Connect to network?</source>
+      <translation>Koppel aan netwerk?</translation>
+    </message>
+    <message id="settings_tcpip_connect">
+      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="171"/>
+      <source>Connect</source>
+      <translation>Koppel</translation>
+    </message>
+    <message id="settings_tcpip_forget_network">
+      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="182"/>
+      <source>Forget network?</source>
+      <translation>Netwerk vergeet?</translation>
+    </message>
+    <message id="settings_tcpip_forget">
+      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="184"/>
+      <source>Forget</source>
+      <translation>Vergeet</translation>
+    </message>
+    <message id="settings_tcpip_forget_confirm">
+      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="196"/>
+      <source>Are you sure that you want to forget this network?</source>
+      <translation>Is jy seker jy wil hierdie netwerk vergeet?</translation>
+    </message>
+    <message id="settings_tcpip_mac_address">
+      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="212"/>
+      <source>MAC address</source>
+      <translation type="unfinished">MAC adres</translation>
+    </message>
+    <message id="settings_tcpip_ip_config">
+      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="221"/>
+      <source>IP configuration</source>
+      <translation>IP-konfigurasie</translation>
+    </message>
+    <message id="settings_tcpip_fixed">
+      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="231"/>
+      <source>Fixed</source>
+      <translation>Vaste</translation>
+    </message>
+    <message id="settings_tcpip_netmask">
+      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="258"/>
+      <source>Netmask</source>
+      <translation type="unfinished">Netmasker</translation>
+    </message>
+    <message id="settings_tcpip_gateway">
+      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="266"/>
+      <source>Gateway</source>
+      <translation>Poort</translation>
+    </message>
+    <message id="settings_tcpip_dns_server">
+      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="274"/>
+      <source>DNS server</source>
+      <translation type="unfinished">DNS-bediener</translation>
+    </message>
+    <message id="settings_tcpip_link_local">
+      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="284"/>
+      <source>Link-local IP address</source>
+      <translation>Skakel-plaaslike IP-adres</translation>
+    </message>
+    <message id="settings_vecan_instance_zero_warning">
+      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="29"/>
+      <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
+      <translation type="unfinished">Versigtig, vir WSD-stelsels, sowel as stelsels met 'n bestuurde battery, moet die CAN-bus-toestelinstansie op 0 gekonfigureer bly. Sien GX-handleiding vir meer inligting.</translation>
+    </message>
+    <message id="settings_vecan_device_instance">
+      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
+      <source>Device Instance</source>
+      <translation>Toestel instansie</translation>
+    </message>
+    <message id="settings_vecan_nad">
+      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="45"/>
+      <source>Network Address</source>
+      <translation>Netwerk adres</translation>
+    </message>
+    <message id="settings_vecan_devices">
+      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
+      <source>VE.CAN devices</source>
+      <translation type="unfinished">VE.CAN toestelle</translation>
+    </message>
+    <message id="settings_vecan_device_number">
+      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="29"/>
+      <source>Device# %1</source>
+      <translation>Toestel# %1</translation>
+    </message>
+    <message id="settings_wifi_no_access_points">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="72"/>
+      <source>No access points</source>
+      <translation>Geen toegangspunte nie</translation>
+    </message>
+    <message id="settings_wifi_no_wifi_adapter_connected">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="74"/>
+      <source>No Wi-Fi adapter connected</source>
+      <translation type="unfinished">Geen Wi-Fi-adapter gekoppel nie</translation>
+    </message>
+    <message id="settings_wifi_create_ap">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="29"/>
+      <source>Create access point</source>
+      <translation>Skep toegangspunt</translation>
+    </message>
+    <message id="settings_wifi_networks">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="64"/>
+      <source>Wi-Fi networks</source>
+      <translation>Wi-Fi-netwerke</translation>
+    </message>
+    <message id="settings_wifi_disable_ap_are_you_sure">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="53"/>
+      <source>Are you sure that you want to disable the access point?</source>
+      <translation>Is jy seker jy wil die toegangspunt deaktiveer?</translation>
+    </message>
+    <message id="settings_tz_date_time_utc">
+      <location filename="../../pages/settings/PageTzInfo.qml" line="87"/>
+      <source>Date/Time UTC</source>
+      <translation>Datum/Tyd UTK</translation>
+    </message>
+    <message id="settings_tz_date_time_local">
+      <location filename="../../pages/settings/PageTzInfo.qml" line="98"/>
+      <source>Date/Time local</source>
+      <translation>Datum/tyd plaaslik</translation>
+    </message>
+    <message id="settings_tz_time_zone">
+      <location filename="../../pages/settings/PageTzInfo.qml" line="117"/>
+      <source>Time zone</source>
+      <translation>Tydsone</translation>
+    </message>
+    <message id="settings_tz_africa">
+      <location filename="../../pages/settings/PageTzInfo.qml" line="206"/>
+      <source>Africa</source>
+      <translation>Afrika</translation>
+    </message>
+    <message id="settings_tz_america">
+      <location filename="../../pages/settings/PageTzInfo.qml" line="212"/>
+      <source>America</source>
+      <translation>Amerika</translation>
+    </message>
+    <message id="settings_tz_antartica">
+      <location filename="../../pages/settings/PageTzInfo.qml" line="218"/>
+      <source>Antartica</source>
+      <translation>Antarktika</translation>
+    </message>
+    <message id="settings_tz_artic">
+      <location filename="../../pages/settings/PageTzInfo.qml" line="224"/>
+      <source>Artic</source>
+      <translation>Artiek</translation>
+    </message>
+    <message id="settings_tz_asia">
+      <location filename="../../pages/settings/PageTzInfo.qml" line="230"/>
+      <source>Asia</source>
+      <translation>Asië</translation>
+    </message>
+    <message id="settings_tz_atlantic">
+      <location filename="../../pages/settings/PageTzInfo.qml" line="236"/>
+      <source>Atlantic</source>
+      <translation>Atlantiese Oseaan</translation>
+    </message>
+    <message id="settings_tz_ustralia">
+      <location filename="../../pages/settings/PageTzInfo.qml" line="242"/>
+      <source>Australia</source>
+      <translation>Australië</translation>
+    </message>
+    <message id="settings_tz_europe">
+      <location filename="../../pages/settings/PageTzInfo.qml" line="248"/>
+      <source>Europe</source>
+      <translation>Europa</translation>
+    </message>
+    <message id="settings_tz_indian">
+      <location filename="../../pages/settings/PageTzInfo.qml" line="254"/>
+      <source>Indian</source>
+      <translation>Indiese</translation>
+    </message>
+    <message id="settings_tz_pacific">
+      <location filename="../../pages/settings/PageTzInfo.qml" line="260"/>
+      <source>Pacific</source>
+      <translation>Stille Oseaan</translation>
+    </message>
+    <message id="settings_tz_etc">
+      <location filename="../../pages/settings/PageTzInfo.qml" line="266"/>
+      <source>Etc</source>
+      <translation>Ens</translation>
+    </message>
+    <message id="settings_vrm_device_instances_unconnected">
+      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="301"/>
+      <source>Unconnected %1</source>
+      <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
+      <translation>Ontkoppel %1</translation>
+    </message>
+    <message id="settings_vrm_device_instances_reboot_now">
+      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="389"/>
+      <source>Reboot now?</source>
+      <translation>Herlaai nou?</translation>
+    </message>
+    <message id="settings_vrm_device_instances_reboot_now_description">
+      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="392"/>
+      <source>VRM instance changes will not be applied until the device is rebooted.</source>
+      <translation>VRM-instansieveranderinge sal nie toegepas word totdat die toestel herselflaai is nie.</translation>
+    </message>
+    <message id="settings_vrm_device_instances_rebooting">
+      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="412"/>
+      <source>Device is rebooting...</source>
+      <translation>Toestel herlaai tans …</translation>
+    </message>
+    <message id="settings_vrm_device_instances_rebooted">
+      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="415"/>
+      <source>Device has been rebooted.</source>
+      <translation>Toestel is herlaai.</translation>
+    </message>
+    <message id="settings_accharger_low_battery_voltage_alarm">
+      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="96"/>
+      <source>Low battery voltage alarm</source>
+      <translation>Lae battery spanning alarm</translation>
+    </message>
+    <message id="settings_accharger_high_battery_voltage_alarm">
+      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="105"/>
+      <source>High battery voltage alarm</source>
+      <translation>Hoë battery spanning alarm</translation>
+    </message>
+    <message id="common_words_last_error">
+      <location filename="../../components/CommonWords.qml" line="559"/>
+      <source>Last error</source>
+      <extracomment>Details of last error</extracomment>
+      <translation>Laaste fout</translation>
+    </message>
+    <message id="common_words_2nd_last_error">
+      <location filename="../../components/CommonWords.qml" line="562"/>
+      <source>2nd last error</source>
+      <extracomment>Details of 2nd last error</extracomment>
+      <translation>2de laaste fout</translation>
+    </message>
+    <message id="common_words_3rd_last_error">
+      <location filename="../../components/CommonWords.qml" line="565"/>
+      <source>3rd last error</source>
+      <extracomment>Details of 3rd last error</extracomment>
+      <translation>3de laaste fout</translation>
+    </message>
+    <message id="common_words_4th_last_error">
+      <location filename="../../components/CommonWords.qml" line="568"/>
+      <source>4th last error</source>
+      <extracomment>Details of 4th last error</extracomment>
+      <translation>4de laaste fout</translation>
+    </message>
+    <message id="charger_networked">
+      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="22"/>
+      <source>Networked</source>
+      <translation>Genetwerk</translation>
+    </message>
+    <message id="charger_mode_setting">
+      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="37"/>
+      <source>Mode setting</source>
+      <translation>Modus instelling</translation>
+    </message>
+    <message id="systemsettings_networkstatus_standalone">
+      <location filename="../../data/SystemSettings.qml" line="103"/>
+      <source>Standalone</source>
+      <extracomment>Network status: Standalone</extracomment>
+      <translation>Selfstandig</translation>
+    </message>
+    <message id="charger_charge">
+      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="48"/>
+      <source>Charge</source>
+      <translation>Laai</translation>
+    </message>
+    <message id="charger_charge_hub_1">
+      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="54"/>
+      <source>Charge &amp; HUB-1</source>
+      <translation>Laai &amp; HUB-1</translation>
+    </message>
+    <message id="charger_bms">
+      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="57"/>
+      <source>BMS</source>
+      <translation>BMS</translation>
+    </message>
+    <message id="charger_charge_bms">
+      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="60"/>
+      <source>Charge &amp; BMS</source>
+      <translation>Laai &amp; BMS</translation>
+    </message>
+    <message id="charger_ext_control_bms">
+      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="63"/>
+      <source>Ext. Control &amp; BMS</source>
+      <translation>Uitbr. Beheer en BMS</translation>
+    </message>
+    <message id="charger_charge_hub_1_bms">
+      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="66"/>
+      <source>Charge, Hub-1 &amp; BMS</source>
+      <translation>Laai, Hub-1 en BMS</translation>
+    </message>
+    <message id="charger_master_setting">
+      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="77"/>
+      <source>Master setting</source>
+      <translation>Meesterinstelling</translation>
+    </message>
+    <message id="systemsettings_networkstatus_slave">
+      <location filename="../../data/SystemSettings.qml" line="87"/>
+      <source>Slave</source>
+      <extracomment>Network status: Slave</extracomment>
+      <translation>Slaaf</translation>
+    </message>
+    <message id="charger_group_master">
+      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="88"/>
+      <source>Group master</source>
+      <translation>Groepmeester</translation>
+    </message>
+    <message id="charger_charge_master">
+      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="91"/>
+      <source>Charge master</source>
+      <translation>Laaimeester</translation>
+    </message>
+    <message id="charger_group_charge_master">
+      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="94"/>
+      <source>Group &amp; Charge master</source>
+      <translation>Groep- &amp; Laaimeester</translation>
+    </message>
+    <message id="charger_charge_voltage">
+      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="105"/>
+      <source>Charge voltage</source>
+      <translation>Laai spanning</translation>
+    </message>
+    <message id="common_words_reset">
+      <location filename="../../components/CommonWords.qml" line="388"/>
+      <source>Reset</source>
+      <extracomment>Reset the BMS control</extracomment>
+      <translation>Herstel</translation>
+    </message>
+    <message id="charger_network_bms_control_info">
+      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="140"/>
+      <source>BMS control is enabled automatically when BMS is present. Reset if the system configuration changed or if there is no BMS present.</source>
+      <translation>BMS-beheer word outomaties geaktiveer wanneer BMS teenwoordig is. Herstel as die stelselkonfigurasie verander het of as daar geen BMS teenwoordig is nie.</translation>
+    </message>
+    <message id="charger_load">
+      <location filename="../../pages/solar/SolarChargerPage.qml" line="117"/>
+      <source>Load</source>
+      <translation>Laai</translation>
+    </message>
+    <message id="charger_history_found_with_count">
+      <location filename="../../pages/solar/SolarChargerPage.qml" line="152"/>
+      <source>%1 found</source>
+      <extracomment>Shows number of items found. %1 = number of items</extracomment>
+      <translation>%1 gevind</translation>
+    </message>
+    <message id="settings_multirs_history_name">
+      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="121"/>
+      <source>%1 History</source>
+      <extracomment>Solar charger historic data information. %1 = charger name</extracomment>
+      <translation>%1 Geskiedenis</translation>
+    </message>
+    <message id="charger_networked_operation">
+      <location filename="../../pages/solar/SolarChargerPage.qml" line="197"/>
+      <source>Networked operation</source>
+      <translation>Genetwerkte werking</translation>
+    </message>
+    <message id="charger_history_table_view">
+      <location filename="../../pages/solar/SolarHistoryPage.qml" line="24"/>
+      <source>Table view</source>
+      <translation>Tafelaansig</translation>
+    </message>
+    <message id="charger_history_chart">
+      <location filename="../../pages/solar/SolarHistoryPage.qml" line="26"/>
+      <source>Chart</source>
+      <translation>Grafiek</translation>
+    </message>
+    <message id="listitems_alarm_level_warning">
+      <location filename="../../components/listitems/core/ListAlarm.qml" line="21"/>
+      <source>Warning</source>
+      <extracomment>Voltage alarm is at "Warning" level</extracomment>
+      <translation>Waarskuwing</translation>
+    </message>
+    <message id="digitalinputs_state_alarm">
+      <location filename="../../src/enums.cpp" line="135"/>
+      <source>Alarm</source>
+      <extracomment>Relay function is 'alarm'</extracomment>
+      <translation>Alarm</translation>
+    </message>
+    <message id="components_volumeunit_volume">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="56"/>
+      <source>Volume</source>
+      <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
+      <translation>Volume</translation>
+    </message>
+    <message id="tank_status_short_circuited">
+      <location filename="../../data/Tanks.qml" line="132"/>
+      <source>Short circuited</source>
+      <translation>Kortsluiting</translation>
+    </message>
+    <message id="tank_status_reverse_polarity">
+      <location filename="../../data/Tanks.qml" line="135"/>
+      <source>Reverse polarity</source>
+      <translation>Omgekeerde polariteit</translation>
+    </message>
+    <message id="evcs_charging_stations">
+      <location filename="../../pages/evcs/EvChargerListPage.qml" line="13"/>
+      <source>EV Charging Stations</source>
+      <translation>EV-laaistasies</translation>
+    </message>
+    <message id="evcs_session">
+      <location filename="../../pages/evcs/EvChargerPage.qml" line="40"/>
+      <source>Session</source>
+      <translation>Sessie</translation>
+    </message>
+    <message id="evcs_charging_time">
+      <location filename="../../pages/evcs/EvChargerPage.qml" line="62"/>
+      <source>Time</source>
+      <extracomment>Charging time for the EV charger</extracomment>
+      <translation>Tyd</translation>
+    </message>
+    <message id="evcs_charge_mode">
+      <location filename="../../pages/evcs/EvChargerPage.qml" line="109"/>
+      <source>Charge mode</source>
+      <translation>Laaimodus</translation>
+    </message>
+    <message id="evcs_manual_caption">
+      <location filename="../../data/EvChargers.qml" line="32"/>
+      <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
+      <translation>Begin en stop die proses self. Gebruik dit vir vinnige laaie en noukeurige monitering.</translation>
+    </message>
+    <message id="evcs_auto_caption">
+      <location filename="../../data/EvChargers.qml" line="38"/>
+      <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
+      <translation>Begin en stop gebaseer op die batterylaaivlak. Laai oornag vir optimale en verlengde ladings om oorlading te vermy.</translation>
+    </message>
+    <message id="evcs_scheduled_caption">
+      <location filename="../../data/EvChargers.qml" line="44"/>
+      <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
+      <translation>Laer elektrisiteitstariewe gedurende nie-spitstye of as jy wil verseker dat jou EV ten volle gelaai is en gereed is teen 'n spesifieke tyd.</translation>
+    </message>
+    <message id="evcs_enable_charging">
+      <location filename="../../pages/evcs/EvChargerPage.qml" line="127"/>
+      <source>Enable charging</source>
+      <translation>Aktiveer laai</translation>
+    </message>
+    <message id="evcs_lock_charger_display">
+      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="29"/>
+      <source>Lock charger display</source>
+      <translation>Sluit laaierskerm</translation>
+    </message>
+    <message id="settings_rvc_source_address">
+      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
+      <source>Source Address</source>
+      <translation>Bronadres</translation>
+    </message>
+    <message id="settings_rvc_configuration">
+      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
+      <source>Configuration</source>
+      <translation>Konfigurasie</translation>
+    </message>
+    <message id="settings_rvc_line_instance_num">
+      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
+      <source>Line instance #%1</source>
+      <extracomment>%1 = number of this line instance</extracomment>
+      <translation>Lyninstansie #%1</translation>
+    </message>
+    <message id="settings_rvc_line_instance">
+      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
+      <source>Line instance</source>
+      <translation>Lyninstansie</translation>
+    </message>
+    <message id="settings_rvc_charger_instance">
+      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
+      <source>Charger instance</source>
+      <translation>Laaier-instansie</translation>
+    </message>
+    <message id="settings_rvc_inverter_instance">
+      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
+      <source>Inverter instance</source>
+      <translation>Omsetter instansie</translation>
+    </message>
+    <message id="settings_rvc_dc_source_#_instance">
+      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="79"/>
+      <source>DC source #%1 instance</source>
+      <extracomment>%1 = number of this DC source</extracomment>
+      <translation>DS bron #%1 instansie</translation>
+    </message>
+    <message id="settings_rvc_dc_source_instance">
+      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
+      <source>DC source instance</source>
+      <translation>DS bron instansie</translation>
+    </message>
+    <message id="settings_rvc_dc_source_#_priority">
+      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="90"/>
+      <source>DC source #%1 priority</source>
+      <extracomment>%1 = number of this DC source</extracomment>
+      <translation>DS bron #%1 prioriteit</translation>
+    </message>
+    <message id="settings_rvc_dc_source_priority">
+      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="92"/>
+      <source>DC source priority</source>
+      <translation>DS bron prioriteit</translation>
+    </message>
+    <message id="settings_rvc_tank_instance">
+      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="102"/>
+      <source>Tank instance</source>
+      <translation>Tenk voorbeeld</translation>
+    </message>
+    <message id="settings_rvc_devices">
+      <location filename="../../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
+      <source>RV-C devices</source>
+      <translation>RV-C toestelle</translation>
+    </message>
+    <message id="settings_page_debug_enable_fps_visualizer">
+      <location filename="../../pages/settings/debug/PageDebug.qml" line="50"/>
+      <source>Enable frame-rate visualizer</source>
+      <translation>Aktiveer raamtempo-visualiseerder</translation>
+    </message>
+    <message id="devicelist_unsupported">
+      <location filename="../../pages/settings/devicelist/delegates/DeviceListDelegate_unsupported.qml" line="14"/>
+      <source>Unsupported</source>
+      <extracomment>Device is not supported</extracomment>
+      <translation>Ongesteun</translation>
+    </message>
+    <message id="devicelist_remove_disconnected_devices">
+      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="59"/>
+      <source>Remove disconnected devices</source>
+      <translation>Verwyder ontkoppelde toestelle</translation>
+    </message>
+    <message id="devicelist_unsupporteddevices_found">
+      <location filename="../../pages/settings/devicelist/PageUnsupportedDevice.qml" line="18"/>
+      <source>Unsupported device found</source>
+      <translation>Ongesteunde toestel gevind</translation>
+    </message>
+    <message id="batterysettingrelay_relay_function">
+      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
+      <source>Relay function</source>
+      <translation>Aflos funksie</translation>
+    </message>
+    <message id="batterysettingrelay_charger_or_generator_start_stop">
+      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
+      <source>Charger or generator start/stop</source>
+      <translation>Laaier of kragopwekker begin/stop</translation>
+    </message>
+    <message id="common_words_manual_control">
+      <location filename="../../components/CommonWords.qml" line="256"/>
+      <source>Manual control</source>
+      <translation>Handmatige beheer</translation>
+    </message>
+    <message id="batterysettingrelay_always_open_dont_use_the_relay">
+      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
+      <source>Always open (don't use the relay)</source>
+      <translation>Altyd oop (moenie die weerstand gebruik nie)</translation>
+    </message>
+    <message id="batterysettingrelay_low_state_of_charge_setting_note">
+      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
+      <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
+      <translation>Let daarop dat die verandering van die Laer toestand-van-laai-instelling ook die Tyd-tot-Bedryf verander, ontlaai vloerinstelling in die batterykieslys </translation>
+    </message>
+    <message id="lynxdistributor_fuse_blown">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
+      <source>Fuse blown</source>
+      <translation>Sekering geblaas</translation>
+    </message>
+    <message id="batterydiagnostics_status_leds">
+      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
+      <source>Status LEDs</source>
+      <translation>Status LED's</translation>
+    </message>
+    <message id="batterydiagnostics_main_switch">
+      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
+      <source>Main Switch</source>
+      <translation>Hoofskakelaar</translation>
+    </message>
+    <message id="batterydiagnostics_heater">
+      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="55"/>
+      <source>Heater</source>
+      <translation>Verwarmer</translation>
+    </message>
+    <message id="batterydiagnostics_internal_fan">
+      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="62"/>
+      <source>Internal Fan</source>
+      <translation>Interne waaier</translation>
+    </message>
+    <message id="batterydiagnostics_warning_flags">
+      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="69"/>
+      <source>Warning Flags</source>
+      <translation>Waarskuwingsvlae</translation>
+    </message>
+    <message id="batterydiagnostics_alarm_flags">
+      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="75"/>
+      <source>Alarm Flags</source>
+      <translation>Alarmvlae</translation>
+    </message>
+    <message id="common_words_switch">
+      <location filename="../../components/CommonWords.qml" line="462"/>
+      <source>Switch</source>
+      <extracomment>Change the battery mode</extracomment>
+      <translation>Skakel oor</translation>
+    </message>
+    <message id="devicelist_battery_initializing">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="46"/>
+      <source>Initializing</source>
+      <translation>Inisialiseer</translation>
+    </message>
+    <message id="devicelist_battery_shutdown">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="57"/>
+      <source>Shutdown</source>
+      <extracomment>Status is 'Shutdown'</extracomment>
+      <translation>Afskakeling</translation>
+    </message>
+    <message id="devicelist_battery_updating">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="61"/>
+      <source>Updating</source>
+      <extracomment>Status is 'Updating'</extracomment>
+      <translation>Dateer tans op</translation>
+    </message>
+    <message id="devicelist_battery_going_to_run">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="67"/>
+      <source>Going to run</source>
+      <extracomment>Status is 'Going to run'</extracomment>
+      <translation>Gaan hardloop</translation>
+    </message>
+    <message id="devicelist_battery_pre_charging">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="71"/>
+      <source>Pre-Charging</source>
+      <extracomment>Status is 'Pre-Charging'</extracomment>
+      <translation>Vooraflaai</translation>
+    </message>
+    <message id="devicelist_battery_contactor_check">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="75"/>
+      <source>Contactor check</source>
+      <extracomment>Status is 'Contactor check'</extracomment>
+      <translation>Kontroleer kontak</translation>
+    </message>
+    <message id="batteryalarms_state_of_health">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
+      <source>State of health</source>
+      <translation>Gesondheidstoestand</translation>
+    </message>
+    <message id="common_words_battery_temperature">
+      <location filename="../../components/CommonWords.qml" line="89"/>
+      <source>Battery temperature</source>
+      <translation>Battery temperatuur</translation>
+    </message>
+    <message id="battery_air_temp">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="200"/>
+      <source>Air temperature</source>
+      <translation>Lug temperatuur</translation>
+    </message>
+    <message id="battery_starter_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="207"/>
+      <source>Starter voltage</source>
+      <translation>Aansitter spanning</translation>
+    </message>
+    <message id="battery_buss_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="255"/>
+      <source>Bus voltage</source>
+      <translation>Busspanning</translation>
+    </message>
+    <message id="battery_top_section_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="223"/>
+      <source>Top section voltage</source>
+      <translation>Top seksie spanning</translation>
+    </message>
+    <message id="battery_bottom_section_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="231"/>
+      <source>Bottom section voltage</source>
+      <translation>Onderste gedeelte spanning</translation>
+    </message>
+    <message id="battery_mid_point_deviation">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="239"/>
+      <source>Mid-point deviation</source>
+      <translation>Middelpuntafwyking</translation>
+    </message>
+    <message id="battery_consumed_amphours">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="247"/>
+      <source>Consumed AmpHours</source>
+      <translation>UurVerbruik AmpUur</translation>
+    </message>
+    <message id="battery_time_to_go">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="263"/>
+      <source>Time-to-go</source>
+      <translation>Tyd om te gaan</translation>
+    </message>
+    <message id="battery_details">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="279"/>
+      <source>Details</source>
+      <translation>Besonderhede</translation>
+    </message>
+    <message id="battery_module_level_alarms">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="303"/>
+      <source>Module level alarms</source>
+      <translation>Module vlak alarms</translation>
+    </message>
+    <message id="battery_settings_diagnostics">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="338"/>
+      <source>Diagnostics</source>
+      <translation>Diagnostiek</translation>
+    </message>
+    <message id="battery_settings_fuses">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="363"/>
+      <source>Fuses</source>
+      <translation>Versekerings</translation>
+    </message>
+    <message id="battery_settings_io">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="379"/>
+      <source>IO</source>
+      <translation>IO</translation>
+    </message>
+    <message id="battery_settings_system">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="394"/>
+      <source>System</source>
+      <translation>Stelsel</translation>
+    </message>
+    <message id="battery_settings_parameters">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="417"/>
+      <source>Parameters</source>
+      <translation>Grense</translation>
+    </message>
+    <message id="battery_redetect_battery">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="442"/>
+      <source>Redetect Battery</source>
+      <translation>Herken Battery</translation>
+    </message>
+    <message id="vebus_device_press_to_redetect">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="203"/>
+      <source>Press to redetect</source>
+      <translation>Druk om te herken</translation>
+    </message>
+    <message id="battery_redetecting_the_battery_note">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="451"/>
+      <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
+      <translation>magDie herbespeuring van die battery mag dalk 60 sekondes neem. Intussen kan die naam van die battery verkeerd wees.</translation>
+    </message>
+    <message id="batteryalarms_high_charge_current">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
+      <source>High charge current</source>
+      <translation>Hoë laaistroom</translation>
+    </message>
+    <message id="batteryalarms_high_discharge_current">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
+      <source>High discharge current</source>
+      <translation>Hoë ontladingsstroom</translation>
+    </message>
+    <message id="evchargers_status_low_state_of_charge">
+      <location filename="../../data/EvChargers.qml" line="127"/>
+      <source>Low SOC</source>
+      <translation>Lae SBS</translation>
+    </message>
+    <message id="batteryalarms_low_starter_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="73"/>
+      <source>Low starter voltage</source>
+      <translation>Lae aansitterspanning</translation>
+    </message>
+    <message id="batteryalarms_high_starter_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="80"/>
+      <source>High starter voltage</source>
+      <translation>Hoë aansitterspanning</translation>
+    </message>
+    <message id="batteryalarms_battery_temperature_sensor">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="99"/>
+      <source>Battery temperature sensor</source>
+      <translation>Battery temperatuur sensor</translation>
+    </message>
+    <message id="batteryalarms_mid_point_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
+      <source>Mid-point voltage</source>
+      <translation>Middelpuntspanning</translation>
+    </message>
+    <message id="batteryalarms_high_internal_temperature">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
+      <source>High internal temperature</source>
+      <translation>Hoë interne temperatuur</translation>
+    </message>
+    <message id="batteryalarms_low_charge_temperature">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
+      <source>Low charge temperature</source>
+      <translation>Lae laai temperatuur</translation>
+    </message>
+    <message id="batteryalarms_high_charge_temperature">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
+      <source>High charge temperature</source>
+      <translation>Hoë laai temperatuur</translation>
+    </message>
+    <message id="batteryalarms_internal_failure">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
+      <source>Internal failure</source>
+      <translation>Interne faling</translation>
+    </message>
+    <message id="batteryalarms_circuit_breaker_tripped">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
+      <source>Circuit breaker tripped</source>
+      <translation>Stroombreker het uitgeskakel</translation>
+    </message>
+    <message id="batteryalarms_cell_imbalance">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="155"/>
+      <source>Cell imbalance</source>
+      <translation>Sel wanbalans</translation>
+    </message>
+    <message id="batteryalarms_low_cell_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="162"/>
+      <source>Low cell voltage</source>
+      <translation>Lae selspanning</translation>
+    </message>
+    <message id="batterydetails_lowest_cell_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
+      <source>Lowest cell voltage</source>
+      <translation>Laagste selspanning</translation>
+    </message>
+    <message id="batterydetails_highest_cell_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
+      <source>Highest cell voltage</source>
+      <translation>Hoogste selspanning</translation>
+    </message>
+    <message id="batterydetails_minimum_cell_temperature">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
+      <source>Minimum cell temperature</source>
+      <translation>Minimum sel temperatuur</translation>
+    </message>
+    <message id="batterydetails_maximum_cell_temperature">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="54"/>
+      <source>Maximum cell temperature</source>
+      <translation>Maksimum sel temperatuur</translation>
+    </message>
+    <message id="batterydetails_modules">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
+      <source>Battery modules</source>
+      <translation>Battery modules</translation>
+    </message>
+    <message id="devicelist_batterydetails_modules_online">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="73"/>
+      <source>%1 online</source>
+      <extracomment>%1 = number of battery modules that are online</extracomment>
+      <translation>%1 aanlyn</translation>
+    </message>
+    <message id="devicelist_batterydetails_modules_offline">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="76"/>
+      <source>%1 offline</source>
+      <extracomment>%1 = number of battery modules that are offline</extracomment>
+      <translation>%1 van lyn af</translation>
+    </message>
+    <message id="batterydetails_number_of_modules_blocking_charge_discharge">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="83"/>
+      <source>Number of modules blocking charge / discharge</source>
+      <translation>Aantal modules wat lading/ontlading blokkeer</translation>
+    </message>
+    <message id="batterydetails_installed_available_capacity">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="90"/>
+      <source>Installed / Available capacity</source>
+      <translation>Geïnstalleerde / Beskikbare kapasiteit</translation>
+    </message>
+    <message id="batteryalarms_deepest_discharge">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
+      <source>Deepest discharge</source>
+      <translation>Diepste ontlading</translation>
+    </message>
+    <message id="batteryhistory_last_discharge">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
+      <source>Last discharge</source>
+      <translation>Laaste ontlading</translation>
+    </message>
+    <message id="batteryhistory_average_discharge">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
+      <source>Average discharge</source>
+      <translation>Gemiddelde ontlading</translation>
+    </message>
+    <message id="batteryhistory_total_charge_cycles">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
+      <source>Total charge cycles</source>
+      <translation>Totale ladingsiklusse</translation>
+    </message>
+    <message id="batteryhistory_number_of_full_discharges">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
+      <source>Number of full discharges</source>
+      <translation>Aantal volle ontladings</translation>
+    </message>
+    <message id="batteryhistory_cumulative_ah_drawn">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
+      <source>Cumulative Ah drawn</source>
+      <translation>Kumulatief Au getrek</translation>
+    </message>
+    <message id="batteryhistory_minimum_cell_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
+      <source>Minimum cell voltage</source>
+      <translation>Minimum selspanning</translation>
+    </message>
+    <message id="batteryhistory_maximum_cell_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
+      <source>Maximum cell voltage</source>
+      <translation>Maksimum selspanning</translation>
+    </message>
+    <message id="batteryhistory_time_since_last_full_charge">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
+      <source>Time since last full charge</source>
+      <translation>Tyd sedert laaste volle lading</translation>
+    </message>
+    <message id="batteryhistory_synchronisation_count">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
+      <source>Synchronisation count</source>
+      <translation>Sinchronisasietelling</translation>
+    </message>
+    <message id="batteryhistory_low_starter_bat_voltage_alarms">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
+      <source>Low starter battery voltage alarms</source>
+      <translation>Lae aansitter battery spanning alarms</translation>
+    </message>
+    <message id="batteryhistory_minimum_starter_bat_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
+      <source>Minimum starter battery voltage</source>
+      <translation>Minimum aansitter battery spanning</translation>
+    </message>
+    <message id="batteryhistory_maximum_starter_bat_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
+      <source>Maximum starter battery voltage</source>
+      <translation>Maksimum aansitter battery spanning</translation>
+    </message>
+    <message id="batteryhistory_discharged_energy">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
+      <source>Discharged energy</source>
+      <translation>Ontlaaide energie</translation>
+    </message>
+    <message id="batteryhistory_charged_energy">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
+      <source>Charged energy</source>
+      <translation>Gelaaide energie</translation>
+    </message>
+    <message id="batteryparameters_charge_voltage_limit_cvl">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
+      <source>Charge Voltage Limit (CVL)</source>
+      <translation type="unfinished">LSBLaaispanningsbeperking (LSB)</translation>
+    </message>
+    <message id="batteryparameters_charge_current_limit_ccl">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
+      <source>Charge Current Limit (CCL)</source>
+      <translation type="unfinished">Laai huidige limiet (LSL)</translation>
+    </message>
+    <message id="batteryparameters_discharge_current_limit_dcl">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
+      <source>Discharge Current Limit (DCL)</source>
+      <translation type="unfinished">Ontladingsstroomlimiet (OSL)</translation>
+    </message>
+    <message id="batteryparameters_low_voltage_disconnect_always_ignored">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
+      <source>Low Voltage Disconnect (always ignored)</source>
+      <translation>Laespanning ontkoppel (ignoreer altyd)</translation>
+    </message>
+    <message id="batterysettings_battery_bank">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
+      <source>Battery bank</source>
+      <translation>Battery bank</translation>
+    </message>
+    <message id="batterysettings_relay_on_battery_monitor">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
+      <source>Relay (on battery monitor)</source>
+      <translation>Weerstand (op batterymonitor)</translation>
+    </message>
+    <message id="batterysettings_restore_factory_defaults">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
+      <source>Restore factory defaults</source>
+      <translation>Herstel fabrieksinstellings</translation>
+    </message>
+    <message id="batterysettings_press_to_restore">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
+      <source>Press to restore</source>
+      <translation>Druk om te herstel</translation>
+    </message>
+    <message id="batterysettings_confirm_restore_factory_defaults">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
+      <source>Restore factory defaults?</source>
+      <translation>Herstel fabrieksverstellings?</translation>
+    </message>
+    <message id="batterysettings_bluetooth_enabled">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
+      <source>Bluetooth Enabled</source>
+      <translation>Bluetooth geaktiveer</translation>
+    </message>
+    <message id="batterysettingsbattery_nominal_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
+      <source>Nominal Voltage</source>
+      <translation>Nominale spanning</translation>
+    </message>
+    <message id="batterysettingsbattery_12_volt">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
+      <source>12 Volt</source>
+      <translation>12 Volt</translation>
+    </message>
+    <message id="batterysettingsbattery_24_volt">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
+      <source>24 Volt</source>
+      <translation>24 Volt</translation>
+    </message>
+    <message id="batterysettingsbattery_48_volt">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
+      <source>48 Volt</source>
+      <translation>48 Volt</translation>
+    </message>
+    <message id="devicelist_tanksetup_capacity">
+      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="19"/>
+      <source>Capacity</source>
+      <translation>Kapasiteit</translation>
+    </message>
+    <message id="batterysettingsbattery_charged_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
+      <source>Charged voltage</source>
+      <translation>Gelaaide spanning</translation>
+    </message>
+    <message id="batterysettingsbattery_tail_current">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
+      <source>Tail current</source>
+      <translation type="unfinished">Stertstroom</translation>
+    </message>
+    <message id="batterysettingsbattery_charged_detection_time">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
+      <source>Charged detection time</source>
+      <translation>Gelaaide opsporingstyd</translation>
+    </message>
+    <message id="batterysettingsbattery_peukert_exponent">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
+      <source>Peukert exponent</source>
+      <translation type="unfinished">Peukert eksponent</translation>
+    </message>
+    <message id="batterysettingsbattery_charge_efficiency_factor">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
+      <source>Charge efficiency factor</source>
+      <translation>Laai doeltreffendsheid faktor</translation>
+    </message>
+    <message id="batterysettingsbattery_current_threshold">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
+      <source>Current threshold</source>
+      <translation>Huidige drempel</translation>
+    </message>
+    <message id="batterysettingsbattery_time_to_go_averaging_period">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
+      <source>Time-to-go averaging period</source>
+      <translation>Tyd-tot-gaan gemiddelde tydperk</translation>
+    </message>
+    <message id="batterysettingsbattery_time_to_go_discharge_floor">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
+      <source>Time-to-go discharge floor</source>
+      <translation type="unfinished">Tyd om te gaan ontslag vloer</translation>
+    </message>
+    <message id="batterysettingsbattery_current_offset">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
+      <source>Current offset</source>
+      <translation type="unfinished">Huidige verrekening</translation>
+    </message>
+    <message id="batterysettingsbattery_synchronise_state_of_charge_to_100%">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
+      <source>Synchronise state-of-charge to 100%</source>
+      <translation>Sinkroniseer lastoestand tot 100%</translation>
+    </message>
+    <message id="batterysettingsbattery_press_to_sync">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
+      <source>Press to sync</source>
+      <translation>Druk om te sinkroniseer</translation>
+    </message>
+    <message id="batterysettingsbattery_calibrate_zero_current">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
+      <source>Calibrate zero current</source>
+      <translation>Kalibreer nulstroom</translation>
+    </message>
+    <message id="batterysettingsbattery_press_to_set_to_0">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
+      <source>Press to set to 0</source>
+      <translation>Druk om na 0 te stel</translation>
+    </message>
+    <message id="batterylynxdistibutor_distributor">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
+      <source>Distributor %1</source>
+      <translation>Verspreider %1</translation>
+    </message>
+    <message id="lynxdistributor_no_power_on_busbar">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
+      <source>No power on busbar</source>
+      <translation>Geen krag op busstaaf nie</translation>
+    </message>
+    <message id="lynxdistributor_count_fuses_blown" numerus="yes">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
+      <source>%n fuse(s) blown</source>
+      <extracomment>%n = number of fuses that have blown</extracomment>
+      <translation type="unfinished">
+        <numerusform>%n smeltdraad(e) geblaas</numerusform>
+        <numerusform>%n lont(e) geblaas</numerusform>
+      </translation>
+    </message>
+    <message id="lynxdistributor_no_information_available">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
+      <source>No information available, see previous page for Distributor status.</source>
+      <translation>Geen inligting beskikbaar nie, sien vorige bladsy vir Verspreiderstatus.</translation>
+    </message>
+    <message id="lynxdistributor_fuse_name">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
+      <source>Fuse %1</source>
+      <extracomment>%1 = name of this fuse</extracomment>
+      <translation type="unfinished">Smeltdraad %1</translation>
+    </message>
+    <message id="lynxdistributor_not_used">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
+      <source>Not used</source>
+      <translation>Nie gebruik nie</translation>
+    </message>
+    <message id="lynxdistributor_blown">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
+      <source>Blown</source>
+      <translation>Geblaas</translation>
+    </message>
+    <message id="lynxiondiagnostics_shutdowns_due_error">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
+      <source>Shutdowns due error</source>
+      <translation>Afsluitings weens fout</translation>
+    </message>
+    <message id="lynxionio_system_switch">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
+      <source>System Switch</source>
+      <translation>Stelsel skakelaar</translation>
+    </message>
+    <message id="lynxionio_external_relay">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="37"/>
+      <source>External relay</source>
+      <translation>Eksterne aflos</translation>
+    </message>
+    <message id="lynxionio_programmable_contact">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="45"/>
+      <source>Programmable Contact</source>
+      <translation>Programmeerbare kontak</translation>
+    </message>
+    <message id="battery_list_page_title">
+      <location filename="../../pages/battery/BatteryListPage.qml" line="15"/>
+      <source>Batteries</source>
+      <translation>Batterye</translation>
+    </message>
+    <message id="lynxionsystem_parallel">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="31"/>
+      <source>Parallel</source>
+      <translation>Parallel</translation>
+    </message>
+    <message id="lynxionsystem_series">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="37"/>
+      <source>Series</source>
+      <translation>Serie</translation>
+    </message>
+    <message id="lynxionsystem_min_max_cell_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="49"/>
+      <source>Min/max cell voltage</source>
+      <translation>Min/maksimum selspanning</translation>
+    </message>
+    <message id="lynxionsystem_min_max_cell_temperature">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="69"/>
+      <source>Min/max cell temperature</source>
+      <translation>Min/maks seltemperatuur</translation>
+    </message>
+    <message id="lynxionsystem_balancer_balancing">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="113"/>
+      <source>Balancing</source>
+      <translation>Balansering</translation>
+    </message>
+    <message id="dc_output">
+      <location filename="../../components/listitems/ListDcOutputQuantityGroup.qml" line="16"/>
+      <source>Output</source>
+      <extracomment>DC output measurement values</extracomment>
+      <translation>Uitset</translation>
+    </message>
+    <message id="alternator_wakespeed_field_drive">
+      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="67"/>
+      <source>Field drive</source>
+      <translation>Veldrit</translation>
+    </message>
+    <message id="alternator_wakespeed_engine_speed">
+      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="90"/>
+      <source>Engine speed</source>
+      <translation>Enjinspoed</translation>
+    </message>
+    <message id="dcmeter_aux_voltage">
+      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
+      <source>Aux voltage</source>
+      <translation>Hulp spanning</translation>
+    </message>
+    <message id="dcmeter_alarms_no_alarms">
+      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
+      <source>No alarms</source>
+      <translation>Geen alarms nie</translation>
+    </message>
+    <message id="dcmeter_alarms_low_voltage">
+      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
+      <source>Low voltage</source>
+      <translation>Lae spanning</translation>
+    </message>
+    <message id="dcmeter_alarms_high_voltage">
+      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
+      <source>High voltage</source>
+      <translation>Hoë spanning</translation>
+    </message>
+    <message id="dcmeter_alarms_low_aux_voltage">
+      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
+      <source>Low aux voltage</source>
+      <translation>Lae hulpspanning</translation>
+    </message>
+    <message id="dcmeter_alarms_high_aux_voltage">
+      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
+      <source>High aux voltage</source>
+      <translation>Hoë hulpspanning</translation>
+    </message>
+    <message id="dcmeter_history_low_aux_voltage_alarms">
+      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
+      <source>Low aux voltage alarms</source>
+      <translation>Lae hulpspanning alarms</translation>
+    </message>
+    <message id="dcmeter_history_high_aux_voltage_alarms">
+      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
+      <source>High aux voltage alarms</source>
+      <translation>Hoë hulpspanning alarms</translation>
+    </message>
+    <message id="dcmeter_history_minimum_aux_voltage">
+      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
+      <source>Minimum aux voltage</source>
+      <translation>Minimum hulpspanning</translation>
+    </message>
+    <message id="dcmeter_history_maximum_aux_voltage">
+      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
+      <source>Maximum aux voltage</source>
+      <translation>Maksimum hulpspanning</translation>
+    </message>
+    <message id="dcmeter_history_produced_energy">
+      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
+      <source>Produced energy</source>
+      <translation>Energie geproduseer</translation>
+    </message>
+    <message id="dcmeter_history_consumed_energy">
+      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
+      <source>Consumed energy</source>
+      <translation>Verbruikte energie</translation>
+    </message>
+    <message id="devicelist_tankalarm_enable_alarm">
+      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
+      <source>Enable alarm</source>
+      <translation>Aktiveer alarm</translation>
+    </message>
+    <message id="devicelist_tankalarm_active_level">
+      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
+      <source>Active level</source>
+      <translation>Aktiewe vlak</translation>
+    </message>
+    <message id="devicelist_tankalarm_restore_level">
+      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
+      <source>Restore level</source>
+      <translation>Herstel vlak</translation>
+    </message>
+    <message id="devicelist_tankalarm_delay">
+      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
+      <source>Delay</source>
+      <translation>Vertraag</translation>
+    </message>
+    <message id="devicelist_tanksensor_level">
+      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="31"/>
+      <source>Level</source>
+      <translation>Vlak</translation>
+    </message>
+    <message id="devicelist_tanksensor_remaining">
+      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="38"/>
+      <source>Remaining</source>
+      <translation>Oorblywende</translation>
+    </message>
+    <message id="temperature_sensor_battery">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="85"/>
+      <source>Sensor battery</source>
+      <translation>Sensor battery</translation>
+    </message>
+    <message id="devicelist_tanksetup_sensor_type">
+      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="32"/>
+      <source>Sensor type</source>
+      <translation>Sensor tipe</translation>
+    </message>
+    <message id="devicelist_tanksetup_standard">
+      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="45"/>
+      <source>Standard</source>
+      <translation>Standaard</translation>
+    </message>
+    <message id="devicelist_tanksetup_european_(0_to_180_ohm)">
+      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="50"/>
+      <source>European (0 to 180 Ohm)</source>
+      <translation>Europees (0 tot 180 Ohm)</translation>
+    </message>
+    <message id="devicelist_tanksetup_us_(240_to_30_ohm)">
+      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="52"/>
+      <source>US (240 to 30 Ohm)</source>
+      <translation>VSA (240 tot 30 Ohm)</translation>
+    </message>
+    <message id="settings_tailscale_custom">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="113"/>
+      <source>Custom</source>
+      <translation>Pasgemaak</translation>
+    </message>
+    <message id="devicelist_tanksetup_sensor_value_when_empty">
+      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="60"/>
+      <source>Sensor value when empty</source>
+      <translation>Sensorwaarde wanneer leeg</translation>
+    </message>
+    <message id="devicelist_tanksetup_fluid_type">
+      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="80"/>
+      <source>Fluid type</source>
+      <translation>Vloeistof tipe</translation>
+    </message>
+    <message id="devicelist_tanksetup_butane_ratio">
+      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="89"/>
+      <source>Butane ratio</source>
+      <translation>Butaan verhouding</translation>
+    </message>
+    <message id="devicelist_tanksetup_custom_shape">
+      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="99"/>
+      <source>Custom shape</source>
+      <translation>Pasgemaakte vorm</translation>
+    </message>
+    <message id="devicelist_tanksetup_averaging_time">
+      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="115"/>
+      <source>Averaging time</source>
+      <translation>Gemiddelde tyd</translation>
+    </message>
+    <message id="devicelist_tanksetup_sensor_value">
+      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="123"/>
+      <source>Sensor value</source>
+      <translation>Sensorwaarde</translation>
+    </message>
+    <message id="devicelist_tankshape_empty">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+      <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
+      <translation>Geen pasgemaakte vorm gedefinieer nie. Jy kan een definieer met tot tien punte. Let daarop dat 0% en 100% geïmpliseer word.</translation>
+    </message>
+    <message id="devicelist_tankshape_point">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="86"/>
+      <source>Point %1</source>
+      <extracomment>%1 = the point number</extracomment>
+      <translation>Punt %1</translation>
+    </message>
+    <message id="devicelist_tankshape_add_point">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="122"/>
+      <source>Add point</source>
+      <translation>Voeg punt by</translation>
+    </message>
+    <message id="devicelist_tankshape_sensor_level">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="145"/>
+      <source>Sensor level</source>
+      <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
+      <translation>Sensor vlak</translation>
+    </message>
+    <message id="devicelist_tankshape_duplicate_sensor_level">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="229"/>
+      <source>Duplicate sensor level values are not allowed.</source>
+      <translation>Duplikaat sensorvlakwaardes word nie toegelaat nie.</translation>
+    </message>
+    <message id="devicelist_tankshape_volume_not_increasing">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="235"/>
+      <source>Volume values must be increasing.</source>
+      <translation>Volumewaardes moet toeneem.</translation>
+    </message>
+    <message id="cycle_history_watchdog">
+      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
+      <source>Watchdog</source>
+      <translation>Waghond</translation>
+    </message>
+    <message id="ac-in-setup_unlocked_(kvarh)">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="40"/>
+      <source>Unlocked (kVARh)</source>
+      <translation>Ontsluit (kVARh)</translation>
+    </message>
+    <message id="ac-in-setup_unlocked_(2)">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="43"/>
+      <source>Unlocked (2)</source>
+      <translation>Ontsluit (2)</translation>
+    </message>
+    <message id="ac-in-setup_unlocked_(1)">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="46"/>
+      <source>Unlocked (1)</source>
+      <translation>Ontsluit (1)</translation>
+    </message>
+    <message id="ac-in-setup_locked">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="49"/>
+      <source>Locked</source>
+      <translation>Gesluit</translation>
+    </message>
+    <message id="ac-in-setup_phase_configuration">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="106"/>
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="137"/>
+      <source>Phase configuration</source>
+      <translation>Fase konfigurasie</translation>
+    </message>
+    <message id="ac-in-setup_switch_position">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="122"/>
+      <source>Switch position</source>
+      <translation>Skakel posisie</translation>
+    </message>
+    <message id="ac-in-setup_two_phase">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="144"/>
+      <source>2-phase</source>
+      <translation>2-fase</translation>
+    </message>
+    <message id="ac-in-setup_three_phase">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="146"/>
+      <source>3-phase</source>
+      <translation>3-fase</translation>
+    </message>
+    <message id="ac-in-genset_ac">
+      <location filename="../../components/PageGensetModel.qml" line="161"/>
+      <source>AC</source>
+      <translation>WS</translation>
+    </message>
+    <message id="ac-in-genset_engine">
+      <location filename="../../components/PageGensetModel.qml" line="200"/>
+      <source>Engine</source>
+      <translation>Enjin</translation>
+    </message>
+    <message id="ac-in-genset_coolant_temperature">
+      <location filename="../../components/PageGensetModel.qml" line="244"/>
+      <source>Coolant temperature</source>
+      <translation>Koelmiddel temperatuur</translation>
+    </message>
+    <message id="ac-in-genset_exhaust_temperature">
+      <location filename="../../components/PageGensetModel.qml" line="252"/>
+      <source>Exhaust temperature</source>
+      <translation>Uitlaat temperatuur</translation>
+    </message>
+    <message id="ac-in-genset_winding_temperature">
+      <location filename="../../components/PageGensetModel.qml" line="259"/>
+      <source>Winding temperature</source>
+      <translation>Wind temperatuur</translation>
+    </message>
+    <message id="ac-in-genset_starter_battery_voltage">
+      <location filename="../../components/PageGensetModel.qml" line="273"/>
+      <source>Starter battery voltage</source>
+      <translation>Aansitter battery spanning</translation>
+    </message>
+    <message id="ac-in-genset_number_of_starts">
+      <location filename="../../components/PageGensetModel.qml" line="281"/>
+      <source>Number of starts</source>
+      <translation>Aantal begin</translation>
+    </message>
+    <message id="ac-in-modeldefault_front_selector_locked">
+      <location filename="../../components/listitems/ListAcInError.qml" line="23"/>
+      <source>Front selector locked (%1)</source>
+      <extracomment>%1 = the error number</extracomment>
+      <translation>Voorste keurder gesluit (%1)</translation>
+    </message>
+    <message id="ac-in-modeldefault_no_error">
+      <location filename="../../components/listitems/ListAcInError.qml" line="27"/>
+      <source>No error (%1)</source>
+      <extracomment>%1 = the error number</extracomment>
+      <translation>Geen fout (%1)</translation>
+    </message>
+    <message id="ac-in-modeldefault_ac_totals">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="85"/>
+      <source>AC Totals</source>
+      <translation>WS Totale</translation>
+    </message>
+    <message id="ac-in-modeldefault_energy_x">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="110"/>
+      <source>Energy L%1</source>
+      <extracomment>%1 = phase number (1-3)</extracomment>
+      <translation>Energie L%1</translation>
+    </message>
+    <message id="ac-in-modeldefault_phase_sequence">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="126"/>
+      <source>Phase Sequence</source>
+      <translation>Fase volgorde</translation>
+    </message>
+    <message id="ac-in-modeldefault_phase_sequence_l3_first">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="132"/>
+      <source>L1-L3-L2</source>
+      <extracomment>Phase sequence L1-L3-L2</extracomment>
+      <translation>L1-L3-L2</translation>
+    </message>
+    <message id="ac-in-modeldefault_phase_sequence_ordered">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="135"/>
+      <source>L1-L2-L3</source>
+      <extracomment>Phase sequence L1-L2-L3</extracomment>
+      <translation>L1-L2-L3</translation>
+    </message>
+    <message id="ac-in-modeldefault_data_manager_version">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="175"/>
+      <source>Data manager version</source>
+      <translation>Data bestuurder weergawe</translation>
+    </message>
+    <message id="smappee_ct_list_type">
+      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
+      <source>%1: %2</source>
+      <extracomment>%1 = device number, %2 = device type</extracomment>
+      <translation>%1: %2</translation>
+    </message>
+    <message id="smappeect_title">
+      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
+      <source>CT %1</source>
+      <extracomment>%1 = CT device number</extracomment>
+      <translation>CT %1</translation>
+    </message>
+    <message id="smappeect_flashing_led_indicates_this_ct">
+      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
+      <source>Flashing LED indicates this CT</source>
+      <translation>Flikkerende LED dui hierdie RT aan</translation>
+    </message>
+    <message id="smappee_device_list_bus_devices">
+      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
+      <source>Smappee bus devices</source>
+      <translation>Smappee-bustoestelle</translation>
+    </message>
+    <message id="solardevices_pv_charger">
+      <location filename="../../pages/solar/SolarDeviceListPage.qml" line="118"/>
+      <source>PV Charger</source>
+      <translation>PV-laaier</translation>
+    </message>
+    <message id="common_words_setting_disabled_when_dmc_connected">
+      <location filename="../../components/CommonWords.qml" line="301"/>
+      <source>This setting is disabled when a Digital Multi Control is connected.</source>
+      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
+      <translation>Hierdie instelling is gedeaktiveer wanneer 'n Digitale Multi Beheer gekoppel is.</translation>
+    </message>
+    <message id="common_words_setting_disabled_when_bms_connected">
+      <location filename="../../components/CommonWords.qml" line="304"/>
+      <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
+      <translation>Hierdie instelling is gedeaktiveer wanneer 'n VE.Bus BMS gekoppel is.</translation>
+    </message>
+    <message id="settings_multirs_ac_in_phase">
+      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="172"/>
+      <source>AC in %1</source>
+      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+      <translation>WS in %1</translation>
+    </message>
+    <message id="common_words_dc">
+      <location filename="../../components/CommonWords.qml" line="129"/>
+      <source>DC</source>
+      <translation>DS</translation>
+    </message>
+    <message id="pulsecounter_setup_inverted">
+      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="20"/>
+      <source>Inverted</source>
+      <translation>Omgeskakel</translation>
+    </message>
+    <message id="digitalinput_invert_alarm_logic">
+      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="59"/>
+      <source>Invert alarm logic</source>
+      <translation>Omsetter alarm logika </translation>
+    </message>
+    <message id="page_meteo_irradiance">
+      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="38"/>
+      <source>Irradiance</source>
+      <translation>Bestraling</translation>
+    </message>
+    <message id="page_meteo_cell_temperature">
+      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="47"/>
+      <source>Cell temperature</source>
+      <translation>Sel temperatuur</translation>
+    </message>
+    <message id="page_meteo_external_temperature_1">
+      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="56"/>
+      <source>External temperature (1)</source>
+      <translation>Eksterne temperatuur (1)</translation>
+    </message>
+    <message id="page_meteo_external_temperature">
+      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="58"/>
+      <source>External temperature</source>
+      <translation>Eksterne temperatuur</translation>
+    </message>
+    <message id="page_meteo_external_temperature_2">
+      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="69"/>
+      <source>External temperature (2)</source>
+      <translation>Eksterne temperatuur (2)</translation>
+    </message>
+    <message id="page_meteo_wind_speed">
+      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="77"/>
+      <source>Wind speed</source>
+      <translation>Wind spoed</translation>
+    </message>
+    <message id="page_meteo_settings_auto_detect">
+      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
+      <source>Auto-detect</source>
+      <translation>Outo-bespeur</translation>
+    </message>
+    <message id="page_meteo_settings_wind_speed_sensor">
+      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
+      <source>Wind speed sensor</source>
+      <translation>Windspoedsensor</translation>
+    </message>
+    <message id="page_meteo_settings_external_temperature_sensor">
+      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
+      <source>External temperature sensor</source>
+      <translation>Eksterne temperatuursensor</translation>
+    </message>
+    <message id="pulsecounter_aggregate">
+      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="25"/>
+      <source>Aggregate</source>
+      <translation>Aggregaat</translation>
+    </message>
+    <message id="pulsecounter_setup_multiplier">
+      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="26"/>
+      <source>Multiplier</source>
+      <translation>Vermenigvuldiger</translation>
+    </message>
+    <message id="pulsecounter_setup_reset_counter">
+      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="32"/>
+      <source>Reset counter</source>
+      <translation>Stel teller terug</translation>
+    </message>
+    <message id="temperature_sensor_battery_low">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="51"/>
+      <source>Sensor battery low</source>
+      <translation>Sensorbattery laag</translation>
+    </message>
+    <message id="temperature_humidity">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="67"/>
+      <source>Humidity</source>
+      <translation>Humiditeit</translation>
+    </message>
+    <message id="temperature_pressure">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="75"/>
+      <source>Pressure</source>
+      <translation>Druk</translation>
+    </message>
+    <message id="temperature_offset">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
+      <source>Offset</source>
+      <translation>Verreken</translation>
+    </message>
+    <message id="temperature_scale">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
+      <source>Scale</source>
+      <translation>Skaal</translation>
+    </message>
+    <message id="temperature_sensor_voltage">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="62"/>
+      <source>Sensor voltage</source>
+      <translation>Sensor spanning</translation>
+    </message>
+    <message id="settings_multirs_total_pv_power">
+      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="222"/>
+      <source>Total PV Power</source>
+      <translation>Totale PV-krag</translation>
+    </message>
+    <message id="common_words_product_page">
+      <location filename="../../components/CommonWords.qml" line="371"/>
+      <source>Product page</source>
+      <translation>Produk bladsy</translation>
+    </message>
+    <message id="vebus_device_ac_sensor_x_y">
+      <location filename="../../pages/vebusdevice/PageAcSensor.qml" line="26"/>
+      <source>AC sensor %1 %2</source>
+      <translation>WS-sensor %1 %2</translation>
+    </message>
+    <message id="vebus_mk3_new_version_available">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="95"/>
+      <source>A new MK3 version is available.
+NOTE: The update might temporarily stop the system.</source>
+      <translation>'n Nuwe MK3-weergawe is beskikbaar.
+LET WEL: Die opdatering kan die stelsel tydelik stop.</translation>
+    </message>
+    <message id="vebus_device_update_the_mk3">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="101"/>
+      <source>Update the MK3</source>
+      <translation>Dateer die MK3 op</translation>
+    </message>
+    <message id="vebus_device_press_to_update">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="103"/>
+      <source>Press to update</source>
+      <translation>Druk om op te dateer</translation>
+    </message>
+    <message id="vebus_device_updating_the_mk3">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="107"/>
+      <source>Updating the MK3, values will reappear after the update is complete</source>
+      <translation>Na die MK3 opdatering, sal waardes weer verskyn sodra die opdatering voltooi is</translation>
+    </message>
+    <message id="vebus_device_charging_the_battery_to_100">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="154"/>
+      <source>Charging the battery to 100%</source>
+      <translation>Laai die battery tot 100%</translation>
+    </message>
+    <message id="vebus_device_in_progress">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="141"/>
+      <source>In progress</source>
+      <translation>In proses</translation>
+    </message>
+    <message id="vebus_device_press_to_stop">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="148"/>
+      <source>Press to stop</source>
+      <translation>Druk om te stop</translation>
+    </message>
+    <message id="vebus_device_press_to_start">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="116"/>
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="151"/>
+      <source>Press to start</source>
+      <translation>Druk om te begin</translation>
+    </message>
+    <message id="vebus_device_charge_the_battery_to_100">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="157"/>
+      <source>Charge the battery to 100%</source>
+      <translation>Laai die battery tot 100%</translation>
+    </message>
+    <message id="vebus_device_return_to_normal_operation">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="166"/>
+      <source>The system will return to normal operation, prioritizing renewable energy.
+Do you want to continue?</source>
+      <translation>Die stelsel sal terugkeer na normale werking, met die prioritering van hernubare energie.
+Wil jy voortgaan?</translation>
+    </message>
+    <message id="vebus_device_use_shore_power">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="184"/>
+      <source>Shore power will be used when available and the "Solar &amp; wind priority" option will be ignored.
+Do you want to continue?</source>
+      <translation>Landkrag sal gebruik word wanneer dit beskikbaar is en die "Solar &amp; wind prioriteit" opsie sal geïgnoreer word.
+Wil jy voortgaan?</translation>
+    </message>
+    <message id="ebus_device_use_shore_power_once">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="189"/>
+      <source>Shore power will be used to complete a full battery charge for one time.
+After the charging process is complete, the system will return to normal operation, prioritizing solar and wind energy.
+Do you want to continue?</source>
+      <translation>Landkrag sal gebruik word om 'n volle batterylading vir een keer te voltooi.
+Nadat die laaiproses voltooi is, sal die stelsel terugkeer na normale werking en son- en windenergie prioritiseer.
+Wil jy voortgaan?</translation>
+    </message>
+    <message id="vebus_device_page_dc_voltage">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="217"/>
+      <source>DC Voltage</source>
+      <translation>DS Spanning</translation>
+    </message>
+    <message id="vebus_device_page_dc_current">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="224"/>
+      <source>DC Current</source>
+      <translation>DC Stroom</translation>
+    </message>
+    <message id="settings_tailscale_advanced">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="300"/>
+      <source>Advanced</source>
+      <translation>Gevorderd</translation>
+    </message>
+    <message id="common_words_alarm_setup">
+      <location filename="../../components/CommonWords.qml" line="59"/>
+      <source>Alarm setup</source>
+      <translation>Alarm opstelling</translation>
+    </message>
+    <message id="vebus_device_bms_message">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="280"/>
+      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</source>
+      <translation>'n VE.Bus BMS skakel die stelsel outomaties af wanneer dit nodig is om die battery te beskerm. Om die stelsel vanaf die Kleurbeheer te beheer is dus nie moontlik nie.</translation>
+    </message>
+    <message id="vebus_device_bms_not_found">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="286"/>
+      <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
+      <translation>'n BMS-assistent is geïnstalleer, gekonfigureer vir 'n VE.Bus BMS, maar die VE.Bus BMS word nie gevind nie!</translation>
+    </message>
+    <message id="vebus_device_vebus_bms">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="292"/>
+      <source>VE.Bus BMS</source>
+      <translation>VE.Bus BMS</translation>
+    </message>
+    <message id="vebus_device_warning">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="91"/>
+      <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
+      <translation type="unfinished">Waarskuwing: Aktivering van gelykmaking in 'n WSD-stelsel met sonkraglaaiers kan veroorsaak dat die battery teen hoë spanning met 'n te hoë stroom laai.</translation>
+    </message>
+    <message id="vebus_device_switch_to_float">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="95"/>
+      <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
+      <translation>Die stelsel sal outomaties oorskakel om te dryf sodra die gelykstelling lading voltooi is.</translation>
+    </message>
+    <message id="vebus_device_interrupt_equalization">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="102"/>
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="151"/>
+      <source>Interrupt equalization</source>
+      <translation>Onderbreek gelykstelling</translation>
+    </message>
+    <message id="vebus_device_equalization">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="104"/>
+      <source>Equalization</source>
+      <translation>Gelykstelling</translation>
+    </message>
+    <message id="vebus_device_interrupting">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="108"/>
+      <source>Interrupting...</source>
+      <translation>Onderbreek tans …</translation>
+    </message>
+    <message id="settings_tailscale_starting">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="51"/>
+      <source>Starting...</source>
+      <translation>Begin tans …</translation>
+    </message>
+    <message id="vebus_device_press_to_interrupt">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="114"/>
+      <source>Press to interrupt</source>
+      <translation>Druk om te onderbreek</translation>
+    </message>
+    <message id="vebus_device_interrupt_and_restart_absorption">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="155"/>
+      <source>Interrupt and restart absorption</source>
+      <translation>Onderbreek en herbegin absorpsie</translation>
+    </message>
+    <message id="vebus_device_interrupt_and_go_to_float">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="161"/>
+      <source>Interrupt and go to float</source>
+      <translation>Onderbreek en gaan dryf</translation>
+    </message>
+    <message id="vebus_device_interrupt">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="167"/>
+      <source>Interrupt</source>
+      <translation>Onderbreek</translation>
+    </message>
+    <message id="vebus_device_do_not_interrupt">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="173"/>
+      <source>Do not interrupt</source>
+      <translation>Moenie onderbreek nie</translation>
+    </message>
+    <message id="vebus_device_redectect_vebus_system">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="198"/>
+      <source>Redetect VE.Bus system</source>
+      <translation>Heropspoor VE.Bus-stelsel</translation>
+    </message>
+    <message id="vebus_device_redetecting">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="201"/>
+      <source>Redetecting...</source>
+      <translation>Heropsporing tans …</translation>
+    </message>
+    <message id="vebus_device_restart_vebus_system">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="210"/>
+      <source>Restart VE.Bus system</source>
+      <translation>Herbegin VE.Bus-stelsel</translation>
+    </message>
+    <message id="vebus_device_restarting">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="213"/>
+      <source>Restarting...</source>
+      <translation>Herbegin tans …</translation>
+    </message>
+    <message id="vebus_device_press_to_restart">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="215"/>
+      <source>Press to restart</source>
+      <translation>Druk om te herbegin</translation>
+    </message>
+    <message id="vebus_device_ac_input_1_ignored">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="222"/>
+      <source>AC input 1 ignored</source>
+      <translation>WS-invoer 1 geïgnoreer</translation>
+    </message>
+    <message id="vebus_device_ac_input_2_ignored">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="230"/>
+      <source>AC input 2 ignored</source>
+      <translation>WS-invoer 2 geïgnoreer</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="238"/>
+      <source>ESS Relay test</source>
+      <translation>WSD Weerstand toets</translation>
+    </message>
+    <message id="cycle_history_completed">
+      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
+      <source>Completed</source>
+      <translation>Voltooi</translation>
+    </message>
+    <message id="common_words_pending">
+      <location filename="../../components/CommonWords.qml" line="345"/>
+      <source>Pending</source>
+      <translation>Hangend</translation>
+    </message>
+    <message id="vebus_diagnostics">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="253"/>
+      <source>VE.Bus diagnostics</source>
+      <translation>VE.Bus diagnostiek</translation>
+    </message>
+    <message id="vebus_veice_network_quality_counter">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="272"/>
+      <source>Network quality counter Phase L%1, device %2 (%3)</source>
+      <translation>Netwerkkwaliteitteller Fase L%1, toestel %2 (%3)</translation>
+    </message>
+    <message id="vebus_device_error_8_11_report">
+      <location filename="../../pages/vebusdevice/PageVeBusAlarms.qml" line="61"/>
+      <source>VE.Bus Error 8 / 11 report</source>
+      <translation>VE.Bus Fout 8 / 11 verslag</translation>
+    </message>
+    <message id="alarm_level_alarm_only">
+      <location filename="../../components/listitems/ListAlarmLevelRadioButtonGroup.qml" line="13"/>
+      <source>Alarm only</source>
+      <translation>Slegs alarm</translation>
+    </message>
+    <message id="alarm_level_alarms_and_warnings">
+      <location filename="../../components/listitems/ListAlarmLevelRadioButtonGroup.qml" line="15"/>
+      <source>Alarms &amp; warnings</source>
+      <translation>Alarms en waarskuwings</translation>
+    </message>
+    <message id="vebus_device_bms_error">
+      <location filename="../../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
+      <source>BMS Error</source>
+      <extracomment>Bouers Bestuurs Sisteem</extracomment>
+      <translation type="unfinished">BBS fout</translation>
+    </message>
+    <message id="vebus_device_serial_numbers">
+      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="34"/>
+      <location filename="../../pages/vebusdevice/PageVeBusDeviceInfo.qml" line="38"/>
+      <source>Serial numbers</source>
+      <translation>Reeksnommers</translation>
+    </message>
+    <message id="vebus_device_last_vebus_error_11_report">
+      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
+      <source>Last VE.Bus Error 11 report #%1</source>
+      <translation>Laaste VE.Bus-fout 11-verslag #%1</translation>
+    </message>
+    <message id="vebus_device_bf_safety_test_in_progress">
+      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
+      <source>BF safety test in progress</source>
+      <translation type="unfinished">BF veiligheidstoets aan die gang</translation>
+    </message>
+    <message id="vebus_device_bf_safety_test_ok">
+      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
+      <source>BF safety test OK</source>
+      <translation type="unfinished">BF veiligheidstoets OK</translation>
+    </message>
+    <message id="vebus_device_ac0_ac1_mismatch">
+      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
+      <source>AC0 /AC1 mismatch</source>
+      <translation type="unfinished">AC0 / AC1 wanverhouding</translation>
+    </message>
+    <message id="vebus_device_communication_error">
+      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
+      <source>Communication error</source>
+      <translation>Kommunikasie fout</translation>
+    </message>
+    <message id="vebus_device_ground_relay_error">
+      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
+      <source>GND Relay Error</source>
+      <extracomment>Ground = Grond (GND)</extracomment>
+      <translation>GND Weerstandsfout</translation>
+    </message>
+    <message id="vebus_device_umains_mismatch">
+      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
+      <source>UMains mismatch</source>
+      <translation>U- Hoofskakelaar wanverhouding</translation>
+    </message>
+    <message id="vebus_device_period_time_mismatch">
+      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
+      <source>Period Time mismatch</source>
+      <translation>Periode Tyd wanverhouding</translation>
+    </message>
+    <message id="vebus_device_drive_of_bf_relay_mismatch">
+      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
+      <source>Drive of BF relay mismatch</source>
+      <translation type="unfinished">Ry van BF-aflos wanaanpassing</translation>
+    </message>
+    <message id="vebus_device_error_pe2_open">
+      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
+      <source>Error: PE2 open</source>
+      <translation>Fout: PE2 oop</translation>
+    </message>
+    <message id="vebus_device_error_pe2_closed">
+      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
+      <source>Error: PE2 closed</source>
+      <translation>Fout: PE2 gesluit</translation>
+    </message>
+    <message id="vebus_device_failing_step">
+      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
+      <source>Failing step: %1</source>
+      <translation>Stap faal : %1</translation>
+    </message>
+    <message id="vebus_device_phase_x_device_x_index_x">
+      <location filename="../../pages/vebusdevice/PageVeBusError11Menu.qml" line="34"/>
+      <source>Phase L%1, device %2 (%3)</source>
+      <extracomment>eg. 'Phase L1, device 3 (6)', where '(6)' is the index into the list of reported values</extracomment>
+      <translation>Fase L%1, toestel %2 (%3)</translation>
+    </message>
+    <message id="vebus_error_11_reporting_requires_v454">
+      <location filename="../../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
+      <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
+      <translation type="unfinished">VE.Bus Fout 11-verslagdoening vereis minimum VE.Bus-firmware weergawe 454.</translation>
+    </message>
+    <message id="vebus_quirks">
+      <location filename="../../pages/vebusdevice/PageVeBusKwhCounters.qml" line="20"/>
+      <source>VE.Bus Quirks</source>
+      <translation>VE.Bus Eienskappe</translation>
+    </message>
+    <message id="vebus_ac_sensor_energy">
+      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
+      <source>energy</source>
+      <translation>energie</translation>
+    </message>
+    <message id="vebus_ac_sensor_power">
+      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
+      <source>power</source>
+      <translation>krag</translation>
+    </message>
+    <message id="vebus_ac_sensor_voltage">
+      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
+      <source>voltage</source>
+      <translation>Spanning</translation>
+    </message>
+    <message id="vebus_ac_sensor_current">
+      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
+      <source>current</source>
+      <translation>Stroom</translation>
+    </message>
+    <message id="vebus_ac_sensor_location">
+      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
+      <source>location</source>
+      <translation>ligging</translation>
+    </message>
+    <message id="vebus_ac_sensor_phase">
+      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
+      <source>phase</source>
+      <translation>fase</translation>
+    </message>
+    <message id="vebus_device_active_ac_input">
+      <location filename="../../components/listitems/ListActiveAcInput.qml" line="21"/>
+      <source>Active AC Input</source>
+      <translation>Aktiewe WS-invoer</translation>
+    </message>
+    <message id="vebus_device_high_dc_ripple">
+      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
+      <source>High DC ripple</source>
+      <translation>Hoë DS-rimpeling</translation>
+    </message>
+    <message id="vebus_device_high_dc_voltage">
+      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
+      <source>High DC voltage</source>
+      <translation>Hoë WS spanning</translation>
+    </message>
+    <message id="vebus_device_high_dc_current">
+      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
+      <source>High DC current</source>
+      <translation>Hoë DS-stroom</translation>
+    </message>
+    <message id="vebus_device_temperature_sense_error">
+      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="21"/>
+      <source>Temperature sense error</source>
+      <translation>Temperatuurwaarnemingsfout</translation>
+    </message>
+    <message id="vebus_device_voltage_sense_error">
+      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
+      <source>Voltage sense error</source>
+      <translation>Spanningswaarnemingsfout</translation>
+    </message>
+    <message id="rssystemalarms_overload">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
+      <source>Overload</source>
+      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
+      <translation>Oorlading</translation>
+    </message>
+    <message id="common_words_alarm_setting_dc_ripple">
+      <location filename="../../components/CommonWords.qml" line="56"/>
+      <source>DC ripple</source>
+      <extracomment>Alarm configuration when 'DC ripple' state is triggered</extracomment>
+      <translation>DS rimpeling</translation>
+    </message>
+    <message id="vebus_device_voltage_sensor">
+      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
+      <source>Voltage Sensor</source>
+      <translation>Spanning sensor</translation>
+    </message>
+    <message id="rssystemalarms_phase_rotation">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
+      <source>Phase rotation</source>
+      <translation>Fase rotasie</translation>
+    </message>
+    <message id="vebus_device_vebus_version">
+      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
+      <source>VE.Bus version</source>
+      <translation>VE.Bus weergawe</translation>
+    </message>
+    <message id="vebus_device_mk2_device">
+      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
+      <source>MK2 device</source>
+      <translation>MK2 toestel</translation>
+    </message>
+    <message id="vebus_device_mk2_version">
+      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
+      <source>MK2 version</source>
+      <translation>MK2 weergawe</translation>
+    </message>
+    <message id="vebus_device_multi_control_version">
+      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
+      <source>Multi Control version</source>
+      <translation>Multi Beheer weergawe</translation>
+    </message>
+    <message id="vebus_device_bms_version">
+      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
+      <source>VE.Bus BMS version</source>
+      <translation>VE.Bus BMS weergawe</translation>
+    </message>
+    <message id="ess_unless_grid_fails">
+      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="32"/>
+      <source>Unless grid fails</source>
+      <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
+      <translation>Tensy die rooster faal</translation>
+    </message>
+    <message id="common_words_ac_in">
+      <location filename="../../components/CommonWords.qml" line="14"/>
+      <source>AC In</source>
+      <translation>WS in</translation>
+    </message>
+    <message id="common_words_ac_input">
+      <location filename="../../components/CommonWords.qml" line="525"/>
+      <source>AC Input</source>
+      <translation>WS-invoer</translation>
+    </message>
+    <message id="common_words_ac_input_1">
+      <location filename="../../components/CommonWords.qml" line="521"/>
+      <source>AC Input 1</source>
+      <translation>WS-invoer 1</translation>
+    </message>
+    <message id="common_words_ac_input_2">
+      <location filename="../../components/CommonWords.qml" line="523"/>
+      <source>AC Input 2</source>
+      <translation>WS-invoer 2</translation>
+    </message>
+    <message id="common_words_ac_input_role">
+      <location filename="../../components/CommonWords.qml" line="21"/>
+      <source>Role</source>
+      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
+      <translation>Rol</translation>
+    </message>
+    <message id="common_words_ac_load">
+      <location filename="../../components/CommonWords.qml" line="24"/>
+      <source>AC load</source>
+      <translation>WS las</translation>
+    </message>
+    <message id="common_words_ac_out">
+      <location filename="../../components/CommonWords.qml" line="27"/>
+      <source>AC Out</source>
+      <translation>WS Uit</translation>
+    </message>
+    <message id="common_words_ac_output">
+      <location filename="../../components/CommonWords.qml" line="30"/>
+      <source>AC Output</source>
+      <translation>WS Uitset</translation>
+    </message>
+    <message id="common_words_ac_phase_x">
+      <location filename="../../components/CommonWords.qml" line="34"/>
+      <source>AC Phase L%1</source>
+      <extracomment>%1 = phase number (1-3)</extracomment>
+      <translation>WS-fase L%1</translation>
+    </message>
+    <message id="common_words_ac_sensor_x">
+      <location filename="../../components/CommonWords.qml" line="37"/>
+      <source>AC Sensor %1</source>
+      <translation>WS-sensor %1</translation>
+    </message>
+    <message id="common_words_ac_sensor">
+      <location filename="../../components/CommonWords.qml" line="40"/>
+      <source>AC Sensors</source>
+      <translation>WS sensors</translation>
+    </message>
+    <message id="common_words_active">
+      <location filename="../../components/CommonWords.qml" line="44"/>
+      <source>Active</source>
+      <extracomment>Status is 'active'</extracomment>
+      <translation>Aktief</translation>
+    </message>
+    <message id="common_words_alarm_status">
+      <location filename="../../components/CommonWords.qml" line="62"/>
+      <source>Alarm status</source>
+      <translation>Alarm status</translation>
+    </message>
+    <message id="common_words_alarms">
+      <location filename="../../components/CommonWords.qml" line="65"/>
+      <source>Alarms</source>
+      <translation>Alarms</translation>
+    </message>
+    <message id="common_words_allow_to_charge">
+      <location filename="../../components/CommonWords.qml" line="68"/>
+      <source>Allow to charge</source>
+      <translation>Laat toe om te laai</translation>
+    </message>
+    <message id="common_words_allow_to_discharge">
+      <location filename="../../components/CommonWords.qml" line="71"/>
+      <source>Allow to discharge</source>
+      <translation>Laat toe om te ontlaai</translation>
+    </message>
+    <message id="common_words_automatic_scanning">
+      <location filename="../../components/CommonWords.qml" line="77"/>
+      <source>Automatic scanning</source>
+      <translation>Outomatiese skandering</translation>
+    </message>
+    <message id="gauges_battery">
+      <location filename="../../components/Gauges.js" line="19"/>
+      <source>Battery</source>
+      <translation>Battery</translation>
+    </message>
+    <message id="common_words_battery_current">
+      <location filename="../../components/CommonWords.qml" line="86"/>
+      <source>Battery current</source>
+      <translation>Batterystroom</translation>
+    </message>
+    <message id="common_words_battery_voltage">
+      <location filename="../../components/CommonWords.qml" line="92"/>
+      <source>Battery voltage</source>
+      <translation>Battery spanning</translation>
+    </message>
+    <message id="common_words_charge_current">
+      <location filename="../../components/CommonWords.qml" line="98"/>
+      <source>Charge current</source>
+      <translation>Laaistroom</translation>
+    </message>
+    <message id="battery_mode_charging">
+      <location filename="../../src/enums.cpp" line="30"/>
+      <source>Charging</source>
+      <extracomment>"Charging" state</extracomment>
+      <translation>Laai</translation>
+    </message>
+    <message id="common_words_clear_error_action">
+      <location filename="../../components/CommonWords.qml" line="106"/>
+      <source>Clear error</source>
+      <extracomment>Action to clear an error state</extracomment>
+      <translation>Vee fout uit</translation>
+    </message>
+    <message id="digitalinputs_state_closed">
+      <location filename="../../src/enums.cpp" line="127"/>
+      <source>Closed</source>
+      <extracomment>Status is 'closed'</extracomment>
+      <translation>Gesluit</translation>
+    </message>
+    <message id="evchargers_status_connected">
+      <location filename="../../data/EvChargers.qml" line="110"/>
+      <source>Connected</source>
+      <translation>Gekoppel</translation>
+    </message>
+    <message id="common_words_current_amps">
+      <location filename="../../components/CommonWords.qml" line="117"/>
+      <source>Current</source>
+      <extracomment>Electric current, as measured in Amps</extracomment>
+      <translation>Huidige</translation>
+    </message>
+    <message id="common_words_current_transformers">
+      <location filename="../../components/CommonWords.qml" line="120"/>
+      <source>Current transformers</source>
+      <translation>Stroom transformators</translation>
+    </message>
+    <message id="common_words_custom_name">
+      <location filename="../../components/CommonWords.qml" line="123"/>
+      <source>Custom name</source>
+      <translation>Gepasmaakte naam</translation>
+    </message>
+    <message id="common_words_debug">
+      <location filename="../../components/CommonWords.qml" line="133"/>
+      <source>Debug</source>
+      <extracomment>Title for a menu item which displays debugging information</extracomment>
+      <translation>Ontfout</translation>
+    </message>
+    <message id="common_words_device">
+      <location filename="../../components/CommonWords.qml" line="137"/>
+      <source>Device</source>
+      <extracomment>Title for device information</extracomment>
+      <translation>Toestel</translation>
+    </message>
+    <message id="battery_mode_discharging">
+      <location filename="../../src/enums.cpp" line="34"/>
+      <source>Discharging</source>
+      <extracomment>Battery mode</extracomment>
+      <translation>Ontlaai</translation>
+    </message>
+    <message id="evchargers_status_disconnected">
+      <location filename="../../data/EvChargers.qml" line="107"/>
+      <source>Disconnected</source>
+      <oldsource>Unplugged</oldsource>
+      <translation>Ontkoppel</translation>
+    </message>
+    <message id="common_words_enable">
+      <location filename="../../components/CommonWords.qml" line="149"/>
+      <source>Enable</source>
+      <translation>Aktiveer</translation>
+    </message>
+    <message id="common_words_enabled">
+      <location filename="../../components/CommonWords.qml" line="152"/>
+      <source>Enabled</source>
+      <translation>Geaktiveer</translation>
+    </message>
+    <message id="common_words_energy">
+      <location filename="../../components/CommonWords.qml" line="156"/>
+      <source>Energy</source>
+      <extracomment>Amount of charged energy</extracomment>
+      <translation>Energie</translation>
+    </message>
+    <message id="pvinverter_statusCode_error">
+      <location filename="../../src/enums.cpp" line="177"/>
+      <source>Error</source>
+      <extracomment>PV inverter status code</extracomment>
+      <translation>Fout</translation>
+    </message>
+    <message id="common_words_error_colon">
+      <location filename="../../components/CommonWords.qml" line="162"/>
+      <source>Error:</source>
+      <translation>Fout:</translation>
+    </message>
+    <message id="common_words_error_code">
+      <location filename="../../components/CommonWords.qml" line="165"/>
+      <source>Error code</source>
+      <translation>Foutkode</translation>
+    </message>
+    <message id="common_words_firmware_version">
+      <location filename="../../components/CommonWords.qml" line="174"/>
+      <source>Firmware version</source>
+      <translation>Firmware weergawe</translation>
+    </message>
+    <message id="digitalinputs_type_generator">
+      <location filename="../../src/enums.cpp" line="84"/>
+      <source>Generator</source>
+      <translation>Opwekker</translation>
+    </message>
+    <message id="common_words_high_battery_temperature">
+      <location filename="../../components/CommonWords.qml" line="183"/>
+      <source>High battery temperature</source>
+      <translation>Hoë battery temperatuur</translation>
+    </message>
+    <message id="common_words_high_level_alarm">
+      <location filename="../../components/CommonWords.qml" line="190"/>
+      <source>High level alarm</source>
+      <extracomment>An alarm that triggers when the level is too high</extracomment>
+      <translation>Hoë vlak alarm</translation>
+    </message>
+    <message id="common_words_high_starter_battery_voltage">
+      <location filename="../../components/CommonWords.qml" line="193"/>
+      <source>High starter battery voltage</source>
+      <translation>Hoë aansitter battery spanning</translation>
+    </message>
+    <message id="common_words_high_temperature">
+      <location filename="../../components/CommonWords.qml" line="196"/>
+      <source>High temperature</source>
+      <translation>Hoë temperatuur</translation>
+    </message>
+    <message id="common_words_high_voltage_alarms">
+      <location filename="../../components/CommonWords.qml" line="199"/>
+      <source>High voltage alarms</source>
+      <translation>Hoëspanning alarms</translation>
+    </message>
+    <message id="common_words_history">
+      <location filename="../../components/CommonWords.qml" line="202"/>
+      <source>History</source>
+      <translation>Geskiedenis</translation>
+    </message>
+    <message id="common_words_x_hours">
+      <location filename="../../components/CommonWords.qml" line="205"/>
+      <source>%1 Hour(s)</source>
+      <translation>%1 uur</translation>
+    </message>
+    <message id="battery_mode_idle">
+      <location filename="../../src/enums.cpp" line="26"/>
+      <source>Idle</source>
+      <extracomment>Battery mode</extracomment>
+      <translation>Ledig</translation>
+    </message>
+    <message id="scheduled_charge_inactive">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="71"/>
+      <source>Inactive</source>
+      <extracomment>Status is 'inactive'</extracomment>
+      <translation>Onaktief</translation>
+    </message>
+    <message id="common_words_ip_address">
+      <location filename="../../components/CommonWords.qml" line="228"/>
+      <source>IP address</source>
+      <translation>IP adres</translation>
+    </message>
+    <message id="common_words_low_battery_temperature">
+      <location filename="../../components/CommonWords.qml" line="231"/>
+      <source>Low battery temperature</source>
+      <translation>Lae battery temperatuur</translation>
+    </message>
+    <message id="common_words_low_level_alarm">
+      <location filename="../../components/CommonWords.qml" line="238"/>
+      <source>Low level alarm</source>
+      <extracomment>An alarm that triggers when the level is too low</extracomment>
+      <translation>Lae vlak alarm</translation>
+    </message>
+    <message id="common_words_low_starter_battery_voltage">
+      <location filename="../../components/CommonWords.qml" line="241"/>
+      <source>Low starter battery voltage</source>
+      <translation>Lae aansitter battery spanning</translation>
+    </message>
+    <message id="common_words_low_state_of_charge">
+      <location filename="../../components/CommonWords.qml" line="244"/>
+      <source>Low state-of-charge</source>
+      <translation>Lae toestand van lading</translation>
+    </message>
+    <message id="common_words_low_temperature">
+      <location filename="../../components/CommonWords.qml" line="247"/>
+      <source>Low temperature</source>
+      <translation>Lae temperatuur</translation>
+    </message>
+    <message id="common_words_low_voltage_alarms">
+      <location filename="../../components/CommonWords.qml" line="250"/>
+      <source>Low voltage alarms</source>
+      <translation>Lae spanning alarms</translation>
+    </message>
+    <message id="common_words_manufacturer">
+      <location filename="../../components/CommonWords.qml" line="265"/>
+      <source>Manufacturer</source>
+      <translation>Vervaardiger</translation>
+    </message>
+    <message id="common_words_maximum_temperature">
+      <location filename="../../components/CommonWords.qml" line="274"/>
+      <source>Maximum temperature</source>
+      <translation>Maksimum temperatuur</translation>
+    </message>
+    <message id="common_words_maximum_voltage">
+      <location filename="../../components/CommonWords.qml" line="277"/>
+      <source>Maximum voltage</source>
+      <translation>Maksimum spanning</translation>
+    </message>
+    <message id="common_words_minimum_temperature">
+      <location filename="../../components/CommonWords.qml" line="283"/>
+      <source>Minimum temperature</source>
+      <translation>Minimum temperatuur</translation>
+    </message>
+    <message id="common_words_minimum_voltage">
+      <location filename="../../components/CommonWords.qml" line="286"/>
+      <source>Minimum voltage</source>
+      <translation>Minimum spanning</translation>
+    </message>
+    <message id="common_words_mode">
+      <location filename="../../components/CommonWords.qml" line="289"/>
+      <source>Mode</source>
+      <translation>Modus</translation>
+    </message>
+    <message id="common_words_model_name">
+      <location filename="../../components/CommonWords.qml" line="292"/>
+      <source>Model name</source>
+      <translation>Model naam</translation>
+    </message>
+    <message id="digitalinputs_state_no">
+      <location filename="../../src/enums.cpp" line="115"/>
+      <source>No</source>
+      <extracomment>Digital input state</extracomment>
+      <translation>Nee/geen/nie</translation>
+    </message>
+    <message id="common_words_no_error">
+      <location filename="../../components/CommonWords.qml" line="307"/>
+      <source>No error</source>
+      <translation>Geen fout nie</translation>
+    </message>
+    <message id="acInputs_not_available">
+      <location filename="../../data/AcInputs.qml" line="100"/>
+      <source>Not available</source>
+      <translation>Nie beskikbaar nie</translation>
+    </message>
+    <message id="common_words_not_connected">
+      <location filename="../../components/CommonWords.qml" line="317"/>
+      <source>Not connected</source>
+      <translation>Nie gekonnekteer nie</translation>
+    </message>
+    <message id="common_words_offline">
+      <location filename="../../components/CommonWords.qml" line="323"/>
+      <source>Offline</source>
+      <translation>Van lyn af</translation>
+    </message>
+    <message id="digitalinputs_state_ok">
+      <location filename="../../src/enums.cpp" line="131"/>
+      <source>OK</source>
+      <extracomment>Voltage alarm is at "OK" level</extracomment>
+      <translation>Reg</translation>
+    </message>
+    <message id="digitalinputs_state_on">
+      <location filename="../../src/enums.cpp" line="111"/>
+      <source>On</source>
+      <extracomment>Digital input state</extracomment>
+      <translation>Aan</translation>
+    </message>
+    <message id="common_words_online">
+      <location filename="../../components/CommonWords.qml" line="332"/>
+      <source>Online</source>
+      <translation>Aanlyn</translation>
+    </message>
+    <message id="digitalinputs_state_open">
+      <location filename="../../src/enums.cpp" line="123"/>
+      <source>Open</source>
+      <extracomment>Status is 'open'</extracomment>
+      <translation>Oop</translation>
+    </message>
+    <message id="common_words_password">
+      <location filename="../../components/CommonWords.qml" line="348"/>
+      <source>Password</source>
+      <translation>Wagwoord</translation>
+    </message>
+    <message id="common_words_phase">
+      <location filename="../../components/CommonWords.qml" line="355"/>
+      <source>Phase</source>
+      <translation>Fase</translation>
+    </message>
+    <message id="common_words_press_to_clear">
+      <location filename="../../components/CommonWords.qml" line="362"/>
+      <source>Press to clear</source>
+      <translation>Druk om skoon te maak</translation>
+    </message>
+    <message id="common_words_press_to_reset">
+      <location filename="../../components/CommonWords.qml" line="365"/>
+      <source>Press to reset</source>
+      <translation>Druk om terug te stel</translation>
+    </message>
+    <message id="common_words_press_to_scan">
+      <location filename="../../components/CommonWords.qml" line="368"/>
+      <source>Press to scan</source>
+      <translation>Druk om te skandeer</translation>
+    </message>
+    <message id="common_words_pv_inverter">
+      <location filename="../../components/CommonWords.qml" line="374"/>
+      <source>PV Inverter</source>
+      <translation>PV-omsetter</translation>
+    </message>
+    <message id="common_words_pv_power">
+      <location filename="../../components/CommonWords.qml" line="378"/>
+      <source>PV Power</source>
+      <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
+      <translation>PV krag</translation>
+    </message>
+    <message id="common_words_quiet_hours">
+      <location filename="../../components/CommonWords.qml" line="381"/>
+      <source>Quiet hours</source>
+      <translation type="unfinished">Stil ure</translation>
+    </message>
+    <message id="common_words_relay">
+      <location filename="../../components/CommonWords.qml" line="385"/>
+      <source>Relay</source>
+      <extracomment>Relay switch</extracomment>
+      <translation>Aflos</translation>
+    </message>
+    <message id="common_words_reboot">
+      <location filename="../../components/CommonWords.qml" line="391"/>
+      <source>Reboot</source>
+      <translation>Herlaai</translation>
+    </message>
+    <message id="common_words_remove">
+      <location filename="../../components/CommonWords.qml" line="394"/>
+      <source>Remove</source>
+      <translation>Verwyder</translation>
+    </message>
+    <message id="pvinverter_statusCode_running">
+      <location filename="../../src/enums.cpp" line="165"/>
+      <source>Running</source>
+      <extracomment>Status = "running"</extracomment>
+      <translation>Hardloop</translation>
+    </message>
+    <message id="common_words_scanning">
+      <location filename="../../components/CommonWords.qml" line="401"/>
+      <source>Scanning %1%</source>
+      <translation>Skandeer tans %1%</translation>
+    </message>
+    <message id="common_words_serial_number">
+      <location filename="../../components/CommonWords.qml" line="404"/>
+      <source>Serial number</source>
+      <translation>Reeksnommer</translation>
+    </message>
+    <message id="nav_settings">
+      <location filename="../../pages/SettingsPage.qml" line="18"/>
+      <source>Settings</source>
+      <translation>Instellings</translation>
+    </message>
+    <message id="common_words_setup">
+      <location filename="../../components/CommonWords.qml" line="410"/>
+      <source>Setup</source>
+      <translation>Stel op</translation>
+    </message>
+    <message id="common_words_signal_strength">
+      <location filename="../../components/CommonWords.qml" line="413"/>
+      <source>Signal strength</source>
+      <translation>Sein sterkte</translation>
+    </message>
+    <message id="pvinverter_statusCode_standby">
+      <location filename="../../src/enums.cpp" line="169"/>
+      <source>Standby</source>
+      <extracomment>PV inverter status code</extracomment>
+      <translation>Staan by</translation>
+    </message>
+    <message id="common_words_start_after_condition_reached_for">
+      <location filename="../../components/CommonWords.qml" line="427"/>
+      <source>Start after the condition is reached for</source>
+      <translation>Begin nadat die toestand bereik is vir</translation>
+    </message>
+    <message id="common_words_start_time">
+      <location filename="../../components/CommonWords.qml" line="430"/>
+      <source>Start time</source>
+      <translation>Begin Tyd</translation>
+    </message>
+    <message id="common_words_start_value_during_quiet_hours">
+      <location filename="../../components/CommonWords.qml" line="433"/>
+      <source>Start value during quiet hours</source>
+      <translation>Beginwaarde tydens stil ure</translation>
+    </message>
+    <message id="common_words_start_when_warning_is_active_for">
+      <location filename="../../components/CommonWords.qml" line="436"/>
+      <source>Start when warning is active for</source>
+      <translation>Begin wanneer waarskuwing aktief is vir</translation>
+    </message>
+    <message id="common_words_state_of_charge">
+      <location filename="../../components/CommonWords.qml" line="442"/>
+      <source>State of charge</source>
+      <translation>Herlaai toestand</translation>
+    </message>
+    <message id="common_words_status">
+      <location filename="../../components/CommonWords.qml" line="445"/>
+      <source>Status</source>
+      <translation>Status</translation>
+    </message>
+    <message id="pvinverter_statusCode_startup">
+      <location filename="../../src/enums.cpp" line="161"/>
+      <source>Startup (%1)</source>
+      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
+      <translation type="unfinished">Opstart (%1)</translation>
+    </message>
+    <message id="common_words_stop_value_during_quiet_hours">
+      <location filename="../../components/CommonWords.qml" line="452"/>
+      <source>Stop value during quiet hours</source>
+      <translation>Stop waarde tydens stil ure</translation>
+    </message>
+    <message id="common_words_stop_after_the_condition_is_reached_for">
+      <location filename="../../components/CommonWords.qml" line="455"/>
+      <source>Stop after the condition is reached for</source>
+      <translation>Stop nadat die toestand bereik is vir</translation>
+    </message>
+    <message id="digitalinputs_state_stopped">
+      <location filename="../../src/enums.cpp" line="143"/>
+      <source>Stopped</source>
+      <extracomment>Digital input state</extracomment>
+      <translation>Gestop</translation>
+    </message>
+    <message id="common_words_temperature">
+      <location filename="../../components/CommonWords.qml" line="465"/>
+      <source>Temperature</source>
+      <translation>Temperatuur</translation>
+    </message>
+    <message id="common_words_temperature_sensor">
+      <location filename="../../components/CommonWords.qml" line="468"/>
+      <source>Temperature sensor</source>
+      <translation>Temperatuur sensor</translation>
+    </message>
+    <message id="common_words_today">
+      <location filename="../../components/CommonWords.qml" line="471"/>
+      <source>Today</source>
+      <translation>Vandag</translation>
+    </message>
+    <message id="common_words_total">
+      <location filename="../../components/CommonWords.qml" line="474"/>
+      <source>Total</source>
+      <translation>Totaal</translation>
+    </message>
+    <message id="common_words_tracker">
+      <location filename="../../components/CommonWords.qml" line="478"/>
+      <source>Tracker</source>
+      <extracomment>Solar tracker</extracomment>
+      <translation type="unfinished">Opvolger</translation>
+    </message>
+    <message id="common_words_type">
+      <location filename="../../components/CommonWords.qml" line="481"/>
+      <source>Type</source>
+      <translation>Tipe</translation>
+    </message>
+    <message id="common_words_unique_id_number">
+      <location filename="../../components/CommonWords.qml" line="484"/>
+      <source>Unique Identity Number</source>
+      <translation>Unieke identiteitsnommer</translation>
+    </message>
+    <message id="evchargers_status_unknown">
+      <location filename="../../data/EvChargers.qml" line="170"/>
+      <source>Unknown</source>
+      <translation>Onbekend</translation>
+    </message>
+    <message id="common_words_vebus_error">
+      <location filename="../../components/CommonWords.qml" line="491"/>
+      <source>VE.Bus Error</source>
+      <translation>VE.Bus Fout</translation>
+    </message>
+    <message id="common_words_voltage">
+      <location filename="../../components/CommonWords.qml" line="494"/>
+      <source>Voltage</source>
+      <translation>Spanning</translation>
+    </message>
+    <message id="common_words_vrm_instance">
+      <location filename="../../components/CommonWords.qml" line="497"/>
+      <source>VRM instance</source>
+      <translation>VRM-instansie</translation>
+    </message>
+    <message id="common_words_when_warning_is_cleared_stop_after">
+      <location filename="../../components/CommonWords.qml" line="500"/>
+      <source>When warning is cleared stop after</source>
+      <translation>Wanneer waarskuwing uitgevee is, stop daarna</translation>
+    </message>
+    <message id="digitalinputs_state_yes">
+      <location filename="../../src/enums.cpp" line="119"/>
+      <source>Yes</source>
+      <extracomment>Digital input state</extracomment>
+      <translation>Ja</translation>
+    </message>
+    <message id="common_words_yesterday">
+      <location filename="../../components/CommonWords.qml" line="506"/>
+      <source>Yesterday</source>
+      <translation>Gister</translation>
+    </message>
+    <message id="common_words_yield_kwh">
+      <location filename="../../components/CommonWords.qml" line="510"/>
+      <source>Yield</source>
+      <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
+      <translation>Opbrengs</translation>
+    </message>
+    <message id="common_words_zero_feed_in_power_limit">
+      <location filename="../../components/CommonWords.qml" line="517"/>
+      <source>Zero feed-in power limit</source>
+      <translation>Geen toevoerkraglimiet nie</translation>
+    </message>
+    <message id="dateselectordialog_set_date">
+      <location filename="../../components/dialogs/DateSelectorDialog.qml" line="17"/>
+      <source>Set date</source>
+      <translation>Stel datum</translation>
+    </message>
+    <message id="controlcard_generator_startdialog_start_now">
+      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="13"/>
+      <source>Start Now</source>
+      <translation>Begin nou</translation>
+    </message>
+    <message id="controlcard_generator_startdialog_timed_run">
+      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="46"/>
+      <source>Timed run</source>
+      <translation>Tydige hardloop</translation>
+    </message>
+    <message id="controlcard_generator_stopdialog_stop_now">
+      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="13"/>
+      <source>Stop Now</source>
+      <translation>Stop nou</translation>
+    </message>
+    <message id="controlcard_generator_stopdialog_total_run_time">
+      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="61"/>
+      <source>Total Run Time</source>
+      <translation>Totale Looptyd</translation>
+    </message>
+    <message id="controlcard_generator_stopdialog_set_time">
+      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="80"/>
+      <source>Set Time %1</source>
+      <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
+      <translation>Stel tyd %1</translation>
+    </message>
+    <message id="controlcard_generator_stopdialog_description">
+      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="94"/>
+      <source>Generator will keep running if an autostart condition is met.</source>
+      <translation>Kragopwekker sal aanhou loop as daar aan 'n outostart-voorwaarde voldoen word.</translation>
+    </message>
+    <message id="controlcard_inverter_charger_mode">
+      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="27"/>
+      <source>Inverter / Charger mode</source>
+      <translation>Omsetter/laaiermodus</translation>
+    </message>
+    <message id="modaldialog_set">
+      <location filename="../../components/dialogs/ModalDialog.qml" line="25"/>
+      <source>Set</source>
+      <translation>Stel</translation>
+    </message>
+    <message id="common_words_cancel">
+      <location filename="../../components/CommonWords.qml" line="95"/>
+      <source>Cancel</source>
+      <translation>Kanselleer</translation>
+    </message>
+    <message id="settings_vrm_device_instances_close">
+      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="398"/>
+      <source>Close</source>
+      <translation>Naby</translation>
+    </message>
+    <message id="timeselectordialog_set_time">
+      <location filename="../../components/dialogs/TimeSelectorDialog.qml" line="19"/>
+      <source>Set time</source>
+      <translation>Vasgestelde tyd</translation>
+    </message>
+    <message id="deviceinstanceswap_already_assigned">
+      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="84"/>
+      <source>Already in use</source>
+      <translation>Alreeds in gebruik</translation>
+    </message>
+    <message id="deviceinstanceswap_swap_error">
+      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="87"/>
+      <source>Swap error</source>
+      <translation type="unfinished">Verwissel fout</translation>
+    </message>
+    <message id="deviceinstanceswap_swap_completed">
+      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
+      <source>Swap complete</source>
+      <translation>Ruil voltooi</translation>
+    </message>
+    <message id="deviceinstanceswap_busy">
+      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="95"/>
+      <source>Swapping device instances...</source>
+      <translation>Ruil tans toestelgevalle uit …</translation>
+    </message>
+    <message id="deviceinstanceswap_already_assigned_description_with_name">
+      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="100"/>
+      <source>Device instance %1 is already used by '%3'. Swap device instances and assign that to %2?</source>
+      <extracomment>%1 and %2 are unique device instance numbers, %3 = another device's name</extracomment>
+      <translation>Toestelinstansie %1 word reeds deur '%3' gebruik. Wissel toestelgevalle uit en ken dit toe aan %2?</translation>
+    </message>
+    <message id="deviceinstanceswap_already_assigned_description">
+      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="107"/>
+      <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
+      <extracomment>%1 and %2 are unique device instance numbers</extracomment>
+      <translation>Toestelinstansie %1 word reeds deur 'n ander toestel van dieselfde tipe gebruik. Wissel toestelgevalle uit en ken dit toe aan %2?</translation>
+    </message>
+    <message id="deviceinstanceswap_timed_out">
+      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="115"/>
+      <source>Cannot swap device instances: operation timed out.</source>
+      <translation type="unfinished">Kan nie toestelgevalle omruil nie: werking  tyd uit</translation>
+    </message>
+    <message id="deviceinstanceswap_active_on_reboot">
+      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
+      <source>New device instances will be active on reboot.</source>
+      <translation>Nuwe toestelgevalle sal aktief wees met selfherlaai.</translation>
+    </message>
+    <message id="deviceinstanceswap_swap">
+      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="124"/>
+      <source>Swap</source>
+      <extracomment>Confirm that the two devices' instance number should be swapped.</extracomment>
+      <translation>Ruil</translation>
+    </message>
+    <message id="settings_firmware_error_during_checking_for_updates">
+      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
+      <source>Error while checking for firmware updates</source>
+      <translation>Fout terwyl fermware-opdaterings gekontroleur word.</translation>
+    </message>
+    <message id="settings_firmware_downloading_and_installing">
+      <location filename="../../components/FirmwareUpdate.qml" line="63"/>
+      <source>Downloading and installing firmware %1...</source>
+      <extracomment>%1 = firmware version</extracomment>
+      <translation>Laai tans af en installeer fermware % 1...</translation>
+    </message>
+    <message id="settings_firmware_installing_firmware">
+      <location filename="../../components/FirmwareUpdate.qml" line="70"/>
+      <source>Installing firmware...</source>
+      <translation>Installeer tans fermware...</translation>
+    </message>
+    <message id="settings_firmware_error_during_installation">
+      <location filename="../../components/FirmwareUpdate.qml" line="75"/>
+      <source>Error during firmware installation</source>
+      <translation>Fout tydens fermware-installasie</translation>
+    </message>
+    <message id="settings_firmware_no_newer_version_available">
+      <location filename="../../components/FirmwareUpdate.qml" line="185"/>
+      <source>No newer version available</source>
+      <translation>Geen nuwer weergawe beskikbaar nie</translation>
+    </message>
+    <message id="settings_firmware_no_firmware_found">
+      <location filename="../../components/FirmwareUpdate.qml" line="188"/>
+      <source>No firmware found</source>
+      <translation>Geen fermware gevind nie</translation>
+    </message>
+    <message id="gauges_fuel">
+      <location filename="../../components/Gauges.js" line="27"/>
+      <source>Fuel</source>
+      <translation>Brandstof</translation>
+    </message>
+    <message id="gauges_fresh_water">
+      <location filename="../../components/Gauges.js" line="35"/>
+      <source>Fresh water</source>
+      <translation>Vars water</translation>
+    </message>
+    <message id="gauges_waste_water">
+      <location filename="../../components/Gauges.js" line="43"/>
+      <source>Waste water</source>
+      <translation>Afvalwater</translation>
+    </message>
+    <message id="gauges_live_well">
+      <location filename="../../components/Gauges.js" line="51"/>
+      <source>Live well</source>
+      <translation type="unfinished">Leef goed</translation>
+    </message>
+    <message id="gauges_oil">
+      <location filename="../../components/Gauges.js" line="59"/>
+      <source>Oil</source>
+      <translation>Olie</translation>
+    </message>
+    <message id="gauges_black_water">
+      <location filename="../../components/Gauges.js" line="67"/>
+      <source>Black water</source>
+      <translation>Swart water</translation>
+    </message>
+    <message id="gauges_gasoline">
+      <location filename="../../components/Gauges.js" line="75"/>
+      <source>Gasoline</source>
+      <translation>Petrol</translation>
+    </message>
+    <message id="gauges_diesel">
+      <location filename="../../components/Gauges.js" line="83"/>
+      <source>Diesel</source>
+      <translation>Diesel</translation>
+    </message>
+    <message id="gauges_lpg">
+      <location filename="../../components/Gauges.js" line="91"/>
+      <source>LPG</source>
+      <translation>VPG</translation>
+    </message>
+    <message id="gauges_lng">
+      <location filename="../../components/Gauges.js" line="99"/>
+      <source>LNG</source>
+      <extracomment>Vloeibare Natuurlike Gas</extracomment>
+      <translation>VNG</translation>
+    </message>
+    <message id="gauges_hydraulic_oil">
+      <location filename="../../components/Gauges.js" line="107"/>
+      <source>Hydraulic oil</source>
+      <translation>Hidroliese olie</translation>
+    </message>
+    <message id="gauges_raw_water">
+      <location filename="../../components/Gauges.js" line="115"/>
+      <source>Raw water</source>
+      <translation>Rou water</translation>
+    </message>
+    <message id="settings_radio_button_group_no_access">
+      <location filename="../../components/listitems/core/ListRadioButtonGroup.qml" line="62"/>
+      <source>Setting locked for access level</source>
+      <translation>Instelling gesluit vir toegangsvlak</translation>
+    </message>
+    <message id="settings_access_incorrect_password">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="93"/>
+      <source>Incorrect password</source>
+      <translation>Verkeerde wagwoord</translation>
+    </message>
+    <message id="welcome_brief_title">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="82"/>
+      <source>Brief</source>
+      <translation>Kort</translation>
+    </message>
+    <message id="welcome_overview_title">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="91"/>
+      <source>Overview</source>
+      <translation>Oorsig</translation>
+    </message>
+    <message id="nav_levels">
+      <location filename="../../pages/LevelsPage.qml" line="19"/>
+      <source>Levels</source>
+      <translation>Vlakke</translation>
+    </message>
+    <message id="nav_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="14"/>
+      <source>Notifications</source>
+      <translation>Kennisgewings</translation>
+    </message>
+    <message id="utils_formatTimestamp_now">
+      <location filename="../../components/Utils.js" line="256"/>
+      <source>now</source>
+      <extracomment>Indicates an event happened very recently</extracomment>
+      <translation>nou</translation>
+    </message>
+    <message id="utils_formatTimestamp_min_ago">
+      <location filename="../../components/Utils.js" line="261"/>
+      <source>%1m ago</source>
+      <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
+      <translation>%1m gelede</translation>
+    </message>
+    <message id="utils_formatTimestamp_hours_min_ago">
+      <location filename="../../components/Utils.js" line="268"/>
+      <source>%1h %2m ago</source>
+      <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
+      <translation>%1h %2m gelede</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_every_day">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="17"/>
+      <source>Every day</source>
+      <translation>Elke dag</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_weekdays">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="19"/>
+      <source>Weekdays</source>
+      <translation>Weeksdae</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_weekends">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="21"/>
+      <source>Weekends</source>
+      <translation>Naweke</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_monday">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="25"/>
+      <source>Monday</source>
+      <translation>Maandag</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_tuesday">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="27"/>
+      <source>Tuesday</source>
+      <translation>Dinsdag</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_wednesday">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="29"/>
+      <source>Wednesday</source>
+      <translation>Woensdag</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_thursday">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="31"/>
+      <source>Thursday</source>
+      <translation>Donderdag</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_friday">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="33"/>
+      <source>Friday</source>
+      <translation>Vrydag</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_saturday">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="35"/>
+      <source>Saturday</source>
+      <translation>Saterdag</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_sunday">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="37"/>
+      <source>Sunday</source>
+      <translation>Sondag</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_format_no_soc">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="70"/>
+      <source>%1 %2 (%3)</source>
+      <translation>%1 %2 (%3)</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_format_soc">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="73"/>
+      <source>%1 %2 (%3 or %4%)</source>
+      <translation>%1 %2 (%3 of %4%)</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_name">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="79"/>
+      <source>Schedule %1</source>
+      <translation>Skedule %1</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_day">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="127"/>
+      <source>Day</source>
+      <translation>Dag</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_day_not_set">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="131"/>
+      <source>Not set</source>
+      <translation>Nie gestel nie</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_soc_limit">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="154"/>
+      <source>SOC limit</source>
+      <translation type="unfinished">SBS limiet</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_self_consumption_above_limit">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="165"/>
+      <source>Self-consumption above limit</source>
+      <translation>Selfverbruik bo limiet</translation>
+    </message>
+    <message id="settings_multirs_pv">
+      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="205"/>
+      <source>PV</source>
+      <translation>PV</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_pv_and_battery">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="172"/>
+      <source>PV &amp; Battery</source>
+      <translation>PV &amp; Battery</translation>
+    </message>
+    <message id="settings_firmware_checking">
+      <location filename="../../components/listitems/ListFirmwareCheckButton.qml" line="16"/>
+      <source>Checking...</source>
+      <translation>Nagaan...</translation>
+    </message>
+    <message id="list_alarm_state">
+      <location filename="../../components/listitems/ListAlarmState.qml" line="11"/>
+      <source>Alarm state</source>
+      <translation>Alarm toestand</translation>
+    </message>
+    <message id="clear_history_button_clear_history">
+      <location filename="../../components/listitems/ListClearHistoryButton.qml" line="15"/>
+      <source>Clear History</source>
+      <translation>Verwyder geskiedenis</translation>
+    </message>
+    <message id="clear_history_button_clearing">
+      <location filename="../../components/listitems/ListClearHistoryButton.qml" line="19"/>
+      <source>Clearing</source>
+      <translation>Skoonmaak</translation>
+    </message>
+    <message id="settings_dvcc_switch_forced_on">
+      <location filename="../../components/listitems/core/ListSwitchForced.qml" line="19"/>
+      <source>Forced on</source>
+      <translation>Geforseer</translation>
+    </message>
+    <message id="settings_dvcc_switch_forced_off">
+      <location filename="../../components/listitems/core/ListSwitchForced.qml" line="22"/>
+      <source>Forced off</source>
+      <translation>Afgedwing</translation>
+    </message>
+    <message id="list_relay_state">
+      <location filename="../../components/listitems/ListRelayState.qml" line="11"/>
+      <source>Relay state</source>
+      <translation>Aflos toestand</translation>
+    </message>
+    <message id="batteryhistory_reset_history_on_the_monitor_itself">
+      <location filename="../../components/listitems/ListResetHistory.qml" line="29"/>
+      <source>Reset history on the monitor itself</source>
+      <translation>Stel geskiedenis op die monitor self terug</translation>
+    </message>
+    <message id="components_mount_state_press_to_eject">
+      <location filename="../../components/listitems/ListMountStateButton.qml" line="17"/>
+      <source>Press to eject</source>
+      <translation>Druk om uit te stoot</translation>
+    </message>
+    <message id="components_mount_state_ejecting">
+      <location filename="../../components/listitems/ListMountStateButton.qml" line="21"/>
+      <source>Ejecting, please wait</source>
+      <translation>Besi met uitstoot, wag asseblief</translation>
+    </message>
+    <message id="components_mount_state_no_storage_found">
+      <location filename="../../components/listitems/ListMountStateButton.qml" line="24"/>
+      <source>No storage found</source>
+      <translation>Geen berging gevind nie</translation>
+    </message>
+    <message id="components_mount_state_microsd_usb">
+      <location filename="../../components/listitems/ListMountStateButton.qml" line="29"/>
+      <source>microSD / USB</source>
+      <translation>microSD / USB</translation>
+    </message>
+    <message id="settings_relay_title_type_only">
+      <location filename="../../components/listitems/ListTemperatureRelay.qml" line="28"/>
+      <source>%1 temperature sensor</source>
+      <extracomment>%1 = temperature sensor type</extracomment>
+      <translation>%1 temperatuursensor</translation>
+    </message>
+    <message id="settings_relay_title_type_and_number">
+      <location filename="../../components/listitems/ListTemperatureRelay.qml" line="32"/>
+      <source>%1 temperature sensor (%2)</source>
+      <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
+      <translation>%1 temperatuursensor (%2)</translation>
+    </message>
+    <message id="settings_relay_title_number_only">
+      <location filename="../../components/listitems/ListTemperatureRelay.qml" line="41"/>
+      <source>Temperature sensor (%1)</source>
+      <extracomment>%1 = input number of the sensor</extracomment>
+      <translation>Temperatuursensor (%1)</translation>
+    </message>
+    <message id="settings_relay_no_actions">
+      <location filename="../../components/listitems/ListTemperatureRelay.qml" line="52"/>
+      <source>No actions</source>
+      <translation>Geen aksies nie</translation>
+    </message>
+    <message id="settings_relay_c0_desc">
+      <location filename="../../components/listitems/ListTemperatureRelay.qml" line="57"/>
+      <source>C1: %1, %2</source>
+      <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
+      <translation>C1: %1, %2</translation>
+    </message>
+    <message id="settings_relay_c1_desc">
+      <location filename="../../components/listitems/ListTemperatureRelay.qml" line="62"/>
+      <source>C2: %1, %2</source>
+      <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
+      <translation>C2: %1, %2</translation>
+    </message>
+    <message id="settings_relay_equal_values_warning">
+      <location filename="../../components/TemperatureRelaySettings.qml" line="23"/>
+      <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
+      <translation>Waarskuwing: Aktiverings- en deaktiveringstemperature is op dieselfde waarde gestel. Dit sal daartoe lei dat die toestand geïgnoreer word.</translation>
+    </message>
+    <message id="settings_relay_condition">
+      <location filename="../../components/TemperatureRelaySettings.qml" line="35"/>
+      <source>Condition %1</source>
+      <translation>Toestand %1</translation>
+    </message>
+    <message id="settings_relay_function_disabled">
+      <location filename="../../components/TemperatureRelaySettings.qml" line="41"/>
+      <source>Function disabled</source>
+      <translation>Funksie gedeaktiveer</translation>
+    </message>
+    <message id="settings_relay_none">
+      <location filename="../../components/TemperatureRelaySettings.qml" line="52"/>
+      <source>None (Disable)</source>
+      <translation>Geen (Deaktiveer)</translation>
+    </message>
+    <message id="settings_relay1">
+      <location filename="../../components/TemperatureRelaySettings.qml" line="54"/>
+      <source>Relay 1</source>
+      <translation>Aflos 1</translation>
+    </message>
+    <message id="settings_relay2">
+      <location filename="../../components/TemperatureRelaySettings.qml" line="56"/>
+      <source>Relay 2</source>
+      <translation>Aflos 2</translation>
+    </message>
+    <message id="settings_relay_invalid_temp_config_warning">
+      <location filename="../../components/TemperatureRelaySettings.qml" line="61"/>
+      <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
+      <translation>Waarskuwing: Die bogenoemde geselekteerde aflos is nie vir temperatuur gekonfigureer nie, hierdie toestand sal geïgnoreer word.</translation>
+    </message>
+    <message id="settings_relay_activation_value">
+      <location filename="../../components/TemperatureRelaySettings.qml" line="70"/>
+      <source>Activation value</source>
+      <translation>Aktiveringswaarde</translation>
+    </message>
+    <message id="components_volumeunit_title">
+      <location filename="../../components/listitems/ListVolumeUnitRadioButtonGroup.qml" line="11"/>
+      <source>Volume unit</source>
+      <translation>Volume eenheid</translation>
+    </message>
+    <message id="components_volumeunit_cubic_meters">
+      <location filename="../../components/listitems/ListVolumeUnitRadioButtonGroup.qml" line="15"/>
+      <source>Cubic meters</source>
+      <translation>Kubieke meter</translation>
+    </message>
+    <message id="components_volumeunit_liters">
+      <location filename="../../components/listitems/ListVolumeUnitRadioButtonGroup.qml" line="17"/>
+      <source>Liters</source>
+      <translation>Liters</translation>
+    </message>
+    <message id="components_volumeunit_gallons_us">
+      <location filename="../../components/listitems/ListVolumeUnitRadioButtonGroup.qml" line="19"/>
+      <source>Gallons (US)</source>
+      <translation>Gallon (VSA)</translation>
+    </message>
+    <message id="components_volumeunit_gallons_imperial">
+      <location filename="../../components/listitems/ListVolumeUnitRadioButtonGroup.qml" line="21"/>
+      <source>Gallons (Imperial)</source>
+      <translation>Gallon (Imperial)</translation>
+    </message>
+    <message id="charger_history_box_min_voltage">
+      <location filename="../../components/SolarDetailBox.qml" line="58"/>
+      <source>Min Voltage</source>
+      <translation>Min spanning</translation>
+    </message>
+    <message id="charger_history_max_voltage">
+      <location filename="../../components/SolarHistoryTableView.qml" line="87"/>
+      <source>Max Voltage</source>
+      <translation>Maksimum spanning</translation>
+    </message>
+    <message id="charger_history_box_max_current">
+      <location filename="../../components/SolarDetailBox.qml" line="70"/>
+      <source>Max Current</source>
+      <translation>Maksimum stroom</translation>
+    </message>
+    <message id="charger_history_charge_time">
+      <location filename="../../components/SolarDetailBox.qml" line="121"/>
+      <source>Charge time</source>
+      <extracomment>Statistics for battery charging time</extracomment>
+      <translation>Laai tyd</translation>
+    </message>
+    <message id="solarchargers_state_bulk">
+      <location filename="../../src/enums.cpp" line="202"/>
+      <source>Bulk</source>
+      <translation>Grootmaat</translation>
+    </message>
+    <message id="charger_history_box_abs">
+      <location filename="../../components/SolarDetailBox.qml" line="142"/>
+      <source>Abs</source>
+      <extracomment>Battery: time spent in 'Absorption' mode</extracomment>
+      <translation>Abs</translation>
+    </message>
+    <message id="solarchargers_state_float">
+      <location filename="../../src/enums.cpp" line="208"/>
+      <source>Float</source>
+      <translation>Vlot</translation>
+    </message>
+    <message id="timeselector_hr">
+      <location filename="../../components/TimeSelector.qml" line="34"/>
+      <source>hr</source>
+      <translation>hr</translation>
+    </message>
+    <message id="charger_history_errors_occurred">
+      <location filename="../../components/SolarHistoryErrorView.qml" line="96"/>
+      <source>%1 error(s) occurred</source>
+      <translation>%1 fout(e) het voorgekom</translation>
+    </message>
+    <message id="charger_history_errors_last">
+      <location filename="../../components/SolarHistoryErrorView.qml" line="120"/>
+      <source>Last</source>
+      <extracomment>Details of last error</extracomment>
+      <translation>Laaste</translation>
+    </message>
+    <message id="charger_history_errors_2nd_last">
+      <location filename="../../components/SolarHistoryErrorView.qml" line="123"/>
+      <source>2nd last</source>
+      <extracomment>Details of 2nd last error</extracomment>
+      <translation>2de laaste</translation>
+    </message>
+    <message id="charger_history_errors_3rd_last">
+      <location filename="../../components/SolarHistoryErrorView.qml" line="126"/>
+      <source>3rd last</source>
+      <extracomment>Details of 3rd last error</extracomment>
+      <translation>3de laaste</translation>
+    </message>
+    <message id="charger_history_errors_4th_last">
+      <location filename="../../components/SolarHistoryErrorView.qml" line="129"/>
+      <source>4th last</source>
+      <extracomment>Details of 4th last error</extracomment>
+      <translation>4de laaste</translation>
+    </message>
+    <message id="charger_history_max_power">
+      <location filename="../../components/SolarHistoryTableView.qml" line="93"/>
+      <source>Max Power</source>
+      <translation>Maksimum krag</translation>
+    </message>
+    <message id="splash_view_unable_to_connect">
+      <location filename="../../components/SplashView.qml" line="231"/>
+      <source>Unable to connect</source>
+      <translation>Kan nie koppel nie</translation>
+    </message>
+    <message id="splash_view_reconnecting">
+      <location filename="../../components/SplashView.qml" line="233"/>
+      <source>Disconnected, attempting to reconnect</source>
+      <translation>Ontkoppel, probeer om weer te koppel</translation>
+    </message>
+    <message id="utils_connman_connecting">
+      <location filename="../../components/Utils.js" line="283"/>
+      <source>Connecting</source>
+      <translation>Verbind</translation>
+    </message>
+    <message id="splash_view_connected">
+      <location filename="../../components/SplashView.qml" line="238"/>
+      <source>Connected, awaiting broker messages</source>
+      <translation type="unfinished">Verbonde, wagtende makelaarboodskappe</translation>
+    </message>
+    <message id="splash_view_initializing">
+      <location filename="../../components/SplashView.qml" line="240"/>
+      <source>Connected, receiving broker messages</source>
+      <translation type="unfinished">Gekoppel, ontvang makelaar boodskappe</translation>
+    </message>
+    <message id="splash_view_ready">
+      <location filename="../../components/SplashView.qml" line="242"/>
+      <source>Connected, loading user interface</source>
+      <translation>Gekoppel, laai gebruikerskoppelvlak</translation>
+    </message>
+    <message id="splash_view_invalid_protocol_version">
+      <location filename="../../components/SplashView.qml" line="257"/>
+      <source>Invalid protocol version</source>
+      <translation>Ongeldige protokolweergawe</translation>
+    </message>
+    <message id="splash_view_client_id_rejected">
+      <location filename="../../components/SplashView.qml" line="259"/>
+      <source>Client ID rejected</source>
+      <translation>Kliënt-ID is afgekeur</translation>
+    </message>
+    <message id="splash_view_server_unavailable">
+      <location filename="../../components/SplashView.qml" line="261"/>
+      <source>Broker service not available</source>
+      <translation type="unfinished">Makelaardiens nie beskikbaar nie</translation>
+    </message>
+    <message id="splash_view_bad_username_or_password">
+      <location filename="../../components/SplashView.qml" line="263"/>
+      <source>Bad username or password</source>
+      <translation>Slegte gebruikersnaam of wagwoord</translation>
+    </message>
+    <message id="splash_view_not_authorized">
+      <location filename="../../components/SplashView.qml" line="265"/>
+      <source>Client not authorized</source>
+      <translation>Kliënt nie gemagtig nie</translation>
+    </message>
+    <message id="splash_view_transport_invalid">
+      <location filename="../../components/SplashView.qml" line="267"/>
+      <source>Transport connection error</source>
+      <translation>Vervoerverbindingsfout</translation>
+    </message>
+    <message id="splash_view_protocol_violation">
+      <location filename="../../components/SplashView.qml" line="269"/>
+      <source>Protocol violation error</source>
+      <translation>Protokol oortreding fout</translation>
+    </message>
+    <message id="splash_view_mqtt5_error">
+      <location filename="../../components/SplashView.qml" line="273"/>
+      <source>MQTT protocol level 5 error</source>
+      <translation type="unfinished">MQTT protokol vlak 5 fout</translation>
+    </message>
+    <message id="notifications_silence_alarm">
+      <location filename="../../components/StatusBar.qml" line="228"/>
+      <source>Silence alarm</source>
+      <translation>Stil alarm</translation>
+    </message>
+    <message id="vebus_device_page_total_power">
+      <location filename="../../components/ThreePhaseQuantityTable.qml" line="77"/>
+      <source>Total Power</source>
+      <translation>Totale krag</translation>
+    </message>
+    <message id="timeselector_min">
+      <location filename="../../components/TimeSelector.qml" line="62"/>
+      <source>min</source>
+      <translation>min</translation>
+    </message>
+    <message id="utils_format_days_hours">
+      <location filename="../../components/Utils.js" line="196"/>
+      <source>%1d %2h</source>
+      <translation>%1d %2h</translation>
+    </message>
+    <message id="utils_format_hours_min">
+      <location filename="../../components/Utils.js" line="201"/>
+      <source>%1h %2m</source>
+      <translation>%1h %2m</translation>
+    </message>
+    <message id="utils_format_min_sec">
+      <location filename="../../components/Utils.js" line="222"/>
+      <source>%1m %2s</source>
+      <translation>%1m %2s</translation>
+    </message>
+    <message id="utils_format_min">
+      <location filename="../../components/Utils.js" line="224"/>
+      <source>%1m</source>
+      <translation>%1m</translation>
+    </message>
+    <message id="utils_format_sec">
+      <location filename="../../components/Utils.js" line="228"/>
+      <source>%1s</source>
+      <translation>%1s</translation>
+    </message>
+    <message id="utils_zero_minutes">
+      <location filename="../../components/Utils.js" line="230"/>
+      <source>0m</source>
+      <translation type="unfinished">0m</translation>
+    </message>
+    <message id="utils_connman_failure">
+      <location filename="../../components/Utils.js" line="280"/>
+      <source>Failure</source>
+      <translation>Mislukking</translation>
+    </message>
+    <message id="utils_connman_retrieving_ip_address">
+      <location filename="../../components/Utils.js" line="286"/>
+      <source>Retrieving IP address</source>
+      <translation>Haal tans IP-adres op</translation>
+    </message>
+    <message id="utils_connman_disconnect">
+      <location filename="../../components/Utils.js" line="293"/>
+      <source>Disconnect</source>
+      <translation>Ontkoppel</translation>
+    </message>
+    <message id="overview_widget_acloads_title">
+      <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
+      <source>AC Loads</source>
+      <translation>WS-ladings</translation>
+    </message>
+    <message id="overview_widget_dcloads_title">
+      <location filename="../../components/widgets/DcLoadsWidget.qml" line="24"/>
+      <source>DC Loads</source>
+      <translation>DG-ladings</translation>
+    </message>
+    <message id="overview_widget_evcs_title">
+      <location filename="../../components/widgets/EvcsWidget.qml" line="23"/>
+      <source>EVCS</source>
+      <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
+      <translation type="unfinished">EVLS</translation>
+    </message>
+    <message id="overview_widget_wind_title">
+      <location filename="../../components/widgets/WindWidget.qml" line="13"/>
+      <source>Wind</source>
+      <translation>Wind</translation>
+    </message>
+    <message id="acInputs_shore">
+      <location filename="../../data/AcInputs.qml" line="107"/>
+      <source>Shore</source>
+      <translation>Strand</translation>
+    </message>
+    <message id="acInputs_current_limit_grid">
+      <location filename="../../data/AcInputs.qml" line="133"/>
+      <source>Grid current limit</source>
+      <translation>Netstroomlimiet</translation>
+    </message>
+    <message id="acInputs_current_limit_generator">
+      <location filename="../../data/AcInputs.qml" line="136"/>
+      <source>Generator current limit</source>
+      <translation>Opwekker stroom limiet</translation>
+    </message>
+    <message id="acInputs_current_limit_shore">
+      <location filename="../../data/AcInputs.qml" line="139"/>
+      <source>Shore current limit</source>
+      <translation>Strandstroomlimiet</translation>
+    </message>
+    <message id="page_generator_stopping">
+      <location filename="../../data/Generators.qml" line="55"/>
+      <source>Stopping</source>
+      <translation>Stop</translation>
+    </message>
+    <message id="utils_format_time_to_go">
+      <location filename="../../components/Utils.js" line="145"/>
+      <source>%1 to go</source>
+      <extracomment>%1 = time remaining, e.g. '3h 2m'</extracomment>
+      <translation>%1 om te gaan</translation>
+    </message>
+    <message id="tank_description">
+      <location filename="../../data/common/TankDescription.qml" line="24"/>
+      <source>%1 tank (%2)</source>
+      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+      <translation>%1 tenk (%2)</translation>
+    </message>
+    <message id="dcInputs_ac_charger">
+      <location filename="../../data/DcInputs.qml" line="112"/>
+      <source>AC charger</source>
+      <translation>WS-laaier</translation>
+    </message>
+    <message id="dcInputs_alternator">
+      <location filename="../../data/DcInputs.qml" line="115"/>
+      <source>Alternator</source>
+      <translation>Alternator</translation>
+    </message>
+    <message id="dcInputs_dccharger">
+      <location filename="../../data/DcInputs.qml" line="118"/>
+      <source>DC charger</source>
+      <translation>GS-laaier</translation>
+    </message>
+    <message id="dcInputs_dc_generator">
+      <location filename="../../data/DcInputs.qml" line="121"/>
+      <source>DC generator</source>
+      <translation>GS kragopwekker</translation>
+    </message>
+    <message id="dcInputs_dc_system">
+      <location filename="../../data/DcInputs.qml" line="124"/>
+      <source>DC system</source>
+      <translation>GS stelsel</translation>
+    </message>
+    <message id="dcInputs_fuelcell">
+      <location filename="../../data/DcInputs.qml" line="127"/>
+      <source>Fuel cell</source>
+      <translation>Brandstofsel</translation>
+    </message>
+    <message id="dcInputs_shaft_generator">
+      <location filename="../../data/DcInputs.qml" line="130"/>
+      <source>Shaft generator</source>
+      <translation>As kragopwekker</translation>
+    </message>
+    <message id="dcInputs_water_generator">
+      <location filename="../../data/DcInputs.qml" line="133"/>
+      <source>Water generator</source>
+      <translation>Water kragopwekker</translation>
+    </message>
+    <message id="dcInputs_wind_charger">
+      <location filename="../../data/DcInputs.qml" line="136"/>
+      <source>Wind charger</source>
+      <translation>Windlaaier</translation>
+    </message>
+    <message id="digitalinputs_state_low">
+      <location filename="../../src/enums.cpp" line="99"/>
+      <source>Low</source>
+      <extracomment>Digital input state</extracomment>
+      <translation>Laag</translation>
+    </message>
+    <message id="digitalinputs_state_high">
+      <location filename="../../src/enums.cpp" line="103"/>
+      <source>High</source>
+      <extracomment>Digital input state</extracomment>
+      <translation>Hoog</translation>
+    </message>
+    <message id="ess_state_keep_batteries_charged">
+      <location filename="../../data/Ess.qml" line="47"/>
+      <source>Keep batteries charged</source>
+      <translation>Hou batterye gelaai</translation>
+    </message>
+    <message id="ess_state_optimized_with_battery_life">
+      <location filename="../../data/Ess.qml" line="33"/>
+      <source>Optimized with battery life</source>
+      <translation>Geoptimaliseer met batterylewe</translation>
+    </message>
+    <message id="ess_state_optimized_without_battery_life">
+      <location filename="../../data/Ess.qml" line="40"/>
+      <source>Optimized without battery life</source>
+      <translation>Geoptimaliseer sonder batterylewe</translation>
+    </message>
+    <message id="evchargers_status_charged">
+      <location filename="../../data/EvChargers.qml" line="115"/>
+      <source>Charged</source>
+      <translation>Gelaai</translation>
+    </message>
+    <message id="evchargers_status_waiting_for_sun">
+      <location filename="../../data/EvChargers.qml" line="118"/>
+      <source>Waiting for sun</source>
+      <translation>Wag vir son</translation>
+    </message>
+    <message id="evchargers_status_waiting_for_rfid">
+      <location filename="../../data/EvChargers.qml" line="121"/>
+      <source>Waiting for RFID</source>
+      <translation>Wag vir RFID</translation>
+    </message>
+    <message id="evchargers_status_waiting_for_start">
+      <location filename="../../data/EvChargers.qml" line="124"/>
+      <source>Waiting for start</source>
+      <translation>Wag vir begin</translation>
+    </message>
+    <message id="evchargers_status_ground_test_error">
+      <location filename="../../data/EvChargers.qml" line="130"/>
+      <source>Ground test error</source>
+      <translation>Grondtoetsfout</translation>
+    </message>
+    <message id="evchargers_status_cp_input_test_error">
+      <location filename="../../data/EvChargers.qml" line="136"/>
+      <source>CP input test error</source>
+      <translation>CP-invoertoetsfout</translation>
+    </message>
+    <message id="evchargers_status_residual_current_detected">
+      <location filename="../../data/EvChargers.qml" line="139"/>
+      <source>Residual current detected</source>
+      <translation>Residuele stroom bespeur</translation>
+    </message>
+    <message id="evchargers_status_undervoltage_detected">
+      <location filename="../../data/EvChargers.qml" line="142"/>
+      <source>Undervoltage detected</source>
+      <translation>Onderspanning bespeur</translation>
+    </message>
+    <message id="evchargers_status_overvoltage_detected">
+      <location filename="../../data/EvChargers.qml" line="145"/>
+      <source>Overvoltage detected</source>
+      <translation>Oorspanning bespeur</translation>
+    </message>
+    <message id="evchargers_status_overheating_detected">
+      <location filename="../../data/EvChargers.qml" line="148"/>
+      <source>Overheating detected</source>
+      <translation>Oorverhitting bespeur</translation>
+    </message>
+    <message id="evchargers_status_charging_limit">
+      <location filename="../../data/EvChargers.qml" line="151"/>
+      <source>Charging limit</source>
+      <translation>Laai limiet</translation>
+    </message>
+    <message id="evchargers_status_start_charging">
+      <location filename="../../data/EvChargers.qml" line="154"/>
+      <source>Start charging</source>
+      <translation>Begin laai</translation>
+    </message>
+    <message id="inverters_state_scheduledcharge">
+      <location filename="../../data/System.qml" line="200"/>
+      <source>Scheduled</source>
+      <translation>Geskeduleer</translation>
+    </message>
+    <message id="page_generator_warm_up">
+      <location filename="../../data/Generators.qml" line="49"/>
+      <source>Warm-up</source>
+      <translation>Maak warm</translation>
+    </message>
+    <message id="page_generator_cool_down">
+      <location filename="../../data/Generators.qml" line="52"/>
+      <source>Cool-down</source>
+      <translation>Koel af</translation>
+    </message>
+    <message id="generator_manually_started">
+      <location filename="../../data/Generators.qml" line="70"/>
+      <source>Manually started</source>
+      <translation>Handmatig begin</translation>
+    </message>
+    <message id="notifications_toast_short_text">
+      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="13"/>
+      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
+      <translation type="unfinished">Mollitia quis est quas deleniti quibusdam explicabo quasi.</translation>
+    </message>
+    <message id="notifications_toast_long_text">
+      <location filename="../../data/mock/config/NotificationsPageConfig.qml" line="16"/>
+      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
+      <translation type="unfinished">Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</translation>
+    </message>
+    <message id="pvinverters_statusCode_boot_loading">
+      <location filename="../../src/enums.cpp" line="173"/>
+      <source>Boot loading</source>
+      <extracomment>PV inverter status code</extracomment>
+      <translation>Selflaai laai</translation>
+    </message>
+    <message id="pvinverter_statusCode_running_mppt">
+      <location filename="../../src/enums.cpp" line="181"/>
+      <source>Running (MPPT)</source>
+      <extracomment>PV inverter status code</extracomment>
+      <translation>Hardloop (MPPT)</translation>
+    </message>
+    <message id="pvinverter_running_throttled">
+      <location filename="../../src/enums.cpp" line="185"/>
+      <source>Running (Throttled)</source>
+      <extracomment>PV inverter status code</extracomment>
+      <translation>Hardloop (Versmoor)</translation>
+    </message>
+    <message id="controlcard_switches_relay_name">
+      <location filename="../../pages/controlcards/SwitchesCard.qml" line="34"/>
+      <source>Relay %1</source>
+      <extracomment>%1 = Relay number</extracomment>
+      <translation>Aflos %1</translation>
+    </message>
+    <message id="solarchargers_state_fault">
+      <location filename="../../src/enums.cpp" line="199"/>
+      <source>Fault</source>
+      <translation>Fout</translation>
+    </message>
+    <message id="solarchargers_state_absorption">
+      <location filename="../../src/enums.cpp" line="205"/>
+      <source>Absorption</source>
+      <translation>Absorpsie</translation>
+    </message>
+    <message id="solarchargers_state_storage">
+      <location filename="../../src/enums.cpp" line="211"/>
+      <source>Storage</source>
+      <translation>Berging</translation>
+    </message>
+    <message id="solarchargers_state_equalize">
+      <location filename="../../src/enums.cpp" line="214"/>
+      <source>Equalize</source>
+      <translation>Maak gelyk</translation>
+    </message>
+    <message id="inverters_state_aes_mode">
+      <location filename="../../data/System.qml" line="130"/>
+      <source>AES mode</source>
+      <translation>AES-modus</translation>
+    </message>
+    <message id="inverters_state_faultcondition">
+      <location filename="../../data/System.qml" line="133"/>
+      <source>Fault condition</source>
+      <translation>Fout toestand</translation>
+    </message>
+    <message id="inverters_state_bulkcharging">
+      <location filename="../../data/System.qml" line="136"/>
+      <source>Bulk charging</source>
+      <translation>Grootmaat laai</translation>
+    </message>
+    <message id="inverters_state_absorptioncharging">
+      <location filename="../../data/System.qml" line="139"/>
+      <source>Absorption charging</source>
+      <translation>Absorpsie laai</translation>
+    </message>
+    <message id="inverters_state_floatcharging">
+      <location filename="../../data/System.qml" line="142"/>
+      <source>Float charging</source>
+      <translation>Float laai</translation>
+    </message>
+    <message id="inverters_state_storagemode">
+      <location filename="../../data/System.qml" line="145"/>
+      <source>Storage mode</source>
+      <translation>Bergingsmodus</translation>
+    </message>
+    <message id="inverters_state_equalisationcharging">
+      <location filename="../../data/System.qml" line="148"/>
+      <source>Equalization charging</source>
+      <translation>Gelykstelling laai</translation>
+    </message>
+    <message id="inverters_state_passthru">
+      <location filename="../../data/System.qml" line="151"/>
+      <source>Pass-thru</source>
+      <translation>Deurgaan</translation>
+    </message>
+    <message id="inverters_state_inverting">
+      <location filename="../../data/System.qml" line="154"/>
+      <source>Inverting</source>
+      <translation>Omsetter</translation>
+    </message>
+    <message id="inverters_state_assisting">
+      <location filename="../../data/System.qml" line="157"/>
+      <source>Assisting</source>
+      <translation>Assisteer</translation>
+    </message>
+    <message id="inverters_state_powersupplymode">
+      <location filename="../../data/System.qml" line="160"/>
+      <source>Power supply mode</source>
+      <translation>Kragtoevoermodus</translation>
+    </message>
+    <message id="inverters_state_wakeup">
+      <location filename="../../data/System.qml" line="167"/>
+      <source>Wake up</source>
+      <translation>Word wakker</translation>
+    </message>
+    <message id="inverters_state_repeatedabsorption">
+      <location filename="../../data/System.qml" line="170"/>
+      <source>Repeated absorption</source>
+      <translation>Herhaalde absorpsie</translation>
+    </message>
+    <message id="inverters_state_autoequalize">
+      <location filename="../../data/System.qml" line="173"/>
+      <source>Auto equalize</source>
+      <translation>Outomatiese gelykstelling</translation>
+    </message>
+    <message id="inverters_state_battery_safe">
+      <location filename="../../data/System.qml" line="176"/>
+      <source>Battery safe</source>
+      <translation>Battery veilig</translation>
+    </message>
+    <message id="inverters_state_loaddetect">
+      <location filename="../../data/System.qml" line="179"/>
+      <source>Load detect</source>
+      <translation>Lading bespeur</translation>
+    </message>
+    <message id="inverters_state_blocked">
+      <location filename="../../data/System.qml" line="182"/>
+      <source>Blocked</source>
+      <translation>Geblokkeer</translation>
+    </message>
+    <message id="inverters_state_test">
+      <location filename="../../data/System.qml" line="185"/>
+      <source>Test</source>
+      <translation>Toets</translation>
+    </message>
+    <message id="settings_rs_ess_dess">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="98"/>
+      <source>Dynamic ESS</source>
+      <translation type="unfinished">Dinamiese WSD</translation>
+    </message>
+    <message id="systemsettings_networkstatus_group_master">
+      <location filename="../../data/SystemSettings.qml" line="91"/>
+      <source>Group Master</source>
+      <extracomment>Network status: Group Master</extracomment>
+      <translation>Groepmeester</translation>
+    </message>
+    <message id="systemsettings_networkstatus_instance_master">
+      <location filename="../../data/SystemSettings.qml" line="95"/>
+      <source>Instance Master</source>
+      <extracomment>Network status: Instance Master</extracomment>
+      <translation>Instansie Meester</translation>
+    </message>
+    <message id="systemsettings_networkstatus_group_and_instance_master">
+      <location filename="../../data/SystemSettings.qml" line="99"/>
+      <source>Group &amp; Instance Master</source>
+      <extracomment>Network status: Group &amp; Instance Master</extracomment>
+      <translation>Groep- en instansiemeester</translation>
+    </message>
+    <message id="systemsettings_networkstatus_standalone_and_group_master">
+      <location filename="../../data/SystemSettings.qml" line="107"/>
+      <source>Standalone &amp; Group Master</source>
+      <extracomment>Network status: Standalone &amp; Group Master</extracomment>
+      <translation>Selfstandige &amp; Groepmeester</translation>
+    </message>
+    <message id="inverterCharger_mode_charger_only">
+      <location filename="../../data/InverterChargers.qml" line="91"/>
+      <source>Charger only</source>
+      <translation>Slegs laaier</translation>
+    </message>
+    <message id="inverterCharger_mode_inverter_only">
+      <location filename="../../data/InverterChargers.qml" line="94"/>
+      <source>Inverter only</source>
+      <translation>Slegs Omsetter</translation>
+    </message>
+    <message id="charger_alarms_short_circuit_alarm">
+      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="58"/>
+      <source>Short circuit alarm</source>
+      <translation>Kortsluiting alarm</translation>
+    </message>
+    <message id="settings_wifi_disable_ap">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="51"/>
+      <source>Disable Access Point</source>
+      <translation>Deaktiveer toegangspunt</translation>
+    </message>
+    <message id="settings_minmax_dc_input">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
+      <source>DC input</source>
+      <translation>GS-invoer</translation>
+    </message>
+    <message id="ess_recommended">
+      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="63"/>
+      <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
+      <translation>Vir litiumbatterye word onder 10% laai nie aanbeveel nie. Vir ander batterytipes, gaan die datablad na vir die minimum vlak wat deur die vervaardiger aanbeveel word.</translation>
+    </message>
+    <message id="controlcard_generator_disableautostartdialog_title">
+      <location filename="../../pages/controlcards/GeneratorCard.qml" line="91"/>
+      <source>Disable autostart?</source>
+      <oldsource>Disable Autostart?</oldsource>
+      <translation>Deaktiveer outobegin?</translation>
+    </message>
+    <message id="controlcard_inverter_charger">
+      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="25"/>
+      <source>Inverter / Charger (%1)</source>
+      <extracomment>%1 = the inverter/charger name</extracomment>
+      <oldsource>Inverter / Charger</oldsource>
+      <translation>Omsetter/laaier (%1)</translation>
+    </message>
+    <message id="settings_page_debug_display_cpu_usage">
+      <location filename="../../pages/settings/debug/PageDebug.qml" line="57"/>
+      <source>Display CPU usage</source>
+      <extracomment>Sentrale Prosseserings Eenheid</extracomment>
+      <translation>Vertoon SPE-gebruik</translation>
+    </message>
+    <message id="settings_page_debug_quit_application">
+      <location filename="../../pages/settings/debug/PageDebug.qml" line="40"/>
+      <source>Quit application</source>
+      <oldsource>Quit Application</oldsource>
+      <translation>Verlaat toepassing</translation>
+    </message>
+    <message id="settings_page_debug_quit">
+      <location filename="../../pages/settings/debug/PageDebug.qml" line="43"/>
+      <source>Quit</source>
+      <translation>Hou op</translation>
+    </message>
+    <message id="settings_page_debug_application_version">
+      <location filename="../../pages/settings/debug/PageDebug.qml" line="104"/>
+      <source>Application version</source>
+      <translation>Toepassing weergawe</translation>
+    </message>
+    <message id="ac-in-genset_oil_temperature">
+      <location filename="../../components/PageGensetModel.qml" line="236"/>
+      <source>Oil temperature</source>
+      <translation>Olie temperatuur</translation>
+    </message>
+    <message id="batterysettingsbattery_time_to_go_discharge_note">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
+      <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
+      <translation>Let daarop dat die verandering van die Tyd -om-te-gaan-ontladingsvloerinstelling ook die Lae toestand-van-lading-instelling in die afloskieslys verander.</translation>
+    </message>
+    <message id="alternator_wakespeed_operation_time">
+      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="121"/>
+      <source>Operation time</source>
+      <translation>Bedryfs tyd</translation>
+    </message>
+    <message id="alternator_wakespeed_charged_ah">
+      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="129"/>
+      <source>Charged Ah</source>
+      <translation>Gelaai Ah</translation>
+    </message>
+    <message id="alternator_wakespeed_cycles_started">
+      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="138"/>
+      <source>Cycles started</source>
+      <translation>Siklusse het begin</translation>
+    </message>
+    <message id="alternator_wakespeed_cycles_completed">
+      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="145"/>
+      <source>Cycles completed</source>
+      <translation>Siklusse voltooi</translation>
+    </message>
+    <message id="alternator_wakespeed_nr_of_power_ups">
+      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="152"/>
+      <source>Number of power-ups</source>
+      <translation>Aantal krag-pieke</translation>
+    </message>
+    <message id="alternator_wakespeed_nr_of_deep_discharges">
+      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="159"/>
+      <source>Number of deep discharges</source>
+      <translation>Aantal diep ontladings</translation>
+    </message>
+    <message id="alternator_wakespeed_charge_cycle_history">
+      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="178"/>
+      <source>Charge cycle history</source>
+      <translation>Laai siklus geskiedenis</translation>
+    </message>
+    <message id="devicelist_tanksetup_sensor_value_when_full">
+      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="70"/>
+      <source>Sensor value when full</source>
+      <translation>Sensorwaarde wanneer vol</translation>
+    </message>
+    <message id="settings_page_relay_generator_auto_start_enabled">
+      <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
+      <source>Autostart functionality</source>
+      <oldsource>Auto start functionality</oldsource>
+      <translation>Autostart-funksie</translation>
+    </message>
+    <message id="page_generator_conditions_make_sure_generator_is_not_connected">
+      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="97"/>
+      <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
+      <translation>Maak seker dat die kragopwekker nie aan WS-invoer %1 gekoppel is wanneer hierdie opsie gebruik word nie</translation>
+    </message>
+    <message id="page_settings_run_time_and_service_service_timer_has_been_reset">
+      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="184"/>
+      <source>The service timer has been reset</source>
+      <translation>Die dienstydteller is teruggestel</translation>
+    </message>
+    <message id="settings_continuous_scan_may_interfere">
+      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
+      <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
+      <translation>Deurlopende skandering kan inmeng met Wi-Fi-werking.</translation>
+    </message>
+    <message id="settings_display_minmax">
+      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="164"/>
+      <source>Minimum and maximum gauge ranges</source>
+      <translation>Minimum en maksimum meter reekse</translation>
+    </message>
+    <message id="settings_restarting_app">
+      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="231"/>
+      <source>Restarting application...</source>
+      <translation>Herbegin applikasie</translation>
+    </message>
+    <message id="settings_language_change_failed">
+      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="139"/>
+      <source>Failed to change language!</source>
+      <translation>Faal om taal te verander!</translation>
+    </message>
+    <message id="settings_language_please_wait">
+      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="144"/>
+      <source>Please wait while the language is changed.</source>
+      <oldsource>Please wait while the language is changed</oldsource>
+      <translation>Wag asseblief terwyl die taal verander word.</translation>
+    </message>
+    <message id="settings_briefview_unit">
+      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="53"/>
+      <source>Brief view unit</source>
+      <extracomment>Show percentage values in Brief view</extracomment>
+      <translation>Kort aansig eenheid</translation>
+    </message>
+    <message id="settings_briefview_unit_none">
+      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="56"/>
+      <source>No labels</source>
+      <translation>Geen etikette nie</translation>
+    </message>
+    <message id="settings_briefview_unit_absolute">
+      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="58"/>
+      <source>Show tank volumes</source>
+      <translation>Toon tenkvolumes</translation>
+    </message>
+    <message id="settings_briefview_unit_percentages">
+      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="60"/>
+      <source>Show percentages</source>
+      <translation>Wys persentasies</translation>
+    </message>
+    <message id="settings_units_amps_exceptions">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="28"/>
+      <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
+      <translation>Let wel: As stroom nie vertoon kan word nie (byvoorbeeld wanneer 'n totaal vir gekombineerde WS- en GS-bronne gewys word), sal krag eerder gewys word.</translation>
+    </message>
+    <message id="settings_dvcc_charge_current_limits">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="31"/>
+      <source>Charge current limits</source>
+      <oldsource>Charge Current limits</oldsource>
+      <translation>Laai Huidige limiete</translation>
+    </message>
+    <message id="settings_firmware_official_release">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
+      <source>Official release</source>
+      <translation>Amptelike vrystelling</translation>
+    </message>
+    <message id="settings_firmware_beta_release">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
+      <source>Beta release</source>
+      <translation>Beta vrystelling</translation>
+    </message>
+    <message id="settings_firmware_testing_internal">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
+      <source>Testing (Victron internal)</source>
+      <extracomment>Select the 'Testing' update feed</extracomment>
+      <translation>Toetsing (Victron intern)</translation>
+    </message>
+    <message id="settings_firmware_develop_internal">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
+      <source>Develop (Victron internal)</source>
+      <extracomment>Select the 'Develop' update feed</extracomment>
+      <translation>Ontwikkel (Victron intern)</translation>
+    </message>
+    <message id="dialoglayer_rebooting">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="326"/>
+      <source>Rebooting...</source>
+      <translation>Herlaai tans …</translation>
+    </message>
+    <message id="settings_enable_status_leds">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="352"/>
+      <source>Enable status LEDs</source>
+      <translation>Aktiveer status-LED's</translation>
+    </message>
+    <message id="settings_page_generator_warm_up_cool_down">
+      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="43"/>
+      <source>Warm-up &amp; cool-down</source>
+      <translation>Opwarming en afkoeling</translation>
+    </message>
+    <message id="page_settings_generator_stop_time">
+      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="74"/>
+      <source>Generator stop time</source>
+      <translation>Kragopwekker stop tyd</translation>
+    </message>
+    <message id="page_settings_generator_alarm_when_not_in_auto_start">
+      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="121"/>
+      <source>Alarm when generator is not in autostart mode</source>
+      <oldsource>Alarm when generator is not in auto start mode</oldsource>
+      <translation>Alarm wanneer kragopwekker nie in outostart-modus is nie</translation>
+    </message>
+    <message id="page_settings_generator_alarm_info">
+      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="127"/>
+      <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
+      <translation>'n Alarm sal geaktiveer word wanneer outobeginfunksie vir meer as 10 minute gedeaktiveer gelaat word</translation>
+    </message>
+    <message id="settings_ess_self_consumption_battery">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="71"/>
+      <source>Self-consumption from battery</source>
+      <translation>Selfverbruik uit battery</translation>
+    </message>
+    <message id="settings_ess_all_system_loads">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="76"/>
+      <source>All system loads</source>
+      <translation>Alle stelsel laai</translation>
+    </message>
+    <message id="settings_ess_only_critical_loads">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
+      <source>Only critical loads</source>
+      <translation>Slegs kritieke vragte</translation>
+    </message>
+    <message id="settings_ess_batteryLife_state">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="143"/>
+      <source>Battery life state</source>
+      <oldsource>BatteryLife state</oldsource>
+      <translation>Battery lewe toestand</translation>
+    </message>
+    <message id="settings_large_access_signal_k">
+      <location filename="../../pages/settings/PageSettingsLarge.qml" line="30"/>
+      <source>Access Signal K at http://venus.local:3000 and via VRM.</source>
+      <oldsource>Access Signal K at http://venus.local:3000 and via VRM</oldsource>
+      <translation>Toegang tot Signal K by http://venus.local:3000 en via VRM.</translation>
+    </message>
+    <message id="settings_large_access_node_red">
+      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
+      <source>Access Node-RED at https://venus.local:1881 and via VRM.</source>
+      <oldsource>Access Node-RED at https://venus.local:1881 and via VRM</oldsource>
+      <translation>Toegang tot Node-RED by https://venus.local:1881 en via VRM.</translation>
+    </message>
+    <message id="settings_system_battery_measurements">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="190"/>
+      <source>Battery measurements</source>
+      <oldsource>Battery Measurements</oldsource>
+      <translation>Battery metings</translation>
+    </message>
+    <message id="settings_system_system_status">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="196"/>
+      <source>System status</source>
+      <oldsource>System Status</oldsource>
+      <translation>Stelsel Status</translation>
+    </message>
+    <message id="settings_device_list">
+      <location filename="../../pages/SettingsPage.qml" line="31"/>
+      <source>Device list</source>
+      <oldsource>Device List</oldsource>
+      <translation>Toestellys</translation>
+    </message>
+    <message id="settings_vrm_device_instances">
+      <location filename="../../pages/SettingsPage.qml" line="148"/>
+      <source>VRM device instances</source>
+      <oldsource>VRM Device Instances</oldsource>
+      <translation>VRM-toestelgevalle</translation>
+    </message>
+    <message id="charger_alarms_high_temperature_alarm">
+      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="49"/>
+      <source>High temperature alarm</source>
+      <translation>Hoë temperatuur alarm</translation>
+    </message>
+    <message id="charger_network_bms_controlled">
+      <location filename="../../pages/solar/SolarChargerNetworkedOperationPage.qml" line="120"/>
+      <source>BMS controlled</source>
+      <oldsource>BMS Controlled</oldsource>
+      <translation>BBS beheer</translation>
+    </message>
+    <message id="charger_alarms_alarms_and_errors">
+      <location filename="../../pages/solar/SolarChargerPage.qml" line="147"/>
+      <source>Alarms &amp; Errors</source>
+      <oldsource>Alarms and Errors</oldsource>
+      <translation>Alarms en foute</translation>
+    </message>
+    <message id="vebus_device_update_firmware">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="124"/>
+      <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
+      <translation>Hierdie kenmerk vereis firmware weergawe 400 of hoër. Kontak jou installeerder om jou Multi/Quattro op te dateer.</translation>
+    </message>
+    <message id="vebus_device_charger_not_ready">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="130"/>
+      <source>Charger not ready, equalization cannot be started</source>
+      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
+      <translation>Laaier nie gereed nie, gelykstelling kan nie begin word nie</translation>
+    </message>
+    <message id="vebus_device_no_equalisation_during_bulk">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="134"/>
+      <source>Equalization cannot be triggered during bulk charge state</source>
+      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
+      <translation>Gelykstelling kan nie tydens grootmaatladingtoestand geaktiveer word nie</translation>
+    </message>
+    <message id="common_words_inverter_mode_eco">
+      <location filename="../../components/CommonWords.qml" line="222"/>
+      <source>Eco</source>
+      <extracomment>Inverter 'Eco' mode</extracomment>
+      <translation>Eko</translation>
+    </message>
+    <message id="common_words_maximum_current">
+      <location filename="../../components/CommonWords.qml" line="268"/>
+      <source>Maximum current</source>
+      <translation>Maksimum stroom</translation>
+    </message>
+    <message id="common_words_maximum_power">
+      <location filename="../../components/CommonWords.qml" line="271"/>
+      <source>Maximum power</source>
+      <translation>Maksimum krag</translation>
+    </message>
+    <message id="common_words_minimum_current">
+      <location filename="../../components/CommonWords.qml" line="280"/>
+      <source>Minimum current</source>
+      <translation>Minimum stroom</translation>
+    </message>
+    <message id="common_words_overall_history">
+      <location filename="../../components/CommonWords.qml" line="342"/>
+      <source>Overall history</source>
+      <translation>Algehele geskiedenis</translation>
+    </message>
+    <message id="common_words_yield_today">
+      <location filename="../../components/CommonWords.qml" line="514"/>
+      <source>Yield Today</source>
+      <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+      <oldsource>Yield today</oldsource>
+      <translation>Opbrengs vandag</translation>
+    </message>
+    <message id="settings_firmware_installed_rebooting">
+      <location filename="../../components/FirmwareUpdate.qml" line="79"/>
+      <source>Firmware installed, device rebooting</source>
+      <oldsource>Firmware installed, rebooting.</oldsource>
+      <translation>Fermware geïnstalleer, toestel herlaai</translation>
+    </message>
+    <message id="digitalinputs_touch_input_control">
+      <location filename="../../src/enums.cpp" line="87"/>
+      <source>Touch input control</source>
+      <translation>Raak invoerbeheer</translation>
+    </message>
+    <message id="evchargers_status_welded_contacts_error">
+      <location filename="../../data/EvChargers.qml" line="133"/>
+      <source>Welded contacts test error (shorted)</source>
+      <oldsource>Welded contacts error</oldsource>
+      <translation>Gelaste kontakte toetsfout (verkort)</translation>
+    </message>
+    <message id="evchargers_status_switching_to_three_phase">
+      <location filename="../../data/EvChargers.qml" line="157"/>
+      <source>Switching to 3 phase</source>
+      <oldsource>Switching to 3-phase</oldsource>
+      <translation>Skakel oor na 3 fase</translation>
+    </message>
+    <message id="evchargers_status_switching_to_single_phase">
+      <location filename="../../data/EvChargers.qml" line="160"/>
+      <source>Switching to 1 phase</source>
+      <oldsource>Switching to single phase</oldsource>
+      <translation>Skakel oor na 1 fase</translation>
+    </message>
+    <message id="evchargers_status_stop_charging">
+      <location filename="../../data/EvChargers.qml" line="163"/>
+      <source>Stop charging</source>
+      <translation>Hou op laai</translation>
+    </message>
+    <message id="evchargers_status_reserved">
+      <location filename="../../data/EvChargers.qml" line="167"/>
+      <source>Reserved</source>
+      <translation>Voorbehou</translation>
+    </message>
+    <message id="notification_description_and_value">
+      <location filename="../../components/NotificationDelegate.qml" line="77"/>
+      <source>%1 %2</source>
+      <extracomment>%1 = notification description (e.g. 'High temperature'), %2 = the value that triggered the notification (e.g. '25 C')</extracomment>
+      <translation>%1 %2</translation>
+    </message>
+    <message id="controlcard_inverter_mode">
+      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="25"/>
+      <source>Inverter mode</source>
+      <translation>Omskakelaarmodus</translation>
+    </message>
+    <message id="inverter_ac-out_num">
+      <location filename="../../components/InverterAcOutSettings.qml" line="45"/>
+      <source>AC Out L%1</source>
+      <extracomment>%1 = phase number (1-3)</extracomment>
+      <translation>WS Out L%1</translation>
+    </message>
+    <message id="dc_input">
+      <location filename="../../components/listitems/ListDcInputQuantityGroup.qml" line="16"/>
+      <source>Input</source>
+      <extracomment>DC input measurement values</extracomment>
+      <translation>Invoer</translation>
+    </message>
+    <message id="inverterCharger_mode_passthrough">
+      <location filename="../../data/InverterChargers.qml" line="99"/>
+      <source>Passthrough</source>
+      <translation>Deurloop</translation>
+    </message>
+    <message id="firmware_installed_build_page_will_reload">
+      <location filename="../../pages/DialogLayer.qml" line="57"/>
+      <source>Page will automatically reload in ten seconds to load the latest version.</source>
+      <translation>Bladsy sal outomaties binne tien sekondes herlaai om die nuutste weergawe te laai.</translation>
+    </message>
+    <message id="controlcard_inverter">
+      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="22"/>
+      <source>Inverter (%1)</source>
+      <extracomment>%1 = the inverter name</extracomment>
+      <translation>Omsetter (%1)</translation>
+    </message>
+    <message id="inverter_chargers_title">
+      <location filename="../../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
+      <source>Inverter/Chargers</source>
+      <translation>Omsetter/laaiers</translation>
+    </message>
+    <message id="settings_cgwacs_no_energy_meters">
+      <location filename="../../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
+      <source>No energy meters found
+
+Note that this menu only shows Carlo Gavazzi meters connected over RS485. For any other meter, including Carlo Gavazzi meters connected over ethernet, see the Modbus TCP/UDP devices menu instead.</source>
+      <translation type="unfinished">Geen energiemeters gevind nie
+
+Let daarop dat hierdie indekslys slegs Carlo Gavazzi-meters wys wat oor RS485 gekoppel is. Vir enige ander meter, insluitend Carlo Gavazzi-meters wat oor ethernet gekoppel is, sien eerder die Modbus TCP/UDP-toestelle-kieslys.</translation>
+    </message>
+    <message id="settings_minmax_autorange">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
+      <source>Auto-ranging</source>
+      <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
+      <translation>Outo-bereik</translation>
+    </message>
+    <message id="settings_minmax_autorange_desc">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="25"/>
+      <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
+      <translation>Wanneer dit geaktiveer is, word die minimum en maksimum van meters en grafieke outomaties aangepas op grond van vorige waardes.</translation>
+    </message>
+    <message id="settings_minmax_reset">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="32"/>
+      <source>Reset all range values to zero</source>
+      <translation>Stel alle reekswaardes terug na nul</translation>
+    </message>
+    <message id="settings_minmax_reset_range_values">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="42"/>
+      <source>Reset Range Values</source>
+      <translation>Stel reekswaardes terug</translation>
+    </message>
+    <message id="settings_minmax_reset_are_you_sure">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="44"/>
+      <source>Are you sure that you want to reset all the values to zero?</source>
+      <translation>Is jy seker jy wil al die waardes na nul terugstel?</translation>
+    </message>
+    <message id="settings_minmax_ac_in_header_with_source">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="87"/>
+      <source>%1 (%2)</source>
+      <extracomment>%1 = 'AC input 1' or 'AC input 2', %2 = name of connected input (e.g. Grid, Shore)</extracomment>
+      <translation>%1 (%2)</translation>
+    </message>
+    <message id="settings_minmax_acout_max_acin1">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="129"/>
+      <source>Maximum current: AC in 1 connected</source>
+      <translation>Maksimum stroom: WS in 1 gekoppel</translation>
+    </message>
+    <message id="settings_minmax_acout_max_acin2">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="137"/>
+      <source>Maximum current: AC in 2 connected</source>
+      <translation>Maksimum stroom: WS in 2 gekoppel</translation>
+    </message>
+    <message id="settings_minmax_acout_max">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="145"/>
+      <source>Maximum current: no AC inputs</source>
+      <translation>Maksimum stroom: geen WS-insette nie</translation>
+    </message>
+    <message id="settings_minmax_dc_out">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="152"/>
+      <source>DC output</source>
+      <translation>GS uitset</translation>
+    </message>
+    <message id="settings_minmax_solar">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="164"/>
+      <source>Solar</source>
+      <translation>Sonkrag</translation>
+    </message>
+    <message id="devicelist_motordrive_motorrpm">
+      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="25"/>
+      <source>Motor RPM</source>
+      <translation>Motor RPM</translation>
+    </message>
+    <message id="devicelist_motordrive_motortemperature">
+      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="33"/>
+      <source>Motor Temperature</source>
+      <translation>Motor temperatuur</translation>
+    </message>
+    <message id="devicelist_motordrive_controllertemperature">
+      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="62"/>
+      <source>Controller Temperature</source>
+      <translation>Kontroleerder temperatuur</translation>
+    </message>
+    <message id="cycle_history_active">
+      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
+      <source>Active cycle</source>
+      <translation>Aktiewe siklus</translation>
+    </message>
+    <message id="cycle_history_num">
+      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
+      <source>Cycle %1</source>
+      <extracomment>%1 = cycle number</extracomment>
+      <translation>Siklus %1</translation>
+    </message>
+    <message id="cycle_history_dc_disconnect">
+      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
+      <source>DC Disconnect</source>
+      <translation>WS Ontkoppel</translation>
+    </message>
+    <message id="cycle_history_powered_off">
+      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
+      <source>Powered off</source>
+      <translation>Afgeskakel</translation>
+    </message>
+    <message id="cycle_history_function_change">
+      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
+      <source>Function change</source>
+      <translation>Funksie verandering</translation>
+    </message>
+    <message id="cycle_history_firmware_update">
+      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
+      <source>Firmware update</source>
+      <translation>Firmware-opdatering</translation>
+    </message>
+    <message id="cycle_history_software_reset">
+      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
+      <source>Software reset</source>
+      <translation>Sagteware herstel</translation>
+    </message>
+    <message id="cycle_history_incomplete">
+      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
+      <source>Incomplete</source>
+      <translation>Onvolledig</translation>
+    </message>
+    <message id="cycle_history_elapsed_time">
+      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
+      <source>Elapsed time</source>
+      <translation>Verstreke tyd</translation>
+    </message>
+    <message id="cycle_history_charge_maintain_ah">
+      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="65"/>
+      <source>Charge / maintain (Ah)</source>
+      <translation>Laai / onderhou (Ah)</translation>
+    </message>
+    <message id="cycle_history_battery_voltage">
+      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="80"/>
+      <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
+      <translation>Battery (V&lt;sub&gt;begin&lt;/sub&gt;/V&lt;sub&gt;einde&lt;/sub&gt;)</translation>
+    </message>
+    <message id="rs_alarm_low_ac_out_voltage">
+      <location filename="../../data/InverterChargers.qml" line="59"/>
+      <source>Low AC OUT voltage</source>
+      <translation>Lae WS OUT spanning</translation>
+    </message>
+    <message id="rs_alarm_high_ac_out_voltage">
+      <location filename="../../data/InverterChargers.qml" line="61"/>
+      <source>High AC OUT voltage</source>
+      <translation>Hoë WS OUT spanning</translation>
+    </message>
+    <message id="settings_multirs_total_yield">
+      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="91"/>
+      <source>Total yield</source>
+      <translation>Totale opbrengs</translation>
+    </message>
+    <message id="settings_multirs_system_yield">
+      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="99"/>
+      <source>System yield</source>
+      <translation>Stelsel opbrengs</translation>
+    </message>
+    <message id="common_words_daily_history">
+      <location filename="../../components/CommonWords.qml" line="126"/>
+      <source>Daily history</source>
+      <translation>Daaglikse geskiedenis</translation>
+    </message>
+    <message id="rs_alarm_no_alarms_to_be_configured">
+      <location filename="../../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
+      <source>No alarms to be configured</source>
+      <translation>Geen alarms om op te stel nie</translation>
+    </message>
+    <message id="inverter_maximum_pv_voltage">
+      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
+      <source>Maximum PV voltage</source>
+      <translation>Maksimum PV-spanning</translation>
+    </message>
+    <message id="inverter_maximum_battery_voltage">
+      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
+      <source>Maximum battery voltage</source>
+      <translation>Maksimum battery spanning</translation>
+    </message>
+    <message id="inverter_minimum_battery_voltage">
+      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
+      <source>Minimum battery voltage</source>
+      <translation>Minimum battery spanning</translation>
+    </message>
+    <message id="battery_bank_error">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="93"/>
+      <source>Battery bank error</source>
+      <translation type="unfinished">Batterybank fout</translation>
+    </message>
+    <message id="battery_bank_error_voltage_not_supported">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="102"/>
+      <source>Battery voltage not supported</source>
+      <translation>Batteryspanning word nie ondersteun nie</translation>
+    </message>
+    <message id="battery_bank_error_incorrect_number_of_batteries">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="105"/>
+      <source>Incorrect number of batteries</source>
+      <translation>Verkeerde aantal batterye</translation>
+    </message>
+    <message id="battery_bank_error_invalid_configuration">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="108"/>
+      <source>Invalid battery configuration</source>
+      <translation>Ongeldige batteryopstelling</translation>
+    </message>
+    <message id="lynxionsystem_balancer_status">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="103"/>
+      <source>Balancer status</source>
+      <translation>Balanser status</translation>
+    </message>
+    <message id="lynxionsystem_balancer_balanced">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
+      <source>Balanced</source>
+      <translation>Gebalanseerd</translation>
+    </message>
+    <message id="lynxionsystem_balancer_imbalance">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="116"/>
+      <source>Imbalance</source>
+      <translation>Wanbalans</translation>
+    </message>
+    <message id="settings_ess_use_this_option_for_systems_no_peak_shaving">
+      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
+      <source>Use this option in systems that do not perform peak shaving.</source>
+      <translation>Gebruik hierdie opsie in stelsels wat nie piek skeer verrig nie.</translation>
+    </message>
+    <message id="settings_ess_use_this_option_for_peak_shaving">
+      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
+      <source>Use this option for peak shaving.</source>
+      <oldsource>Use this option for peak shaving.
+
+The peak shaving threshold is set using the AC input current limit setting.
+
+See documentation for further information.</oldsource>
+      <translation>Gebruik hierdie opsie vir  piek skeer</translation>
+    </message>
+    <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
+      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
+      <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
+      <translation>Die piek skeer drempel word gestel deur die AC-insetstroomlimietinstelling te gebruik. Sien dokumentasie vir verdere inligting.</translation>
+    </message>
+    <message id="settings_ess_use_this_option_for_peak_shaving_with_grid_meter">
+      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
+      <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
+      <translation type="unfinished">Die piek skeerdrempels vir invoer en uitvoer kan op hierdie skerm verander word. Sien dokumentasie vir verdere inligting.</translation>
+    </message>
+    <message id="settings_ess_limit_system_ac_import_current">
+      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
+      <source>Limit system AC import current</source>
+      <translation>Beperk stelsel AC invoerstroom</translation>
+    </message>
+    <message id="settings_ess_limit_ac_import_restrictions">
+      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="105"/>
+      <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
+      <translation>Om hierdie kenmerk te gebruik, moet roostermeting op Eksterne meter gestel word, en 'n bygewerkte ESS-assistent moet geïnstalleer word.</translation>
+    </message>
+    <message id="settings_ess_max_system_import_current">
+      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="112"/>
+      <source>Maximum system import current (per phase)</source>
+      <translation>Maksimum stelsel invoerstroom (per fase)</translation>
+    </message>
+    <message id="settings_ess_limit_ac_export_restrictions">
+      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="146"/>
+      <source>Grid metering must be set to External meter to use this feature.</source>
+      <translation>Roostermeting moet op Eksterne meter gestel word om hierdie kenmerk te gebruik.</translation>
+    </message>
+    <message id="settings_ess_max_system_export_current">
+      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="153"/>
+      <source>Maximum system export current (per phase)</source>
+      <translation>Maksimum stelsel uitvoerstroom (per fase)</translation>
+    </message>
+    <message id="settings_tcpip_wired">
+      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="144"/>
+      <source>Wired</source>
+      <translation>Bedrading</translation>
+    </message>
+    <message id="nav_brief_close_side_panel_high_cpu">
+      <location filename="../../pages/BriefPage.qml" line="486"/>
+      <source>System load high, closing the side panel to reduce CPU load</source>
+      <translation>Stelsellading hoog, maak die sypaneel toe om SVE-lading te verminder</translation>
+    </message>
+    <message id="common_words_input_current_limit">
+      <location filename="../../components/CommonWords.qml" line="215"/>
+      <source>Input current limit</source>
+      <translation>Invoerstroomlimiet</translation>
+    </message>
+    <message id="rs_alarm_short_circuit">
+      <location filename="../../data/InverterChargers.qml" line="65"/>
+      <source>Short circuit</source>
+      <translation>Kortsluiting</translation>
+    </message>
+    <message id="settings_ess_buying">
+      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
+      <source>Buying</source>
+      <translation>Koop</translation>
+    </message>
+    <message id="settings_ess_selling">
+      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
+      <source>Selling</source>
+      <translation>Verkoop</translation>
+    </message>
+    <message id="settings_ess_target_soc">
+      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
+      <source>Target SOC</source>
+      <translation type="unfinished">Teiken SOC</translation>
+    </message>
+    <message id="settings_multirs_ac_out_phase">
+      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="179"/>
+      <source>AC out %1</source>
+      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+      <translation>WS uit %1</translation>
+    </message>
+    <message id="settings_multirs_trackers">
+      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="229"/>
+      <source>Trackers</source>
+      <translation>Spoorsnyers</translation>
+    </message>
+    <message id="settings_rs_devices">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="98"/>
+      <source>RS devices</source>
+      <translation type="unfinished">RS toestelle</translation>
+    </message>
+    <message id="settings_page_debug_pause_electron_animations">
+      <location filename="../../pages/settings/debug/PageDebug.qml" line="65"/>
+      <source>Pause electron animations</source>
+      <translation>Onderbreek elektronanimasies</translation>
+    </message>
+    <message id="devicelist_battery_total_capacity">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="146"/>
+      <source>Total Capacity</source>
+      <translation>Totale kapasiteit</translation>
+    </message>
+    <message id="devicelist_battery_number_of_bmses">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="172"/>
+      <source>Number of BMSes</source>
+      <translation>Aantal BBS'e</translation>
+    </message>
+    <message id="settings_canbus_bms">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="82"/>
+      <source>CAN-bus BMS LV (500 kbit/s)</source>
+      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
+      <translation>CAN-bus BBS LV (500 kbit/s)</translation>
+    </message>
+    <message id="settings_canbus_high_voltage">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="88"/>
+      <source>CAN-bus BMS HV (500 kbit/s)</source>
+      <translation>CAN-bus BBS HV (500 kbit/s)</translation>
+    </message>
+    <message id="settings_ess_limit_system_ac_export_current">
+      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="127"/>
+      <source>Limit system AC export current</source>
+      <translation>Beperk stelsel WS uitvoerstroom</translation>
+    </message>
+    <message id="settings_modbus_tcp_udp_devices">
+      <location filename="../../pages/SettingsPage.qml" line="85"/>
+      <source>Modbus TCP/UDP devices</source>
+      <translation type="unfinished">Modbus TCP/UDP-toestelle</translation>
+    </message>
+    <message id="common_words_add_device">
+      <location filename="../../components/CommonWords.qml" line="17"/>
+      <source>Add device</source>
+      <translation>Voeg toestel by</translation>
+    </message>
+    <message id="page_settings_modbus_scan_for_devices">
+      <location filename="../../pages/settings/PageSettingsModbus.qml" line="37"/>
+      <source>Scan for devices</source>
+      <translation>Soek vir toestelle</translation>
+    </message>
+    <message id="page_settings_modbus_saved_devices">
+      <location filename="../../pages/settings/PageSettingsModbus.qml" line="45"/>
+      <source>Saved devices</source>
+      <translation>Gestoorde toestelle</translation>
+    </message>
+    <message id="page_settings_modbus_discovered_devices">
+      <location filename="../../pages/settings/PageSettingsModbus.qml" line="51"/>
+      <source>Discovered devices</source>
+      <translation>Toestelle ontdek</translation>
+    </message>
+    <message id="add_modbus_tcp_udp_device">
+      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="17"/>
+      <source>Add Modbus TCP/UDP device</source>
+      <translation type="unfinished">Voeg Modbus TCP/UDP toestel by</translation>
+    </message>
+    <message id="modbus_add_device_tcp">
+      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
+      <source>TCP</source>
+      <extracomment>Transmisie Beheer Protokol</extracomment>
+      <translation type="unfinished">TBP</translation>
+    </message>
+    <message id="modbus_add_device_udp">
+      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="33"/>
+      <source>UDP</source>
+      <extracomment>Gebruikers Diagram Protokol</extracomment>
+      <translation type="unfinished">GDP</translation>
+    </message>
+    <message id="modbus_add_device_protocol">
+      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="36"/>
+      <source>Protocol</source>
+      <translation>Protokol</translation>
+    </message>
+    <message id="port_field_title">
+      <location filename="../../components/listitems/core/ListPortField.qml" line="13"/>
+      <source>Port</source>
+      <translation>Poort</translation>
+    </message>
+    <message id="modbus_add_device_unit">
+      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="57"/>
+      <source>Unit</source>
+      <translation>Eenheid</translation>
+    </message>
+    <message id="settings_modbus_no_devices_saved">
+      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="40"/>
+      <source>No Modbus devices saved</source>
+      <translation type="unfinished">Geen Modbus-toestelle gestoor nie</translation>
+    </message>
+    <message id="page_settings_modbus_device_number">
+      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="53"/>
+      <source>Device %1</source>
+      <translation>Toestel %1</translation>
+    </message>
+    <message id="page_settings_modbus_device_remove_device">
+      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="111"/>
+      <source>Remove Modbus device?</source>
+      <translation type="unfinished">Verwyder Modbus-toestel?</translation>
+    </message>
+    <message id="settings_modbus_no_devices_discovered">
+      <location filename="../../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
+      <source>No Modbus devices discovered</source>
+      <translation type="unfinished">Geen Modbus-toestelle ontdek nie</translation>
+    </message>
+    <message id="settings_accharger_battery">
+      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="61"/>
+      <source>Battery %1</source>
+      <extracomment>%1 = battery number</extracomment>
+      <translation>Battery %1</translation>
+    </message>
+    <message id="settings_accharger_current">
+      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="88"/>
+      <source>AC current</source>
+      <extracomment>Wissel Stroom / WS</extracomment>
+      <translation>WS stroom</translation>
+    </message>
+    <message id="generator_dialog_disabled">
+      <location filename="../../components/GeneratorManualControlButton.qml" line="103"/>
+      <source>Generator start/stop disabled</source>
+      <translation>Generator begin/stop gedeaktiveer</translation>
+    </message>
+    <message id="generator_dialog_remote_start_disabled">
+      <location filename="../../components/GeneratorManualControlButton.qml" line="106"/>
+      <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
+      <translation>Die afstandbeginfunksie is op die opwekker gedeaktiveer. Die GX sal nie nou die opwekker kan begin of stop nie. Aktiveer dit op die opwekker-kontrolepaneel.</translation>
+    </message>
+    <message id="ac-in-genset_auto_start_functionality">
+      <location filename="../../components/PageGensetModel.qml" line="58"/>
+      <source>Auto start functionality</source>
+      <translation>Outo-begin funksionaliteit</translation>
+    </message>
+    <message id="ac-in-genset_auto_control_status">
+      <location filename="../../components/PageGensetModel.qml" line="84"/>
+      <source>Control status</source>
+      <translation>Beheer status</translation>
+    </message>
+    <message id="ac-in-genset_status">
+      <location filename="../../components/PageGensetModel.qml" line="110"/>
+      <source>Genset status</source>
+      <translation>Genset status</translation>
+    </message>
+    <message id="ac-in-genset_remote_start_mode">
+      <location filename="../../components/PageGensetModel.qml" line="188"/>
+      <source>Remote start mode</source>
+      <translation>Afstandbeginmodus</translation>
+    </message>
+    <message id="ac-in-genset_oil_pressure">
+      <location filename="../../components/PageGensetModel.qml" line="228"/>
+      <source>Oil pressure</source>
+      <oldsource>Oil Pressure</oldsource>
+      <translation>Oliedruk</translation>
+    </message>
+    <message id="settings_rs_scheduled_charge_levels">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="66"/>
+      <source>Scheduled charge levels</source>
+      <translation>Geskeduleerde  opwekkingsvlakke</translation>
+    </message>
+    <message id="scheduled_charge_active">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="69"/>
+      <source>Active (%1)</source>
+      <translation>Aktief (%1)</translation>
+    </message>
+    <message id="common_words_manual_stop">
+      <location filename="../../components/CommonWords.qml" line="262"/>
+      <source>Manual stop</source>
+      <translation>Handmatige stop</translation>
+    </message>
+    <message id="common_words_open_circuit">
+      <location filename="../../components/CommonWords.qml" line="339"/>
+      <source>Open circuit</source>
+      <translation>Oop kring</translation>
+    </message>
+    <message id="common_words_format_error">
+      <location filename="../../components/CommonWords.qml" line="553"/>
+      <source>#%1 %2</source>
+      <extracomment>%1 = error number, %2 = text description of this error</extracomment>
+      <translation>#%1 %2</translation>
+    </message>
+    <message id="settings_minmax_ac_in_not_available">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="83"/>
+      <source>%1 (not available)</source>
+      <extracomment>%1 = 'AC input 1' or 'AC input 2'</extracomment>
+      <translation>%1 (nie beskikbaar nie)</translation>
+    </message>
+    <message id="application_content_touch_input_on">
+      <location filename="../../ApplicationContent.qml" line="71"/>
+      <source>Touch input on</source>
+      <translation>Raak invoer aan</translation>
+    </message>
+    <message id="application_content_touch_input_off">
+      <location filename="../../ApplicationContent.qml" line="73"/>
+      <source>Touch input off</source>
+      <translation>Raak invoer af</translation>
+    </message>
+    <message id="application_content_touch_input_disabled">
+      <location filename="../../ApplicationContent.qml" line="88"/>
+      <source>Touch input disabled</source>
+      <translation>Raak invoer gedeaktiveer</translation>
+    </message>
+    <message id="notifications_acknowledge_alerts">
+      <location filename="../../components/StatusBar.qml" line="213"/>
+      <source>Acknowledge alerts</source>
+      <translation>Erken waarskuwings</translation>
+    </message>
+    <message id="ac-in-genset_control_error_code">
+      <location filename="../../components/PageGensetModel.qml" line="103"/>
+      <source>Control error code</source>
+      <translation>Beheer foutkode</translation>
+    </message>
+    <message id="settings_batteries_intro">
+      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="45"/>
+      <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
+      <translation>Gebruik hierdie kieslys om die batterydata te definieer wat gewys word wanneer die Battery-ikoon op die Oorsig-bladsy geklik word. Dieselfde keuse is ook sigbaar op die VRM-portaal.</translation>
+    </message>
+    <message id="devicelist_battery_system_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="158"/>
+      <source>System voltage</source>
+      <translation>Stelsel spanning</translation>
+    </message>
+    <message id="batterydetails_connection_information">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="100"/>
+      <source>Connection information</source>
+      <translation>Verbinding inligting</translation>
+    </message>
+    <message id="settings_security_profile_indeterminate">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="109"/>
+      <source>Please select...</source>
+      <translation>Kies asseblief...</translation>
+    </message>
+    <message id="settings_security_profile_secured">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="113"/>
+      <source>Secured</source>
+      <translation>Beveilig</translation>
+    </message>
+    <message id="settings_security_profile_secured_caption">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="116"/>
+      <source>Password protected and the network communication is encrypted</source>
+      <translation>Wagwoord beskerm en die netwerk kommunikasie is geïnkripteer</translation>
+    </message>
+    <message id="settings_security_profile_weak">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="121"/>
+      <source>Weak</source>
+      <translation>Swak</translation>
+    </message>
+    <message id="settings_security_profile_weak_caption">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
+      <source>Password protected, but the network communication is not encrypted</source>
+      <translation>Wagwoord beskerm, maar die netwerkkommunikasie is nie geïnkripteer nie</translation>
+    </message>
+    <message id="settings_security_profile_unsecured">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="129"/>
+      <source>Unsecured</source>
+      <translation>Onbeveilig</translation>
+    </message>
+    <message id="settings_security_profile_unsecured_caption">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="132"/>
+      <source>No password and the network communication is not encrypted</source>
+      <translation>Geen wagwoord nie en die netwerkkommunikasie is nie geïnkripteer nie</translation>
+    </message>
+    <message id="settings_root_too_short_password">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="225"/>
+      <source>Password needs to be at least 8 characters long</source>
+      <translation>Wagwoord moet ten minste 8 karakters lank wees</translation>
+    </message>
+    <message id="settings_security_profile_secured_title">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="172"/>
+      <source>Select 'Secured' profile?</source>
+      <translation>Kies 'Beveilig' profiel?</translation>
+    </message>
+    <message id="settings_security_profile_weak_title">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="175"/>
+      <source>Select 'Weak' profile?</source>
+      <translation>Kies 'Swak' profiel?</translation>
+    </message>
+    <message id="settings_security_profile_unsecured_title">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="178"/>
+      <source>Select 'Unsecured' profile?</source>
+      <translation>Kies 'Onbeveiligde' profiel?</translation>
+    </message>
+    <message id="settings_security_profile_secured_description">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="186"/>
+      <source>• Local network services are password protected
+• The network communication is encrypted
+• A secure connection with VRM is enabled
+• Insecure settings cannot be enabled</source>
+      <translation>• Plaaslike netwerkdienste is wagwoordbeskerm
+• Die netwerkkommunikasie is geïnkripteer
+• 'n Veilige verbinding met VRM is geaktiveer
+• Onveilige instellings kan nie geaktiveer word nie</translation>
+    </message>
+    <message id="settings_security_profile_weak_description">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="189"/>
+      <source>• Local network services are password protected
+• Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
+      <translation>• Plaaslike netwerkdienste is wagwoordbeskerm
+• Ongeënkripteerde toegang tot plaaslike webwerwe is ook geaktiveer (HTTP/HTTPS)</translation>
+    </message>
+    <message id="settings_security_profile_unsecured_description">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="192"/>
+      <source>• Local network services do not need a password
+• Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
+      <translation>• Plaaslike netwerkdienste het nie 'n wagwoord nodig nie
+• Ongeënkripteerde toegang tot plaaslike webwerwe is ook geaktiveer (HTTP/HTTPS)</translation>
+    </message>
+    <message id="settings_root_password">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="217"/>
+      <source>Root password</source>
+      <translation>Hoof/Wortel wagwoord</translation>
+    </message>
+    <message id="settings_logout">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="271"/>
+      <source>Logout</source>
+      <translation>Teken/meld uit</translation>
+    </message>
+    <message id="settings_tailscale_logout_button">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="234"/>
+      <source>Log out now</source>
+      <translation>Meld nou uit</translation>
+    </message>
+    <message id="settings_logout_dialog_title">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="285"/>
+      <source>Log out?</source>
+      <translation>Meld af?</translation>
+    </message>
+    <message id="settings_logout_dialog_description">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="287"/>
+      <source>This will disconnect all local network connections.</source>
+      <translation>Dit sal alle plaaslike netwerkverbindings ontkoppel.</translation>
+    </message>
+    <message id="settings_logout_dialog_accept_text">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="289"/>
+      <source>Log out</source>
+      <translation>Teken/meld uit</translation>
+    </message>
+    <message id="settings_vrm_portal_readonly">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="53"/>
+      <source>Read-only</source>
+      <translation>Lees alleen</translation>
+    </message>
+    <message id="settings_vrm_portal_full">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="55"/>
+      <source>Full</source>
+      <translation>Vol</translation>
+    </message>
+    <message id="settings_vrm_portal_mode_confirm_title">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="75"/>
+      <source>Are you sure?</source>
+      <translation>Is jy seker?</translation>
+    </message>
+    <message id="settings_vrm_portal_mode_confirm_description">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="77"/>
+      <source>Changing this setting to Read-only or Off will lock you out.</source>
+      <translation>Deur hierdie instelling na Lees alleen of Af te verander, sal jy uit teken</translation>
+    </message>
+    <message id="settings_services_mqtt_access">
+      <location filename="../../components/listitems/ListMqttAccessSwitch.qml" line="11"/>
+      <source>MQTT Access</source>
+      <translation type="unfinished">MQTT Toegang</translation>
+    </message>
+    <message id="common_words_error_not_a_number">
+      <location filename="../../components/CommonWords.qml" line="168"/>
+      <source>'%1' is not a number.</source>
+      <translation>'%1' is nie 'n nommer nie.</translation>
+    </message>
+    <message id="settings_radio_button_group_confirm">
+      <location filename="../../components/listitems/core/ListRadioButtonGroup.qml" line="160"/>
+      <source>Confirm</source>
+      <extracomment>Confirm password, and verify it if possible</extracomment>
+      <translation>Bevestig</translation>
+    </message>
+    <message id="number_field_input_too_long">
+      <location filename="../../components/listitems/core/ListIntField.qml" line="21"/>
+      <source>Use a number with %1 digits or less.</source>
+      <translation>Gebruik 'n nommer met %1 syfers of minder.</translation>
+    </message>
+    <message id="ip_address_input_not_valid">
+      <location filename="../../components/listitems/core/ListIpAddressField.qml" line="34"/>
+      <source>'%1' is not a valid IP address.</source>
+      <translation>'%1' is nie 'n geldige IP-adres nie.</translation>
+    </message>
+    <message id="port_input_not_valid">
+      <location filename="../../components/listitems/core/ListPortField.qml" line="26"/>
+      <source>'%1' is not a valid port number. Use a number between 0-65535.</source>
+      <translation>'%1' is nie 'n geldige poortnommer nie. Gebruik 'n nommer tussen 0-65535.</translation>
+    </message>
+    <message id="modbus_add_unit_invalid">
+      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="63"/>
+      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
+      <translation>%1 is nie 'n geldige eenheidnommer nie. Gebruik 'n nommer tussen 1-247.</translation>
+    </message>
+    <message id="settings_page_relay_generator_run_time">
+      <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
+      <source>Current run time</source>
+      <oldsource>Run time</oldsource>
+      <translation>Huidige looptyd</translation>
+    </message>
+    <message id="ac-in-genset_error">
+      <location filename="../../components/PageGensetModel.qml" line="121"/>
+      <source>Genset error codes</source>
+      <translation>Opwekker foutkodes</translation>
+    </message>
+    <message id="genset_heatsink_temperature">
+      <location filename="../../components/PageGensetModel.qml" line="266"/>
+      <source>Heatsink temperature</source>
+      <translation>Verkoeler temperatuur</translation>
+    </message>
+    <message id="genset_charge_voltage_controlled_by_bms">
+      <location filename="../../components/PageGensetModel.qml" line="343"/>
+      <source>The charge voltage is currently controlled by the BMS.</source>
+      <translation>Die laaispanning word tans deur die BBS beheer.</translation>
+    </message>
+    <message id="genset_charge_current_limit">
+      <location filename="../../components/PageGensetModel.qml" line="349"/>
+      <source>Charge current limit</source>
+      <translation>Laai stroom limiet</translation>
+    </message>
+    <message id="genset_bms_controlled">
+      <location filename="../../components/PageGensetModel.qml" line="359"/>
+      <source>BMS Controlled</source>
+      <translation>BBS beheer</translation>
+    </message>
+    <message id="genset_bms_control_enabled_automatically">
+      <location filename="../../components/PageGensetModel.qml" line="365"/>
+      <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
+      <translation>BBS-beheer word outomaties geaktiveer wanneer 'n BMS teenwoordig is. Stel dit terug as die stelselkonfigurasie verander het of as daar geen BMS teenwoordig is nie.</translation>
+    </message>
+    <message id="page_settings_run_time_and_service_service_time_disabled">
+      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="171"/>
+      <source>Service timer disabled.</source>
+      <translation>Dienstydteller is gedeaktiveer.</translation>
+    </message>
+    <message id="settings_logging_vrm_portal">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="45"/>
+      <source>VRM Portal</source>
+      <translation type="unfinished">VRM-portaal</translation>
+    </message>
+    <message id="settings_services_tailscale_remote_vpn_access">
+      <location filename="../../pages/settings/PageSettingsServices.qml" line="31"/>
+      <source>Tailscale (remote VPN access)</source>
+      <translation type="unfinished">Stertskaal (VPN-toegang op afstand)</translation>
+    </message>
+    <message id="common_words_soc">
+      <location filename="../../components/CommonWords.qml" line="417"/>
+      <source>SOC %1</source>
+      <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
+      <translation type="unfinished">SOC %1</translation>
+    </message>
+    <message id="settings_security_warning_profile_configuration_order">
+      <location filename="../../components/listitems/ListMqttAccessSwitch.qml" line="19"/>
+      <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
+      <translation>'n Sekuriteitsprofiel moet opgestel word voordat die netwerkdienste geaktiveer kan word, sien Instellings - Algemeen</translation>
+    </message>
+    <message id="settings_tailscale_replaced_invalid_characters">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="36"/>
+      <source>'%1' was replaced with '%2' since it contained invalid characters.</source>
+      <translation>'%1' is vervang met '%2' aangesien dit ongeldige karakters bevat het.</translation>
+    </message>
+    <message id="settings_tailscale_initializing">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="57"/>
+      <source>Initializing...</source>
+      <translation>Inisialiseer tans …</translation>
+    </message>
+    <message id="settings_tailscale_backend_starting">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="60"/>
+      <source>Backend starting...</source>
+      <translation type="unfinished">Agterkant begin …</translation>
+    </message>
+    <message id="settings_tailscale_backend_stopped">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="63"/>
+      <source>Backend stopped.</source>
+      <translation type="unfinished">Agterkant het gestop.</translation>
+    </message>
+    <message id="settings_tailscale_connection_failed">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="66"/>
+      <source>Connection failed.</source>
+      <translation>Konneksie het misluk.</translation>
+    </message>
+    <message id="settings_tailscale_logged_out">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="69"/>
+      <source>This GX device is logged out of Tailscale.
+
+Please wait or check your internet connection.</source>
+      <translation type="unfinished">Hierdie GX-toestel is by Tailscale afgemeld.
+
+Wag asseblief of gaan jou internetverbinding na.</translation>
+    </message>
+    <message id="settings_tailscale_wait_for_response">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="72"/>
+      <source>Waiting for a response from Tailscale...</source>
+      <translation type="unfinished">Wag tans vir 'n antwoord van Tailscale...</translation>
+    </message>
+    <message id="settings_tailscale_wait_for_login">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="75"/>
+      <source>Connect this GX device to your Tailscale account by opening this link:</source>
+      <translation>Koppel hierdie GX-toestel aan jou Tailscale-rekening deur hierdie skakel oop te maak:</translation>
+    </message>
+    <message id="settings_tailscale_check_internet_connection">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="83"/>
+      <source>Please wait or check your internet connection.</source>
+      <translation>Wag asseblief of gaan jou internetverbinding na.</translation>
+    </message>
+    <message id="settings_tailscale_unknown_state">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="87"/>
+      <source>Unknown state: #%1</source>
+      <extracomment>%1 = number code for the connect state</extracomment>
+      <translation>Onbekende toestand: #%1</translation>
+    </message>
+    <message id="settings_tailscale_error">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="92"/>
+      <source>ERROR: %1</source>
+      <translation>Fout: %1</translation>
+    </message>
+    <message id="settings_tailscale_wifi">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="108"/>
+      <source>WiFi</source>
+      <translation>Wi-Fi</translation>
+    </message>
+    <message id="settings_tailscale_disable_to_edit">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="128"/>
+      <source>Disable Tailscale to edit these settings.</source>
+      <translation>Deaktiveer Tailscale om hierdie instellings te wysig.</translation>
+    </message>
+    <message id="settings_tailscale_enable">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="169"/>
+      <source>Enable Tailscale</source>
+      <translation>Aktiveer Tailscale</translation>
+    </message>
+    <message id="settings_tailscale_machinename">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="207"/>
+      <source>Machine name</source>
+      <translation>Masjiennaam</translation>
+    </message>
+    <message id="settings_tailscale_ipv4">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="218"/>
+      <source>IPv4</source>
+      <translation>IPv4</translation>
+    </message>
+    <message id="settings_tailscale_ipv6">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="225"/>
+      <source>IPv6</source>
+      <translation>IPv6</translation>
+    </message>
+    <message id="settings_tailscale_logout">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="232"/>
+      <source>Logout from Tailscale account</source>
+      <translation>Teken uit van Tailscale-rekening</translation>
+    </message>
+    <message id="settings_tailscale_local_network_access">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="242"/>
+      <source>Local network access</source>
+      <translation>Plaaslike netwerktoegang</translation>
+    </message>
+    <message id="settings_tailscale_local_network_access_ethernet">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="256"/>
+      <source>Access local ethernet network</source>
+      <translation>Toegang tot plaaslike Ethernet-netwerk</translation>
+    </message>
+    <message id="settings_tailscale_local_network_access_wifi">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="263"/>
+      <source>Access local WiFi network</source>
+      <translation>Toegang tot plaaslike WiFi-netwerk</translation>
+    </message>
+    <message id="settings_tailscale_local_network_access_custom_networks">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="270"/>
+      <source>Custom network(s)</source>
+      <translation>Gepasmaakte netwerk(e)</translation>
+    </message>
+    <message id="settings_tailscale_local_network_access_custom_networks_placeholder">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="273"/>
+      <source>Example: 192.168.1.0/24</source>
+      <translation>Voorbeeld: 192.168.1.0/24</translation>
+    </message>
+    <message id="settings_tailscale_local_network_access_explanation">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="286"/>
+      <source>Explanation:
+
+This feature, called subnet routes by Tailscale, allows remote access to other devices in the local network(s).
+
+The custom networks field accepts a comma-separated list of CIDR notation subnets.
+
+After adding/enabling a new network, you need to approve it in the Tailscale admin console once.</source>
+      <translation>-Verduideliking:
+
+Hierdie kenmerk, wat subnet-roetes deur Tailscale genoem word, laat afstandtoegang tot ander toestelle in die plaaslike netwerk(e) toe.
+
+Die pasgemaakte netwerke-veld aanvaar 'n komma-geskeide lys van CIDR-notasie-subnette.
+
+Nadat u 'n nuwe netwerk bygevoeg/geaktiveer het, moet u dit een keer in die Tailscale-administrasiekonsole goedkeur.</translation>
+    </message>
+    <message id="settings_tailscale_advanced_custom_tailscale_up_arguments">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="313"/>
+      <source>Custom "tailscale up" arguments</source>
+      <translation type="unfinished">Pasgemaakte "stertskaal op" argumente</translation>
+    </message>
+    <message id="settings_tailscale_advanced_custom_server_url">
+      <location filename="../../pages/settings/PageSettingsTailscale.qml" line="324"/>
+      <source>Custom server URL (Headscale)</source>
+      <translation type="unfinished">Pasgemaakte bediener-URL (kopskaal)</translation>
+    </message>
+    <message id="genset_controller_requires_helper_relay">
+      <location filename="../../components/PageGensetModel.qml" line="53"/>
+      <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to "Connected genset helper relay".</source>
+      <translation>Hierdie opwerkker-beheerd vereis 'n hulp-relais beheer, maar die hulp-relais is nie gekonfigureer nie. Stel asseblief Relais 1 op onder Instellings → Relais na "Gekoppelde opwekker hulp-relais".</translation>
+    </message>
+    <message id="batteryhistory_high_starter_bat_voltage_alarms">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
+      <source>High starter battery voltage alarms</source>
+      <oldsource>High starter batttery voltage alarms</oldsource>
+      <translation>Hoë aansitter battery spanning alarms</translation>
+    </message>
+    <message id="settings_generator_condition_skip_warmup">
+      <location filename="../../pages/settings/GeneratorCondition.qml" line="138"/>
+      <source>Skip generator warm-up</source>
+      <translation>Slaan kragopwarming oor</translation>
+    </message>
+    <message id="settings_up_but_no_services_500">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
+      <source>Up, but no services (500 kbit/s)</source>
+      <translation>Op, maar geen dienste (500 kbit/s)</translation>
+    </message>
+    <message id="settings_root_password_changed_to">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="231"/>
+      <source>Root password changed to %1</source>
+      <translation>Wortelwagwoord verander na %1</translation>
+    </message>
+    <message id="settings_relay_genset_helper_relay">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="30"/>
+      <source>Connected genset helper relay</source>
+      <translation>Gekoppelde opwekker hulp-relais</translation>
+    </message>
+    <message id="settings_system_ac_position">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="100"/>
+      <source>Position of AC loads</source>
+      <translation>Posisie van WS-ladings</translation>
+    </message>
+    <message id="settings_system_ac_input_and_output">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="119"/>
+      <source>AC input &amp; output</source>
+      <translation>WS inset en uitset</translation>
+    </message>
+    <message id="settings_system_ac_output_only">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="113"/>
+      <source>AC output only</source>
+      <translation>Slegs WS-uitset</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_monthly">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="23"/>
+      <source>Monthly</source>
+      <translation>Maandeliks</translation>
+    </message>
+    <message id="acInputs_evcharger">
+      <location filename="../../data/AcInputs.qml" line="39"/>
+      <source>EV Charger</source>
+      <translation>EV-laaier</translation>
+    </message>
+    <message id="acInputs_heat_pump">
+      <location filename="../../data/AcInputs.qml" line="41"/>
+      <source>Heat pump</source>
+      <translation>Hittepomp</translation>
+    </message>
+    <message id="overview_widget_essential_loads_title">
+      <location filename="../../components/widgets/EssentialLoadsWidget.qml" line="13"/>
+      <source>Essential Loads</source>
+      <translation>Noodsaaklike vragte</translation>
+    </message>
+    <message id="controlcard_generator_autostart_conditions">
+      <location filename="../../pages/controlcards/GeneratorCard.qml" line="66"/>
+      <source>Start and stop the generator based on the configured autostart conditions.</source>
+      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
+      <translation>Begin en stop die kragopwekker gebaseer op die gekonfigureerde outostart toestande.</translation>
+    </message>
+    <message id="page_genset_model_dc_genset_settings">
+      <location filename="../../components/PageGensetModel.qml" line="305"/>
+      <source>DC genset settings</source>
+      <translation>GS opwekker instellings</translation>
+    </message>
+    <message id="alternator_temperature">
+      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="32"/>
+      <source>Alternator Temperature</source>
+      <translation>Alternator temperatuur</translation>
+    </message>
+    <message id="engine_temperature">
+      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="98"/>
+      <source>Engine Temperature</source>
+      <translation>Enjin temperatuur</translation>
+    </message>
+    <message id="page_settings_run_time_and_service_total_run_time">
+      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
+      <source>Total run time</source>
+      <translation>Totale looptyd</translation>
+    </message>
+    <message id="settings_network_security_profile">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="104"/>
+      <source>Network security profile</source>
+      <translation>Netwerk sekuriteit profiel</translation>
+    </message>
+    <message id="charger_history_last_x_days">
+      <location filename="../../pages/solar/SolarHistoryPage.qml" line="62"/>
+      <source>Last %1 days</source>
+      <extracomment>%1 = number of days of solar history that will be shown</extracomment>
+      <translation>Laaste %1 dae</translation>
+    </message>
+    <message id="generator_start_dialog_will_stop_in_x">
+      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="69"/>
+      <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
+      <translation>Kragopwekker sal in %1 stop tensy outobegin toestande geaktiveer is wat dit aan die gang hou.</translation>
+    </message>
+    <message id="generator_start_dialog_will_run_until_manually_stopped">
+      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="71"/>
+      <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
+      <translation>Kragopwekker sal loop totdat dit met die hand gestop word, tensy outobegintoestande geaktiveer is wat dit aan die gang hou.</translation>
+    </message>
+    <message id="settings_display_classic_ui">
+      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="194"/>
+      <source>Classic UI</source>
+      <translation>Klassieke UI</translation>
+    </message>
+    <message id="settings_display_new_ui">
+      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="199"/>
+      <source>New UI</source>
+      <translation>Nuwe UI</translation>
+    </message>
+    <message id="settings_language_change_succeeded">
+      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="142"/>
+      <source>Successfully changed language!</source>
+      <translation>Taal suksesvol verander!</translation>
+    </message>
+    <message id="settings_ess_rs_information">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="31"/>
+      <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
+      <translation>Vir Multi-RS- en HS19-toestelle is ESS-instellings beskikbaar op die RS Systeem-produkbladsy.</translation>
+    </message>
+    <message id="settings_relay_genset_start_stop">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="28"/>
+      <source>Genset start/stop</source>
+      <translation>Opwekker begin/stop</translation>
+    </message>
+    <message id="settings_firmware_switching_not_possible_indeterminate_profile">
+      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
+      <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
+      <translation>Verandering van firmware-weergawe is nie moontlik sonder dat "Netwerksekuriteitsprofiel" in "Instellings / Algemeen" gekies is nie.</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_duration">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="143"/>
+      <source>Duration</source>
+      <oldsource>Duration (hh:mm)</oldsource>
+      <translation>Duur</translation>
+    </message>
+    <message id="rssystem_system_alarms">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="81"/>
+      <source>System alarms</source>
+      <translation>Stelsel alarms</translation>
+    </message>
+    <message id="rs_no_system_alarms">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
+      <source>No system alarms</source>
+      <translation>Geen stelselalarms nie</translation>
+    </message>
+    <message id="welcome_page_back">
+      <location filename="../../pages/welcome/WelcomePage.qml" line="94"/>
+      <source>Back</source>
+      <translation>Terug</translation>
+    </message>
+    <message id="welcome_whatsnew">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="35"/>
+      <source>What's New</source>
+      <translation>Wat is nuut</translation>
+    </message>
+    <message id="welcome_skip">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="45"/>
+      <source>Skip</source>
+      <translation>Slaan oor</translation>
+    </message>
+    <message id="welcome_landing_title">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="64"/>
+      <source>Welcome!</source>
+      <translation>Welkom!</translation>
+    </message>
+    <message id="welcome_landing_text">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="70"/>
+      <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
+
+With streamlined navigation and a fresh look, everything you love is now even easier to access and more visually appealing.</source>
+      <translation>Ons is opgewonde om 'n heeltemal herontwerpte koppelvlak bekend te stel wat beide die bruikbaarheid en estetika van jou GX verbeter.
+
+Met vaartbelynde navigasie en 'n vars voorkoms is alles waarvan jy hou nou selfs makliker toeganklik en meer visueel aantreklik.</translation>
+    </message>
+    <message id="welcome_colors_title">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="74"/>
+      <source>Dark - light mode</source>
+      <translation>Donker - ligte modus</translation>
+    </message>
+    <message id="welcome_colors_text">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="78"/>
+      <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
+      <translation>Verskillende omgewings vra vir verskillende vertoon instellings. Donker- en Ligmodusse verseker die beste kykervaring, ongeag waar jy is.</translation>
+    </message>
+    <message id="welcome_brief_text">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="87"/>
+      <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
+      <translation>Al die sleutel inligting wat jy nodig het, aangebied in 'n skoon en eenvoudige uitleg. Die middelpunt is 'n aanpasbare legstuk met ringe, wat jou met 'n oogopslag vinnige toegang gee tot jou stelselinsigte.</translation>
+    </message>
+    <message id="welcome_overview_text">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="95"/>
+      <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
+      <translation>Kry groter beheer met ons opgedateerde Oorsig-paneel, wat intydse stelseldata bevat – alles op een plek vir maklike monitering.</translation>
+    </message>
+    <message id="welcome_controls_title">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="99"/>
+      <source>Controls</source>
+      <translation>Kontroles</translation>
+    </message>
+    <message id="welcome_units_title">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="106"/>
+      <source>Watts &amp; Amps</source>
+      <translation>Watt &amp; Ampere</translation>
+    </message>
+    <message id="welcome_units_text">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="110"/>
+      <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
+      <translation>Jy kan nou wissel tussen Watt en Ampere. Kies die eenheid wat die beste by jou voorkeur pas.</translation>
+    </message>
+    <message id="welcome_more_title">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="114"/>
+      <source>Learn more</source>
+      <translation>Kom meer te wete</translation>
+    </message>
+    <message id="welcome_more_text_wasm">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="119"/>
+      <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</source>
+      <extracomment>%1 = link to URL with more information</extracomment>
+      <translation>Gaan na die skakel hieronder om meer uit te vind oor die hernude UI.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</translation>
+    </message>
+    <message id="welcome_more_text">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="121"/>
+      <source>Scan the QR code to find out more about the Renewed UI.</source>
+      <translation type="unfinished">Skandeer die QR-kode om meer uit te vind oor die Hernude UI.</translation>
+    </message>
+    <message id="welcome_done">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="137"/>
+      <source>Done</source>
+      <translation>Klaar</translation>
+    </message>
+    <message id="welcome_next">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="139"/>
+      <source>Next</source>
+      <translation>Volgende</translation>
+    </message>
+    <message id="devicelist_solarcharger_error">
+      <location filename="../../pages/settings/devicelist/delegates/DeviceListDelegate_solarcharger.qml" line="15"/>
+      <source>Error: #%1</source>
+      <extracomment>%1 = error number</extracomment>
+      <oldsource>Error: %1</oldsource>
+      <translation>Fout: #%1</translation>
+    </message>
+    <message id="charger_alarms_header_active_errors">
+      <location filename="../../pages/solar/SolarChargerAlarmsAndErrorsPage.qml" line="69"/>
+      <source>Active Error</source>
+      <translation>Aktiewe fout</translation>
+    </message>
+    <message id="page_settings_run_time_and_service_generator_total_run_time">
+      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
+      <source>Generator total run time (hours)</source>
+      <translation>Opwekker totale looptyd (ure)</translation>
+    </message>
+    <message id="settings_startpage_name">
+      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
+      <source>Start page</source>
+      <translation>Begin bladsy</translation>
+    </message>
+    <message id="settings_display_onscreen_ui">
+      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="185"/>
+      <source>User interface</source>
+      <translation>Gebruikerskoppelvlak</translation>
+    </message>
+    <message id="settings_display_remote_console_ui">
+      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="187"/>
+      <source>User interface (Remote Console)</source>
+      <translation>Gebruikerskoppelvlak (Afstandskonsole)</translation>
+    </message>
+    <message id="settings_app_restarted">
+      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="234"/>
+      <source>%1 updated</source>
+      <extracomment>%1 = The name of the setting being updated</extracomment>
+      <translation>%1 opgedateer</translation>
+    </message>
+    <message id="settings_switch_ui">
+      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="238"/>
+      <source>User interface will switch to %1.</source>
+      <extracomment>%1 = the UI version that the system is switching to</extracomment>
+      <translation>Gebruikerskoppelvlak sal oorskakel na %1.</translation>
+    </message>
+    <message id="settings_has_switched_ui">
+      <location filename="../../pages/settings/PageSettingsDisplay.qml" line="242"/>
+      <source>%1 is set to %2</source>
+      <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
+      <translation>%1 is op %2 gestel</translation>
+    </message>
+    <message id="press_ok_to_reboot">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="309"/>
+      <source>Press 'OK' to reboot</source>
+      <translation>Druk 'OK' om te herlaai</translation>
+    </message>
+    <message id="page_settings_nodered_factory_reset">
+      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="31"/>
+      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="45"/>
+      <source>Node-RED factory reset</source>
+      <translation type="unfinished">Node-RED fabriekterugstelling</translation>
+    </message>
+    <message id="page_settings_nodered_factory_reset_confirmation">
+      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="47"/>
+      <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
+      <translation type="unfinished">Is jy seker dat jy Node-RED na fabrieksverstekings wil terugstel? Dit sal al jou vloei uitvee.</translation>
+    </message>
+    <message id="settings_connection_status">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="179"/>
+      <source>Connection status</source>
+      <translation>Verbindingstatus</translation>
+    </message>
+    <message id="settings_connection_error_https_channel">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="220"/>
+      <source>Connection status (HTTPS channel)</source>
+      <translation>Verbindingstatus (HTTPS-kanaal)</translation>
+    </message>
+    <message id="settings_connection_error_http_channel">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="222"/>
+      <source>Connection status (HTTP channel)</source>
+      <translation>Verbindingstatus (HTTP-kanaal)</translation>
+    </message>
+    <message id="settings_connection_error_realtime_channel">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="240"/>
+      <source>Connection status (MQTT Real-time channel)</source>
+      <translation>Verbindingstatus (MQTT-intydse kanaal)</translation>
+    </message>
+    <message id="settings_connection_error_rpc_channel">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="247"/>
+      <source>Connection status (MQTT RPC channel)</source>
+      <translation>Verbindingstatus (MQTT RPC-kanaal)</translation>
+    </message>
+    <message id="controlcard_generator_autostarted">
+      <location filename="../../components/CommonWords.qml" line="80"/>
+      <source>Auto-started • %1</source>
+      <translation>Outo-begin • %1</translation>
+    </message>
+    <message id="settings_relay_deactivation_value">
+      <location filename="../../components/TemperatureRelaySettings.qml" line="89"/>
+      <source>Deactivation value</source>
+      <oldsource>Deativation value</oldsource>
+      <translation>Deaktiveringswaarde</translation>
+    </message>
+    <message id="generator_not_running">
+      <location filename="../../data/Generators.qml" line="67"/>
+      <source>Not running</source>
+      <translation>Nie hardloop nie</translation>
+    </message>
+    <message id="settings_loss_of_communication">
+      <location filename="../../data/Generators.qml" line="76"/>
+      <source>Loss of communication</source>
+      <translation>Verlies aan kommunikasie</translation>
+    </message>
+    <message id="settings_soc_condition">
+      <location filename="../../data/Generators.qml" line="79"/>
+      <source>SOC condition</source>
+      <extracomment>State of Charge = Toestand van Laai</extracomment>
+      <translation type="unfinished">TVL toestand</translation>
+    </message>
+    <message id="settings_ac_load_condition">
+      <location filename="../../data/Generators.qml" line="82"/>
+      <source>AC load condition</source>
+      <translation>WS las toestand</translation>
+    </message>
+    <message id="settings_battery_current_condition">
+      <location filename="../../data/Generators.qml" line="85"/>
+      <source>Battery current condition</source>
+      <translation>Battery huidige toestand</translation>
+    </message>
+    <message id="settings_battery_voltage_condition">
+      <location filename="../../data/Generators.qml" line="88"/>
+      <source>Battery voltage condition</source>
+      <translation>Batteryspanning toestand</translation>
+    </message>
+    <message id="settings_inverter_overload_condition">
+      <location filename="../../data/Generators.qml" line="94"/>
+      <source>Inverter overload condition</source>
+      <translation>Omsetter oorlading toestand</translation>
+    </message>
+    <message id="ess_flags">
+      <location filename="../../components/SystemReason.qml" line="15"/>
+      <source>ESS %1</source>
+      <extracomment>Energy Storage System =  Energie Storings Sisteem</extracomment>
+      <translation>ESS %1</translation>
+    </message>
+    <message id="systemreason_charge_discharge_disabled">
+      <location filename="../../components/SystemReason.qml" line="47"/>
+      <source>ESS %1 Charge/Discharge Disabled</source>
+      <translation>ESS %1 Laai/ontlading gedeaktiveer</translation>
+    </message>
+    <message id="systemreason_charge_disabled">
+      <location filename="../../components/SystemReason.qml" line="50"/>
+      <source>ESS %1 Charge Disabled</source>
+      <translation>ESS %1 heffing gedeaktiveer</translation>
+    </message>
+    <message id="systemreason_discharge_disabled">
+      <location filename="../../components/SystemReason.qml" line="53"/>
+      <source>ESS %1 Discharge Disabled</source>
+      <translation>ESS %1 Ontlading gedeaktiveer</translation>
+    </message>
+    <message id="startpage_option_brief_with_panel">
+      <location filename="../../data/StartPageConfiguration.qml" line="28"/>
+      <source>Brief (side panel open)</source>
+      <extracomment>The 'Brief' page, with the side panel opened</extracomment>
+      <translation>Kort (sypaneel oop)</translation>
+    </message>
+    <message id="startpage_option_levels_tanks">
+      <location filename="../../data/StartPageConfiguration.qml" line="40"/>
+      <source>Levels (Tanks)</source>
+      <extracomment>The 'Levels' page, with the "Tanks" section opened</extracomment>
+      <translation>Vlakke (Tenks)</translation>
+    </message>
+    <message id="startpage_option_levels_environment">
+      <location filename="../../data/StartPageConfiguration.qml" line="46"/>
+      <source>Levels (Environment)</source>
+      <extracomment>The 'Levels' page, with the "Environment" section opened</extracomment>
+      <translation>Vlakke (Omgewing)</translation>
+    </message>
+    <message id="startpage_option_battery list">
+      <location filename="../../data/StartPageConfiguration.qml" line="51"/>
+      <source>Battery list</source>
+      <translation>Battery lys</translation>
+    </message>
+    <message id="firmware_installed_build_gx_device_updated">
+      <location filename="../../pages/DialogLayer.qml" line="55"/>
+      <source>GX device has been updated</source>
+      <translation>GX-toestel is opgedateer</translation>
+    </message>
+    <message id="settings_startpage_timeout_minutes" numerus="yes">
+      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
+      <source>After %n minute(s)</source>
+      <translation>
+        <numerusform>Na %n minuut(e)</numerusform>
+        <numerusform></numerusform>
+      </translation>
+    </message>
+    <message id="settings_startpage_description">
+      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="63"/>
+      <source>Go to this page when the application starts.</source>
+      <translation>Gaan na hierdie bladsy wanneer die toepassing begin.</translation>
+    </message>
+    <message id="settings_startpage_timeout">
+      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="74"/>
+      <source>Timeout</source>
+      <translation>Tyd uit</translation>
+    </message>
+    <message id="settings_startpage_timeout_description">
+      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="84"/>
+      <source>Revert to the start page when the application is inactive.</source>
+      <translation>Verwys terug na die begin bladsy wanneer die toepassing onaktief is.</translation>
+    </message>
+    <message id="settings_startpage_auto_description">
+      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="115"/>
+      <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
+      <translation>Na een minuut van onaktiwiteit, kies die huidige bladsy as die begin bladsy, as dit in hierdie lys is.</translation>
+    </message>
+    <message id="rs_current_limit_not_adjustable">
+      <location filename="../../components/CurrentLimitButton.qml" line="30"/>
+      <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
+      <translation>Hierdie huidige limiet is vasgestel in die stelselkonfigurasie. Dit kan nie aangepas word nie.</translation>
+    </message>
+    <message id="inverter_mode_not_adjustable">
+      <location filename="../../components/InverterChargerModeButton.qml" line="39"/>
+      <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
+      <translation>Die modus is vasgestel in die stelselkonfigurasie. Dit kan nie aangepas word nie.</translation>
+    </message>
+    <message id="settings_generator_function_not_enabled">
+      <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
+      <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
+      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
+      <translation>Kragopwekker begin/stop-funksie is nie geaktiveer nie, gaan na aflosinstellings en stel funksie op "Genset start/stop"</translation>
+    </message>
+    <message id="welcome_controls_text">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="102"/>
+      <source>All the day to day controls are now combined together in the new Controls pane. Accessible from anywhere by tapping the dedicated button on top left of the display.</source>
+      <translation>Al die dag-tot-dag kontroles is nou saam gekombineer in die nuwe kontrolepaneel. Toeganklik vanaf enige plek deur op die toegewyde knoppie links bo op die skerm te tik.</translation>
+    </message>
+    <message id="batteryalarms_high_cell_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
+      <source>High cell voltage</source>
+      <translation>Hoë selspanning</translation>
+    </message>
+    <message id="settings_system_ac_input_only">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="106"/>
+      <source>AC input only</source>
+      <translation>Slegs WS-invoer</translation>
+    </message>
+    <message id="settings_system_ac_input_only_description">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="108"/>
+      <source>The AC output of the Inverter/Charger is not used.</source>
+      <translation>Die WS-uitset van die omsetter/laaier word nie gebruik nie.</translation>
+    </message>
+    <message id="settings_system_ac_output_only_description">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="115"/>
+      <source>All AC loads are on the output of the Inverter/Charger.</source>
+      <translation>Alle WS-ladings is op die uitset van die omsetter/laaier.</translation>
+    </message>
+    <message id="settings_system_ac_input_and_output_description">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="121"/>
+      <source>The system will automatically display loads on the input of the Inverter/Charger if a grid meter is present. Loads on the output are always displayed.</source>
+      <translation>Die stelsel sal outomaties vragte op die insette van die omsetter/laaier vertoon indien 'n rooster-meter teenwoordig is. Vragte op die uitset word altyd vertoon.</translation>
+    </message>
+    <message id="ess_state_optimized_with_battery_life_button">
+      <location filename="../../data/Ess.qml" line="35"/>
+      <source>Optimized + battery life</source>
+      <translation>Geoptimaliseerd + batterylewe</translation>
+    </message>
+    <message id="ess_state_optimized_without_battery_life_button">
+      <location filename="../../data/Ess.qml" line="42"/>
+      <source>Optimized</source>
+      <translation>Geoptimaliseer</translation>
+    </message>
+    <message id="ess_state_keep_batteries_charged_button">
+      <location filename="../../data/Ess.qml" line="49"/>
+      <source>Keep charged</source>
+      <translation>Hou gelaai</translation>
+    </message>
+    <message id="controlcard_inverter_charger_ess_mode">
+      <location filename="../../components/dialogs/InverterChargerEssModeDialog.qml" line="18"/>
+      <source>ESS mode</source>
+      <translation type="unfinished">ESS-modus</translation>
+    </message>
+    <message id="settings_page_run_time_and_service_time_to_service">
+      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="149"/>
+      <source>Runtime until service</source>
+      <translation>Looptyd tot diens</translation>
+    </message>
+    <message id="batteryalarms_high_current">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="45"/>
+      <source>High current</source>
+      <translation>Hoë stroom</translation>
+    </message>
+    <message id="batteryalarms_bms_cable">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="169"/>
+      <source>BMS cable fault</source>
+      <translation>BBS kabel fout</translation>
+    </message>
+    <message id="batteryalarms_contactor">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="176"/>
+      <source>Bad contactor</source>
+      <translation type="unfinished">
+Slegte kontakor</translation>
+    </message>
+    <message id="lynxionsystem_cells_per_battery">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="43"/>
+      <source>Cells per battery</source>
+      <translation>Selle per battery</translation>
+    </message>
+    <message id="alternator_wakespeed_utilization">
+      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="75"/>
+      <source>Utilization</source>
+      <translation>Benutting</translation>
+    </message>
+    <message id="controlcard_evcs_title">
+      <location filename="../../pages/controlcards/EVCSCard.qml" line="24"/>
+      <source>EVCS (%1)</source>
+      <extracomment>%1 = the EVCS name</extracomment>
+      <translation type="unfinished">EVCS (%1)</translation>
+    </message>
+    <message id="page_meteo_wind_direction">
+      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="86"/>
+      <source>Wind direction</source>
+      <translation>Windrigting</translation>
+    </message>
+    <message id="page_meteo_installation_power">
+      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="94"/>
+      <source>Installation Power</source>
+      <translation>Installasie Krag</translation>
+    </message>
+    <message id="page_meteo_daily_yield">
+      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="103"/>
+      <source>Today's yield</source>
+      <translation>Vandag se opbrengs</translation>
+    </message>
+    <message id="page_settings_fronius_inverter_power_limiting">
+      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="65"/>
+      <source>Power limiting</source>
+      <translation>Krag beperking</translation>
+    </message>
+    <message id="page_settings_fronius_inverter_power_limiting_label">
+      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="75"/>
+      <source>This PV inverter has support for power limiting. Disable this setting if it interferes with normal operation.</source>
+      <translation>Hierdie PV-omsetteer  het ondersteuning vir  kragbeperking. Deaktiveer hierdie instelling as dit inmeng met normale funksies.</translation>
+    </message>
+    <message id="settings_vrm_portal_mode">
+      <location filename="../../pages/SettingsPage.qml" line="66"/>
+      <source>VRM Portal mode</source>
+      <translation type="unfinished">VRM-portaalmodus</translation>
+    </message>
+    <message id="direction_north">
+      <location filename="../../src/units.cpp" line="449"/>
+      <source>N</source>
+      <translation>N</translation>
+    </message>
+    <message id="direction_northeast">
+      <location filename="../../src/units.cpp" line="451"/>
+      <source>NE</source>
+      <translation type="unfinished">NO</translation>
+    </message>
+    <message id="direction_east">
+      <location filename="../../src/units.cpp" line="453"/>
+      <source>E</source>
+      <translation type="unfinished">O</translation>
+    </message>
+    <message id="direction_southeast">
+      <location filename="../../src/units.cpp" line="455"/>
+      <source>SE</source>
+      <translation type="unfinished">SO</translation>
+    </message>
+    <message id="direction_south">
+      <location filename="../../src/units.cpp" line="457"/>
+      <source>S</source>
+      <translation>S</translation>
+    </message>
+    <message id="direction_southwest">
+      <location filename="../../src/units.cpp" line="459"/>
+      <source>SW</source>
+      <translation>SW</translation>
+    </message>
+    <message id="direction_west">
+      <location filename="../../src/units.cpp" line="461"/>
+      <source>W</source>
+      <translation>W</translation>
+    </message>
+    <message id="direction_northwest">
+      <location filename="../../src/units.cpp" line="463"/>
+      <source>NW</source>
+      <translation>NW</translation>
+    </message>
+    <message id="settings_dvcc_control_all_vebus_devices">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="217"/>
+      <source>Managed battery controls all Multis and Quattros</source>
+      <translation type="unfinished">Bestuurde battery beheer Multis en Quattros</translation>
+    </message>
+    <message id="settings_dvcc_control_all_vebus_devices_label">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="230"/>
+      <source>When enabled, the managed battery controls all Multis and Quattros. When disabled, only the device on the built-in port is controlled. See documentation for further information.</source>
+      <translation type="unfinished">Wanneer gekoppel sal die battery bestuurs kontrole alle Mulis en Quattros beheer. Wanneer ontkoppel is sal slegs  die toestel op die ingeboude portaal beheer word.  Sien dokumentasie vir verdere inligting.</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAfricaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
+      <source>Morocco Standard Time</source>
+      <translation>Marokko Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
+      <source>W. Central Africa Standard Time</source>
+      <translation>W. Sentraal-Afrika Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
+      <source>South Africa Standard Time</source>
+      <translation>Suid-Afrika Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
+      <source>Namibia Standard Time</source>
+      <translation>Namibië Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
+      <source>Egypt Standard Time</source>
+      <translation>Egipte Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
+      <source>E. Africa Standard Time</source>
+      <translation>O. Afrika Standaardtyd</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAmericaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
+      <source>Argentina Standard Time</source>
+      <translation>Argentinië Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
+      <source>E. South America Standard Time</source>
+      <translation>O. Suid-Amerika Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
+      <source>Greenland Standard Time</source>
+      <translation>Groenland Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
+      <source>Montevideo Standard Time</source>
+      <translation>Montevideo Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
+      <source>Newfoundland Standard Time</source>
+      <translation>Newfoundland Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
+      <source>SA Eastern Standard Time</source>
+      <translation>SA Oostelike Standardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
+      <source>Atlantic Standard Time</source>
+      <translation>Atlantiese Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
+      <source>Central Brazilian Standard Time</source>
+      <translation>Sentraal Brasiliaanse standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>Stille Oseaan SA Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
+      <source>Paraguay Standard Time</source>
+      <translation>Paraguay Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
+      <source>SA Western Standard Time</source>
+      <translation>SA Westelike Standardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
+      <source>Venezuela Standard Time</source>
+      <translation>Venezuela Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
+      <source>Eastern Standard Time</source>
+      <translation>Oostelike Standardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
+      <source>SA Pacific Standard Time</source>
+      <translation>SA Stille Oseaan Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
+      <source>US Eastern Standard Time</source>
+      <translation>Amerikaanse Oostelie Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
+      <source>Canada Central Standard Time</source>
+      <translation>Kanada Sentraal Standaardttyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
+      <source>Central America Standard Time</source>
+      <translation>Sentraal-Amerika Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
+      <source>Central Standard Time (Mexico)</source>
+      <translation>Sentrale Standaardtyd (Mexiko)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
+      <source>Central Standard Time</source>
+      <translation>Sentrale Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
+      <source>Mountain Standard Time (Mexico)</source>
+      <translation>Berg Standaardtyd (Mexiko)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
+      <source>Mountain Standard Time</source>
+      <translation>Berg Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
+      <source>US Mountain Standard Time</source>
+      <translation>Amerikaanse bergestandaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
+      <source>Pacific Standard Time (Mexico)</source>
+      <translation>Stille Oseaan Standardtyd (Mexiko)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
+      <source>Pacific Standard Time</source>
+      <translation>Stille Oseaan Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
+      <source>Alaskan Standard Time</source>
+      <translation>Alaska Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
+      <source>Hawaii-Aleutian</source>
+      <translation>Hawaii-Aleuties</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAntarcticaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+      <source>New Zealand Standard Time</source>
+      <translation>Nieu-Seeland Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>Sentraal-Stille Oseaan Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+      <source>West Pacific Standard Time</source>
+      <translation>Westelike Stille Oseaan Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+      <source>W. Australia Standard Time</source>
+      <translation>W. Australië Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+      <source>SE Asia Standard Time</source>
+      <translation>SO Asië Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+      <source>Central Asia Standard Time</source>
+      <translation>Sentraal-Asië Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+      <source>West Asia Standard Time</source>
+      <translation>Wes-Asië standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+      <source>E. Africa Standard Time</source>
+      <translation>O. Afrika Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>Stille Oseaan SA Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+      <source>SA Western Standard Time</source>
+      <translation>SA Western Standard Time</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzArcticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
+      <source>W. Europe Standard Time</source>
+      <translation>W. Europa Standaard Tyd</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAsiaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
+      <source>Kamchatka Standard Time</source>
+      <translation>Kamchatka Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
+      <source>Magadan Standard Time</source>
+      <translation>Magadan Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
+      <source>Vladivostok Standard Time</source>
+      <translation>Vladivostok Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
+      <source>Yakutsk Standard Time</source>
+      <translation>Yakutsk Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
+      <source>Tokyo Standard Time</source>
+      <translation>Tokio Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
+      <source>Korea Standard Time</source>
+      <translation>Korea Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
+      <source>Singapore Standard Time</source>
+      <translation>Singapoer Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
+      <source>Ulaanbaatar Standard Time</source>
+      <translation>Ulaanbaatar Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
+      <source>Taipei Standard Time</source>
+      <translation>Taipei Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
+      <source>North Asia East Standard Time</source>
+      <translation>Noord-Asië Oos Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
+      <source>China Standard Time</source>
+      <translation>China Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
+      <source>SE Asia Standard Time</source>
+      <translation>SO Asië Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
+      <source>North Asia Standard Time</source>
+      <translation>Noord-Asië Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
+      <source>Myanmar Standard Time</source>
+      <translation>Myanmar Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
+      <source>N. Central Asia Standard Time</source>
+      <translation>N. Sentraal-Asië Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
+      <source>Central Asia Standard Time</source>
+      <translation>Sentraal-Asië Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
+      <source>Bangladesh Standard Time</source>
+      <translation>Bangladesj Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
+      <source>Nepal Standard Time</source>
+      <translation>Nepal Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
+      <source>Sri Lanka Standard Time</source>
+      <translation>Sri Lanka Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
+      <source>India Standard Time</source>
+      <translation>Indië Standaard Tyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
+      <source>West Asia Standard Time</source>
+      <translation>Wes-Asië standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
+      <source>Pakistan Standard Time</source>
+      <translation>Pakistan Standaard Tyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
+      <source>Ekaterinburg Standard Time</source>
+      <translation>Ekaterinburg Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
+      <source>Georgian Standard Time</source>
+      <translation>Georgiese Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
+      <source>Caucasus Standard Time</source>
+      <translation>Kaukasus Standaard Tyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
+      <source>Azerbaijan Standard Time</source>
+      <translation>Azerbeidjan Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
+      <source>Arabian Standard Time</source>
+      <translation>Arabiese Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
+      <source>Afghanistan Standard Time</source>
+      <translation>Afghanistan Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
+      <source>Iran Standard Time</source>
+      <translation>Iran Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
+      <source>Arabic Standard Time</source>
+      <translation>Arabiese Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
+      <source>Arab Standard Time</source>
+      <translation>Arabiese Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
+      <source>Syria Standard Time</source>
+      <translation>Sirië Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
+      <source>Middle East Standard Time</source>
+      <translation>Midde-Ooste Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
+      <source>Jordan Standard Time</source>
+      <translation>Jordan Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
+      <source>Israel Standard Time</source>
+      <translation>Israel Standaardtyd</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAtlanticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+      <source>Greenwich Standard Time</source>
+      <translation>Greenwich Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+      <source>Azores Standard Time</source>
+      <translation>Asore Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+      <source>Cape Verde Standard Time</source>
+      <translation>Kaap Verdiese Standaardtyd</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAustraliaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+      <source>Tasmania Standard Time</source>
+      <translation>Tasmanië Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+      <source>E. Australia Standard Time</source>
+      <translation>O. Australië Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+      <source>AUS Eastern Standard Time</source>
+      <translation>Oostelike Eastern Standardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+      <source>Cen. Australia Standard Time</source>
+      <translation>Cen. Australië Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+      <source>AUS Central Standard Time</source>
+      <translation>AUS Sentrale Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+      <source>W. Australia Standard Time</source>
+      <translation>W. Australië Standaardtyd</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEtcData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
+      <source>GMT +12</source>
+      <translation>GMT +12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
+      <source>GMT </source>
+      <translation>GMT </translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
+      <source>Mid-Atlantic Standard Time</source>
+      <translation>Mid-Atlantiese Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
+      <source>GMT -02</source>
+      <translation>GMT -02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
+      <source>GMT -11</source>
+      <translation>GMT -11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
+      <source>Dateline Standard Time</source>
+      <translation>Datumlyn Standaardtyd</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEuropeData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
+      <source>GMT Standard Time</source>
+      <translation>GMT Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
+      <source>Central Europe Standard Time</source>
+      <translation>Sentraal-Europa Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
+      <source>Central European Standard Time</source>
+      <translation>Sentraal-Europese Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
+      <source>Romance Standard Time</source>
+      <translation>Romanse Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
+      <source>W. Europe Standard Time</source>
+      <translation>W. Europa Standaard Tyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
+      <source>E. Europe Standard Time</source>
+      <translation>E. Europa Standaard Tyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
+      <source>FLE Standard Time</source>
+      <translation>FLE Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
+      <source>GTB Standard Time</source>
+      <translation>GTB Standaard Tyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
+      <source>Belarus Standard Time</source>
+      <translation>Wit-Rusland Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
+      <source>Russian Standard Time</source>
+      <translation>Russiese Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
+      <source>Turkey Standard Time</source>
+      <translation>Turkye Standaardtyd</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzIndianData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
+      <source>Mauritius Standard Time</source>
+      <translation>Mauritius Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
+      <source>Christmas Island Standard Time</source>
+      <translation>Kersfees-eiland Standaardtyd</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzPacificData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
+      <source>Tonga Standard Time</source>
+      <translation>Tonga Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
+      <source>Fiji Standard Time</source>
+      <translation>Fidji Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
+      <source>New Zealand Standard Time</source>
+      <translation>Nieu-Seeland Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>Sentraal-Stille Oseaan Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
+      <source>West Pacific Standard Time</source>
+      <translation>West Stille Oseaan Standardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
+      <source>Samoa Standard Time</source>
+      <translation>Samoa Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
+      <source>Hawaiian Standard Time</source>
+      <translation>Hawaiiaanse standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
+      <source>Easter Island Standard Time</source>
+      <translation>Paaseiland Standaardtyd</translation>
+    </message>
+  </context>
+  <context>
+    <name>AlternatorError</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="22"/>
+      <source>No error</source>
+      <translation>Geen fout nie</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="25"/>
+      <source>Unknown error: %1</source>
+      <translation>Onbekende fout: %1</translation>
+    </message>
+  </context>
+  <context>
+    <name>BmsError</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="10"/>
+      <source>No error</source>
+      <translation>Geen fout nie</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="13"/>
+      <source>Battery initialization error</source>
+      <translation>Battery-initialiseringsfout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="16"/>
+      <source>No batteries connected</source>
+      <translation>Geen batterye gekoppel nie</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="19"/>
+      <source>Unknown battery</source>
+      <translation>Onbekende battery</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="22"/>
+      <source>Different battery types</source>
+      <translation>Verskillende tipes batterye</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="25"/>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="40"/>
+      <source>No. of batteries incorrect</source>
+      <translation>Aantal batterye is verkeerd</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="28"/>
+      <source>Lynx Shunt not found</source>
+      <translation>Lynx-shunt nie gevind nie</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="31"/>
+      <source>Battery measure error</source>
+      <translation>Battery meet fout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="34"/>
+      <source>Internal calculation error</source>
+      <translation>Interne berekeningsfout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="37"/>
+      <source>No. of batteries in series incorrect</source>
+      <translation>Aantal batterye in serie verkeerd</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="44"/>
+      <source>Hardware error</source>
+      <translation>Hardeware fout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="47"/>
+      <source>Watchdog error</source>
+      <translation>Waghondfout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="50"/>
+      <source>Over voltage</source>
+      <translation>Oorspanning</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="53"/>
+      <source>Under voltage</source>
+      <translation>Onder spanning</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="56"/>
+      <source>Over temperature</source>
+      <translation>Oor temperatuur</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="59"/>
+      <source>Under temperature</source>
+      <translation>Onder temperatuur</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="62"/>
+      <source>Under-charge standby</source>
+      <translation>Onderlaai bystand</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="65"/>
+      <source>ADC error</source>
+      <translation type="unfinished">ADO fout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="68"/>
+      <source>Battery comm. error</source>
+      <translation>Battery komm. fout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="71"/>
+      <source>Pre-Charge error</source>
+      <translation>Vooraflaaifout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="75"/>
+      <source>Safety contactor error</source>
+      <translation>Veiligheidskontaktor fout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="79"/>
+      <source>Battery update error</source>
+      <translation>Batteryopdaterings fout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="82"/>
+      <source>BMS cable error</source>
+      <extracomment>Faktuur Bestuursisteem</extracomment>
+      <translation type="unfinished">FBS kabel fout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="85"/>
+      <source>Reference voltage failure</source>
+      <translation>Verwysingsspanningsfout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="88"/>
+      <source>Wrong system voltage</source>
+      <translation>Verkeerde stelselspanning</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="91"/>
+      <source>Pre charge timeout</source>
+      <translation type="unfinished">Voor-veranderings tyd-uit</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="94"/>
+      <source>ATC/ATD failure</source>
+      <translation type="unfinished">ATC/ATD mislukking</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="98"/>
+      <source>Calibration data lost</source>
+      <translation>Kalibrasiedata verloor</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="102"/>
+      <source>Settings invalid</source>
+      <translation>Instellings ongeldig</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="105"/>
+      <source>Interlock</source>
+      <translation type="unfinished">Ineensluiting</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="108"/>
+      <source>Emergency stop</source>
+      <translation>Noodstop</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="111"/>
+      <source>Communication timeout</source>
+      <translation type="unfinished">Kommunikasie-tyduit</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="114"/>
+      <source>Safety lock</source>
+      <translation>Veiligheidslot</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="117"/>
+      <source>Terminal over temperature</source>
+      <translation>Terminale oor verhit</translation>
+    </message>
+  </context>
+  <context>
+    <name>ChargerError</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="7"/>
+      <source>No error</source>
+      <translation>Geen fout nie</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="9"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="103"/>
+      <source>Battery high temperature</source>
+      <translation>Battery hoë temperatuur</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="10"/>
+      <source>Battery high voltage</source>
+      <translation>Battery hoë spanning</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="11"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="12"/>
+      <source>Battery Tsense miswired</source>
+      <translation type="unfinished">Battery Tsense is verkeerd bedraad</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="13"/>
+      <source>Battery Tsense missing</source>
+      <translation type="unfinished">Battery Tsense ontbreek</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="14"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="15"/>
+      <source>Battery Vsense miswired</source>
+      <translation type="unfinished">Battery Vsense verkeerd bedraad</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="16"/>
+      <source>Battery Vsense missing</source>
+      <translation type="unfinished">Battery Vsense ontbreek</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="17"/>
+      <source>Battery high wire losses</source>
+      <translation>Battery hoë draadverliese</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="18"/>
+      <source>Battery low voltage</source>
+      <translation>Battery lae spanning</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="19"/>
+      <source>Battery high ripple voltage</source>
+      <translation>Battery hoë rimpelspanning</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="20"/>
+      <source>Battery low state of charge</source>
+      <translation>Battery lae toestand van lading</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="21"/>
+      <source>Battery mid-point voltage issue</source>
+      <translation>Battery middelpunt spanning kwessie</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="22"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="104"/>
+      <source>Battery temperature too low</source>
+      <translation>Batterytemperatuur te laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="24"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="106"/>
+      <source>Charger high temperature</source>
+      <translation>Laaier hoë temperatuur</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="25"/>
+      <source>Charger excessive current</source>
+      <translation>Oormatige stroom van die laaier</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="26"/>
+      <source>Charger negative current</source>
+      <translation>Laaier negatiewe stroom</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="27"/>
+      <source>Charger bulk time expired</source>
+      <translation>Laaier se grootmaat tyd het verstryk</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="28"/>
+      <source>Charger current sensor issue</source>
+      <translation>Laaier huidige sensor probleem</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="29"/>
+      <source>Internal Tsensor miswired</source>
+      <translation type="unfinished">Interne Tsensor verkeerd bedraad</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="30"/>
+      <source>Internal Tsensor missing</source>
+      <translation type="unfinished">Interne Tsensor ontbreek</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="31"/>
+      <source>Charger fan not detected</source>
+      <translation>Laaiwaaier nie bespeur nie</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="32"/>
+      <source>Charger fan over-current</source>
+      <translation>Laaiwaaier oorstroom</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="33"/>
+      <source>Charger terminal overheat</source>
+      <translation>Laaierterminaal oorverhit</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="34"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="107"/>
+      <source>Charger short circuit</source>
+      <translation>Kortsluiting in die laaier</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="35"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="108"/>
+      <source>Charger power stage issue</source>
+      <translation>Laaier krag status kwessie</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="36"/>
+      <source>Over-charge protection</source>
+      <translation>Oorlaai beskerming</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="38"/>
+      <source>Input high voltage</source>
+      <translation>Invoer hoë spanning</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="39"/>
+      <source>Input excessive current</source>
+      <translation>Voer oormatige stroom in</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="40"/>
+      <source>Input excessive power</source>
+      <translation>Voer oormatige krag in</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="41"/>
+      <source>Input polarity issue</source>
+      <translation>Invoer polariteit kwessie</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="42"/>
+      <source>Input voltage absent</source>
+      <translation>Insetspanning afwesig</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="43"/>
+      <source>Input shutdown (no retries)</source>
+      <translation>Invoerafskakeling (geen herproberings nie)</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="44"/>
+      <source>Input shutdown (retry)</source>
+      <translation>Invoerafskakeling (weer probeer)</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="45"/>
+      <source>Input internal failure</source>
+      <translation>Invoer interne faling</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="47"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="48"/>
+      <source>PV isolation failure</source>
+      <translation>PV isolasie faling</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="49"/>
+      <source>Ground fault detected</source>
+      <translation>Grondfout bespeur</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="51"/>
+      <source>Inverter overload</source>
+      <translation>Omsetter oorlading</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="52"/>
+      <source>Inverter temp too high</source>
+      <translation>Omsetter se temperatuur te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="53"/>
+      <source>Inverter peak current</source>
+      <translation>Omsetter piekstroom</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="54"/>
+      <source>Inverter internal DC level</source>
+      <translation>Omsetter interne WS vlak</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="55"/>
+      <source>Inverter wrong ACout level</source>
+      <translation>Omskakelaar verkeerde ACout-vlak</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="56"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="57"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="59"/>
+      <source>Inverter powerstage fault</source>
+      <translation>Omskakelaar kragverhoog fout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="58"/>
+      <source>Inverter connected to AC</source>
+      <translation>Omskakelaar gekoppel aan WS</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="60"/>
+      <source>ACIN1 relay test fault</source>
+      <translation type="unfinished">ACIN1 weerstand toets fout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="61"/>
+      <source>ACIN2 relay test fault</source>
+      <translation type="unfinished">ACIN2-weerstand-toetsfout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="63"/>
+      <source>Device disappeared</source>
+      <translation>Toestel het verdwyn</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="64"/>
+      <source>Incompatible device</source>
+      <translation>Onversoenbare toestel</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="65"/>
+      <source>BMS connection lost</source>
+      <extracomment>Battery Bestuursisteem</extracomment>
+      <translation type="unfinished">BBS-verbinding verloor</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="66"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="67"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="68"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="69"/>
+      <source>Network misconfigured</source>
+      <translation>Netwerk verkeerd gekonfigureer</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="70"/>
+      <source>Phase rotation</source>
+      <translation>Fase rotasie</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="71"/>
+      <source>Multiple AC inputs</source>
+      <translation>Veelvuldige WS-insette</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="72"/>
+      <source>Phase overload</source>
+      <translation>Fase oorlading</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="74"/>
+      <source>Memory write error</source>
+      <translation>Geheue skryffout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="75"/>
+      <source>CPU temperature too high</source>
+      <translation>SVE temperatuur te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="76"/>
+      <source>Communication lost</source>
+      <translation>Kommunikasie verloor</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="77"/>
+      <source>Calibration data lost</source>
+      <translation>Kalibrasiedata verloor</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="78"/>
+      <source>Incompatible firmware</source>
+      <translation>Onversoenbare firmware</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="79"/>
+      <source>Incompatible hardware</source>
+      <translation>Onversoenbare hardeware</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="80"/>
+      <source>Settings invalid</source>
+      <translation>Instellings ongeldig</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="81"/>
+      <source>Reference voltage failed</source>
+      <translation>Verwysingspanning het misluk</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="82"/>
+      <source>Tester fail</source>
+      <translation>Toetser misluk</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="83"/>
+      <source>History invalid</source>
+      <translation>Geskiedenis ongeldig</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="84"/>
+      <source>kWh counters invalid</source>
+      <translation>kWh tellers ongeldig</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="86"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="87"/>
+      <source>DC voltage error</source>
+      <translation>WS spanning fout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="88"/>
+      <source>GFCI sensor error</source>
+      <translation type="unfinished">GFCI sensor fout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="89"/>
+      <source>3V3 supply error</source>
+      <translation type="unfinished">3V3 toevoer fout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="90"/>
+      <source>5V supply error</source>
+      <translation>5V toevoer fout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="91"/>
+      <source>12V supply error</source>
+      <translation>12V toevoer fout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="92"/>
+      <source>15V supply error</source>
+      <translation>15V toevoer fout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="94"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="95"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="96"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="97"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="98"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="99"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="100"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="101"/>
+      <source>PV Input shutdown</source>
+      <translation>PV-invoer afskakel</translation>
+    </message>
+  </context>
+  <context>
+    <name>PageAcInSetup</name>
+    <message>
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="129"/>
+      <source>Set the switch in an unlocked position to modify the settings.</source>
+      <translation>Stel die skakelaar in 'n oopgesluit posisie om die instellings te verander.</translation>
+    </message>
+  </context>
+  <context>
+    <name>QGuiApplication</name>
+    <message>
+      <location filename="../../src/main.cpp" line="100"/>
+      <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
+      <translation type="unfinished">Gebruik D-Bus-databron: koppel aan die gespesifiseerde D-Bus-adres.</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="101"/>
+      <source>address</source>
+      <comment>D-Bus address</comment>
+      <translation>adres</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="105"/>
+      <source>Use D-Bus data source: connect to the default D-Bus address</source>
+      <translation type="unfinished">Gebruik D-Bus-databron: koppel aan die verstek D-Bus-adres</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="110"/>
+      <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
+      <translation type="unfinished">Gebruik MQTT-databron: koppel aan die gespesifiseerde MQTT-makelaaradres.</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="111"/>
+      <source>address</source>
+      <comment>MQTT broker address</comment>
+      <translation>adres</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="116"/>
+      <source>MQTT data source device portal id.</source>
+      <translation type="unfinished">MQTT databron toestel portaal ID.</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="117"/>
+      <source>portalId</source>
+      <translation type="unfinished">portaalId</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="121"/>
+      <source>MQTT VRM webhost shard</source>
+      <translation type="unfinished">MQTT VRM webgasheer skerf</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="122"/>
+      <source>shard</source>
+      <comment>MQTT VRM webhost shard</comment>
+      <translation type="unfinished">skerf</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="126"/>
+      <source>MQTT data source username</source>
+      <translation type="unfinished">MQTT databron gebruikersnaam</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="127"/>
+      <source>user</source>
+      <comment>MQTT broker username.</comment>
+      <translation>gebruiker</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="131"/>
+      <source>MQTT data source password</source>
+      <translation type="unfinished">MQTT databron wagwoord</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="132"/>
+      <source>pass</source>
+      <comment>MQTT broker password.</comment>
+      <translation>slaag</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="136"/>
+      <source>MQTT data source token</source>
+      <translation type="unfinished">MQTT-databrontoken</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="137"/>
+      <source>token</source>
+      <comment>MQTT broker auth token.</comment>
+      <translation>teken</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="141"/>
+      <source>Enable FPS counter</source>
+      <extracomment>Rame per sekonde</extracomment>
+      <translation type="unfinished">Aktiveer RPS-teller</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="145"/>
+      <source>Skip splash screen</source>
+      <translation>Slaan spatskerm oor</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="149"/>
+      <source>Use mock data source for testing.</source>
+      <translation>Gebruik skyndatabron vir toetsing.</translation>
+    </message>
+  </context>
+  <context>
+    <name>VebusError</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+      <source>Device switched off</source>
+      <translation>Toestel is afgeskakel</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+      <source>Mixed old/new MK2</source>
+      <translation>Gemengde ou/nuwe MK2</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+      <source>Expected devices error</source>
+      <translation>Verwagte toestelfout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+      <source>No other device detected</source>
+      <translation>Geen ander toestel bespeur nie</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+      <source>Overvoltage on AC-out</source>
+      <translation>Oorspanning op WS-out</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+      <source>DDC program error</source>
+      <extracomment>Direkte Digitale Beheer</extracomment>
+      <translation type="unfinished">DDB program fout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+      <source>VE.Bus BMS without assistant</source>
+      <translation type="unfinished">VE.Bus BMS sonder assistent</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+      <source>Ground relay test failed</source>
+      <translation>Grond aflos toets het misluk</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+      <source>System time sync error</source>
+      <translation>Stelseltyd-sinkroniseringsfout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+      <source>Grid relay test fault</source>
+      <translation type="unfinished">Rooster relais-toetsfout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+      <source>Config mismatch with 2nd mcu</source>
+      <extracomment>Mikro beheer eenheid</extracomment>
+      <translation type="unfinished">Konfigureer wanpassing met 2de mbe</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+      <source>Device transmit error</source>
+      <translation>Toesteloordragfout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+      <source>Awaiting configuration or dongle missing</source>
+      <translation>Wag op konfigurasie of dongle ontbreek</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+      <source>Phase master missing</source>
+      <translation>Fase-meester ontbreek</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+      <source>Overvoltage has occurred</source>
+      <translation>Oorspanning het voorgekom</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+      <source>Slave does not have AC input!</source>
+      <translation type="unfinished">Slaaf het nie WS-invoer nie!</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+      <source>Device can't be slave</source>
+      <translation type="unfinished">Toestel kan nie slaaf wees nie</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+      <source>System protection initiated</source>
+      <translation>Stelselbeskerming geïnisieer</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+      <source>Firmware incompatibiltiy</source>
+      <translation>Firmware onversoenbaarheid</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+      <source>Internal error</source>
+      <translation>Interne fout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+      <source>Failing relay test prevents connection</source>
+      <translation>Misluk aflostoets verhoed verbinding</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+      <source>VE.Bus error</source>
+      <translation type="unfinished">VE.Bus Fout</translation>
+    </message>
+  </context>
+  <context>
+    <name>Wakespeed</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="143"/>
+      <source>Unknown error: </source>
+      <translation>Onbekende fout:</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="151"/>
+      <source>Internal error</source>
+      <translation>Interne fout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="156"/>
+      <source>No error</source>
+      <translation>Geen fout nie</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="159"/>
+      <source>Battery high temperature</source>
+      <translation>Battery hoë temperatuur</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="162"/>
+      <source>Battery high voltage</source>
+      <translation>Battery hoë spanning</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="165"/>
+      <source>Battery low voltage</source>
+      <translation>Battery lae spanning</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="168"/>
+      <source>Battery voltage exceeded configured max</source>
+      <translation>Batteryspanning oorskry gekonfigureerde maksimum</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="175"/>
+      <source>Alternator high temperature</source>
+      <translation>Alternator hoë temperatuur</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="178"/>
+      <source>Alternator high RPM</source>
+      <translation>Alternator hoë RPM</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="181"/>
+      <source>Field drive FET high temperature</source>
+      <translation type="unfinished">Veldaandrywing FET hoë temperatuur</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="184"/>
+      <source>Required sensor missing</source>
+      <translation>Vereiste sensor ontbreek</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="187"/>
+      <source>Alternator low voltage</source>
+      <translation>Alternator lae spanning</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="190"/>
+      <source>Alternator high voltage offset</source>
+      <translation>Alternator hoë spanning ontset</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="193"/>
+      <source>Alternator Voltage exceeded configured max</source>
+      <translation>Alternator spanning oorskry opgestel maks</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="196"/>
+      <source>Alternator high voltage</source>
+      <translation>Alternator hoë spanning</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="199"/>
+      <source>Battery disconnected</source>
+      <translation>Battery ontkoppel</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="202"/>
+      <source>Battery high voltage disconnect</source>
+      <translation>Battery hoë spanning ontkoppel</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="205"/>
+      <source>Battery instance ouf of range</source>
+      <translation>Battery-instansie buite bereik</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="208"/>
+      <source>Too many BMS's</source>
+      <translation>Te veel BBS'e</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="211"/>
+      <source>Battery about to disconnect</source>
+      <translation type="unfinished">Battery byna ontkoppel</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="214"/>
+      <source>Too many devices to track</source>
+      <translation>Te veel toestelle om na te spoor</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="217"/>
+      <source>Battery low voltage disconnect</source>
+      <translation>Battery lae spanning ontkoppel</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="220"/>
+      <source>Battery high current disconnect</source>
+      <translation>Battery hoë stroom ontkoppel</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="223"/>
+      <source>Battery high temperature disconnect</source>
+      <translation>Battery hoë temperatuur ontkoppel</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="226"/>
+      <source>Battery low temperature disconnect</source>
+      <translation>Battery lae temperatuur ontkoppel</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="229"/>
+      <source>BMS connection lost</source>
+      <translation type="unfinished">BBS-verbinding verloor</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="232"/>
+      <source>ATC Disabled</source>
+      <extracomment>Beskikbare Oordrags Kapasiteit</extracomment>
+      <translation type="unfinished">BOK/ ATC gedeaktiveer</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="235"/>
+      <source>DC/DC converter not ready</source>
+      <translation type="unfinished">GS/GS-omsetter nie gereed nie</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="238"/>
+      <source>DC/DC high primary voltage</source>
+      <translation type="unfinished">GS/GS hoë primêre spanning</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="241"/>
+      <source>DC/DC low primary voltage</source>
+      <translation type="unfinished">GS/GS lae primêre spanning</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="244"/>
+      <source>DC/DC high secondary voltage</source>
+      <translation type="unfinished">GS/GS hoë sekondêre spanning</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="247"/>
+      <source>DC/DC low secondary voltage</source>
+      <translation type="unfinished">GS/GS lae sekondêre spanning</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="250"/>
+      <source>DC/DC high temperature</source>
+      <translation type="unfinished">GS/GS hoë temperatuur</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
+      <source>DC/DC misconfiguration</source>
+      <translation type="unfinished">GS/GS verkeerde konfigurasie</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="171"/>
+      <source>Battery temperature sensor defective</source>
+      <translation>Batterytemperatuursensor gebrekkig</translation>
+    </message>
+  </context>
+  <context>
+    <name>CRE</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="838"/>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="843"/>
+      <source>Unknown error: </source>
+      <translation>Onbekende fout:</translation>
+    </message>
+  </context>
+  <context>
+    <name>DEIF</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="857"/>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="862"/>
+      <source>Unknown error: </source>
+      <translation>Onbekende fout:</translation>
+    </message>
+  </context>
+  <context>
+    <name>DSE</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="242"/>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="247"/>
+      <source>Unknown error: </source>
+      <translation>Onbekende fout:</translation>
+    </message>
+  </context>
+  <context>
+    <name>FischerPanda</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="87"/>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="92"/>
+      <source>Unknown error: </source>
+      <translation>Onbekende fout:</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="98"/>
+      <source>No error</source>
+      <translation>Geen fout nie</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
+      <source>AC voltage L1 too low</source>
+      <translation>WS-spanning L1 te laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
+      <source>AC voltage too low</source>
+      <translation>WS spanning te laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
+      <source>AC voltage L1 too high</source>
+      <translation>WS-spanning L1 te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
+      <source>AC voltage too high</source>
+      <translation>WS spanning te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
+      <source>AC frequency L1 too low</source>
+      <translation>WS frekwensie L1 te laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
+      <source>AC frequency too low</source>
+      <translation>WS frekwensie te laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
+      <source>AC frequency L1 too high</source>
+      <translation>WS frekwensie L1 te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
+      <source>AC frequency too high</source>
+      <translation>WS frekwensie te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
+      <source>AC current L1 too high</source>
+      <translation>Wisselstroom L1 te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
+      <source>AC current too high</source>
+      <translation>WS-stroom te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
+      <source>AC power L1 too high</source>
+      <translation>WS-krag L1 te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
+      <source>AC power too high</source>
+      <translation>WS-krag te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="107"/>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="231"/>
+      <source>Emergency stop</source>
+      <translation>Noodstop</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="108"/>
+      <source>Servo current too high</source>
+      <translation type="unfinished">Servo-stroom te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="109"/>
+      <source>Oil pressure too low</source>
+      <translation>Oliedruk te laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="110"/>
+      <source>Oil pressure too high</source>
+      <translation>Oliedruk te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="111"/>
+      <source>Engine temperature too low</source>
+      <translation>Enjin temperatuur te laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="112"/>
+      <source>Engine temperature too high</source>
+      <translation>Enjin temperatuur te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="113"/>
+      <source>Winding temperature too low</source>
+      <translation>Windtemperatuur te laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="114"/>
+      <source>Winding temperature too high</source>
+      <translation>Windtemperatuur te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="115"/>
+      <source>Exhaust temperature too low</source>
+      <translation>Uitlaattemperatuur te laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="116"/>
+      <source>Exhaust temperature too high</source>
+      <translation>Uitlaattemperatuur te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="117"/>
+      <source>Electronic temperature low</source>
+      <translation>Elektroniese temperatuur laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="118"/>
+      <source>Electronic temperature high</source>
+      <translation>Elektroniese temperatuur hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="119"/>
+      <source>Starter voltage too low</source>
+      <translation>Aansitterspanning te laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="120"/>
+      <source>Starter current too high</source>
+      <translation>Aansitterstroom te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="121"/>
+      <source>Glow voltage too low</source>
+      <translation>Gloeispanning te laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="122"/>
+      <source>Glow current too high</source>
+      <translation>Gloeistroom te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="123"/>
+      <source>Cold-Start-Aid voltage too high</source>
+      <translation>Koue-begin-hulpspanning te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="124"/>
+      <source>Cold-Start-Aid current too high</source>
+      <translation type="unfinished">KOUE AANSKAKEL HULP -stroom te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="125"/>
+      <source>Fuel holding magnet voltage too low</source>
+      <translation>Brandstof hou magneet spanning te laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="126"/>
+      <source>Fuel holding magnet current too high</source>
+      <translation>Brandstof hou magneet stroom te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="127"/>
+      <source>Stop solenoid hold coil voltage too low</source>
+      <translation>Stop solenoïde hou spoel spanning te laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="128"/>
+      <source>Stop solenoid hold coil current too high</source>
+      <translation>Stop solenoïde hou spoelstroom te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="129"/>
+      <source>Stop solenoid pull coil voltage too low </source>
+      <translation>Stop solenoïde trekspoelspanning te laag </translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="130"/>
+      <source>Stop solenoid pull coil current too high</source>
+      <translation>Stop solenoïde trekspoelstroom te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="131"/>
+      <source>Fan/water pump voltage too low</source>
+      <translation>Waaier/waterpompspanning te laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="132"/>
+      <source>Fan/water pump current too high</source>
+      <translation>Stroom van waaier/waterpomp te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="133"/>
+      <source>Current sensor voltage low</source>
+      <translation>Stroomsensorspanning laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="134"/>
+      <source>Current sensor current high</source>
+      <translation>Stroomsensorstroom hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="135"/>
+      <source>Boost output voltage too low</source>
+      <translation>Verhoog uitsetspanning te laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="136"/>
+      <source>Boost output current too high</source>
+      <translation>Versterk uitsetstroom te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="137"/>
+      <source>Bus supply voltage too low</source>
+      <translation>Bus-toevoerspanning te laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="138"/>
+      <source>Bus supply current too high</source>
+      <translation>Bus-toevoerstroom te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="139"/>
+      <source>Starter battery voltage too low</source>
+      <translation>Aansitter batteryspanning te laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="140"/>
+      <source>Starter battery voltage too high</source>
+      <translation>Aansitter batteryspanning te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="141"/>
+      <source>Rotation too low</source>
+      <translation>Rotasie te laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="142"/>
+      <source>Rotation too high</source>
+      <translation>Rotasie te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="143"/>
+      <source>Unexpected stop/problem with fuel supply</source>
+      <translation>Onverwagte stop/probleem met brandstof toevoer</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="144"/>
+      <source>Power contactor voltage too low</source>
+      <translation>Kragkontaktor spanning te laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="145"/>
+      <source>Power contactor current too high</source>
+      <translation>Kragkontaktor stroom te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="146"/>
+      <source>AC voltage L2 too low</source>
+      <translation>WS spanning L2 te laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="147"/>
+      <source>AC voltage L2 too high</source>
+      <translation>WS spanning L2 te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="148"/>
+      <source>AC frequency L2 too low</source>
+      <translation>WS frekwensie L2 te laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="149"/>
+      <source>AC frequency L2 too high</source>
+      <translation>WS frekwensie L2 te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="150"/>
+      <source>AC current L2 too high</source>
+      <translation>WS stroom L2 te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="151"/>
+      <source>AC power L2 too high</source>
+      <translation>WS-krag L2 te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="152"/>
+      <source>AC voltage L3 too low</source>
+      <translation>WS spanning L3 te laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="153"/>
+      <source>AC voltage L3 too high</source>
+      <translation>WS spanning L3 te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="154"/>
+      <source>AC frequency L3 too low</source>
+      <translation>WS frekwensie L3 te laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="155"/>
+      <source>AC frequency L3 too high</source>
+      <translation>WS frekwensie L3 te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="156"/>
+      <source>AC current L3 too high</source>
+      <translation>WS stroom L3 te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="157"/>
+      <source>AC power L3 too high</source>
+      <translation>WS krag L3 te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="158"/>
+      <source>Output Inverter voltage too low</source>
+      <translation>Uitset-omskakelaar spanning te laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="159"/>
+      <source>Output Inverter current too  high</source>
+      <translation>Uitset-omskakelaar stroom te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="160"/>
+      <source>Universal output (1A) voltage too low</source>
+      <translation>Universele uitset (1A) spanning te laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="161"/>
+      <source>Universal output (1A) current too high</source>
+      <translation>Universele uitset (1A) stroom te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="162"/>
+      <source>Universal output (5A) voltage too low</source>
+      <translation>Universele uitset (5A) spanning te laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="163"/>
+      <source>Universal output (5A) current too high</source>
+      <translation>Universele uitset (5A) stroom te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="164"/>
+      <source>AGT DC voltage 1 low</source>
+      <extracomment>Advanced Generator Technology - Gevorderde Opwekker Tegnologie</extracomment>
+      <translation type="unfinished">AGT GS spanning 1 laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="165"/>
+      <source>AGT DC voltage 1 high</source>
+      <translation type="unfinished">AGT GS spanning 1 hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="166"/>
+      <source>AGT DC current 1 low</source>
+      <translation type="unfinished">AGT GS stroom 1 laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="167"/>
+      <source>AGT DC current 1 high</source>
+      <translation type="unfinished">AGT GS stroom 1 hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="168"/>
+      <source>AGT DC voltage 2 low</source>
+      <translation type="unfinished">AGT GS spanning 2 laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="169"/>
+      <source>AGT DC voltage 2 high</source>
+      <translation type="unfinished">AGT GS spanning 2 hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="170"/>
+      <source>AGT DC current 2 low</source>
+      <translation type="unfinished">AGT GS stroom 2 laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="171"/>
+      <source>AGT DC current 2 high</source>
+      <translation type="unfinished">AGT GS stroom 2 hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="172"/>
+      <source>AGT B6 cooler low</source>
+      <translation>AGT B6 koeler laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="173"/>
+      <source>AGT B6 cooler high</source>
+      <translation>AGT B6 koeler hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="174"/>
+      <source>AGT B6 rail (-) low</source>
+      <translation>AGT B6 spoor (-) laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="175"/>
+      <source>AGT B6 rail (-) high</source>
+      <translation>AGT B6 spoor (-) hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="176"/>
+      <source>AGT B6 rail (+) low</source>
+      <translation>AGT B6 spoor (+) laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="177"/>
+      <source>AGT B6 rail (+) high</source>
+      <translation>AGT B6 spoor (+) hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="178"/>
+      <source>Fuel temperature too low</source>
+      <translation>Brandstoftemperatuur te laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="179"/>
+      <source>Fuel temperature too high</source>
+      <translation>Brandstoftemperatuur te hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="180"/>
+      <source>Fuel level too low</source>
+      <translation>Brandstofvlak te laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="183"/>
+      <source>Lost control unit</source>
+      <translation>Beheereenheid verloor</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="184"/>
+      <source>Lost panel</source>
+      <translation>Paneel verloor</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="185"/>
+      <source>Service needed</source>
+      <translation>Diens benodig</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="186"/>
+      <source>Lost 3-phase module</source>
+      <translation>Verlore 3-fase module</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="187"/>
+      <source>Lost AGT module</source>
+      <extracomment>Gevorderde Opwekkings tegnologie</extracomment>
+      <translation>AGT-module verloor</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="188"/>
+      <source>Synchronization failure</source>
+      <translation>Sinchronisasie mislukking</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="189"/>
+      <source>Lost external ECU</source>
+      <translation type="unfinished">Verlore eksterne ECU</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="190"/>
+      <source>Intake airfilter</source>
+      <translation>Inlaat lugfilter</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="191"/>
+      <source>Diagnostic message (ECU)</source>
+      <translation type="unfinished">Diagnostiese boodskap (ECU)</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="192"/>
+      <source>Lost sync. module</source>
+      <translation>Sinkronisering verloor. module</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="193"/>
+      <source>Load-balance failed</source>
+      <translation>Lasbalans het misluk</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="194"/>
+      <source>Sync-mode deactivated</source>
+      <translation>Sinkronisering-modus gedeaktiveer</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="195"/>
+      <source>Red Stop Lamp (RSL)</source>
+      <translation>Rooi stoplamp (RSL)</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="196"/>
+      <source>Amber Warning Lamp (AWL)</source>
+      <translation>Amber waarskuwingslamp (AWL)</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="197"/>
+      <source>Malfunction Indicator Lamp (MIL)</source>
+      <translation>Wanfunksie-aanwyserlamp (MIL)</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="198"/>
+      <source>Protect Lamp (PL)</source>
+      <translation>Beskerm lamp (PL)</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="199"/>
+      <source>Rotating field wrong</source>
+      <translation type="unfinished">Draai/stroom veld verkeerd</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="200"/>
+      <source>Fuel level sensor lost</source>
+      <translation>Brandstofvlak sensor verloor</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="201"/>
+      <source>Starting without inverter</source>
+      <translation>Begin sonder omsetter</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="202"/>
+      <source>Bus #1 dead</source>
+      <translation type="unfinished">Bus #1 is dood</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="203"/>
+      <source>Start request denied</source>
+      <translation>Begin-versoek geweier</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="204"/>
+      <source>Remote start denied</source>
+      <translation>Afstand-begin geweier</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="205"/>
+      <source>Forced switch off load relay</source>
+      <translation>Geforseerde afskakeling van lasrelais</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="206"/>
+      <source>Synchronization Module is offline</source>
+      <translation>Sinchronisasiemodule is van lyn af</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="207"/>
+      <source>Lost BMS</source>
+      <translation>BBS verloor</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="208"/>
+      <source>Converter DC Link Voltage Low/Reverse</source>
+      <translation>Omsetter GS-skakelspanning laag/omgekeerd</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="209"/>
+      <source>Converter DC Link Current Low</source>
+      <translation>Omskakelaar GS-skakelstroom laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="210"/>
+      <source>Converter DC Precharge Voltage Low</source>
+      <translation>Omsetter GS Voorlaaispanning laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="211"/>
+      <source>Converter DC Precharge Voltage High</source>
+      <translation>Omsetter GS Voorlaaispanning hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="212"/>
+      <source>Converter IGBT/MOSFET Driver Error</source>
+      <translation type="unfinished">Omskakelaar IGBT/MOSFET-bestuurderfout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="213"/>
+      <source>Converter Error Power Control Loop</source>
+      <translation>Omskakelerfout Krag beheerlus</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="214"/>
+      <source>Converter AC Frequency Detection</source>
+      <translation>Omskakelaar WS-frekwensie-opsporing</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="215"/>
+      <source>Converter Control Value Fail</source>
+      <translation>Omskakelaarbeheerwaarde misluk</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="216"/>
+      <source>Factory setting changed</source>
+      <translation>Fabrieksinstelling verander</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="217"/>
+      <source>Parameter changed in admin mode</source>
+      <translation>Parameter verander in admin modus</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="218"/>
+      <source>Manual Intervention (ext. System)</source>
+      <translation>Handmatige intervensie (byl. Stelsel)</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="221"/>
+      <source>Init failed</source>
+      <translation type="unfinished">Init het misluk</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="222"/>
+      <source>Watchdog</source>
+      <translation type="unfinished">Waghond</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="223"/>
+      <source>Inverter temperature high L1</source>
+      <translation>Omskakelaar temperatuur hoog L1</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="224"/>
+      <source>Inverter temperature high L2</source>
+      <translation>Omskakelaar temperatuur hoog L2</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="225"/>
+      <source>Inverter temperature high L3</source>
+      <translation>Omskakelaar temperatuur hoog L3</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="226"/>
+      <source>Inverter temperature high DC link</source>
+      <translation>Omskakelaar temperatuur hoë DC skakel</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="227"/>
+      <source>Inverter overload</source>
+      <translation>Omskakelaar oorlading</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="228"/>
+      <source>Inverter communication lost</source>
+      <translation>Omskakelaar kommunikasie verloor</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="229"/>
+      <source>DC overload</source>
+      <translation>GS oorlading</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="230"/>
+      <source>DC overvoltage</source>
+      <translation>GS oorspanning</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="232"/>
+      <source>No connection</source>
+      <translation>Geen verbinding</translation>
+    </message>
+  </context>
+  <context>
+    <name>GensetError</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="68"/>
+      <source>No error</source>
+      <translation>Geen fout nie</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="79"/>
+      <source>Unknown error: %1</source>
+      <translation>Onbekende fout: %1</translation>
+    </message>
+  </context>
+  <context>
+    <name>Hatz</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="778"/>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="784"/>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="790"/>
+      <source>Unknown error: </source>
+      <translation>Onbekende fout:</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="797"/>
+      <source>Oil pressure</source>
+      <translation>Oliedruk</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="798"/>
+      <source>Cylinder head overtemperature</source>
+      <translation>Silinderkop oorverhit</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="799"/>
+      <source>Charge control</source>
+      <translation>Laai beheer</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="800"/>
+      <source>Speed higher than expected</source>
+      <translation>Spoed hoër as verwag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="801"/>
+      <source>Overspeed</source>
+      <translation>Oorspoed</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="803"/>
+      <source>Oiltemperature higher than expected</source>
+      <translation>Olietemperatuur hoër as verwag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="804"/>
+      <source>Oiltemperature open circuit / short to power</source>
+      <translation>Olietemperatuur oop kring / kort na krag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="805"/>
+      <source>Oiltemperature short to ground</source>
+      <translation>Olietemperatuur kort tot grond</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="806"/>
+      <source>Analog setpoint high / short to power</source>
+      <translation>Analoog stelpunt hoog / kort tot krag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="807"/>
+      <source>Analog setpoint low / short to ground</source>
+      <translation>Analoog stelpunt laag / kort na grond</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="808"/>
+      <source>TSC1 message receive timeout</source>
+      <translation type="unfinished">TSC1-boodskap ontvang uitteltyd</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="809"/>
+      <source>CM1 message receive timeout</source>
+      <translation type="unfinished">CM1-boodskap ontvang uitteltyd</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="810"/>
+      <source>Battery voltage high</source>
+      <translation>Batteryspanning hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="811"/>
+      <source>Battery voltage low</source>
+      <translation>Batteryspanning laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="812"/>
+      <source>Speed signal distorted</source>
+      <translation>Spoedsein vervorm</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="813"/>
+      <source>Internal 5V sensor supply high</source>
+      <translation>Interne 5V sensor toevoer hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="814"/>
+      <source>Internal 5V sensor supply low</source>
+      <translation>Interne 5V sensor toevoer laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="815"/>
+      <source>Barometric pressure high</source>
+      <translation>Barometriese druk hoog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="816"/>
+      <source>Barometric pressure low</source>
+      <translation>Barometriese druk laag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="817"/>
+      <source>Output fuelpump short to power</source>
+      <translation type="unfinished">Uitset brandstofpomp kortsluit na krag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="818"/>
+      <source>Output fuelpump short to ground</source>
+      <translation>Uitset brandstofpomp kortsluit na grond</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="819"/>
+      <source>Output glow plug short to power</source>
+      <translation>Uitset gloeiprop kort na krag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="820"/>
+      <source>Output glow plug short to ground</source>
+      <translation>Uitset gloeiprop kortsluit na grond</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="821"/>
+      <source>Injector open circuit/low side short to ground</source>
+      <translation>Inspuiter oopkring/lae kant kortsluit na grond</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="822"/>
+      <source>Injector coil internal short circuit</source>
+      <translation>Inspuitspoel interne kortsluiting</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="823"/>
+      <source>Injector low side short to power</source>
+      <translation type="unfinished">spuiter lae kant kortsluit na krag</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="824"/>
+      <source>Service hours expired</source>
+      <translation>Diensure het verstryk</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="828"/>
+      <source>Processor failure</source>
+      <translation>Verwerker faling</translation>
+    </message>
+  </context>
+  <context>
+    <name>EnvironmentInputs</name>
+    <message>
+      <location filename="../../data/EnvironmentInputs.qml" line="18"/>
+      <source>Battery</source>
+      <translation>Battery</translation>
+    </message>
+    <message>
+      <location filename="../../data/EnvironmentInputs.qml" line="24"/>
+      <source>Fridge</source>
+      <translation>Yskas</translation>
+    </message>
+    <message>
+      <location filename="../../data/EnvironmentInputs.qml" line="30"/>
+      <source>Generic</source>
+      <translation>Generies</translation>
+    </message>
+    <message>
+      <location filename="../../data/EnvironmentInputs.qml" line="36"/>
+      <source>Room</source>
+      <translation>Kamer</translation>
+    </message>
+    <message>
+      <location filename="../../data/EnvironmentInputs.qml" line="42"/>
+      <source>Outdoor</source>
+      <translation>Buitelug</translation>
+    </message>
+    <message>
+      <location filename="../../data/EnvironmentInputs.qml" line="48"/>
+      <source>Water Heater</source>
+      <translation>Waterverwarmer</translation>
+    </message>
+    <message>
+      <location filename="../../data/EnvironmentInputs.qml" line="54"/>
+      <source>Freezer</source>
+      <translation>Vrieskas</translation>
+    </message>
+  </context>
+</TS>

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -72,6 +72,7 @@ LanguageModel::LanguageModel(QObject *parent)
 	m_roleNames[FontFamilyRole] = "fontFamily";
 
 	addLanguage("English", "en", QLocale::English);
+	addLanguage("Afrikaans", "af", QLocale::Afrikaans);
 	addLanguage("Čeština", "cs", QLocale::Czech);
 	addLanguage("Dansk", "da", QLocale::Danish);
 	addLanguage("Deutsch", "de", QLocale::German);


### PR DESCRIPTION
Note that, in order to test this, all running gui-v2's on the system must support the extra languages. Else it will force the language back to 'en'. Running the native version with the old gui, while testing, fixed that for me.

Afrikaans became a part of venus-platform in version 1.74 (Commit: https://github.com/victronenergy/venus-platform/commit/1d013c52ad2453edd68b1d3f71e379bf95a858a5)