### PR TITLE
PageVeBusDebug.qml: fix property reference error

### DIFF
--- a/pages/vebusdevice/PageVeBusDebug.qml
+++ b/pages/vebusdevice/PageVeBusDebug.qml
@@ -71,7 +71,7 @@ Page {
 				text: "Flags"
 				model: QuantityObjectModel {
 					QuantityObject { object: flagsGroup; key: "sustain" }
-					QuantityObject { object: flagsGroup; lowSoc: "lowSoc" }
+					QuantityObject { object: flagsGroup; key: "lowSoc" }
 				}
 			}
 


### PR DESCRIPTION
This avoids the following error when loading the page:
    Cannot assign to non-existent property "lowSoc"