### PR TITLE
Allow Brief view levels to be set to None

### DIFF
--- a/components/CircularMultiGauge.qml
+++ b/components/CircularMultiGauge.qml
@@ -40,7 +40,6 @@ Item {
 				width: parent.width - (index*_stepSize)
 				height: width
 				anchors.centerIn: parent
-				visible: model.index < Theme.geometry_briefPage_centerGauge_maximumGaugeCount
 				sourceComponent: model.tankType === VenusOS.Tank_Type_Battery ? shinyProgressArc : progressArc
 				onStatusChanged: if (status === Loader.Error) console.warn("Unable to load circular multi gauge progress arc:", errorString())
 
@@ -94,7 +93,6 @@ Item {
 				anchors.verticalCenterOffset: index * _stepSize/2
 				anchors.right: parent.right
 				anchors.rightMargin: Math.max(0, Theme.geometry_circularMultiGauge_icons_maxWidth - iconImage.width)
-				visible: model.index < Theme.geometry_briefPage_centerGauge_maximumGaugeCount
 				height: iconImage.height
 
 				Label {

--- a/data/SystemSettings.qml
+++ b/data/SystemSettings.qml
@@ -130,41 +130,27 @@ QtObject {
 	}
 
 	property QtObject briefView: QtObject {
-		property QtObject centralGauges: QtObject {
-			property var value: []
 
-			function setValue(gaugeTypesArray) {
-				if (gaugeTypesArray.length !== _savedLevels.count) {
-					console.warn("Cannot change central gauges, got gauge array length",
-							gaugeTypesArray.length, "expected", _savedLevels.count)
-					return
-				}
-				for (let i = 0; i < _savedLevels.count; ++i) {
-					const obj = _savedLevels.objectAt(i)
-					if (obj.value !== gaugeTypesArray[i]) {
-						obj.setValue(gaugeTypesArray[i])
-					}
-				}
-			}
+		property QtObject centralGauges: QtObject {
+			property var preferredOrder: []
 
 			function _refresh() {
 				let levels = []
-				for (let i = 0; i < _savedLevels.count; ++i) {
+				for (let i = 0; i < Theme.geometry_briefPage_centerGauge_maximumGaugeCount; ++i) {
 					const obj = _savedLevels.objectAt(i)
-					levels.push(obj && obj.value !== undefined ? obj.value : VenusOS.Tank_Type_Battery)
+					levels.push(obj && obj.isValid ? obj.value : VenusOS.Tank_Type_None)
 				}
-				value = levels
+				preferredOrder = levels
 			}
 
 			property Instantiator _savedLevels: Instantiator {
-				model: Theme.geometry_briefPage_centerGauge_maximumGaugeCount
+				model: VeQItemTableModel {
+					uids: [ root.serviceUid + "/Settings/Gui/BriefView/Level" ]
+					flags: VeQItemTableModel.AddChildren | VeQItemTableModel.AddNonLeaves | VeQItemTableModel.DontAddItem
+				}
 				delegate: VeQuickItem {
-					uid: root.serviceUid + "/Settings/Gui/BriefView/Level/" + model.index
-					onValueChanged: {
-						if (value !== undefined) {
-							Qt.callLater(briefView.centralGauges._refresh)
-						}
-					}
+					uid: model.uid
+					onValueChanged: Qt.callLater(root.briefView.centralGauges._refresh)
 				}
 			}
 		}

--- a/data/mock/config/LevelsPageConfig.qml
+++ b/data/mock/config/LevelsPageConfig.qml
@@ -31,6 +31,10 @@ QtObject {
 			]
 		},
 		{
+			name: "No tanks",
+			tanks: [ ],
+		},
+		{
 			name: "1 tank",
 			tanks: [
 				{ type: VenusOS.Tank_Type_Fuel, level: 46.34, capacity: 1 },

--- a/pages/BriefPage.qml
+++ b/pages/BriefPage.qml
@@ -160,6 +160,10 @@ SwipeViewPage {
 			? VenusOS.StatusBar_RightButton_SidePanelActive
 			: VenusOS.StatusBar_RightButton_SidePanelInactive
 
+	GaugeModel {
+		id: gaugeModel
+	}
+
 	Loader {
 		id: mainGauge
 
@@ -167,7 +171,7 @@ SwipeViewPage {
 		width: Theme.geometry_mainGauge_size
 		height: width
 		x: sidePanel.x/2 - width/2
-		sourceComponent: Global.tanks.totalTankCount === 0 ? singleGauge : multiGauge
+		sourceComponent: gaugeModel.count === 0 ? singleGauge : multiGauge
 		onStatusChanged: if (status === Loader.Error) console.warn("Unable to load main gauge")
 	}
 
@@ -175,10 +179,7 @@ SwipeViewPage {
 		id: multiGauge
 
 		CircularMultiGauge {
-			model: GaugeModel {
-				sourceModel: Gauges.briefCentralGauges
-				maximumGaugeCount: Theme.geometry_briefPage_centerGauge_maximumGaugeCount
-			}
+			model: gaugeModel
 			animationEnabled: root.animationEnabled
 			labelOpacity: root._gaugeLabelOpacity
 			labelMargin: root._gaugeLabelMargin

--- a/src/enums.h
+++ b/src/enums.h
@@ -393,7 +393,8 @@ public:
 		Tank_Type_HydraulicOil,
 		Tank_Type_RawWater,
 
-		// Added for convenience as battery is combined with tanks on Brief page
+		// Added for convenience as these options are combined with the tanks on Brief page gauges
+		Tank_Type_None = 999,
 		Tank_Type_Battery = 1000
 	};
 	Q_ENUM(Tank_Type)


### PR DESCRIPTION
Add 'None' to the Brief view level options. If this is selected, the level will be omitted from the Brief page's center gauges. If all levels are set to None, the Brief page will only show the single- gauge view with battery details.

Rework GaugeModel to load the model based on the preferred gauge order, instead of loading all available tank types and then finding the preferred order for each type.

Also simplify the settings implementation for saving and loading the Brief level settings.

Fixes #541