### PR TITLE
Fix "Limit system feed-in" checked status and on/off behavior

### DIFF
--- a/pages/settings/PageSettingsHub4Feedin.qml
+++ b/pages/settings/PageSettingsHub4Feedin.qml
@@ -44,11 +44,11 @@ Page {
 				//% "Limit system feed-in"
 				text: qsTrId("settings_ess_limit_system_feed_in")
 				preferredVisible: acFeedin.checked || feedInDc.checked
-				checked: maxFeedInPower.value >= 0
+				checked: maxFeedInPower.dataItem.value >= 0
 				onClicked: {
-					if (maxFeedInPower.value < 0) {
+					if (maxFeedInPower.dataItem.value < 0) {
 						maxFeedInPower.dataItem.setValue(1000)
-					} else if (maxFeedInPower.value >= 0) {
+					} else if (maxFeedInPower.dataItem.value >= 0) {
 						maxFeedInPower.dataItem.setValue(-1)
 					}
 				}


### PR DESCRIPTION
The checked binding and onClicked handler must refer to the raw maxFeedInPower.dataItem.value rather than maxFeedInPower.value, since the latter may be modified by the min/max bounds.

Fixes #1877