### PR TITLE
Change the number of decimals used to display sensor values

### DIFF
--- a/pages/settings/devicelist/tank/PageTankSetup.qml
+++ b/pages/settings/devicelist/tank/PageTankSetup.qml
@@ -123,7 +123,7 @@ Page {
 				text: qsTrId("devicelist_tanksetup_sensor_value")
 				dataItem.uid: root.bindPrefix + "/RawValue"
 				preferredVisible: dataItem.isValid
-				secondaryText: dataItem.isValid ? Units.formatNumber(dataItem.value, 1) + (rawUnit.value || "") : "--"
+				secondaryText: dataItem.isValid ? Units.formatNumber(dataItem.value, rawUnit.displayDecimals) + (rawUnit.value || "") : "--"
 			}
 
 			ListNavigation {


### PR DESCRIPTION
In PageTankSetup, we usually use 3 decimals to calibrate 'Sensor value when full/empty'. Change the number of decimals in the 'Sensor value' field to match.

Part of #1836