### PR TITLE
Mock: cycle configurations with , + .

### DIFF
--- a/data/mock/config/MockDataSimulator.qml
+++ b/data/mock/config/MockDataSimulator.qml
@@ -88,13 +88,15 @@ QtObject {
 				event.accepted = true
 			}
 			break
-		case Qt.Key_Left:
+		case Qt.Key_Left: // fall through
+		case Qt.Key_Comma:
 			if (!!Global.pageManager && (currentNavBarUrl() in root._configs)) {
 				previousConfig()
 				event.accepted = true
 			}
 			break
-		case Qt.Key_Right:
+		case Qt.Key_Right: // fall through
+		case Qt.Key_Period:
 			if (!!Global.pageManager && (currentNavBarUrl() in root._configs)) {
 				nextConfig()
 				event.accepted = true


### PR DESCRIPTION
Previously, the left/right keys were used to cycle between configurations.  With KeyNavigation support coming, we need to use different keys to trigger mock configuration cycling.

Use comma and period keys (i.e. < and > keys) for this.