### PR TITLE
Fix changing of access level

### DIFF
--- a/components/RadioButtonListPage.qml
+++ b/components/RadioButtonListPage.qml
@@ -13,6 +13,9 @@ Page {
 	required property var optionModel
 	readonly property alias optionView: optionsListView
 
+	property int showAccessLevel: VenusOS.User_AccessType_User
+	property int writeAccessLevel: VenusOS.User_AccessType_Installer
+
 	property int currentIndex
 	property bool updateCurrentIndexOnClick: true
 	property var popDestination: null
@@ -67,6 +70,8 @@ Page {
 			interactive: !modelObject.readOnly
 			primaryLabel.font.family: modelObject.fontFamily || Global.fontFamily
 			preferredVisible: interactive || checked
+			showAccessLevel: root.showAccessLevel
+			writeAccessLevel: root.writeAccessLevel
 			checked: optionsListView.currentIndex === model.index
 			C.ButtonGroup.group: radioButtonGroup
 
@@ -129,6 +134,8 @@ Page {
 						textField.echoMode: TextInput.Password
 						interactive: radioButton.interactive
 						backgroundRect.color: "transparent"
+						showAccessLevel: root.showAccessLevel
+						writeAccessLevel: root.writeAccessLevel
 						preferredVisible: showField && model.index === optionsListView.currentIndex && !!root.validatePassword
 						validateInput: function() {
 							// Validate the password on Enter/Return, or when "Confirm" is

--- a/components/listitems/ListBriefCenterDetails.qml
+++ b/components/listitems/ListBriefCenterDetails.qml
@@ -92,6 +92,9 @@ ListNavigation {
 				text: section
 			}
 
+			showAccessLevel: root.showAccessLevel
+			writeAccessLevel: root.writeAccessLevel
+
 			onOptionClicked: (index, serviceUid) => {
 				centerService.setValue(serviceUid)
 			}

--- a/components/listitems/core/ListRadioButtonGroup.qml
+++ b/components/listitems/core/ListRadioButtonGroup.qml
@@ -69,6 +69,8 @@ ListNavigation {
 			currentIndex: root.currentIndex
 			updateCurrentIndexOnClick: root.updateCurrentIndexOnClick
 			popDestination: root.popDestination
+			showAccessLevel: root.showAccessLevel
+			writeAccessLevel: root.writeAccessLevel
 			validatePassword: root.validatePassword
 
 			onOptionClicked: (index, value) => {


### PR DESCRIPTION
RadioButtonListPage needs to propagate the show/read access levels down to the radio button and text fields for each delegate. Otherwise, the components will not have the 'user' write access level, and ListItem will prevent the button from being clicked. The validatePassword function also needs to be propagated to the page so that the password can be validated.

Fixes #1996