### PR TITLE
Fix display of current + voltage for single-phase pvinverters

### DIFF
--- a/src/phasemodel.h
+++ b/src/phasemodel.h
@@ -19,6 +19,8 @@ class PhaseModel : public QAbstractListModel
 	Q_PROPERTY(int count READ count NOTIFY countChanged)
 	Q_PROPERTY(int phaseCount READ phaseCount WRITE setPhaseCount NOTIFY phaseCountChanged)
 	Q_PROPERTY(bool l2AndL1OutSummed READ l2AndL1OutSummed WRITE setL2AndL1OutSummed NOTIFY l2AndL1OutSummedChanged)
+	Q_PROPERTY(qreal singlePhaseCurrent READ singlePhaseCurrent NOTIFY singlePhaseCurrentChanged)
+	Q_PROPERTY(qreal singlePhaseVoltage READ singlePhaseVoltage NOTIFY singlePhaseVoltageChanged)
 
 public:
 	enum Role {
@@ -42,6 +44,9 @@ public:
 	bool l2AndL1OutSummed() const;
 	void setL2AndL1OutSummed(bool l2AndL1OutSummed);
 
+	qreal singlePhaseCurrent() const;
+	qreal singlePhaseVoltage() const;
+
 	int rowCount(const QModelIndex &parent) const override;
 	QVariant data(const QModelIndex& index, int role) const override;
 
@@ -52,11 +57,14 @@ Q_SIGNALS:
 	void countChanged();
 	void phaseCountChanged();
 	void l2AndL1OutSummedChanged();
+	void singlePhaseCurrentChanged();
+	void singlePhaseVoltageChanged();
 
 protected:
 	QHash<int, QByteArray> roleNames() const override;
 
 private:
+	void updateSinglePhaseData();
 	struct Phase {
 		qreal power = qQNaN();
 		qreal current = qQNaN();
@@ -71,6 +79,8 @@ private:
 	int m_phaseCount = 0;
 	int m_modelCount = 0;
 	bool m_l2AndL1OutSummed = false;
+	qreal m_singlePhaseCurrent = qQNaN();
+	qreal m_singlePhaseVoltage = qQNaN();
 };
 
 } /* VenusOS */


### PR DESCRIPTION
The /Ac/Current and /Ac/Voltage paths for pvinverters are deprecated / no longer valid.

Instead, determine whether there is a single valid phase available for a given pvinverter, and if so, export that phase's current and voltage as properties.

(If multiple valid phases exist, we cannot export valid aggregate values for current or voltage, so return NaN.)

Contributes to issue #1883

Contributes to issue #1713 in the case where only a single valid phase exists in the pvinverter device.