### PR TITLE
Add support for OrionXS as .dcdc service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,6 +338,7 @@ set (VENUS_QML_MODULE_SOURCES
     components/listitems/ListLink.qml
     components/listitems/ListMqttAccessSwitch.qml
     components/listitems/ListMountStateButton.qml
+    components/listitems/ListOutputBatterySwitch.qml
     components/listitems/ListPvInverterPositionRadioButtonGroup.qml
     components/listitems/ListEvChargerPositionRadioButtonGroup.qml
     components/listitems/ListRebootButton.qml
@@ -576,6 +577,7 @@ set (VENUS_QML_MODULE_SOURCES
     pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml
     pages/settings/devicelist/battery/PageLynxIonIo.qml
     pages/settings/devicelist/battery/PageLynxIonSystem.qml
+    pages/settings/devicelist/dc-in/DcHistorySettingsColumn.qml
     pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml
     pages/settings/devicelist/dc-in/PageAlternator.qml
     pages/settings/devicelist/dc-in/PageAlternatorModel.qml

--- a/components/listitems/ListOutputBatterySwitch.qml
+++ b/components/listitems/ListOutputBatterySwitch.qml
@@ -1,0 +1,29 @@
+/*
+** Copyright (C) 2025 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+ListSwitch {
+	property string bindPrefix
+
+	//% "Output on auxiliary battery"
+	text: qsTrId("output_aux_battery")
+	dataItem.uid: bindPrefix + "/Settings/OutputBattery"
+	preferredVisible: dataItem.valid
+	onToggled: {
+		const msg = checked
+				  //% "%1 changed to DC-DC service"
+				? qsTrId("output_aux_battery_service_changed_dcdc").arg(device.name)
+				  //% "%1 changed to alternator service"
+				: qsTrId("output_aux_battery_service_changed_alternator").arg(device.name)
+		Global.showToastNotification(VenusOS.Notification_Info, msg, 10000)
+	}
+
+	Device {
+		id: device
+		serviceUid: root.bindPrefix
+	}
+}

--- a/components/listitems/core/ListSwitch.qml
+++ b/components/listitems/core/ListSwitch.qml
@@ -19,6 +19,12 @@ ListItem {
 	property int valueTrue: 1
 	property int valueFalse: 0
 
+	property bool _updatingValue
+
+	// Emitted when a click results in a change in the data value, or when checkable=true and the
+	// switch is toggled directly.
+	signal toggled
+
 	interactive: (dataItem.uid === "" || dataItem.valid)
 
 	content.children: [
@@ -37,6 +43,7 @@ ListItem {
 			checked: invertSourceValue ? dataItem.value === valueFalse : dataItem.value === valueTrue
 			checkable: false
 			onClicked: root.clicked()
+			onToggled: root.toggled()
 		}
 	]
 
@@ -48,6 +55,7 @@ ListItem {
 				// (dataItem might not be valid until the first write so we can't simply use
 				// the comparison of dataItem.value === valueFalse) and forget invertSourceValue).
 				// Note that an malformed uid will result in it being empty when inspected.
+				root._updatingValue = true
 				if (invertSourceValue) {
 					dataItem.setValue(switchItem.checked ? valueTrue : valueFalse)
 				} else {
@@ -59,5 +67,11 @@ ListItem {
 
 	VeQuickItem {
 		id: dataItem
+		onValueChanged: {
+			if (root._updatingValue) {
+				root.toggled()
+			}
+			root._updatingValue = false
+		}
 	}
 }

--- a/data/mock/DcInputsImpl.qml
+++ b/data/mock/DcInputsImpl.qml
@@ -113,6 +113,7 @@ QtObject {
 				setMockValue("/Link/TemperatureSense", 25)
 				setMockValue("/Link/NetworkStatus", 4)
 				setMockValue("/Error", 0)
+				setMockValue("/Settings/OutputBattery", 0)
 				setMockValue("/Dc/0/Temperature", Math.random() * 50)
 
 				setMockValue("/Dc/In/I", 3.5)

--- a/pages/settings/devicelist/dc-in/DcHistorySettingsColumn.qml
+++ b/pages/settings/devicelist/dc-in/DcHistorySettingsColumn.qml
@@ -1,0 +1,123 @@
+/*
+** Copyright (C) 2025 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+SettingsColumn {
+	id: root
+
+	required property string bindPrefix
+
+	preferredVisible: overallHistory.preferredVisible || chargeCycleHistory.preferredVisible
+
+	ListNavigation {
+		id: overallHistory
+
+		text: CommonWords.overall_history
+		preferredVisible: overallHistoryMonitor.hasVisibleItem
+		onClicked: {
+			Global.pageManager.pushPage(overallHistoryComponent, { "title": text })
+		}
+
+		// Declare ObjectModelMonitor before the model that it is monitoring. See QTBUG-123496
+		ObjectModelMonitor {
+			id: overallHistoryMonitor
+			model: overallHistoryModel
+		}
+
+		VisibleItemModel {
+			id: overallHistoryModel
+
+			ListText {
+				//% "Operation time"
+				text: qsTrId("alternator_wakespeed_operation_time")
+				secondaryText: Utils.secondsToString(dataItem.value, true)
+				dataItem.uid: root.bindPrefix + "/History/Cumulative/User/OperationTime"
+				preferredVisible: dataItem.valid
+			}
+
+			ListQuantity {
+				//% "Charged Ah"
+				text: qsTrId("alternator_wakespeed_charged_ah")
+				dataItem.uid: root.bindPrefix + "/History/Cumulative/User/ChargedAh"
+				unit: VenusOS.Units_AmpHour
+				precision: 0
+				preferredVisible: dataItem.valid
+			}
+
+			ListText {
+				//% "Cycles started"
+				text: qsTrId("alternator_wakespeed_cycles_started")
+				dataItem.uid: root.bindPrefix + "/History/Cumulative/User/CyclesStarted"
+				preferredVisible: dataItem.valid
+			}
+
+			ListText {
+				//% "Cycles completed"
+				text: qsTrId("alternator_wakespeed_cycles_completed")
+				dataItem.uid: root.bindPrefix + "/History/Cumulative/User/CyclesCompleted"
+				preferredVisible: dataItem.valid
+			}
+
+			ListText {
+				//% "Number of power-ups"
+				text: qsTrId("alternator_wakespeed_nr_of_power_ups")
+				dataItem.uid: root.bindPrefix + "/History/Cumulative/User/NrOfPowerups"
+				preferredVisible: dataItem.valid
+			}
+
+			ListText {
+				//% "Number of deep discharges"
+				text: qsTrId("alternator_wakespeed_nr_of_deep_discharges")
+				dataItem.uid: root.bindPrefix + "/History/Cumulative/User/NrOfDeepDischarges"
+				preferredVisible: dataItem.valid
+			}
+		}
+
+		Component {
+			id: overallHistoryComponent
+
+			Page {
+				GradientListView {
+					model: overallHistoryModel
+				}
+			}
+		}
+	}
+
+	ListNavigation {
+		id: chargeCycleHistory
+
+		//% "Charge cycle history"
+		text: qsTrId("alternator_wakespeed_charge_cycle_history")
+		preferredVisible: historyCyclesAvailable.valid
+		onClicked: {
+			Global.pageManager.pushPage(chargeHistoryComponent, { "title": text })
+		}
+
+		Component {
+			id: chargeHistoryComponent
+
+			Page {
+				GradientListView {
+					model: historyCyclesAvailable.valid ? historyCyclesAvailable.value + 1 : 1
+					delegate: Component {
+						ListCycleHistoryItem {
+							width: parent ? parent.width : 0
+							bindPrefix: root.bindPrefix + "/History/Cycle/" + index
+							cycle: index
+						}
+					}
+				}
+			}
+		}
+
+		VeQuickItem {
+			id: historyCyclesAvailable
+			uid: root.bindPrefix + "/History/Cycle/CyclesAvailable"
+		}
+	}
+}

--- a/pages/settings/devicelist/dc-in/PageAlternatorModel.qml
+++ b/pages/settings/devicelist/dc-in/PageAlternatorModel.qml
@@ -100,108 +100,14 @@ VisibleItemModel {
 		preferredVisible: dataItem.valid
 	}
 
-	ListNavigation {
-		text: CommonWords.overall_history
-		preferredVisible: overallHistoryMonitor.hasVisibleItem
-		onClicked: {
-			Global.pageManager.pushPage(overallHistoryComponent, { "title": text })
-		}
-
-		// Declare ObjectModelMonitor before the model that it is monitoring. See QTBUG-123496
-		ObjectModelMonitor {
-			id: overallHistoryMonitor
-			model: overallHistoryModel
-		}
-
-		VisibleItemModel {
-			id: overallHistoryModel
-
-			ListText {
-				//% "Operation time"
-				text: qsTrId("alternator_wakespeed_operation_time")
-				secondaryText: Utils.secondsToString(dataItem.value, true)
-				dataItem.uid: root.bindPrefix + "/History/Cumulative/User/OperationTime"
-				preferredVisible: dataItem.valid
-			}
-
-			ListQuantity {
-				//% "Charged Ah"
-				text: qsTrId("alternator_wakespeed_charged_ah")
-				dataItem.uid: root.bindPrefix + "/History/Cumulative/User/ChargedAh"
-				unit: VenusOS.Units_AmpHour
-				precision: 0
-				preferredVisible: dataItem.valid
-			}
-
-			ListText {
-				//% "Cycles started"
-				text: qsTrId("alternator_wakespeed_cycles_started")
-				dataItem.uid: root.bindPrefix + "/History/Cumulative/User/CyclesStarted"
-				preferredVisible: dataItem.valid
-			}
-
-			ListText {
-				//% "Cycles completed"
-				text: qsTrId("alternator_wakespeed_cycles_completed")
-				dataItem.uid: root.bindPrefix + "/History/Cumulative/User/CyclesCompleted"
-				preferredVisible: dataItem.valid
-			}
-
-			ListText {
-				//% "Number of power-ups"
-				text: qsTrId("alternator_wakespeed_nr_of_power_ups")
-				dataItem.uid: root.bindPrefix + "/History/Cumulative/User/NrOfPowerups"
-				preferredVisible: dataItem.valid
-			}
-
-			ListText {
-				//% "Number of deep discharges"
-				text: qsTrId("alternator_wakespeed_nr_of_deep_discharges")
-				dataItem.uid: root.bindPrefix + "/History/Cumulative/User/NrOfDeepDischarges"
-				preferredVisible: dataItem.valid
-			}
-		}
-
-		Component {
-			id: overallHistoryComponent
-
-			Page {
-				GradientListView {
-					model: overallHistoryModel
-				}
-			}
-		}
+	ListOutputBatterySwitch {
+		bindPrefix: root.bindPrefix
+		onToggled: Global.pageManager.popPage() // service has changed to .dcdc, so page is no longer relevant
 	}
 
-	ListNavigation {
-		//% "Charge cycle history"
-		text: qsTrId("alternator_wakespeed_charge_cycle_history")
-		preferredVisible: historyCyclesAvailable.valid
-		onClicked: {
-			Global.pageManager.pushPage(chargeHistoryComponent, { "title": text })
-		}
-
-		Component {
-			id: chargeHistoryComponent
-
-			Page {
-				GradientListView {
-					model: historyCyclesAvailable.valid ? historyCyclesAvailable.value + 1 : 1
-					delegate: Component {
-						ListCycleHistoryItem {
-							width: parent ? parent.width : 0
-							bindPrefix: root.bindPrefix + "/History/Cycle/" + index
-							cycle: index
-						}
-					}
-				}
-			}
-		}
-
-		VeQuickItem {
-			id: historyCyclesAvailable
-			uid: root.bindPrefix + "/History/Cycle/CyclesAvailable"
-		}
+	DcHistorySettingsColumn {
+		width: parent?.width ?? 0
+		bindPrefix: root.bindPrefix
 	}
 
 	ListNavigation {

--- a/pages/settings/devicelist/dc-in/PageDcDcConverter.qml
+++ b/pages/settings/devicelist/dc-in/PageDcDcConverter.qml
@@ -55,6 +55,16 @@ Page {
 				secondaryText: dataItem.valid ? ChargerError.description(dataItem.value) : dataItem.invalidText
 			}
 
+			ListOutputBatterySwitch {
+				bindPrefix: root.bindPrefix
+				onToggled: Global.pageManager.popPage() // service has changed to .alternator, so page is no longer relevant
+			}
+
+			DcHistorySettingsColumn {
+				width: parent?.width ?? 0
+				bindPrefix: root.bindPrefix
+			}
+
 			ListNavigation {
 				text: CommonWords.device_info_title
 				onClicked: {


### PR DESCRIPTION
The OrionXS can be configured to change from an .alternator service to a .dcdc service, by changing /Settings/OutputBattery from 0 to 1. When it is a .dcdc service, it is connected with its input to the main battery and the output to some auxiliary battery.

To support this:
- allow the /Settings/OutputBattery setting to be changed from alternator and dcdc settings pages
- since a dcdc service can now have a charger history, move the charger history implementation from the alternator settings page into a common DcHistorySettingsColumn that can be shown in both the alternator and dcdc settings pages
- add ListSwitch toggled() signal so that a toast can be shown when the service type changes between alternator and dcdc

Fixes #2026