### PR TITLE
Clean up solarcharger alarms

### DIFF
--- a/data/mock/SystemSettingsImpl.qml
+++ b/data/mock/SystemSettingsImpl.qml
@@ -312,8 +312,7 @@ QtObject {
 		// Solar charger
 		setMockSolarChargerValue("/Link/NetworkStatus", 1)
 		setMockSolarChargerValue("/Settings/BmsPresent", 1)
-		setMockSolarChargerValue("/Alarms/LowVoltage", VenusOS.Alarm_Level_Warning)
-		setMockSolarChargerValue("/Alarms/HighVoltage", VenusOS.Alarm_Level_OK)
+		setMockSolarChargerValue("/Alarms/HighTemperature", VenusOS.Alarm_Level_Warning)
 
 		setMockSystemValue("/SystemType", "ESS")
 		setMockSettingValue("DynamicEss/Mode", 1)

--- a/pages/solar/PageSolarCharger.qml
+++ b/pages/solar/PageSolarCharger.qml
@@ -51,16 +51,6 @@ Page {
 	}
 
 	VeQuickItem {
-		id: lowBatteryAlarm
-		uid: root.bindPrefix + "/Alarms/LowVoltage"
-	}
-
-	VeQuickItem {
-		id: highBatteryAlarm
-		uid: root.bindPrefix + "/Alarms/HighVoltage"
-	}
-
-	VeQuickItem {
 		id: highTemperatureAlarm
 		uid: root.bindPrefix + "/Alarms/HighTemperature"
 	}
@@ -273,9 +263,7 @@ Page {
 
 		ListNavigation {
 			text: CommonWords.alarm_status
-			preferredVisible: lowBatteryAlarm.valid
-							  || highBatteryAlarm.valid
-							  || highTemperatureAlarm.valid
+			preferredVisible: highTemperatureAlarm.valid
 							  || shortCircuitAlarm.valid
 			onClicked: {
 				Global.pageManager.pushPage(alarmStatusComponent, { "title": text })
@@ -337,10 +325,6 @@ Page {
 		Page {
 			GradientListView {
 				model: [
-					//% "Low battery voltage alarm"
-					{ display: qsTrId("charger_alarms_low_battery_voltage_alarm"), path: lowBatteryAlarm.uid },
-					//% "High battery voltage alarm"
-					{ display: qsTrId("charger_alarms_high_battery_voltage_alarm"), path: highBatteryAlarm.uid },
 					//% "High temperature alarm"
 					{ display: qsTrId("charger_alarms_high_temperature_alarm"), path: highTemperatureAlarm.uid },
 					//% "Short circuit alarm"

--- a/pages/solar/PageSolarCharger.qml
+++ b/pages/solar/PageSolarCharger.qml
@@ -348,7 +348,7 @@ Page {
 				]
 				delegate: ListAlarm {
 					text: modelData.display
-					dataItem.uid: root.bindPrefix + modelData.path
+					dataItem.uid: modelData.path
 					preferredVisible: dataItem.valid
 				}
 			}


### PR DESCRIPTION
This fixes a bug with the alarms not showing up at all (the view is empty), as well as removing the voltage alarms that are no longer present in solar chargers and should be cleaned up everywhere.

Also see https://github.com/victronenergy/venus-private/issues/340

This closes https://github.com/victronenergy/gui-v2/issues/2037