### PR TITLE
Show modifications page only when is backend available

### DIFF
--- a/pages/settings/PageSettingsGeneral.qml
+++ b/pages/settings/PageSettingsGeneral.qml
@@ -154,6 +154,7 @@ Page {
 					//% "Modified"
 					:  qsTrId("pagesettingsmodificationchecks_modified")
 				secondaryLabel.color: fsModifiedStateItem.value === 0 && systemHooksStateItem.isValid && !(systemHooksStateItem.value & VenusOS.ModificationChecks_SystemHooksState_HookLoadedAtBoot) ? Theme.color_font_primary : Theme.color_red
+				preferredVisible: fsModifiedStateItem.isValid && systemHooksStateItem.isValid
 				onClicked: Global.pageManager.pushPage("/pages/settings/PageSettingsModificationChecks.qml", {"title": text})
 
 				VeQuickItem {


### PR DESCRIPTION
Please merge this, if the new released GUI is going to be shipped with v3.5x, else the page will show without the informations available.