### PR TITLE
Do not display TextField if read-only. Fixes #2055

### DIFF
--- a/components/listitems/core/ListTextField.qml
+++ b/components/listitems/core/ListTextField.qml
@@ -122,10 +122,10 @@ ListItem {
 		property bool _validateBeforeSaving
 
 		enabled: root.clickable
+		visible: root.clickable
 		width: Math.max(Theme.geometry_listItem_textField_minimumWidth,
 						Math.min(Theme.geometry_listItem_textField_maximumWidth,
 								 implicitWidth + leftPadding + rightPadding))
-		visible: root.enabled
 		text: dataItem.valid ? dataItem.value : ""
 		rightPadding: suffixLabel.text.length ? suffixLabel.implicitWidth : leftPadding
 		horizontalAlignment: root.suffix ? Text.AlignRight : Text.AlignHCenter
@@ -200,7 +200,7 @@ ListItem {
 
 		text: textField.text.length > 0 ? textField.text : "--"
 		width: Math.min(implicitWidth, root.maximumContentWidth)
-		visible: !root.interactive
+		visible: !textField.visible
 	}
 
 	VeQuickItem {


### PR DESCRIPTION
Fixes #2055

Currently the text field and the read-only label are displayed, if `interactive` is `false`.

![grafik](https://github.com/user-attachments/assets/ae200242-e26a-454e-82f9-debdd81dd7e6)

![grafik](https://github.com/user-attachments/assets/f3535f7a-ff76-46f9-b017-7d9740c38bbb)

![grafik](https://github.com/user-attachments/assets/3c2a813a-6c65-4f6c-93b4-f04a1884bdfa)
