### PR TITLE
Show a toast notification when changing security profiles

### DIFF
--- a/pages/settings/PageSettingsAccessAndSecurity.qml
+++ b/pages/settings/PageSettingsAccessAndSecurity.qml
@@ -202,6 +202,12 @@ Page {
 							// This guards the wasm version to trigger a reload even if the reply isn't received.
 							BackendConnection.securityProtocolChanged()
 							Global.pageManager.popPage()
+							if (Qt.platform.os === "wasm" && !BackendConnection.vrm) {
+								Global.showToastNotification(VenusOS.Notification_Info,
+															 //% "Page will automatically reload in 5 seconds"
+															 qsTrId("access_and_security_page_will_reload"),
+															 3000)
+							}
 						}
 						dialogDoneOptions: VenusOS.ModalDialog_DoneOptions_OkAndCancel
 						height: securityProfile.pendingProfile === VenusOS.Security_Profile_Secured

--- a/src/backendconnection.cpp
+++ b/src/backendconnection.cpp
@@ -199,6 +199,9 @@ void BackendConnection::onReloadPageTimerExpired()
 // that fails and still triggers a reload (albeit a bit later).
 void BackendConnection::securityProtocolChanged()
 {
+	if (isVrm()) {
+		return;
+	}
 	QTimer *timer = new QTimer(this);
 	connect(timer, &QTimer::timeout, this, &BackendConnection::onReloadPageTimerExpired);
 	connect(timer, &QTimer::timeout, timer, &QObject::deleteLater);

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -74,7 +74,6 @@
                 status.innerHTML = 'Loading...';
 
                 const instance = await qtLoad({
-                    arguments: ['--mqtt', (location.protocol === 'https:' ? 'wss://' : 'ws://') + document.location.host + '/websocket-mqtt'], // delete this line to run wasm builds on the desktop
                     qt: {
                         onLoaded: () => showUi(screen),
                         onExit: exitData =>


### PR DESCRIPTION
For wasm builds only. "Page will automatically reload in 5 seconds" Fixes 1881