### PR TITLE
Fix build issue

### DIFF
--- a/src/visibleitemmodel.h
+++ b/src/visibleitemmodel.h
@@ -8,6 +8,7 @@
 
 #include <private/qqmlobjectmodel_p.h>
 #include <qqmlintegration.h>
+#include <QQuickItem>
 
 class VisibleItemModelPrivate;
 


### PR DESCRIPTION
Don't rely on a forward type declaration used in a template type specialisation, instead include the header directly.