### PR TITLE
Hide PvInverter position setting if unavailable

### DIFF
--- a/pages/solar/PvInverterPage.qml
+++ b/pages/solar/PvInverterPage.qml
@@ -78,6 +78,15 @@ Page {
 
 			ListPvInverterPositionRadioButtonGroup {
 				dataItem.uid: root.pvInverter.serviceUid + "/Position"
+				preferredVisible: (!positionIsAdjustable.valid || positionIsAdjustable.value === 1) ? dataItem.valid : false
+
+				// Datapoint will exist in VM-3P75CT energy meters, but usually will not exist.
+				// In cases where the data point does not exist, assume position IS adjustable.
+				// Value will be zero if the position setting is not adjustable via gui-v2.
+				VeQuickItem {
+					id: positionIsAdjustable
+					uid: root.pvInverter.serviceUid + "/PositionIsAdjustable"
+				}
 			}
 
 			ListQuantity {


### PR DESCRIPTION
If an energy meter is configured to show up as a PV inverter, the PV inverter page should hide the position setting, as such devices have an internal setting for the meter position which does not track the position setting used by gui-v2.

The /AllowedRoles path will be invalid in the case where the energy meter has internal settings, and so we can use this as a condition to determine whether to hide or show the position setting.

Contributes to issue #1735