### PR TITLE
Fix vertical centering of arrow icon in SettingsListNavigation

### DIFF
--- a/components/TemperatureRelaySettings.qml
+++ b/components/TemperatureRelaySettings.qml
@@ -56,11 +56,8 @@ SettingsColumn {
 			{ display: qsTrId("settings_relay2"), value: 1, readOnly: !relay1Item.valid },
 		]
 
-		PrimaryListLabel {
-			//% "Warning: The above selected relay is not configured for temperature, this condition will be ignored."
-			text: qsTrId("settings_relay_invalid_temp_config_warning")
-			preferredVisible: root.hasInvalidRelayTempConfig
-		}
+		//% "Warning: The above selected relay is not configured for temperature, this condition will be ignored."
+		caption: root.hasInvalidRelayTempConfig ? qsTrId("settings_relay_invalid_temp_config_warning") : ""
 	}
 
 	ListSpinBox {

--- a/components/listitems/core/ListItem.qml
+++ b/components/listitems/core/ListItem.qml
@@ -86,7 +86,7 @@ Item {
 	signal clicked()
 
 	visible: effectiveVisible
-	implicitHeight: effectiveVisible ? contentLayout.height : 0
+	implicitHeight: effectiveVisible ? contentLayout.implicitHeight : 0
 	implicitWidth: parent ? parent.width : 0
 
 	ListItemBackground {
@@ -150,6 +150,7 @@ Item {
 		id: contentLayout
 
 		width: parent.width
+		anchors.verticalCenter: parent.verticalCenter
 		columns: 2
 		columnSpacing: Theme.geometry_listItem_content_spacing
 		rowSpacing: 0

--- a/pages/settings/debug/PageDebug.qml
+++ b/pages/settings/debug/PageDebug.qml
@@ -98,8 +98,6 @@ Page {
 			ListRadioButtonGroup {
 				//% "Demo mode"
 				text: qsTrId("settings_demo_mode")
-				height: implicitHeight + demoModeCaption.height
-				primaryLabel.anchors.verticalCenterOffset: -(demoModeCaption.height / 2)
 				dataItem.uid: Global.systemSettings.serviceUid + "/Settings/Gui/DemoMode"
 				popDestination: undefined // don't pop page automatically.
 				updateDataOnClick: false // handle option clicked manually.
@@ -113,16 +111,9 @@ Page {
 					{ display: qsTrId("page_settings_demo_2"), value: 3 },
 				]
 
-				PrimaryListLabel {
-					id: demoModeCaption
+				//% "Starting demo mode will change some settings and the user interface will be unresponsive for a moment."
+				caption: qsTrId("settings_demo_mode_caption")
 
-					anchors {
-						bottom: parent.bottom
-						bottomMargin: Theme.geometry_listItem_content_verticalMargin
-					}
-					//% "Starting demo mode will change some settings and the user interface will be unresponsive for a moment."
-					text: qsTrId("settings_demo_mode_caption")
-				}
 				onOptionClicked: function(index) {
 					Qt.callLater(Global.main.rebuildUi)
 					dataItem.setValue(index)


### PR DESCRIPTION
- Fix ListItem's GridLayout (contentLayout) to centerIn: parent so that any changes in the explicit height of ListItem (as applied by SettingsListNavigation) will result in the contentLayout remaining vertically centered in the entire ListItem.
- See ticket for explanation of how the problem was distilled into this tiny fix.

Fixes #1850