### PR TITLE
Support showing individual batteries and tanks in brief page centre gauges

### DIFF
--- a/components/BriefCenterDisplay.qml
+++ b/components/BriefCenterDisplay.qml
@@ -14,8 +14,7 @@ Column {
 	property bool showFullDetails
 	property bool smallTextMode
 
-	readonly property string _serviceUid: centerService.value ?? ""
-	readonly property bool _useTemperature: BackendConnection.serviceTypeFromUid(_serviceUid) === "temperature"
+	readonly property bool _useTemperature: BackendConnection.portableIdInfo(centerService.value).type === "temperature"
 
 	VeQuickItem {
 		id: centerService
@@ -24,7 +23,16 @@ Column {
 
 	VeQuickItem {
 		id: temperature
-		uid: root._useTemperature ? root._serviceUid + "/Temperature" : ""
+		uid: {
+			if (root._useTemperature) {
+				const idInfo = BackendConnection.portableIdInfo(centerService.value)
+				const device = Global.environmentInputs.model.deviceForDeviceInstance(idInfo.instance)
+				if (device) {
+					return device.serviceUid + "/Temperature"
+				}
+			}
+			return ""
+		}
 	}
 
 	Row {

--- a/components/CommonWords.qml
+++ b/components/CommonWords.qml
@@ -312,6 +312,9 @@ QtObject {
 	//% "No error"
 	readonly property string no_error: qsTrId("common_words_no_error")
 
+	//% "None"
+	readonly property string none_option: qsTrId("common_words_none_option")
+
 	//: Indicates there are no errors
 	//% "None"
 	readonly property string none_errors: qsTrId("common_words_none_errors")

--- a/components/GaugeModel.qml
+++ b/components/GaugeModel.qml
@@ -14,84 +14,119 @@ import Victron.Gauges
 ListModel {
 	id: root
 
-	function gaugesToDisplay() {
-		let gaugeTypes = []
-		const preferredGaugeTypes = Global.systemSettings.briefView.centralGauges.preferredOrder
-
-		for (let i = 0; i < preferredGaugeTypes.length; ++i) {
-			if (gaugeTypes.indexOf(preferredGaugeTypes[i]) >= 0) {
-				// Do not show more than one gauge for the same tank type.
-				continue
-			} else if (preferredGaugeTypes[i] === VenusOS.Tank_Type_Battery) {
-				// Assume battery is always available.
-				gaugeTypes.push(VenusOS.Tank_Type_Battery)
-			} else if (preferredGaugeTypes[i] !== VenusOS.Tank_Type_None) {
-				// If there is a tank of this type, then add the type to the displayed gauges. If
-				// not, add another tank that is available on the system. Otherwise, if the user has
-				// not selected any preferred tanks, but does not have any of the tanks from the
-				// default preferences, then the center display would not show any tanks at all.
-				const preferredTankModel = Global.tanks.tankModel(preferredGaugeTypes[i])
-				if (preferredTankModel.count > 0) {
-					gaugeTypes.push(preferredGaugeTypes[i])
-				} else {
-					for (const tankModel of Global.tanks.allTankModels) {
-						if (tankModel.count > 0 && gaugeTypes.indexOf(tankModel.type) < 0) {
-							gaugeTypes.push(tankModel.type)
-							break
-						}
+	function _loadDefaultGauges() {
+		let gauges = []
+		if (Global.tanks.totalTankCount === 0) {
+			// There are no tanks, so there are no gauges to be shown.
+			return []
+		} else {
+			// Show the system battery, followed by gauges with aggregated tank levels for whichever
+			// tank types are available on the system.
+			gauges.push({ centerGaugeType: VenusOS.BriefView_CentralGauge_SystemBattery, value: "" })
+			for (const tankModel of Global.tanks.allTankModels) {
+				if (tankModel.count > 0) {
+					gauges.push({ centerGaugeType: VenusOS.BriefView_CentralGauge_TankAggregate, value: tankModel.type })
+					if (gauges.length >= Theme.geometry_briefPage_centerGauge_maximumGaugeCount) {
+						break
 					}
 				}
 			}
 		}
-		return gaugeTypes
+		return gauges
 	}
 
 	// Rebuild the gauge model, based on the preferred gauges and the tanks available.
 	function _reset() {
-		const gaugeTypes = gaugesToDisplay()
-		if (gaugeTypes != _gaugeObjects.model) {
-			_gaugeObjects.model = []
-
+		let useDefaultGauges = false
+		let gauges = Global.systemSettings.briefView.centralGauges
+		if (gauges.length === 0) {
+			gauges = _loadDefaultGauges()
+			useDefaultGauges = true
+		} else {
+			gauges = gauges.filter((data) => data.centerGaugeType !== VenusOS.BriefView_CentralGauge_None)
+		}
+		if (gauges !== _gaugeObjects.model) {
 			// Clear the model and add default values for each gauge.
-			clear()
-			for (let i = 0; i < gaugeTypes.length; ++i) {
-				append(Object.assign({}, Gauges.tankProperties(gaugeTypes[i]), { tankType: gaugeTypes[i], level: 0, value: 0 }))
+			_gaugeObjects.model = []
+			let hasBatteryId = false
+			for (let i = 0; i < gauges.length; ++i) {
+				if (!hasBatteryId && gauges[i].centerGaugeType === VenusOS.BriefView_CentralGauge_BatteryId) {
+					hasBatteryId = true
+				}
+				root.set(i, {
+					tankType: -1,
+					name: "",
+					icon: "",
+					valueType: VenusOS.Gauges_ValueType_NeutralPercentage,
+					color: Theme.color_ok,
+					level: 0,
+					value: 0,
+				})
 			}
-			_gaugeObjects.model = gaugeTypes
+			while (count > gauges.length) {
+				root.remove(count - 1)
+			}
+
+			root._batteriesItem.active = hasBatteryId
+			root._gaugeObjects.model = gauges
+
+			// If showing aggregated tank types for the available tanks on the system, then refresh
+			// the model whenever the available tanks have changed.
+			root._tankCountConn.enabled = useDefaultGauges
 		}
 	}
 
 	function _updateGauge(gaugeIndex, gauge) {
 		if (gaugeIndex >= 0 && gaugeIndex < count) {
-			const value = Global.systemSettings.briefView.unit.value === VenusOS.BriefView_Unit_Percentage || gauge.isBattery ? gauge.tankLevel : gauge.tankRemaining
-			set(gaugeIndex, { name: gauge.tankName, icon: gauge.tankIcon, level: gauge.tankLevel, value: value })
+			const value = Global.systemSettings.briefView.unit.value === VenusOS.BriefView_Unit_Percentage
+						|| gauge.type === VenusOS.Tank_Type_Battery
+					? gauge.level
+					: gauge.remaining
+			set(gaugeIndex, {
+				tankType: gauge.type,
+				name: gauge.name,
+				icon: gauge.icon,
+				valueType: gauge.valueType,
+				color: gauge.color,
+				level: gauge.level,
+				value: value
+			})
 		}
 	}
 
-	property Instantiator _gaugeObjects: Instantiator {
+	readonly property VeQuickItem _batteriesItem: VeQuickItem {
+		property bool active
+
+		uid: active ? Global.system.serviceUid + "/Batteries" : ""
+	}
+
+	component GaugeSource : QtObject {
+		required property int type
+		property string name
+		property string icon
+		property real level
+		property real remaining
+	}
+
+	readonly property Instantiator _gaugeObjects: Instantiator {
 		id: _gaugeObjects
 
 		model: null
-		delegate: QtObject {
+		delegate: Loader {
 			id: gaugeObject
 
-			required property int modelData
+			required property var modelData
 			required property int index
 
-			readonly property int tankType: modelData
-			readonly property bool isBattery: tankType === VenusOS.Tank_Type_Battery
+			readonly property int type: item?.type ?? -1
+			readonly property string name: item?.name || properties.name || ""
+			readonly property string icon: item?.icon || properties.icon || ""
+			readonly property real level: item?.level ?? NaN
+			readonly property real remaining: item?.remaining ?? NaN
+			readonly property int valueType: properties.valueType ?? VenusOS.Gauges_ValueType_NeutralPercentage
+			readonly property color color: properties.color ?? Theme.color_ok
 
-			readonly property string tankName: _tankProperties.name
-			readonly property string tankIcon: isBattery ? Global.system.battery.icon : _tankProperties.icon
-			readonly property var tankModel: isBattery ? null : Global.tanks.tankModel(tankType)
-			readonly property real tankLevel: isBattery ? Math.round(Global.system.battery.stateOfCharge)
-					: !isNaN(tankModel.averageLevel) ? tankModel.averageLevel
-					: (tankModel.count === 0 || tankModel.totalCapacity === 0) ? 0
-					: ((Math.min(tankModel.totalRemaining / tankModel.totalCapacity, 1.0) * 100))
-			readonly property real tankRemaining: isBattery ? null
-					: Units.convert(tankModel.totalRemaining, VenusOS.Units_Volume_CubicMeter, Global.systemSettings.volumeUnit)
-
-			readonly property var _tankProperties: Gauges.tankProperties(tankType)
+			readonly property var properties: type >= 0 ? Gauges.tankProperties(type) : ({})
 
 			function _updateGaugeModel() {
 				if (root) { // may be null if this object has been destroyed after the Qt.callLater() call
@@ -99,17 +134,104 @@ ListModel {
 				}
 			}
 
+			sourceComponent: modelData.centerGaugeType === VenusOS.BriefView_CentralGauge_BatteryId ? batteryIdSource
+					: modelData.centerGaugeType === VenusOS.BriefView_CentralGauge_SystemBattery ? systemBatterySource
+					: modelData.centerGaugeType === VenusOS.BriefView_CentralGauge_TankAggregate ? tankAggregateSource
+					: tankIdSource
+
 			// If tank data changes, update the model at the end of the event loop to avoid
 			// excess updates if multiple values change simultaneously for the same tank.
-			onTankNameChanged: Qt.callLater(_updateGaugeModel)
-			onTankIconChanged: Qt.callLater(_updateGaugeModel)
-			onTankLevelChanged: Qt.callLater(_updateGaugeModel)
+			onNameChanged: Qt.callLater(_updateGaugeModel)
+			onIconChanged: Qt.callLater(_updateGaugeModel)
+			onLevelChanged: Qt.callLater(_updateGaugeModel)
 
-			property Connections _unitConn: Connections {
+			Connections {
 				target: Global.systemSettings.briefView.unit
 
 				function onValueChanged() {
 					Qt.callLater(_updateGaugeModel)
+				}
+			}
+
+			Component {
+				id: batteryIdSource
+
+				GaugeSource {
+					id: battery
+
+					type: VenusOS.Tank_Type_Battery
+
+					readonly property Connections _batteriesConn: Connections {
+						target: _batteriesItem
+						function onValueChanged() {
+							const batteryId = gaugeObject.modelData.value
+							const batteryList = _batteriesItem.value ?? []
+							let batteryName = ""
+							let batteryIcon = ""
+							let batteryLevel = ""
+							for (const battery of batteryList) {
+								if (battery.id === batteryId) {
+									const power = battery.power ?? NaN
+									batteryName = battery.name ?? ""
+									batteryIcon = VenusOS.battery_iconFromMode(VenusOS.battery_modeFromPower(power))
+									batteryLevel = battery.soc ?? NaN
+									break
+								}
+							}
+							battery.name = batteryName
+							battery.icon = batteryIcon
+							battery.level = batteryLevel
+						}
+					}
+				}
+			}
+
+			Component {
+				id: systemBatterySource
+
+				GaugeSource {
+					type: VenusOS.Tank_Type_Battery
+					icon: Global.system.battery.icon
+					level: Global.system.battery.stateOfCharge
+				}
+			}
+
+			Component {
+				id: tankAggregateSource
+
+				GaugeSource {
+					readonly property TankModel _tankModel: Global.tanks.tankModel(type)
+
+					type: parseInt(gaugeObject.modelData.value)
+					level: _tankModel.count === 0 ? NaN
+							: !isNaN(_tankModel.averageLevel) ? _tankModel.averageLevel
+							: (_tankModel.count === 0 || _tankModel.totalCapacity === 0) ? 0
+							: ((Math.min(_tankModel.totalRemaining / _tankModel.totalCapacity, 1.0) * 100))
+					remaining: Units.convert(_tankModel.totalRemaining, VenusOS.Units_Volume_CubicMeter, Global.systemSettings.volumeUnit)
+				}
+			}
+
+			Component {
+				id: tankIdSource
+
+				GaugeSource {
+					readonly property Tank _device: _findTank()
+
+					function _findTank() {
+						const tankIdInfo = BackendConnection.portableIdInfo(gaugeObject.modelData.value)
+						for (const tankModel of Global.tanks.allTankModels) {
+							const tank = tankModel.deviceForDeviceInstance(tankIdInfo.instance)
+							if (tank) {
+								return tank
+							}
+						}
+						return null
+					}
+
+					name: _device?.name || ""
+					type: _device?.type ?? -1
+					level: _device?.level ?? NaN
+					remaining: Units.convert(_device?.remaining ?? NaN, VenusOS.Units_Volume_CubicMeter, Global.systemSettings.volumeUnit)
 				}
 			}
 		}
@@ -124,9 +246,9 @@ ListModel {
 	}
 
 	property Connections _centralGaugesConn: Connections {
-		target: Global.systemSettings.briefView.centralGauges
+		target: Global.systemSettings.briefView
 
-		function onPreferredOrderChanged() {
+		function onCentralGaugesChanged() {
 			Qt.callLater(root._reset)
 		}
 	}

--- a/components/RadioButtonListPage.qml
+++ b/components/RadioButtonListPage.qml
@@ -67,6 +67,7 @@ Page {
 			height: effectiveVisible ? implicitHeight : -Theme.geometry_gradientList_spacing
 
 			text: modelObject.display || ""
+			secondaryText: modelObject.secondaryText || ""
 			interactive: !modelObject.readOnly
 			primaryLabel.font.family: modelObject.fontFamily || Global.fontFamily
 			preferredVisible: interactive || checked

--- a/components/listitems/ListBriefCenterDetails.qml
+++ b/components/listitems/ListBriefCenterDetails.qml
@@ -9,7 +9,7 @@ import Victron.VenusOS
 ListNavigation {
 	id: root
 
-	readonly property string activeBatteryName: availableBatteryServices.mapObject[activeBatteryService.value] ?? ""
+	required property string activeBatteryName
 	property string customServiceDescription
 
 	function _summaryText(deviceName, deviceInstance) {
@@ -56,26 +56,6 @@ ListNavigation {
 				root.customServiceDescription = root._summaryText(device?.name, device?.deviceInstance)
 			} else {
 				root.customServiceDescription = ""
-			}
-		}
-	}
-
-	VeQuickItem {
-		id: activeBatteryService
-		uid: Global.system.serviceUid + "/ActiveBatteryService"
-	}
-
-	VeQuickItem {
-		id: availableBatteryServices
-
-		property var mapObject: ({})
-
-		uid: Global.system.serviceUid + "/AvailableBatteryServices"
-		onValueChanged: {
-			try {
-				mapObject = JSON.parse(value)
-			} catch (e) {
-				console.warn("Unable to parse JSON:", value, "exception:", e)
 			}
 		}
 	}

--- a/components/listitems/ListBriefCenterDetails.qml
+++ b/components/listitems/ListBriefCenterDetails.qml
@@ -27,13 +27,14 @@ ListNavigation {
 		let deviceOptionModel = [{ display: activeBatteryName, value: "", section: qsTrId("settings_briefview_center_active_battery_monitor") }]
 		for (let i = 0; i < deviceModel.count; ++i) {
 			const device = deviceModel.deviceAt(i)
+			const portableServiceId = BackendConnection.serviceUidToPortableId(device.serviceUid, device.deviceInstance)
 			deviceOptionModel.push({
 				display: root._summaryText(device.name, device.deviceInstance),
-				value: device.serviceUid,
+				value: portableServiceId,
 				//% "Temperature services"
 				section: qsTrId("settings_briefview_center_temperature_services")
 			})
-			if (selectedIndex < 0 && device.serviceUid === centerService.value) {
+			if (selectedIndex < 0 && portableServiceId === centerService.value) {
 				selectedIndex = i
 			}
 		}
@@ -48,12 +49,12 @@ ListNavigation {
 		id: centerService
 		uid: Global.systemSettings.serviceUid + "/Settings/Gui2/BriefView/CenterService"
 		onValueChanged: {
-			const serviceUid = value
-			const serviceType = BackendConnection.serviceTypeFromUid(serviceUid)
-			if (serviceType === "temperature") {
-				const deviceModel = Global.environmentInputs.model
-				const device = deviceModel.deviceAt(deviceModel.indexOf(serviceUid))
-				root.customServiceDescription = root._summaryText(device?.name, device?.deviceInstance)
+			const idInfo = BackendConnection.portableIdInfo(value)
+			if (idInfo.type === "temperature") {
+				const device = Global.environmentInputs.model.deviceForDeviceInstance(idInfo.instance)
+				if (device) {
+					root.customServiceDescription = root._summaryText(device?.name, device?.deviceInstance)
+				}
 			} else {
 				root.customServiceDescription = ""
 			}
@@ -75,8 +76,8 @@ ListNavigation {
 			showAccessLevel: root.showAccessLevel
 			writeAccessLevel: root.writeAccessLevel
 
-			onOptionClicked: (index, serviceUid) => {
-				centerService.setValue(serviceUid)
+			onOptionClicked: (index, serviceId) => {
+				centerService.setValue(serviceId)
 			}
 		}
 	}

--- a/components/listitems/core/ListRadioButton.qml
+++ b/components/listitems/core/ListRadioButton.qml
@@ -12,10 +12,16 @@ ListItem {
 
 	property alias checked: radioButton.checked
 	property alias radioButton: radioButton
+	property string secondaryText
 
 	interactive: true
 
 	content.children: [
+		SecondaryListLabel {
+			text: root.secondaryText
+			width: Math.min(implicitWidth, root.maximumContentWidth - radioButton.width - Theme.geometry_listItem_content_spacing)
+			visible: text.length > 0
+		},
 		RadioButton {
 			id: radioButton
 

--- a/data/mock/BatteriesImpl.qml
+++ b/data/mock/BatteriesImpl.qml
@@ -109,7 +109,7 @@ QtObject {
 	}
 
 	function updateBatteriesList() {
-		const dummyBatteryServiceName = dummyBattery.serviceUid.substring(BackendConnection.uidPrefix().length + 1)
+		const dummyBatteryServiceName = "com.victronenergy.battery/1"
 		const batteryList = [
 			{
 				// System battery
@@ -129,7 +129,8 @@ QtObject {
 				active_battery_service: false,
 				id: dummyBatteryServiceName + ":1",
 				name: "My starter battery",
-				voltage: 0.029999999329447746
+				voltage: 0.029999999329447746,
+				soc: 12.34,
 			}
 		]
 		Global.mockDataSimulator.setMockValue(Global.system.serviceUid + "/Batteries", batteryList)

--- a/data/mock/SystemSettingsImpl.qml
+++ b/data/mock/SystemSettingsImpl.qml
@@ -85,10 +85,15 @@ QtObject {
 		setMockSettingValue("Gui2/StartPageName", "")
 		setMockSettingValue("Gui2/StartPageTimeout", 0)
 
-		setMockSystemValue("AvailableBatteryServices", '{"default": "Automatic", "nobattery": "No battery monitor", "com.victronenergy.vebus/257": "Quattro 24/3000/70-2x50 on VE.Bus", "com.victronenergy.battery/0": "Lynx Smart BMS 500 on VE.Can"}')
-		setMockSystemValue("AutoSelectedBatteryService", "Lynx Smart BMS 500 on VE.Can")
-		setMockSystemValue("AvailableBatteries", '{"com.victronenergy.battery/0": {"name": "Lynx Smart BMS HQ21302VUDQ", "channel": null, "type": "battery"}, "com.victronenergy.vebus/257": {"name": "Quattro 24/3000/70-2x50", "channel": null, "type": "vebus"}}')
-		setMockSystemValue("ActiveBatteryService", "com.victronenergy.battery/0")
+		// Use mock tanks and batteries
+		setMockSettingValue("Gui2/BriefView/Level/0", "com.victronenergy.battery/1:1")
+		setMockSettingValue("Gui2/BriefView/Level/1", "com.victronenergy.tank/0")
+		setMockSettingValue("Gui2/BriefView/Level/2", "" + VenusOS.Tank_Type_Fuel)
+
+		setMockSystemValue("AvailableBatteryServices", '{"default": "Automatic", "nobattery": "No battery monitor", "com.victronenergy.vebus/257": "Quattro 24/3000/70-2x50 on VE.Bus", "com.victronenergy.battery/1": "Lynx Smart BMS HQ21302VUDQ"}')
+		setMockSystemValue("AutoSelectedBatteryService", "Lynx Smart BMS HQ21302VUDQ")
+		setMockSystemValue("AvailableBatteries", '{"com.victronenergy.battery/1": {"name": "Lynx Smart BMS HQ21302VUDQ", "channel": null, "type": "battery"}, "com.victronenergy.vebus/257": {"name": "Quattro 24/3000/70-2x50", "channel": null, "type": "vebus"}}')
+		setMockSystemValue("ActiveBatteryService", "com.victronenergy.battery/1")
 		setMockSettingValue("SystemSetup/Batteries/Configuration/com_victronenergy_battery/0/Enabled", 1)
 		setMockSettingValue("SystemSetup/Batteries/Configuration/com_victronenergy_battery/0/Name", "My battery")
 		setMockSettingValue("SystemSetup/Batteries/Configuration/com_victronenergy_vebus/257/Enabled", 1)
@@ -108,7 +113,7 @@ QtObject {
 		setMockSettingValue("SystemSetup/SharedTemperatureSense", 2)
 		setMockSystemValue("Control/BatteryCurrentSense", 0)
 		setMockSettingValue("SystemSetup/BmsInstance", -1)
-		setMockSystemValue("ActiveBmsService", "com.victronenergy.battery.ttyUSB1")
+		setMockSystemValue("ActiveBmsService", "com.victronenergy.battery.ttyUSB0")
 		setMockSystemValue("ActiveBmsInstance", 1)
 
 		//systemReason.lowSoc.setValue(1)
@@ -214,7 +219,7 @@ QtObject {
 
 		setMockSettingValue("Services/Modbus", 0)
 		setMockModbusTcpValue("Services/Count", 2)
-		setMockModbusTcpValue("Services/0/ServiceName", "com.victronenergy.battery.ttyUSB1")
+		setMockModbusTcpValue("Services/0/ServiceName", "com.victronenergy.battery.ttyUSB0")
 		setMockModbusTcpValue("Services/0/UnitId", 288)
 		setMockModbusTcpValue("Services/1/ServiceName", "com.victronenergy.solarcharger.ttyUSB1")
 		setMockModbusTcpValue("Services/1/UnitId", 289)

--- a/pages/settings/PageSettingsDisplayBrief.qml
+++ b/pages/settings/PageSettingsDisplayBrief.qml
@@ -10,35 +10,206 @@ import Victron.Gauges
 Page {
 	id: root
 
-	readonly property var _gaugeOptionsModel: {
-		const validGaugeOptions = Gauges.briefCentralGauges.map(function(gaugeType) {
-			const name = Gauges.tankProperties(gaugeType).name || ""
-			return { display: name, value: gaugeType }
-		})
-		//% "None"
-		return [ { display: qsTrId("settings_briefview_level_none"), value: VenusOS.Tank_Type_None } ].concat(validGaugeOptions)
+	readonly property string activeBatteryName: availableBatteryServices.mapObject[activeBatteryService.value] ?? ""
+
+	function _levelOptionModel(selectedCenterGaugeType, selectedCenterGaugeValue) {
+		let optionModel = [ { display: CommonWords.none_option, value: "" + VenusOS.Tank_Type_None, section: "" } ]
+		let tankModel
+
+		// Add tank aggregate options for all tank types on the system, or for the currently
+		// selected tank type, if one is selected.
+		for (tankModel of Global.tanks.allTankModels) {
+			if (tankModel.count > 0
+					|| (selectedCenterGaugeType === VenusOS.BriefView_CentralGauge_TankAggregate &&
+						parseInt(selectedCenterGaugeValue) === tankModel.type)) {
+				optionModel.push({
+					display: Gauges.tankProperties(tankModel.type).name,
+					value: "" + tankModel.type,
+					//% "Tank totals"
+					section: qsTrId("settings_briefview_totals")
+				})
+			}
+		}
+
+		// Add individual battery options.
+		const batteryList = batteriesItem.value ?? []
+		let foundSelectedBattery = false
+		for (const battery of batteryList) {
+			_addBatteryGaugeOption(optionModel, battery.id, battery.name || battery.id, "")
+			if (!foundSelectedBattery
+					&& selectedCenterGaugeType === VenusOS.BriefView_CentralGauge_BatteryId
+					&& selectedCenterGaugeValue === battery.id) {
+				foundSelectedBattery = true
+			}
+		}
+		if (!foundSelectedBattery
+				&& selectedCenterGaugeType === VenusOS.BriefView_CentralGauge_BatteryId) {
+			// Add the selected battery as an option, even if it is not in the /Batteries list.
+			const batteryId = selectedCenterGaugeValue
+			//% "Battery is not connected."
+			_addBatteryGaugeOption(optionModel, batteryId, batteryId, qsTrId("settings_briefview_battery_not_connected"))
+		}
+
+		// Add individual tank options
+		let foundSelectedTank = false
+		for (tankModel of Global.tanks.allTankModels) {
+			for (let i = 0; i < tankModel.count; ++i) {
+				const tank = tankModel.deviceAt(i)
+				const portableId = BackendConnection.serviceUidToPortableId(tank.serviceUid, tank.deviceInstance)
+				_addTankGaugeOption(optionModel, `${tank.name} [${tank.deviceInstance}]`, portableId, "")
+				if (!foundSelectedTank
+						&& selectedCenterGaugeType === VenusOS.BriefView_CentralGauge_TankId
+						&& selectedCenterGaugeValue === portableId) {
+					foundSelectedTank = true
+				}
+			}
+		}
+		if (!foundSelectedTank
+				&& selectedCenterGaugeType === VenusOS.BriefView_CentralGauge_TankId) {
+			const tankId = selectedCenterGaugeValue
+			//% "Tank is not connected."
+			_addTankGaugeOption(optionModel, tankId, tankId, qsTrId("settings_briefview_tank_not_connected"))
+		}
+
+		return optionModel
 	}
 
-	// Use this intermediate model that is built when the page loads, to avoid changing the model
-	// while the radio button group sub-page is shown, as that causes the group options to be rebuilt.
-	property var _gaugesModel
-	onIsCurrentPageChanged: {
-		if (isCurrentPage) {
-			_gaugesModel = Global.systemSettings.briefView.centralGauges.preferredOrder
+	function _addBatteryGaugeOption(levelOptionModel, batteryId, name, caption) {
+		const isActiveBattery = batteryId === activeBatteryService.value
+		levelOptionModel.push({
+			display: name,
+			value: isActiveBattery ? VenusOS.Tank_Type_Battery : batteryId,
+			//% "Active battery monitor"
+			secondaryText: isActiveBattery ? qsTrId("settings_briefview_active_battery_monitor") : "",
+			caption: caption,
+			//% "Individual batteries"
+			section: qsTrId("settings_briefview_individual_batteries")
+		})
+	}
+
+	function _addTankGaugeOption(levelOptionModel, tankName, serviceId, caption) {
+		levelOptionModel.push({
+			display: tankName,
+			value: serviceId,
+			caption: caption,
+			//% "Individual tanks"
+			section: qsTrId("settings_briefview_individual_tanks")
+		})
+	}
+
+	function _findSelectedLevel(levelOptionModel, selectedCenterGaugeType, selectedCenterGaugeValue) {
+		for (let i = 0; i < levelOptionModel.length; ++i) {
+			switch (selectedCenterGaugeType) {
+			case VenusOS.BriefView_CentralGauge_None:
+				return 0 // "None" is the first item in the option model
+			case VenusOS.BriefView_CentralGauge_BatteryId:
+				const batteryId = selectedCenterGaugeValue
+				if (levelOptionModel[i].value === batteryId) {
+					return i
+				}
+				break
+			case VenusOS.BriefView_CentralGauge_SystemBattery:
+				if (levelOptionModel[i].value === VenusOS.Tank_Type_Battery) {
+					return i
+				}
+				break
+			case VenusOS.BriefView_CentralGauge_TankAggregate:
+				const tankTypeAsString = "" + selectedCenterGaugeValue
+				if (levelOptionModel[i].value === tankTypeAsString) {
+					return i
+				}
+				break
+			case VenusOS.BriefView_CentralGauge_TankId:
+				const tankServiceId = selectedCenterGaugeValue
+				if (levelOptionModel[i].value === tankServiceId) {
+					return i
+				}
+				break
+			default:
+				// No option has been selected
+				return -1
+			}
 		}
+		return -1
 	}
 
 	GradientListView {
-		model: root._gaugesModel
+		model: Theme.geometry_briefPage_centerGauge_maximumGaugeCount
+		delegate: ListNavigation {
+			id: levelDelegate
 
-		delegate: ListRadioButtonGroup {
 			required property int index
+			readonly property var modelData: Global.systemSettings.briefView.centralGauges[index]
+			readonly property int centerGaugeType: modelData?.centerGaugeType ?? -1
+			readonly property var centerGaugeValue: modelData?.value ?? ""
+
+			readonly property Tank _device: {
+				if (centerGaugeType === VenusOS.BriefView_CentralGauge_TankId) {
+					const tankIdInfo = BackendConnection.portableIdInfo(levelDelegate.centerGaugeValue)
+					for (const tankModel of Global.tanks.allTankModels) {
+						const tank = tankModel.deviceForDeviceInstance(tankIdInfo.instance)
+						if (tank) {
+							return tank
+						}
+					}
+				}
+				return null
+			}
+
+			readonly property string batteryName: {
+				if (levelDelegate.centerGaugeType === VenusOS.BriefView_CentralGauge_BatteryId) {
+					if (batteriesItem.valid) {
+						const batteryList = batteriesItem.value
+						const batteryId = levelDelegate.centerGaugeValue
+						for (const battery of batteryList) {
+							if (battery.id === batteryId) {
+								return battery.name || ""
+							}
+						}
+					}
+				}
+				return ""
+			}
 
 			//: Level number
 			//% "Level %1"
 			text: qsTrId("settings_briefview_level").arg(index + 1)
-			optionModel: root._gaugeOptionsModel
-			dataItem.uid: Global.systemSettings.serviceUid + "/Settings/Gui/BriefView/Level/" + index
+			secondaryText: {
+				switch (centerGaugeType) {
+				case VenusOS.BriefView_CentralGauge_None:
+					return CommonWords.none_option
+				case VenusOS.BriefView_CentralGauge_BatteryId:
+					//% "Battery not connected"
+					return batteryName || qsTrId("settings_briefview_unconnected_battery")
+				case VenusOS.BriefView_CentralGauge_SystemBattery:
+					return root.activeBatteryName
+				case VenusOS.BriefView_CentralGauge_TankAggregate:
+					return Gauges.tankProperties(parseInt(centerGaugeValue))?.name ?? ""
+				case VenusOS.BriefView_CentralGauge_TankId:
+					return _device
+						? _device.name
+						  //% "Tank not connected"
+						: qsTrId("settings_briefview_unconnected_tank")
+				default:
+					//: No option has been selected
+					//% "Not configured"
+					return qsTrId("settings_briefview_not_configured")
+				}
+			}
+			secondaryLabel.color: (centerGaugeType === VenusOS.BriefView_CentralGauge_BatteryId && batteryName.length === 0)
+					|| (centerGaugeType === VenusOS.BriefView_CentralGauge_TankId && !_device)
+				? Theme.color_red
+				: Theme.color_listItem_secondaryText
+
+			onClicked: {
+				const optionModel = root._levelOptionModel(centerGaugeType, centerGaugeValue)
+				Global.pageManager.pushPage(deviceOptionsComponent, {
+					levelIndex: index,
+					title: text,
+					optionModel: optionModel,
+					currentIndex: root._findSelectedLevel(optionModel, centerGaugeType, centerGaugeValue),
+				})
+			}
 		}
 
 		footer: SettingsColumn {
@@ -60,7 +231,60 @@ Page {
 			}
 
 			ListBriefCenterDetails {
+				activeBatteryName: root.activeBatteryName
 			}
 		}
+	}
+
+	Component {
+		id: deviceOptionsComponent
+
+		RadioButtonListPage {
+			id: deviceOptionsPage
+
+			required property int levelIndex
+
+			optionView.section.property: "section"
+			optionView.section.delegate: SettingsListHeader {
+				required property string section
+
+				bottomPadding: Theme.geometry_gradientList_spacing
+				text: section
+			}
+
+			onOptionClicked: (index, value) => {
+				levelItem.setValue(value)
+			}
+
+			VeQuickItem {
+				id: levelItem
+				uid: Global.systemSettings.serviceUid + "/Settings/Gui2/BriefView/Level/" + deviceOptionsPage.levelIndex
+			}
+		}
+	}
+
+	VeQuickItem {
+		id: activeBatteryService
+		uid: Global.system.serviceUid + "/ActiveBatteryService"
+	}
+
+	VeQuickItem {
+		id: availableBatteryServices
+
+		property var mapObject: ({})
+
+		uid: Global.system.serviceUid + "/AvailableBatteryServices"
+		onValueChanged: {
+			try {
+				mapObject = JSON.parse(value)
+			} catch (e) {
+				console.warn("Unable to parse JSON:", value, "exception:", e)
+			}
+		}
+	}
+
+	VeQuickItem {
+		id: batteriesItem
+		uid: Global.system.serviceUid + "/Batteries"
 	}
 }

--- a/src/backendconnection.cpp
+++ b/src/backendconnection.cpp
@@ -705,6 +705,23 @@ QString BackendConnection::uidPrefix() const
 	return QString();
 }
 
+QString BackendConnection::serviceUidToPortableId(const QString &serviceUid, int deviceInstance) const
+{
+	const QString serviceType = serviceTypeFromUid(serviceUid);
+	return QStringLiteral("com.victronenergy.%1/%2").arg(serviceType).arg(QString::number(deviceInstance));
+}
+
+QVariantMap BackendConnection::portableIdInfo(const QString &portableId) const
+{
+	const QStringList parts = portableId.split('/');
+	const QString serviceName = parts.first();
+
+	QVariantMap map;
+	map.insert(QStringLiteral("type"), serviceName.split('.').last());
+	map.insert(QStringLiteral("instance"), parts.last());
+	return map;
+}
+
 void BackendConnection::setMockValue(const QString &uid, const QVariant &value)
 {
 	if (VeQItemMockProducer *producer = qobject_cast<VeQItemMockProducer *>(m_producer)) {

--- a/src/backendconnection.h
+++ b/src/backendconnection.h
@@ -141,6 +141,10 @@ public:
 	Q_INVOKABLE QString serviceUidFromName(const QString &serviceName, int deviceInstance) const;
 	Q_INVOKABLE QString uidPrefix() const;
 
+	// A portable service id has the format "com.victronenergy.<serviceType>/<deviceInstance"
+	Q_INVOKABLE QString serviceUidToPortableId(const QString &serviceUid, int deviceInstance) const;
+	Q_INVOKABLE QVariantMap portableIdInfo(const QString &portableId) const;
+
 	Q_INVOKABLE void logout();
 	Q_INVOKABLE void securityProtocolChanged();
 	Q_INVOKABLE void reloadPage();

--- a/src/enums.h
+++ b/src/enums.h
@@ -378,6 +378,15 @@ public:
 	};
 	Q_ENUM(BriefView_Unit)
 
+	enum BriefView_CentralGauge_Type {
+		BriefView_CentralGauge_None,
+		BriefView_CentralGauge_BatteryId,
+		BriefView_CentralGauge_SystemBattery,
+		BriefView_CentralGauge_TankAggregate,
+		BriefView_CentralGauge_TankId
+	};
+	Q_ENUM(BriefView_CentralGauge_Type)
+
 	enum Tank_Type {
 		// These values align with tank types from dbus
 		// see: https://github.com/victronenergy/venus/wiki/dbus#tank-levels


### PR DESCRIPTION
This needs local settings `/Settings/Gui2/BriefView/Level/<0-3>`, which may not yet be available on the build. So to make it work on a device you need to add the setting, e.g. `dbus -y com.victronenergy.settings /Settings AddSettings '%[{"path": "Gui2/BriefView/Level/0", "default": ""}]'` and repeat for level 1-3.