### PR TITLE
Respect hasDcSystem setting value in system dc power

### DIFF
--- a/data/System.qml
+++ b/data/System.qml
@@ -29,7 +29,7 @@ QtObject {
 	}
 
 	readonly property QtObject dc: QtObject {
-		readonly property real power: _dcSystemPower.valid ? _dcSystemPower.value : NaN
+		readonly property real power: (_hasDcSystem.valid && _hasDcSystem.value && _dcSystemPower.valid) ? _dcSystemPower.value : NaN
 		readonly property real current: (isNaN(power) || isNaN(voltage) || voltage === 0) ? NaN : power / voltage
 		readonly property real voltage: _dcBatteryVoltage.valid ? _dcBatteryVoltage.value : NaN
 		readonly property real maximumPower: _maximumDcPower.valid ? _maximumDcPower.value : NaN
@@ -44,6 +44,10 @@ QtObject {
 
 		readonly property VeQuickItem _maximumDcPower: VeQuickItem {
 			uid: Global.systemSettings.serviceUid + "/Settings/Gui/Gauges/Dc/System/Power/Max"
+		}
+
+		readonly property VeQuickItem _hasDcSystem: VeQuickItem {
+			uid: Global.systemSettings.serviceUid + "/Settings/SystemSetup/HasDcSystem"
 		}
 	}
 

--- a/pages/OverviewPage.qml
+++ b/pages/OverviewPage.qml
@@ -41,7 +41,7 @@ SwipeViewPage {
 			+ (Global.acInputs.input2?.operational ? 1 : 0)
 			+ (Global.system.showInputLoads ? 1 : 0)
 			+ (Global.system.hasAcOutSystem ? 1 : 0)
-			+ (Global.allDevicesModel.combinedDcLoadDevices.count === 0 || isNaN(Global.system.dc.power) ? 0 : 1)
+			+ (Global.allDevicesModel.combinedDcLoadDevices.count > 0 || !isNaN(Global.system.dc.power) ? 1 : 0)
 			+ (Global.solarDevices.model.count === 0 ? 0 : 1)
 			+ (Global.evChargers.model.count === 0 ? 0 : 1)
 			+ Global.evChargers.acInputPositionCount


### PR DESCRIPTION
Set the Global.system.dc.power value to NaN if the hasDcSystem setting gets toggled to false.

Also update the trigger for _resetWidgets() in OverviewPage to ensure that it triggers if either the above dc.power value transitions to/from NaN, or if the count of combined dc load devices transitions to/from a positive value (i.e. properly handle potential negative values).

Contributes to issue #1966