### PR TITLE
Display VRM device heartbeat information in splash view

### DIFF
--- a/ApplicationContent.qml
+++ b/ApplicationContent.qml
@@ -162,7 +162,7 @@ Item {
 
 	// Sometimes, the wasm code may crash. Use a watchdog to detect this and reload the page when necessary.
 	Timer {
-		running: Qt.platform.os === "wasm" && BackendConnection.state === BackendConnection.Ready
+		running: Qt.platform.os === "wasm" && Global.backendReadyLatched
 		repeat: true
 		interval: 1000
 		onTriggered: BackendConnection.hitWatchdog()

--- a/Global.qml
+++ b/Global.qml
@@ -19,6 +19,10 @@ QtObject {
 	property var allDevicesModel
 	property bool applicationActive: true
 
+	readonly property bool backendReady: BackendConnection.state === BackendConnection.Ready
+		&& (Qt.platform.os !== "wasm"
+			|| !BackendConnection.vrm
+			|| BackendConnection.heartbeatState !== BackendConnection.HeartbeatInactive)
 	readonly property string fontFamily: _defaultFontLoader.name
 	readonly property string quantityFontFamily: _quantityFontLoader.name
 	property var dialogLayer
@@ -59,6 +63,9 @@ QtObject {
 
 	readonly property int int32Max: _intValidator.top
 	readonly property int int32Min: _intValidator.bottom
+
+	property bool backendReadyLatched
+	onBackendReadyChanged: if (backendReady) backendReadyLatched = true
 
 	signal aboutToFocusTextField(var textField, var textFieldContainer, var flickable)
 	signal keyPressed(var event)

--- a/Main.qml
+++ b/Main.qml
@@ -49,7 +49,7 @@ Window {
 
 	Loader {
 		id: dataManagerLoader
-		readonly property bool connectionReady: BackendConnection.state === BackendConnection.Ready
+		readonly property bool connectionReady: Global.backendReady
 		onConnectionReadyChanged: {
 			if (connectionReady) {
 				active = true

--- a/data/DataManager.qml
+++ b/data/DataManager.qml
@@ -30,7 +30,7 @@ Item {
 
 	readonly property bool _shouldInitialize: _dataObjectsReady
 			&& BackendConnection.type !== BackendConnection.UnknownSource
-			&& BackendConnection.state === BackendConnection.Ready
+			&& Global.backendReady
 
 	function _setBackendSource() {
 		if (!_shouldInitialize) {

--- a/src/backendconnection.h
+++ b/src/backendconnection.h
@@ -25,6 +25,7 @@ class BackendConnection : public QObject
 	QML_ELEMENT
 	QML_SINGLETON
 	Q_PROPERTY(State state READ state NOTIFY stateChanged FINAL)
+	Q_PROPERTY(HeartbeatState heartbeatState READ heartbeatState NOTIFY heartbeatStateChanged FINAL)
 	Q_PROPERTY(SourceType type READ type NOTIFY typeChanged FINAL)
 	Q_PROPERTY(MqttClientError mqttClientError READ mqttClientError NOTIFY mqttClientErrorChanged FINAL)
 	Q_PROPERTY(QString username READ username WRITE setUsername NOTIFY usernameChanged FINAL)
@@ -61,6 +62,14 @@ public:
 	};
 	Q_ENUM(State)
 
+	// Same as VeQItemMqttProducer::HeartbeatState
+	enum HeartbeatState {
+		HeartbeatActive,
+		HeartbeatMissing,
+		HeartbeatInactive,
+	};
+	Q_ENUM(HeartbeatState)
+
 	enum MqttClientError {
 		MqttClient_NoError = QMqttClient::NoError,
 		MqttClient_InvalidProtocolVersion = QMqttClient::InvalidProtocolVersion,
@@ -78,6 +87,7 @@ public:
 	static BackendConnection* create(QQmlEngine *engine = nullptr, QJSEngine *jsEngine = nullptr);
 
 	State state() const;
+	HeartbeatState heartbeatState() const;
 	MqttClientError mqttClientError() const;
 
 	void loadConfiguration();
@@ -145,6 +155,7 @@ public:
 
 Q_SIGNALS:
 	void stateChanged();
+	void heartbeatStateChanged();
 	void typeChanged();
 	void mqttClientErrorChanged();
 	void usernameChanged();
@@ -166,6 +177,8 @@ private:
 	void setState(State backendConnectionState);
 	void setState(VeQItemMqttProducer::ConnectionState backendConnectionState);
 	void setState(bool connected);
+	void setHeartbeatState(HeartbeatState backendHeartbeatState);
+	void setHeartbeatState(VeQItemMqttProducer::HeartbeatState backendHeartbeatState);
 	void mqttErrorChanged();
 	void addSettings(VeQItemSettingsInfo *info);
 
@@ -188,6 +201,7 @@ private:
 	bool m_needsWasmKeyboardHandler = false;
 
 	State m_state = BackendConnection::State::Idle;
+	HeartbeatState m_heartbeatState = BackendConnection::HeartbeatState::HeartbeatActive;
 	SourceType m_type = UnknownSource;
 	QMqttClient::ClientError m_mqttClientError = QMqttClient::NoError;
 


### PR DESCRIPTION
Even if we manage to connect to the VRM broker, this doesn't mean that we will receive data from the device (e.g. if the device itself has lost internet connectivity or power, and thus is not connected to VRM).

In this case, the splash screen will simply tell the user that they are Connected (implicitly: to VRM) but will never progress to Ready state since no data from the device will be received.

This commit ensures that we tell the user that the heartbeat is missing in this case.

It also ensures we return to the splash view if we are connected to VRM and the heartbeat becomes inactive, since we don't want to continue to display stale data to the user.

Contributes to issue #1710