### PR TITLE
Don't use specific kilolitres codepoint glyph in WebAssembly

### DIFF
--- a/src/units.cpp
+++ b/src/units.cpp
@@ -308,8 +308,10 @@ quantityInfo Units::getDisplayTextWithHysteresis(VenusOS::Enums::Units_Type unit
 		// Litre scaling is special, only kilo range scaling is supported
 		if (unit == VenusOS::Enums::Units_Volume_Liter) {
 			if (isOverLimit(scaleMatch, VenusOS::Enums::Units_Scale_Kilo, previousScale)) {
-				// \u2113 = l, \u3398 = kl
-				quantity.unit = QStringLiteral("\u3398");
+				// \u2113 = litres symbol.
+				// we don't use \u3398 (kilolitres symbol)
+				// as it isn't available in the required font.
+				quantity.unit = QStringLiteral("k\u2113");
 				quantity.scale = VenusOS::Enums::Units_Scale_Kilo;
 				scaledValue = scaledValue / 1000.0;
 			}

--- a/tests/units/tst_units.qml
+++ b/tests/units/tst_units.qml
@@ -111,8 +111,8 @@ TestCase {
 
 			if (Units.isScalingSupported(unit)) {
 				if (unit === VenusOS.Units_Volume_Liter) {
-					expect(unit, 12345, "12", "㎘")
-					expect(unit, 123456789, "123457", "㎘")
+					expect(unit, 12345, "12", "k" + unitString)
+					expect(unit, 123456789, "123457", "k" + unitString)
 				} else {
 					expect(unit, 12345, "12", "k" + unitString)
 					expect(unit, 123456789, "123", "M" + unitString)


### PR DESCRIPTION
The font we use doesn't support that glyph, so work around it.

Contributes to issue #1830