### PR TITLE
Device List: show correct settings page for .dcdc services

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -585,7 +585,7 @@ set (VENUS_QML_MODULE_SOURCES
     pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml
     pages/settings/devicelist/dc-in/PageDcMeterHistory.qml
     pages/settings/devicelist/delegates/AcInDeviceListDelegate.qml
-    pages/settings/devicelist/delegates/DcMeterDeviceListDelegate.qml
+    pages/settings/devicelist/delegates/DcDeviceListDelegate.qml
     pages/settings/devicelist/delegates/DeviceListDelegate_acload.qml
     pages/settings/devicelist/delegates/DeviceListDelegate_acsystem.qml
     pages/settings/devicelist/delegates/DeviceListDelegate_alternator.qml

--- a/pages/settings/devicelist/delegates/DcDeviceListDelegate.qml
+++ b/pages/settings/devicelist/delegates/DcDeviceListDelegate.qml
@@ -17,8 +17,13 @@ DeviceListDelegate {
 	}
 
 	onClicked: {
-		Global.pageManager.pushPage("/pages/settings/devicelist/dc-in/PageDcMeter.qml",
-				{ bindPrefix : root.device.serviceUid })
+		if (BackendConnection.serviceTypeFromUid(device.serviceUid) === "dcdc") {
+			Global.pageManager.pushPage("/pages/settings/devicelist/dc-in/PageDcDcConverter.qml",
+					{ "bindPrefix": device.serviceUid })
+		} else {
+			Global.pageManager.pushPage("/pages/settings/devicelist/dc-in/PageDcMeter.qml",
+					{ "bindPrefix": device.serviceUid })
+		}
 	}
 
 	VeQuickItem {

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_dcdc.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_dcdc.qml
@@ -6,6 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 
-DcMeterDeviceListDelegate {
+DcDeviceListDelegate {
 }
 

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_dcload.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_dcload.qml
@@ -6,6 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 
-DcMeterDeviceListDelegate {
+DcDeviceListDelegate {
 }
 

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_dcsource.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_dcsource.qml
@@ -6,6 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 
-DcMeterDeviceListDelegate {
+DcDeviceListDelegate {
 }
 

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_dcsystem.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_dcsystem.qml
@@ -6,6 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 
-DcMeterDeviceListDelegate {
+DcDeviceListDelegate {
 }
 

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_fuelcell.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_fuelcell.qml
@@ -6,5 +6,5 @@
 import QtQuick
 import Victron.VenusOS
 
-DcMeterDeviceListDelegate {
+DcDeviceListDelegate {
 }


### PR DESCRIPTION
When a .dcdc service is clicked in the Device List, PageDcDcConverter should be opened, instead of PageDcMeter. This aligns with the (correct) behavior that occurs in the Overview DC Loads widget when a .dcdc service is clicked there.

Rename DcMeterDeviceListDelegate to DcDeviceListDelegate as it now works for DC devices that may not be DC meters.

Fixes #2019