### PR TITLE
Fix User Access Password can be revealed

### DIFF
--- a/components/listitems/core/ListTextField.qml
+++ b/components/listitems/core/ListTextField.qml
@@ -190,7 +190,6 @@ ListItem {
 		}
 	}
 
-	enabled: userHasWriteAccess && (dataItem.uid === "" || dataItem.valid)
 	content.children: [
 		defaultContent,
 		readonlyLabel
@@ -201,7 +200,7 @@ ListItem {
 
 		text: textField.text.length > 0 ? textField.text : "--"
 		width: Math.min(implicitWidth, root.maximumContentWidth)
-		visible: !root.enabled
+		visible: !root.interactive
 	}
 
 	VeQuickItem {


### PR DESCRIPTION
- Remove ListTextField enabled binding which causes the change of userHasWriteAccess to be reflected in the SecondaryListLabel (ListTextField's interactive binding is sufficient)
- Update SecondaryListLabel visible binding to use interactive

Fixes #1971