### PR TITLE
Control cards: exclude energy meters from EVCS model

### DIFF
--- a/components/ServiceDeviceModel.qml
+++ b/components/ServiceDeviceModel.qml
@@ -15,19 +15,21 @@ DeviceModel {
 
 	required property string serviceType
 
-	readonly property Instantiator _objects: Instantiator {
-		model: modelLoader.item
-		delegate: Device {
-			id: device
-			serviceUid: model.uid
-			onValidChanged: {
-				if (valid) {
-					root.addDevice(device)
-				} else {
-					root.removeDevice(device.serviceUid)
-				}
+	property Component deviceDelegate: Device {
+		id: device
+		serviceUid: model.uid
+		onValidChanged: {
+			if (valid) {
+				root.addDevice(device)
+			} else {
+				root.removeDevice(device.serviceUid)
 			}
 		}
+	}
+
+	readonly property Instantiator _objects: Instantiator {
+		model: modelLoader.item
+		delegate: root.deviceDelegate
 	}
 
 	readonly property ServiceModelLoader modelLoader: ServiceModelLoader {

--- a/pages/ControlCardsPage.qml
+++ b/pages/ControlCardsPage.qml
@@ -56,11 +56,11 @@ Page {
 				spacing: Theme.geometry_controlCardsPage_spacing
 
 				Repeater {
-					model: Global.evChargers.model
+					model: evChargerModel
 
 					EVCSCard {
 						width: root.cardWidth
-						evCharger: model.device
+						serviceUid: model.device.serviceUid
 					}
 				}
 			}
@@ -124,6 +124,35 @@ Page {
 				}
 
 				ManualRelayModel { id: manualRelays }
+			}
+		}
+	}
+
+	// A model of evcharger services that represent controllable EV chargers, i.e. those with a
+	// valid /Mode value. Global.evChargers.model cannot be used in the control cards, as it
+	// includes services without a /Mode, such as Energy Meters configured as EV chargers.
+	ServiceDeviceModel {
+		id: evChargerModel
+
+		serviceType: "evcharger"
+		modelId: "evcharger"
+		deviceDelegate: Device {
+			id: device
+
+			required property string uid
+			readonly property bool isRealCharger: valid && _chargerMode.valid
+
+			readonly property VeQuickItem _chargerMode: VeQuickItem {
+				uid: device.serviceUid + "/Mode"
+			}
+
+			serviceUid: uid
+			onIsRealChargerChanged: {
+				if (isRealCharger) {
+					evChargerModel.addDevice(device)
+				} else {
+					evChargerModel.removeDevice(device.serviceUid)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
The evcharger services on the system may include energy meters acting as EV chargers, which just provide measurements and are not real EV chargers that actually charge. We know they are energy meters if the /Mode value is not valid.

In the control cards, these energy meters are excluded from the display as they are not controllable EV chargers. Instead of excluding them by setting visible=false on the relevant EVCSCard, use a different model that excludes these energy meters.

This simplifies the upcoming key navigation implementation, as the key navigation feature will not need to attempt to skip over invisible cards.

Part of #1030