### PR TITLE
Use ObjectAcConnection to fetch /Ac/PvOn* phase totals

### DIFF
--- a/components/ObjectAcConnection.qml
+++ b/components/ObjectAcConnection.qml
@@ -12,6 +12,7 @@ QtObject {
 	property string bindPrefix
 	property string powerKey: "Power"
 	property string currentKey: "Current"
+	readonly property alias phaseCount: _phases.phaseCount
 
 	readonly property VeQuickItem powerL1: VeQuickItem {
 		uid: bindPrefix ? bindPrefix + "/L1/" + root.powerKey : ""
@@ -53,6 +54,7 @@ QtObject {
 	readonly property real current: _phaseCount.value === 1 && _currentL1.isValid ? _currentL1.value : NaN
 
 	readonly property PhaseModel phases: PhaseModel {
+		id: _phases
 		l2AndL1OutSummed: root.l2AndL1OutSummed
 		phaseCount: _phaseCount.value || 0
 	}


### PR DESCRIPTION
The /Ac/PvOnGrid, /Ac/PvOnGenset and /Ac/PvOnOutput values may change frequently, so the PvMonitor implementation was sub-optimal as it re-calculated the phase totals for these values whenever a single phase value was changed.

Use ObjectAcConnection to monitor these values instead, as that only calculates the totals once per second.

Fixes #1908