### PR TITLE
ThemeParser should skip hidden files starting with a dot

### DIFF
--- a/tools/themeparser.py
+++ b/tools/themeparser.py
@@ -252,7 +252,9 @@ class JsonThemeParser:
 def generate_theme_code(themes_dir, output_header_name):
     parser = JsonThemeParser()
     for subdir in os.listdir(themes_dir):
-        parser.parse_theme_subdir(os.path.join(themes_dir, subdir))
+        # skip hidden files that could wrongly be identified as folders
+        if not subdir.startswith("."):
+            parser.parse_theme_subdir(os.path.join(themes_dir, subdir))
 
     theme_properties = parser.sorted_theme_properties()
     property_declarations = [theme_property.property_declaration() for theme_property in theme_properties]


### PR DESCRIPTION
Fix an issue where .DS_Store files are interpreted as directories

Fixes #1817