### PR TITLE
Device List: fix source check to ensure delegate is loaded

### DIFF
--- a/pages/settings/devicelist/DeviceListPage.qml
+++ b/pages/settings/devicelist/DeviceListPage.qml
@@ -32,7 +32,7 @@ Page {
 						console.warn("DeviceList: cannot load delegate, cannot read service type from serviceUid:", device.serviceUid)
 						return
 					}
-					if (!source || !_usingCustomDelegate) {
+					if (source.toString().length === 0 || !_usingCustomDelegate) {
 						setSource("delegates/DeviceListDelegate_%1.qml".arg(serviceType), {
 							device: Qt.binding(function() { return delegateLoader.device }),
 							sourceModel: Qt.binding(function() { return delegateLoader.sourceModel }),
@@ -40,7 +40,7 @@ Page {
 						_usingCustomDelegate = true
 					}
 				} else {
-					if (!source || _usingCustomDelegate) {
+					if (source.toString().length === 0 || _usingCustomDelegate) {
 						setSource("delegates/DisconnectedDeviceListDelegate.qml", {
 							cachedDeviceName: Qt.binding(function() { return delegateLoader.cachedDeviceName }),
 						})


### PR DESCRIPTION
Since source is a url and not a string, the boolean coercion returns true even if the source is empty because an empty url does not equate to an empty string. So, convert the source to a string before doing the boolean check.

Fixes #1925