### PR TITLE
Clip main view on desktop as well as wasm

### DIFF
--- a/Main.qml
+++ b/Main.qml
@@ -88,7 +88,7 @@ Window {
 	Loader {
 		id: guiLoader
 
-		clip: Qt.platform.os == "wasm"
+		clip: Qt.platform.os == "wasm" || Global.isDesktop
 		width: Theme.geometry_screen_width
 		height: Theme.geometry_screen_height
 		anchors.horizontalCenter: parent.horizontalCenter


### PR DESCRIPTION
Otherwise, the NavBar is visible to the left of the content on ultrawide screens after opening a drilldown view.

For testing, you may run on desktop and resize the window horizontally larger, then open a drilldown from either the overview or settings pages.

We don't want to clip on GX devices, as this will incur a performance overhead, and offscreen content is not visible on that platform due to the physical screen.

Contributes to issue #1756