### PR TITLE
Show devices firmware version only when available

### DIFF
--- a/pages/settings/PageDeviceInfo.qml
+++ b/pages/settings/PageDeviceInfo.qml
@@ -52,6 +52,7 @@ Page {
 			ListFirmwareVersion {
 				bindPrefix: root.bindPrefix
 				dataItem.invalidate: false
+				preferredVisible: dataItem.valid
 			}
 
 			ListText {


### PR DESCRIPTION
BLE connected devices don't advertise the firmware version, so instead of showing '--' as version, don't show anything.

This is visible mainly for BLE sensors (Ruuvi, Mopeka and such).