### PR TITLE
Improve support for Etc timezones

### DIFF
--- a/pages/settings/PageTzInfo.qml
+++ b/pages/settings/PageTzInfo.qml
@@ -271,7 +271,7 @@ Page {
 	}
 	TzEtcData {
 		id: tzEtc
-		//% "Etc"
+		//% "Other"
 		readonly property string name: qsTrId("settings_tz_etc")
 		readonly property string region: "Etc"
 	}

--- a/pages/settings/tz/TzAtlanticData.qml
+++ b/pages/settings/tz/TzAtlanticData.qml
@@ -10,4 +10,5 @@ ListModel {
 	ListElement { display: QT_TR_NOOP("Greenwich Standard Time"); city: "Atlantic/Reykjavik"; caption: "(GMT) Monrovia, Reykjavik" }
 	ListElement { display: QT_TR_NOOP("Azores Standard Time"); city: "Atlantic/Azores"; caption: "(GMT -01:00) Azores" }
 	ListElement { display: QT_TR_NOOP("Cape Verde Standard Time"); city: "Atlantic/Cape_Verde"; caption: "(GMT -01:00) Cape Verde Is." }
+	ListElement { display: QT_TR_NOOP("Mid-Atlantic Standard Time"); city: "GMT+2"; caption: "(GMT -02:00) Mid-Atlantic" }
 }

--- a/pages/settings/tz/TzEtcData.qml
+++ b/pages/settings/tz/TzEtcData.qml
@@ -7,10 +7,31 @@ import QtQuick
 
 ListModel {
 	id: tzCity
-	ListElement { display: QT_TR_NOOP("GMT +12"); city: "GMT-12"; caption: "(GMT +12:00) Coordinated Universal Time+12" }
-	ListElement { display: QT_TR_NOOP("GMT "); city: "GMT"; caption: "(GMT) Coordinated Universal Time" }
-	ListElement { display: QT_TR_NOOP("Mid-Atlantic Standard Time"); city: "GMT+2"; caption: "(GMT -02:00) Mid-Atlantic" }
-	ListElement { display: QT_TR_NOOP("GMT -02"); city: "GMT+2"; caption: "(GMT -02:00) Coordinated Universal Time-02" }
-	ListElement { display: QT_TR_NOOP("GMT -11"); city: "GMT+11"; caption: "(GMT -11:00) Coordinated Universal Time-11" }
-	ListElement { display: QT_TR_NOOP("Dateline Standard Time"); city: "GMT+12"; caption: "(GMT -12:00) International Date Line West" }
+	ListElement { display: QT_TR_NOOP("GMT -13"); city: "GMT-13"; caption: "(GMT -13:00) Coordinated Universal Time-13" }
+	ListElement { display: QT_TR_NOOP("GMT -12"); city: "GMT-12"; caption: "(GMT -12:00) Coordinated Universal Time-12" }
+	ListElement { display: QT_TR_NOOP("GMT -11"); city: "GMT-11"; caption: "(GMT -11:00) Coordinated Universal Time-11" }
+	ListElement { display: QT_TR_NOOP("GMT -10"); city: "GMT-10"; caption: "(GMT -10:00) Coordinated Universal Time-10" }
+	ListElement { display: QT_TR_NOOP("GMT -09"); city: "GMT-9"; caption: "(GMT -09:00) Coordinated Universal Time-09" }
+	ListElement { display: QT_TR_NOOP("GMT -08"); city: "GMT-8"; caption: "(GMT -08:00) Coordinated Universal Time-08" }
+	ListElement { display: QT_TR_NOOP("GMT -07"); city: "GMT-7"; caption: "(GMT -07:00) Coordinated Universal Time-07" }
+	ListElement { display: QT_TR_NOOP("GMT -06"); city: "GMT-6"; caption: "(GMT -06:00) Coordinated Universal Time-06" }
+	ListElement { display: QT_TR_NOOP("GMT -05"); city: "GMT-5"; caption: "(GMT -05:00) Coordinated Universal Time-05" }
+	ListElement { display: QT_TR_NOOP("GMT -04"); city: "GMT-4"; caption: "(GMT -04:00) Coordinated Universal Time-04" }
+	ListElement { display: QT_TR_NOOP("GMT -03"); city: "GMT-3"; caption: "(GMT -03:00) Coordinated Universal Time-03" }
+	ListElement { display: QT_TR_NOOP("GMT -02"); city: "GMT-2"; caption: "(GMT -02:00) Coordinated Universal Time-02" }
+	ListElement { display: QT_TR_NOOP("GMT -01"); city: "GMT-1"; caption: "(GMT -01:00) Coordinated Universal Time-01" }
+	ListElement { display: QT_TR_NOOP("GMT"); city: "GMT"; caption: "(GMT) Coordinated Universal Time" }
+	ListElement { display: QT_TR_NOOP("GMT +01"); city: "GMT+1"; caption: "(GMT +01:00) Coordinated Universal Time+01" }
+	ListElement { display: QT_TR_NOOP("GMT +02"); city: "GMT+2"; caption: "(GMT +02:00) Coordinated Universal Time+02" }
+	ListElement { display: QT_TR_NOOP("GMT +03"); city: "GMT+3"; caption: "(GMT +03:00) Coordinated Universal Time+03" }
+	ListElement { display: QT_TR_NOOP("GMT +04"); city: "GMT+4"; caption: "(GMT +04:00) Coordinated Universal Time+04" }
+	ListElement { display: QT_TR_NOOP("GMT +05"); city: "GMT+5"; caption: "(GMT +05:00) Coordinated Universal Time+05" }
+	ListElement { display: QT_TR_NOOP("GMT +06"); city: "GMT+6"; caption: "(GMT +06:00) Coordinated Universal Time+06" }
+	ListElement { display: QT_TR_NOOP("GMT +07"); city: "GMT+7"; caption: "(GMT +07:00) Coordinated Universal Time+07" }
+	ListElement { display: QT_TR_NOOP("GMT +08"); city: "GMT+8"; caption: "(GMT +08:00) Coordinated Universal Time+08" }
+	ListElement { display: QT_TR_NOOP("GMT +09"); city: "GMT+9"; caption: "(GMT +09:00) Coordinated Universal Time+09" }
+	ListElement { display: QT_TR_NOOP("GMT +10"); city: "GMT+10"; caption: "(GMT +10:00) Coordinated Universal Time+10" }
+	ListElement { display: QT_TR_NOOP("GMT +11"); city: "GMT+11"; caption: "(GMT +11:00) Coordinated Universal Time+11" }
+	ListElement { display: QT_TR_NOOP("GMT +12"); city: "GMT+12"; caption: "(GMT +12:00) Coordinated Universal Time+12" }
+	ListElement { display: QT_TR_NOOP("UTC"); city: "UTC"; caption: "(GMT) Coordinated Universal Time" }
 }


### PR DESCRIPTION
Change the Etc page title to "Other"
Add every (hour boundary) timezone from /usr/share/zoneinfo/Etc to the Etc timezones list page
Move the mid-atlantic timezone to the Atlantic timezones list page

Contributes to issue #1335