### PR TITLE
Add SettingsColumn with preferredVisible and built-in spacing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,7 @@ set (VENUS_QML_MODULE_SOURCES
     components/SeparatorBar.qml
     components/ServiceDeviceModel.qml
     components/ServiceModelLoader.qml
+    components/SettingsColumn.qml
     components/SettingsRangeSlider.qml
     components/SettingsSlider.qml
     components/ShinyProgressArc.qml

--- a/components/InverterAcOutSettings.qml
+++ b/components/InverterAcOutSettings.qml
@@ -6,7 +6,7 @@
 import QtQuick
 import Victron.VenusOS
 
-Column {
+SettingsColumn {
 	id: root
 
 	property string bindPrefix
@@ -16,7 +16,6 @@ Column {
 			: inverterData.phase1
 
 	width: parent ? parent.width : 0
-	spacing: Theme.geometry_gradientList_spacing
 
 	VeQuickItem {
 		id: isInverterChargerItem

--- a/components/PageGensetModel.qml
+++ b/components/PageGensetModel.qml
@@ -149,9 +149,9 @@ VisibleItemModel {
 		}
 	}
 
-	Column {
+	SettingsColumn {
 		width: parent ? parent.width : 0
-		spacing: Theme.geometry_gradientList_spacing
+		preferredVisible: phaseRepeater.count > 0
 
 		Repeater {
 			id: phaseRepeater

--- a/components/RsSystemAcIODisplay.qml
+++ b/components/RsSystemAcIODisplay.qml
@@ -23,12 +23,10 @@ Loader {
 	Component {
 		id: singlePhaseAcInOut
 
-		Column {
+		SettingsColumn {
 			readonly property string singlePhaseName: acOutL3.isValid ? "L3"
 					: acOutL2.isValid ? "L2"
 					: "L1"  // i.e. if _phase.value === 0 || !_phase.isValid
-
-			spacing: Theme.geometry_gradientList_spacing
 
 			VeQuickItem { id: acOutL1; uid: root.serviceUid + "/Ac/Out/L1/P" }
 			VeQuickItem { id: acOutL2; uid: root.serviceUid + "/Ac/Out/L2/P" }

--- a/components/SettingsColumn.qml
+++ b/components/SettingsColumn.qml
@@ -1,0 +1,14 @@
+/*
+** Copyright (C) 2025 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+Column {
+	property bool preferredVisible
+	readonly property bool effectiveVisible: preferredVisible
+
+	spacing: Theme.geometry_gradientList_spacing
+}

--- a/components/TemperatureRelaySettings.qml
+++ b/components/TemperatureRelaySettings.qml
@@ -6,7 +6,7 @@
 import QtQuick
 import Victron.VenusOS
 
-Column {
+SettingsColumn {
 	id: root
 
 	property int relayNumber
@@ -24,7 +24,6 @@ Column {
 	}
 
 	width: parent ? parent.width : 0
-	spacing: Theme.geometry_gradientList_spacing
 
 	VeQuickItem {
 		id: relay1Item

--- a/components/VeBusAcIODisplay.qml
+++ b/components/VeBusAcIODisplay.qml
@@ -29,9 +29,7 @@ Loader {
 	Component {
 		id: singlePhaseAcInOut
 
-		Column {
-			spacing: Theme.geometry_gradientList_spacing
-
+		SettingsColumn {
 			PVCFListQuantityGroup {
 				text: CommonWords.ac_in
 				data: AcPhase { serviceUid: root.serviceUid + "/Ac/ActiveIn/L1" }

--- a/components/listitems/core/ListRadioButtonGroup.qml
+++ b/components/listitems/core/ListRadioButtonGroup.qml
@@ -133,7 +133,7 @@ ListNavigation {
 					Component {
 						id: passwordComponent
 
-						Column {
+						SettingsColumn {
 							function focusPasswordInput() {
 								passwordField.showField = true
 								passwordField.secondaryText = ""
@@ -141,7 +141,6 @@ ListNavigation {
 							}
 
 							width: parent.width
-							spacing: Theme.geometry_gradientList_spacing
 
 							PrimaryListLabel {
 								topPadding: 0

--- a/pages/battery/BatteryListPage.qml
+++ b/pages/battery/BatteryListPage.qml
@@ -15,7 +15,6 @@ Page {
 
 	GradientListView {
 		model: batteryModel
-		spacing: Theme.geometry_gradientList_spacing
 		delegate: ListItemBackground {
 			id: batteryDelegate
 

--- a/pages/invertercharger/OverviewInverterChargerPage.qml
+++ b/pages/invertercharger/OverviewInverterChargerPage.qml
@@ -70,12 +70,13 @@ Page {
 				dataItem.uid: root.serviceUid + "/State"
 			}
 
-			Column {
+			SettingsColumn {
 				width: parent ? parent.width : 0
-				spacing: Theme.geometry_gradientList_spacing
+				preferredVisible: inputSettingsModel.count > 0
 
 				Repeater {
 					model: AcInputSettingsModel {
+						id: inputSettingsModel
 						serviceUid: root.serviceUid
 					}
 					delegate: ListItem {

--- a/pages/settings/DvccCommonSettings.qml
+++ b/pages/settings/DvccCommonSettings.qml
@@ -6,11 +6,9 @@
 import QtQuick
 import Victron.VenusOS
 
-Column {
+SettingsColumn {
 	property alias dvccActive: dvccSwitch.checked
 	readonly property alias userHasWriteAccess: dvccSwitch.userHasWriteAccess
-
-	spacing: Theme.geometry_gradientList_spacing
 
 	ListSwitchForced {
 		id: dvccSwitch

--- a/pages/settings/PageSettingsBatteries.qml
+++ b/pages/settings/PageSettingsBatteries.qml
@@ -51,9 +51,9 @@ Page {
 					&& batteryMonitorRadioButtons.optionModel[batteryMonitorRadioButtons.currentIndex].value === "default"
 			}
 
-			Column {
-				spacing: Theme.geometry_gradientList_spacing
+			SettingsColumn {
 				width: parent ? parent.width : 0
+				preferredVisible: batteryModel.count > 0
 
 				Repeater {
 					model: batteryModel

--- a/pages/settings/PageSettingsBleSensors.qml
+++ b/pages/settings/PageSettingsBleSensors.qml
@@ -82,11 +82,12 @@ Page {
 				}
 			}
 
-			Column {
+			SettingsColumn {
 				width: parent ? parent.width : 0
-				spacing: Theme.geometry_gradientList_spacing
+				preferredVisible: sensorRepeater.count > 0
 
 				Repeater {
+					id: sensorRepeater
 					model: VeQItemSortTableModel {
 						model: VeQItemChildModel {
 							model: sensors

--- a/pages/settings/PageSettingsConnectivity.qml
+++ b/pages/settings/PageSettingsConnectivity.qml
@@ -67,11 +67,12 @@ Page {
 				onClicked: Global.pageManager.pushPage("/pages/settings/PageSettingsGpsList.qml", {"title": text})
 			}
 
-			Column {
+			SettingsColumn {
 				width: parent ? parent.width : 0
-				spacing: Theme.geometry_gradientList_spacing
+				preferredVisible: canInterfaceRepeater.count > 0
 
 				Repeater {
+					id: canInterfaceRepeater
 					model: canInterfaces.value || []
 					delegate: ListNavigation {
 						text: modelData["name"] || ""

--- a/pages/settings/PageSettingsDisplayBrief.qml
+++ b/pages/settings/PageSettingsDisplayBrief.qml
@@ -41,10 +41,9 @@ Page {
 			dataItem.uid: Global.systemSettings.serviceUid + "/Settings/Gui/BriefView/Level/" + index
 		}
 
-		footer: Column {
+		footer: SettingsColumn {
 			topPadding: Theme.geometry_gradientList_spacing
 			width: parent.width
-			spacing: Theme.geometry_gradientList_spacing
 
 			ListRadioButtonGroup {
 				//: Show percentage values in Brief view

--- a/pages/settings/PageSettingsDisplayMinMax.qml
+++ b/pages/settings/PageSettingsDisplayMinMax.qml
@@ -51,15 +51,14 @@ Page {
 				}
 			}
 
-			Column {
+			SettingsColumn {
 				width: parent ? parent.width : 0
-				spacing: Theme.geometry_gradientList_spacing
 
 				Repeater {
 					id: acInputsRepeater
 
 					model: 2
-					delegate: Column {
+					delegate: SettingsColumn {
 						required property int index
 						function reset() {
 							acInputMinCurrent.dataItem.setValue(0)
@@ -67,7 +66,6 @@ Page {
 						}
 
 						width: parent ? parent.width : 0
-						spacing: Theme.geometry_gradientList_spacing
 
 						SettingsListHeader {
 							text: {

--- a/pages/settings/PageSettingsDisplayStartPage.qml
+++ b/pages/settings/PageSettingsDisplayStartPage.qml
@@ -103,9 +103,8 @@ Page {
 						}
 					}
 
-					Column {
+					SettingsColumn {
 						width: parent ? parent.width : 0
-						spacing: Theme.geometry_gradientList_spacing
 
 						Repeater {
 							model: Global.systemSettings.startPageConfiguration.options

--- a/pages/settings/PageSettingsModbusDevices.qml
+++ b/pages/settings/PageSettingsModbusDevices.qml
@@ -40,11 +40,12 @@ Page {
 			text: qsTrId("settings_modbus_no_devices_saved")
 		}
 		model: VisibleItemModel {
-			Column {
+			SettingsColumn {
 				width: parent ? parent.width : 0
-				spacing: Theme.geometry_gradientList_spacing
+				preferredVisible: modbusDeviceRepeater.count > 0
 
 				Repeater {
+					id: modbusDeviceRepeater
 					model: _devices.value ? _devices.value.split(',') : []
 					delegate: ListItem {
 						property int deviceNumber: index + 1

--- a/pages/settings/PageSettingsRvcDeviceConfiguration.qml
+++ b/pages/settings/PageSettingsRvcDeviceConfiguration.qml
@@ -69,11 +69,12 @@ Page {
 
 				Repeater {
 					model: 3
-					delegate: Column {
+					delegate: SettingsColumn {
 						width: parent ? parent.width : 0
-						spacing: Theme.geometry_gradientList_spacing
+						preferredVisible: dcSourceInstance.dataItem.isValid || dcSourcePriority.dataItem.isValid
 
 						ListSpinBox {
+							id: dcSourceInstance
 							text: root._hasMultipleDcSources
 								  //: %1 = number of this DC source
 								  //% "DC source #%1 instance"
@@ -85,6 +86,7 @@ Page {
 						}
 
 						ListSpinBox {
+							id: dcSourcePriority
 							text: root._hasMultipleDcSources
 								  //: %1 = number of this DC source
 								  //% "DC source #%1 priority"

--- a/pages/settings/PageSettingsWifi.qml
+++ b/pages/settings/PageSettingsWifi.qml
@@ -22,9 +22,8 @@ Page {
 			id: wifiModel
 		}
 
-		header: Column {
+		header: SettingsColumn {
 			width: parent.width
-			spacing: Theme.geometry_gradientList_spacing
 
 			ListSwitch {
 				//% "Create access point"

--- a/pages/settings/PageTzInfo.qml
+++ b/pages/settings/PageTzInfo.qml
@@ -154,7 +154,7 @@ Page {
 						GradientListView {
 							id: tzListView
 
-							header: Column {
+							header: SettingsColumn {
 								width: parent.width
 								bottomPadding: Theme.geometry_gradientList_spacing
 

--- a/pages/settings/devicelist/DeviceListPage.qml
+++ b/pages/settings/devicelist/DeviceListPage.qml
@@ -65,10 +65,9 @@ Page {
 			Component.onCompleted: _resetSource()
 		}
 
-		footer: Column {
+		footer: SettingsColumn {
 			width: parent.width
 			topPadding: Theme.geometry_gradientList_spacing
-			spacing: Theme.geometry_gradientList_spacing
 
 			ListButton {
 				//% "Remove disconnected devices"

--- a/pages/settings/devicelist/PageAcCharger.qml
+++ b/pages/settings/devicelist/PageAcCharger.qml
@@ -45,9 +45,9 @@ Page {
 				decimals: 1
 			}
 
-			Column {
+			SettingsColumn {
 				width: parent ? parent.width : 0
-				spacing: Theme.geometry_gradientList_spacing
+				preferredVisible: outputRepeater.count > 0
 
 				VeQuickItem {
 					id: nrOfOutputs
@@ -55,6 +55,7 @@ Page {
 				}
 
 				Repeater {
+					id: outputRepeater
 					model: nrOfOutputs.value || 1
 					delegate: ListQuantityGroup {
 						id: phaseDelegate

--- a/pages/settings/devicelist/ac-in/PageAcInModel.qml
+++ b/pages/settings/devicelist/ac-in/PageAcInModel.qml
@@ -43,9 +43,9 @@ VisibleItemModel {
 		bindPrefix: root.bindPrefix
 	}
 
-	Column {
+	SettingsColumn {
 		width: parent ? parent.width : 0
-		spacing: Theme.geometry_gradientList_spacing
+		preferredVisible: root.phaseNumbers.length > 0
 
 		Repeater {
 			model: root.phaseNumbers
@@ -101,9 +101,9 @@ VisibleItemModel {
 		}
 	}
 
-	Column {
+	SettingsColumn {
 		width: parent ? parent.width : 0
-		spacing: Theme.geometry_gradientList_spacing
+		preferredVisible: root.phaseNumbers.length > 0
 
 		Repeater {
 			model: root.phaseNumbers
@@ -167,11 +167,13 @@ VisibleItemModel {
 
 				bindPrefix: root.bindPrefix
 
-				settingsListView.footer: Column {
+				settingsListView.footer: SettingsColumn {
 					topPadding: Theme.geometry_gradientList_spacing
 					width: parent.width
+					preferredVisible: dataManagerVersion.preferredVisible
 
 					ListText {
+						id: dataManagerVersion
 						//% "Data manager version"
 						text: qsTrId("ac-in-modeldefault_data_manager_version")
 						dataItem.uid: root.bindPrefix + "/DataManagerVersion"

--- a/pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml
+++ b/pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml
@@ -20,9 +20,8 @@ Page {
 				preferredVisible: dataItem.isValid
 			}
 
-			Column {
+			SettingsColumn {
 				width: parent ? parent.width : 0
-				spacing: Theme.geometry_gradientList_spacing
 
 				Repeater {
 					model: [

--- a/pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml
+++ b/pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml
@@ -6,13 +6,11 @@
 import QtQuick
 import Victron.VenusOS
 
-Column {
+SettingsColumn {
 	id: root
 
 	property int cycle
 	property string bindPrefix
-
-	spacing: Theme.geometry_gradientList_spacing
 
 	PrimaryListLabel {
 		text: cycle == 0

--- a/pages/settings/devicelist/inverter/PageSolarStats.qml
+++ b/pages/settings/devicelist/inverter/PageSolarStats.qml
@@ -37,9 +37,9 @@ Page {
 				preferredVisible: dataItem.isValid
 			}
 
-			Column {
+			SettingsColumn {
 				width: parent ? parent.width : 0
-				spacing: Theme.geometry_gradientList_spacing
+				preferredVisible: errorModel.count > 0
 
 				Repeater {
 					model: SolarHistoryErrorModel {

--- a/pages/settings/devicelist/rs/PageMultiRs.qml
+++ b/pages/settings/devicelist/rs/PageMultiRs.qml
@@ -152,11 +152,10 @@ Page {
 	Component {
 		id: singlePhaseAcInOut
 
-		Column {
+		SettingsColumn {
 			readonly property string singlePhaseName: _phase.value === 2 ? "L3"
 					: _phase.value === 1 ? "L2"
 					: "L1"  // _phase.value === 0 || !_phase.isValid
-			spacing: Theme.geometry_gradientList_spacing
 
 			PVCFListQuantityGroup {
 				//: %1 = phase name (e.g. L1, L2, L3)
@@ -210,9 +209,8 @@ Page {
 	Component {
 		id: multiTrackerComponent
 
-		Column {
+		SettingsColumn {
 			width: parent ? parent.width : 0
-			spacing: Theme.geometry_gradientList_spacing
 
 			ListQuantity {
 				//% "Total PV Power"

--- a/pages/settings/devicelist/rs/PageRsSystem.qml
+++ b/pages/settings/devicelist/rs/PageRsSystem.qml
@@ -45,12 +45,13 @@ Page {
 				dataItem.uid: root.bindPrefix + "/State"
 			}
 
-			Column {
+			SettingsColumn {
 				width: parent ? parent.width : 0
-				spacing: Theme.geometry_gradientList_spacing
+				preferredVisible: inputSettingsModel.count > 0
 
 				Repeater {
 					model: AcInputSettingsModel {
+						id: inputSettingsModel
 						serviceUid: root.bindPrefix
 					}
 					delegate: ListItem {

--- a/pages/vebusdevice/PageAcSensor.qml
+++ b/pages/vebusdevice/PageAcSensor.qml
@@ -15,12 +15,12 @@ Page {
 	GradientListView {
 		model: VisibleItemModel {
 
-			Column {
+			SettingsColumn {
 				width: parent ? parent.width : 0
-				spacing: Theme.geometry_gradientList_spacing
+				preferredVisible: sensorModel.count > 0
 
 				Repeater {
-					model: VeBusAcSensorModel { }
+					model: VeBusAcSensorModel { id: sensorModel }
 
 					ListText {
 						//% "AC sensor %1 %2"

--- a/pages/vebusdevice/PageAcSensors.qml
+++ b/pages/vebusdevice/PageAcSensors.qml
@@ -13,9 +13,8 @@ Page {
 
 	GradientListView {
 		model: VisibleItemModel {
-			Column {
+			SettingsColumn {
 				width: parent ? parent.width : 0
-				spacing: Theme.geometry_gradientList_spacing
 
 				Repeater {
 					model: 4

--- a/pages/vebusdevice/PageVeBus.qml
+++ b/pages/vebusdevice/PageVeBus.qml
@@ -111,12 +111,13 @@ Page {
 
 			/*	This shows the current limits for Ac/In/<x>/CurrentLimit.
 				Note that gui-v1 instead shows a single current limit based on Ac/ActiveIn/CurrentLimit, which is deprecated in the dbus doco. */
-			Column {
+			SettingsColumn {
 				width: parent ? parent.width : 0
-				spacing: Theme.geometry_gradientList_spacing
+				preferredVisible: inputSettingsModel.count > 0
 
 				Repeater {
 					model: AcInputSettingsModel {
+						id: inputSettingsModel
 						serviceUid: root.bindPrefix
 					}
 					delegate: ListItem {

--- a/pages/vebusdevice/PageVeBusAdvanced.qml
+++ b/pages/vebusdevice/PageVeBusAdvanced.qml
@@ -264,9 +264,8 @@ Page {
 					Page {
 						GradientListView {
 							model: VisibleItemModel {
-								Column {
+								SettingsColumn {
 									width: parent ? parent.width : 0
-									spacing: Theme.geometry_gradientList_spacing
 
 									Repeater {
 										model: 18

--- a/pages/vebusdevice/PageVeBusAlarms.qml
+++ b/pages/vebusdevice/PageVeBusAlarms.qml
@@ -30,9 +30,9 @@ Page {
 				dataItem.uid: root.bindPrefix + "/VebusError"
 			}
 
-			Column {
+			SettingsColumn {
 				width: parent ? parent.width : 0
-				spacing: Theme.geometry_gradientList_spacing
+				preferredVisible: alarmStatusModel.count > 0
 
 				Repeater {
 					model: VeBusDeviceAlarmStatusModel { id: alarmStatusModel }

--- a/pages/vebusdevice/PageVeBusDeviceInfo.qml
+++ b/pages/vebusdevice/PageVeBusDeviceInfo.qml
@@ -16,12 +16,12 @@ PageDeviceInfo {
 
 	Component {
 		id: veBusDeviceInfoComponent
-		Column {
+		SettingsColumn {
 			width: parent ? parent.width : 0
-			spacing: Theme.geometry_gradientList_spacing
+			preferredVisible: deviceInfoModel.count > 0
 
 			Repeater {
-				model: VeBusDeviceInfoModel { }
+				model: VeBusDeviceInfoModel { id: deviceInfoModel }
 
 				ListText {
 					text: displayText

--- a/pages/vebusdevice/PageVeBusError11View.qml
+++ b/pages/vebusdevice/PageVeBusError11View.qml
@@ -26,9 +26,8 @@ Page {
 				preferredVisible: !firstCode.seen
 			}
 
-			Column {
+			SettingsColumn {
 				width: parent ? parent.width : 0
-				spacing: Theme.geometry_gradientList_spacing
 
 				Repeater {
 					model: 18

--- a/pages/vebusdevice/PageVeBusKwhCounters.qml
+++ b/pages/vebusdevice/PageVeBusKwhCounters.qml
@@ -34,12 +34,12 @@ Page {
 				]
 			}
 
-			Column {
+			SettingsColumn {
 				width: parent ? parent.width : 0
-				spacing: Theme.geometry_gradientList_spacing
+				preferredVisible: countersModel.count > 0
 
 				Repeater {
-					model: VeBusDeviceKwhCountersModel { }
+					model: VeBusDeviceKwhCountersModel { id: countersModel }
 
 					ListText {
 

--- a/pages/vebusdevice/PageVeBusSerialNumbers.qml
+++ b/pages/vebusdevice/PageVeBusSerialNumbers.qml
@@ -32,9 +32,9 @@ Page {
 	GradientListView {
 		model: VisibleItemModel {
 
-			Column {
+			SettingsColumn {
 				width: parent ? parent.width : 0
-				spacing: Theme.geometry_gradientList_spacing
+				preferredVisible: tableModel.rowCount > 0
 
 				Repeater {
 					model: tableModel


### PR DESCRIPTION
Add preferredVisible to allow the column to be filtered out of VisibleItemModel if it does not contain any visible children.

Add the built-in spacing as a convenience.

Fixes #1953