### PR TITLE
Optimize build process

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -39,20 +39,21 @@ jobs:
 
       - name: Check for a cached version
         uses: actions/cache@v4
-        id: cached_qt_emscripten
+        id: cached-versions
         with:
           path: |
+            # Cache the Qt and emscripten installation
             ${{ env.OUTPUTDIR }}
           # Adding version as cache key
-          key: ${{ runner.os }}-qt-${{ env.QT_VERSION }}-em-${{ env.EMSCRIPTEN }}-libegl1
+          key: ${{ runner.os }}__qt-${{ env.QT_VERSION }}__em-${{ env.EMSCRIPTEN }}__libegl1
 
-      - name: Install requirements
-        if: steps.cached_qt_emscripten.outputs.cache-hit != true
+      - name: Install requirements (cache miss)
+        if: steps.cached-versions.outputs.cache-hit != 'true'
         run: |
           bash scripts/build-wasm-install-requirements.sh
 
-      - name: Install libraries needed for building the wasm
-        if: steps.cached_qt_emscripten.outputs.cache-hit == true
+      - name: Install libraries needed for building the wasm (cache hit)
+        if: steps.cached-versions.outputs.cache-hit == 'true'
         run: |
           sudo apt-get update -yq
           sudo apt-get install -y libegl1
@@ -65,16 +66,16 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: venus-webassembly
-          path: build-wasm
+          path: build-wasm_files_to_copy
           retention-days: 5
 
-      - name: ZIP wasm files for release
+      - name: Release - ZIP wasm files
         if: startsWith(github.ref, 'refs/tags/')
         run: |
-          cd build-wasm
+          cd build-wasm_files_to_copy
           zip -r ../venus-webassembly.zip wasm
 
-      - name: Release tagged wasm files
+      - name: Release - Create release with wasm files
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -77,7 +77,7 @@ jobs:
           export PATH=$PATH:${{env.OUTPUTDIR}}/Qt/Tools/CMake/bin
           export QTDIR=${{env.OUTPUTDIR}}/Qt/$QT_VERSION/gcc_64
           ${QTDIR}/bin/qt-configure-module ..
-          cmake --build .
+          cmake --build . --parallel $(nproc)
           cmake --install . --prefix ${QTDIR} --verbose
 
       - name: Configure CMake
@@ -91,7 +91,7 @@ jobs:
       - name: Build unit tests
         run: |
           cd build
-          cmake --build . --config ${{env.BUILD_TYPE}}
+          cmake --build . --config ${{env.BUILD_TYPE}} --parallel $(nproc)
 
       - name: Run unit test
         run: |

--- a/scripts/build-gx.sh
+++ b/scripts/build-gx.sh
@@ -23,6 +23,11 @@ while [[ $# -gt 0 ]]; do
             PRESERVE=1
             shift
             ;;
+        # IP or hostname of the GX device for direct upload
+        -H|--host)
+            HOST="${2}"
+            shift 2
+            ;;
         -h|--help)
             echo "Usage: ${0} [options]"
             echo "Options:"
@@ -111,3 +116,71 @@ fi
 
 echo "Elapsed time: ${SECONDS} seconds"
 echo
+
+
+# Check if HOST is set
+if [[ -n "${HOST}" ]]; then
+    echo
+    echo -e "\e[33mThe automated file upload to the GX device after build was selected\e[0m"
+
+    # Check if an SSH key exists
+    if [ ! -f "${HOME}/.ssh/id_rsa" ]; then
+        echo "No SSH key found. Generating a new SSH key..."
+        ssh-keygen -t rsa -b 2048 -f "${HOME}/.ssh/id_rsa" -N ""
+        echo
+    fi
+
+    # Test SSH connection
+    echo "Testing SSH connection to ${HOST}..."
+    ssh -o BatchMode=yes -o ConnectTimeout=5 root@${HOST} "exit" 2>/dev/null
+
+    if [ $? -ne 0 ]; then
+        echo
+        echo -e "\e[33mSSH authentication failed. Uploading SSH key to ${HOST}...\e[0m"
+        echo -e "\e[33mYou will be prompted for the password to upload the SSH key.\e[0m"
+        echo "Make sure you set a password on the GX device else it won't work. See https://www.victronenergy.com/live/ccgx:root_access#root_access"
+        echo
+        ssh-copy-id root@${HOST}
+        if [ $? -ne 0 ]; then
+            echo -e "\e[31mFailed to upload SSH key. Please check your password and try again.\e[0m"
+            exit 1
+        fi
+        echo
+        echo -e "\e[32mSSH key uploaded successfully.\e[0m"
+    else
+        echo -e "\e[32mSSH authentication successful.\e[0m"
+    fi
+    echo
+
+    # Make filesystem writable
+    echo -n "Making GX device filesystem writable..."
+    ssh root@${HOST} "/opt/victronenergy/swupdate-scripts/remount-rw.sh"
+    echo " done."
+
+    # Stop service on the GX device
+    echo -n "Stopping service on the GX device..."
+    ssh root@${HOST} "svc -d /service/start-gui"
+    echo " done."
+
+    # Upload the files to the GX device
+    echo "Uploading files to the GX device at ${HOST}..."
+
+    # Copy the files to the GX device, only output errors
+    scp -r ../build-gx_files_to_copy/* root@${HOST}:/opt/victronenergy/gui-v2/ 1>/dev/null
+    if [ $? -ne 0 ]; then
+        echo -e "\e[31mFailed to upload files. Please check your connection and disk space on the GX device then try again.\e[0m"
+        echo
+        echo "GX device disk space:"
+        ssh root@${HOST} "df -h | head -n 2"
+        echo
+        exit 1
+    fi
+    echo -e "\e[32mFiles uploaded successfully.\e[0m"
+    echo
+
+    # Start service on the GX device
+    echo -n "Starting service on the GX device..."
+    ssh root@${HOST} "svc -u /service/start-gui"
+    echo " done."
+    echo
+fi

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -23,6 +23,11 @@ while [[ $# -gt 0 ]]; do
             PRESERVE=1
             shift
             ;;
+        # IP or hostname of the GX device for direct upload
+        -H|--host)
+            HOST="${2}"
+            shift 2
+            ;;
         -h|--help)
             echo "Usage: ${0} [options]"
             echo "Options:"
@@ -128,3 +133,67 @@ fi
 
 echo "Elapsed time: ${SECONDS} seconds"
 echo
+
+
+# Check if HOST is set
+if [[ -n "${HOST}" ]]; then
+    echo
+    echo -e "\e[33mThe automated file upload to the GX device after build was selected\e[0m"
+
+    # Check if an SSH key exists
+    if [ ! -f "${HOME}/.ssh/id_rsa" ]; then
+        echo "No SSH key found. Generating a new SSH key..."
+        ssh-keygen -t rsa -b 2048 -f "${HOME}/.ssh/id_rsa" -N ""
+        echo
+    fi
+
+    # Test SSH connection
+    echo "Testing SSH connection to ${HOST}..."
+    ssh -o BatchMode=yes -o ConnectTimeout=5 root@${HOST} "exit" 2>/dev/null
+
+    if [ $? -ne 0 ]; then
+        echo
+        echo -e "\e[33mSSH authentication failed. Uploading SSH key to ${HOST}...\e[0m"
+        echo -e "\e[33mYou will be prompted for the password to upload the SSH key.\e[0m"
+        echo "Make sure you set a password on the GX device else it won't work. See https://www.victronenergy.com/live/ccgx:root_access#root_access"
+        echo
+        ssh-copy-id root@${HOST}
+        if [ $? -ne 0 ]; then
+            echo -e "\e[31mFailed to upload SSH key. Please check your password and try again.\e[0m"
+            exit 1
+        fi
+        echo
+        echo -e "\e[32mSSH key uploaded successfully.\e[0m"
+    else
+        echo -e "\e[32mSSH authentication successful.\e[0m"
+    fi
+    echo
+
+    # Make filesystem writable
+    echo -n "Making GX device filesystem writable..."
+    ssh root@${HOST} "/opt/victronenergy/swupdate-scripts/remount-rw.sh"
+    echo " done."
+    echo
+
+    # Upload the files to the GX device
+    echo "Uploading files to the GX device at ${HOST}..."
+
+    # Copy the files to the GX device, only output errors
+    scp -r ../build-wasm_files_to_copy/wasm/* root@${HOST}:/var/www/venus/gui-v2/ 1>/dev/null
+    if [ $? -ne 0 ]; then
+        echo -e "\e[31mFailed to upload files. Please check your connection and disk space on the GX device then try again.\e[0m"
+        echo
+        echo "GX device disk space:"
+        ssh root@${HOST} "df -h | head -n 2"
+        echo
+        exit 1
+    fi
+    echo -e "\e[32mFiles uploaded successfully.\e[0m"
+    echo
+
+    # Restart vmrlogger to make GUIv2 changes visible in VRM portal
+    echo -n "Restarting vmrlogger on GX device..."
+    ssh root@${HOST} "svc -t /service/vrmlogger"
+    echo " done."
+    echo
+fi


### PR DESCRIPTION
I optimized the build scripts and GitHub action workflow.

GitHub Actions: Instead of about 11 minutes, it takes now about 6 minutes
Local PC: Instead of about 11 minutes, it takes now about 2 minutes

Is there any reason for not using `--parallel $(nproc)` with `cmake --build`?

I also added an option to directly upload the compiled files to the GX device by using `-H venus-ip-or-hostname` or `--host venus-ip-or-hostname` This checks, if there is already an SSH key present and if not generates one and uploads it. If there is already one present it only uploads it, if missing.

It's also possible to give more than one host for file upload by providing a comma separated list:
`-H 192.168.1.10,192.168.1.11,192.168.1.12`