### PR TITLE
Show brief page single center gauge power with selected units

### DIFF
--- a/components/CircularSingleGauge.qml
+++ b/components/CircularSingleGauge.qml
@@ -15,7 +15,8 @@ Item {
 	property alias icon: icon
 	property alias name: nameLabel.text
 	property alias voltage: voltageLabel.value
-	property alias current: currentLabel.value
+	property real current: NaN
+	property real power: NaN
 	property alias value: arc.value
 	property int status
 	property alias caption: captionLabel.text
@@ -101,10 +102,13 @@ Item {
 			QuantityLabel {
 				id: currentLabel
 
+				readonly property bool unitAmps: (Global.systemSettings.electricalQuantity === VenusOS.Units_Amp && !isNaN(gauges.current))
+						|| (!isNaN(gauges.current) && isNaN(gauges.power))
 				valueColor: Theme.color_briefPage_battery_value_text_color
 				unitColor: Theme.color_briefPage_battery_unit_text_color
 				font.pixelSize: Theme.font_briefPage_battery_voltage_pixelSize
-				unit: VenusOS.Units_Amp
+				value: currentLabel.unitAmps ? gauges.current : gauges.power
+				unit: currentLabel.unitAmps ? VenusOS.Units_Amp : VenusOS.Units_Watt
 			}
 		}
 

--- a/pages/BriefPage.qml
+++ b/pages/BriefPage.qml
@@ -198,6 +198,7 @@ SwipeViewPage {
 			value: visible && !isNaN(battery.stateOfCharge) ? battery.stateOfCharge : 0
 			voltage: battery.voltage
 			current: battery.current
+			power: battery.power
 			status: Theme.getValueStatus(value, properties.valueType)
 			caption: Utils.formatBatteryTimeToGo(battery.timeToGo, VenusOS.Battery_TimeToGo_LongFormat)
 			animationEnabled: root.animationEnabled


### PR DESCRIPTION
The user can set a setting which determines whether to display electrical quantities as current (amps) or power (watts).

This commit ensures that we respect the value of that setting also for the quantity label shown in the single circular gauge on the brief page.

Contributes to issue #1857