### PR TITLE
PageSettingsWifi: allow page to be loaded

### DIFF
--- a/components/listitems/core/SettingsListHeader.qml
+++ b/components/listitems/core/SettingsListHeader.qml
@@ -7,6 +7,11 @@ import QtQuick
 import Victron.VenusOS
 
 Label {
+	// These mimic the same properties from ListItem, so that the item can be
+	// marked as hidden by VisibleItemModel.
+	readonly property bool effectiveVisible: preferredVisible
+	property bool preferredVisible: true
+
 	anchors {
 		left: parent ? parent.left : undefined
 		leftMargin: Theme.geometry_listItem_content_horizontalMargin


### PR DESCRIPTION
The page could not be loaded due to this warning:
Cannot assign to non-existent property "preferredVisible"