### PR TITLE
Don't include offline tanks in tank totals calculations

### DIFF
--- a/components/ExpandedTanksView.qml
+++ b/components/ExpandedTanksView.qml
@@ -21,6 +21,7 @@ BaseListView {
 
 		width: Gauges.width(root.model.count, Theme.geometry_levelsPage_max_tank_count, Theme.geometry_screen_width)
 		height: Theme.geometry_levelsPage_panel_expanded_height
+		status: device.status
 		fluidType: device.type
 		name: device.name
 		level: device.level
@@ -32,6 +33,9 @@ BaseListView {
 			valueType: tankDelegate.tankProperties.valueType
 			animationEnabled: root.animationEnabled
 			value: tankDelegate.device.level / 100
+			surfaceColor: tankDelegate.status === VenusOS.Tank_Status_Ok
+				? Theme.color_levelsPage_gauge_separatorBarColor
+				: tankDelegate.color
 		}
 	}
 }

--- a/components/TankItem.qml
+++ b/components/TankItem.qml
@@ -11,6 +11,7 @@ import QtQuick.Controls.impl as CP
 Rectangle {
 	id: root
 
+	property int status
 	property int fluidType
 	property string name
 	property real level
@@ -20,7 +21,7 @@ Rectangle {
 
 	readonly property var tankProperties: Gauges.tankProperties(fluidType)
 
-	color: Theme.color_levelsPage_gauge_backgroundColor
+	color: status === VenusOS.Tank_Status_Ok ? Theme.color_levelsPage_gauge_backgroundColor : Theme.color_levelsPage_panel_border_color
 	radius: Theme.geometry_levelsPage_panel_radius
 	border.width: Theme.geometry_levelsPage_panel_border_width
 	border.color: Theme.color_levelsPage_panel_border_color
@@ -39,7 +40,7 @@ Rectangle {
 			topMargin: Theme.geometry_levelsPage_panel_spacing
 			horizontalCenter: parent.horizontalCenter
 		}
-		color: Theme.color_levelsPage_tankIcon
+		color: root.status === VenusOS.Tank_Status_Ok ? Theme.color_levelsPage_tankIcon : Theme.color_warning
 		source: root.tankProperties.icon
 	}
 

--- a/data/common/Tank.qml
+++ b/data/common/Tank.qml
@@ -9,7 +9,6 @@ import Victron.VenusOS
 BaseTankDevice {
 	id: tank
 
-	readonly property int status: _status.valid ? _status.value : VenusOS.Tank_Status_Unknown
 	readonly property real temperature: _temperature.valid ? _temperature.value : NaN
 
 	property TankModel _tankModel
@@ -48,6 +47,7 @@ BaseTankDevice {
 	productName: device.productName
 	customName: device.customName
 	name: _description.description
+	status: _status.valid ? _status.value : VenusOS.Tank_Status_Unknown
 	type: _type.valid ? _type.value : -1
 	level: _level.valid ? _level.value : NaN
 	capacity: _capacity.valid ? _capacity.value : NaN

--- a/data/mock/config/LevelsPageConfig.qml
+++ b/data/mock/config/LevelsPageConfig.qml
@@ -175,6 +175,27 @@ QtObject {
 				{ type: VenusOS.Tank_Type_BlackWater, level: 25, capacity: .2 },
 			]
 		},
+		{
+			// the total capacity and level etc should NOT include the error-state tank.
+			name: "2 Freshwater tanks, one in error state",
+			tanks: [
+				{ type: VenusOS.Tank_Type_FreshWater, level: 25, capacity: 10 },
+				{ type: VenusOS.Tank_Type_FreshWater, level: 75, capacity: 20, status: VenusOS.Tank_Status_Error },
+			]
+		},
+		{
+			// the total capacity and level etc should NOT include the error-state tank.
+			name: "Merge 2 Freshwater tanks, one in error state",
+			tanks: [
+				{ type: VenusOS.Tank_Type_FreshWater, level: 25, capacity: 10 },
+				{ type: VenusOS.Tank_Type_FreshWater, level: 75, capacity: 20, status: VenusOS.Tank_Status_Error },
+				{ type: VenusOS.Tank_Type_Fuel, level: 10 },
+				{ type: VenusOS.Tank_Type_WasteWater, level: 75.334 },
+				{ type: VenusOS.Tank_Type_LiveWell, capacity: 1, remaining: 2.5 },
+				{ type: VenusOS.Tank_Type_Oil, level: 80.2, capacity: .1 },
+				{ type: VenusOS.Tank_Type_BlackWater, level: 25, capacity: .2 },
+			]
+		},
 	]
 
 	property var environmentConfigs: [

--- a/pages/TanksTab.qml
+++ b/pages/TanksTab.qml
@@ -31,6 +31,7 @@ LevelsTab {
 
 		width: Gauges.width(root.count, Theme.geometry_levelsPage_max_tank_count, root.width)
 		height: Gauges.height(!!Global.pageManager && Global.pageManager.expandLayout)
+		status: isGroup ? VenusOS.Tank_Status_Ok : (tank?.status ?? VenusOS.Tank_Status_Unknown)
 		fluidType: tankModel.type
 		name: tank?.name ?? ""
 		gauge: isGroup ? gaugeGroupComponent : singleGaugeComponent
@@ -65,6 +66,9 @@ LevelsTab {
 				valueType: tankOrGroupDelegate.tankProperties.valueType
 				value: tankOrGroupDelegate.tank ? tankOrGroupDelegate.tank.level / 100 : NaN
 				isGrouped: false
+				surfaceColor: tankOrGroupDelegate.status === VenusOS.Tank_Status_Ok
+						? Theme.color_levelsPage_gauge_separatorBarColor
+						: tankOrGroupDelegate.color
 			}
 		}
 
@@ -89,6 +93,9 @@ LevelsTab {
 						valueType: tankOrGroupDelegate.tankProperties.valueType
 						value: device.level / 100
 						isGrouped: true
+						surfaceColor: tankOrGroupDelegate.status === VenusOS.Tank_Status_Ok
+								? Theme.color_levelsPage_gauge_separatorBarColor
+								: tankOrGroupDelegate.color
 					}
 				}
 			}

--- a/src/basetankdevice.cpp
+++ b/src/basetankdevice.cpp
@@ -55,6 +55,19 @@ void BaseTankDevice::updateMeasurements(const qreal prevLevel, const qreal prevC
 	}
 }
 
+int BaseTankDevice::status() const
+{
+	return m_status;
+}
+
+void BaseTankDevice::setStatus(int s)
+{
+	if (m_status != s) {
+		m_status = s;
+		emit statusChanged();
+	}
+}
+
 int BaseTankDevice::type() const
 {
 	return m_type;

--- a/src/basetankdevice.h
+++ b/src/basetankdevice.h
@@ -10,6 +10,7 @@
 #include <QtGlobal>
 
 #include "basedevice.h"
+#include "enums.h"
 
 namespace Victron {
 namespace VenusOS {
@@ -18,6 +19,7 @@ class BaseTankDevice : public BaseDevice
 {
 	Q_OBJECT
 	QML_ELEMENT
+	Q_PROPERTY(int status READ status WRITE setStatus NOTIFY statusChanged)
 	Q_PROPERTY(int type READ type WRITE setType NOTIFY typeChanged)
 	Q_PROPERTY(qreal level READ level WRITE setLevel NOTIFY levelChanged)
 	Q_PROPERTY(qreal capacity READ capacity WRITE setCapacity NOTIFY capacityChanged)
@@ -25,6 +27,9 @@ class BaseTankDevice : public BaseDevice
 
 public:
 	explicit BaseTankDevice(QObject *parent = nullptr);
+
+	int status() const;
+	void setStatus(int s);
 
 	int type() const;
 	void setType(int type);
@@ -40,6 +45,7 @@ public:
 	void setRemaining(qreal remaining);
 
 Q_SIGNALS:
+	void statusChanged();
 	void typeChanged();
 	void levelChanged();
 	void capacityChanged();
@@ -48,6 +54,7 @@ Q_SIGNALS:
 private:
 	void updateMeasurements(const qreal prevLevel, const qreal prevCacpacity, const qreal prevRemaining);
 
+	int m_status = Enums::Tank_Status_Ok; // assume ok by default
 	int m_type = 0;
 	qreal m_level = qQNaN();
 	qreal m_capacity = qQNaN();

--- a/src/basetankdevicemodel.cpp
+++ b/src/basetankdevicemodel.cpp
@@ -79,6 +79,9 @@ void BaseTankDeviceModel::modelRowsInserted(const QModelIndex &parent, int first
 		// changes all of these values at the same time for each device, so delay the update until
 		// the end of the event loop to minimize unnecessary recalculations.
 		if (BaseTankDevice *tank = tankAt(i)) {
+			connect(tank, &BaseTankDevice::statusChanged,
+					this, &BaseTankDeviceModel::updateTotals,
+					Qt::QueuedConnection);
 			connect(tank, &BaseTankDevice::levelChanged,
 					this, &BaseTankDeviceModel::updateTotals,
 					Qt::QueuedConnection);
@@ -123,7 +126,8 @@ void BaseTankDeviceModel::updateTotals()
 	bool requireFallback = false;
 
 	for (int i = 0; i < count(); ++i) {
-		if (const BaseTankDevice *tank = tankAt(i)) {
+		if (const BaseTankDevice *tank = tankAt(i);
+				tank && tank->status() == Enums::Tank_Status_Ok) {
 			totalLevel = sumOf(totalLevel, tank->level());
 			totalCapacity = sumOf(totalCapacity, tank->capacity());
 			totalRemaining = sumOf(totalRemaining, tank->remaining());

--- a/tests/basetankdevicemodel/tst_basetankdevicemodel.qml
+++ b/tests/basetankdevicemodel/tst_basetankdevicemodel.qml
@@ -55,18 +55,27 @@ TestCase {
 				// combined level.
 				// Crude average level = 25+75/2 = 50%, but actual combined average = 15.5/22 = 70%
 				tanks: [
-					{ level: 25, capacity: 2, remaining: 0.5 },
-					{ level: 75, capacity: 20, remaining: 15 },
+					{ level: 25, capacity: 2, remaining: 0.5, status: VenusOS.Tank_Status_Ok },
+					{ level: 75, capacity: 20, remaining: 15, status: VenusOS.Tank_Status_Ok },
 				],
 				averageLevel: 70.4545454,
 			},
 			{
 				// No capacity and remaining, so calculate a crude average level.
 				tanks: [
-					{ level: 25, capacity: NaN, remaining: NaN },
-					{ level: 75, capacity: NaN, remaining: NaN },
+					{ level: 25, capacity: NaN, remaining: NaN, status: VenusOS.Tank_Status_Ok },
+					{ level: 75, capacity: NaN, remaining: NaN, status: VenusOS.Tank_Status_Ok },
 				],
 				averageLevel: 50,
+			},
+			{
+				// Capacity and remaining provided for all tanks, but one tank is in error state
+				// so we ignore it for the purposes of the calculation.
+				tanks: [
+					{ level: 25, capacity: 2, remaining: 0.5, status: VenusOS.Tank_Status_Ok },
+					{ level: 75, capacity: 20, remaining: 15, status: VenusOS.Tank_Status_Error },
+				],
+				averageLevel: 25,
 			},
 		]
 	}
@@ -79,6 +88,7 @@ TestCase {
 			tank.level = tankData.level
 			tank.capacity = tankData.capacity
 			tank.remaining = tankData.remaining
+			tank.status = tankData.status
 			tankModel.addDevice(tank)
 		}
 		tryCompare(tankModel, "averageLevel", data.averageLevel, 1)
@@ -91,8 +101,66 @@ TestCase {
 			tank.level = tankData.level
 			tank.capacity = tankData.capacity
 			tank.remaining = tankData.remaining
+			tank.status = tankData.status
 		}
 		tryCompare(tankModel, "averageLevel", data.averageLevel, 1)
+		tankModel.deleteAllAndClear()
+	}
+
+	function test_totalCapacity_states_data() {
+		return [
+			{
+				// Capacity provided for all tanks, so the total capacity is the sum.
+				tanks: [
+					{ level: 25, capacity: 2, remaining: 0.5, status: VenusOS.Tank_Status_Ok },
+					{ level: 75, capacity: 20, remaining: 15, status: VenusOS.Tank_Status_Ok },
+				],
+				totalCapacity: 22,
+			},
+			{
+				// Capacity provided for one tank, so the total capacity is that capacity.
+				tanks: [
+					{ level: 25, capacity: 2, remaining: 0.5, status: VenusOS.Tank_Status_Ok },
+					{ level: 75, capacity: NaN, remaining: NaN, status: VenusOS.Tank_Status_Ok },
+				],
+				totalCapacity: 2,
+			},
+			{
+				// Capacity provided for all tanks, but one tank is in error state
+				// so we ignore it for the purposes of the calculation.
+				tanks: [
+					{ level: 25, capacity: 2, remaining: 0.5, status: VenusOS.Tank_Status_Ok },
+					{ level: 75, capacity: 20, remaining: 15, status: VenusOS.Tank_Status_Error },
+				],
+				totalCapacity: 2,
+			},
+		]
+	}
+
+	function test_totalCapacity_states(data) {
+		// Add tanks with the values already set.
+		let tankData
+		for (tankData of data.tanks) {
+			const tank = createTank()
+			tank.level = tankData.level
+			tank.capacity = tankData.capacity
+			tank.remaining = tankData.remaining
+			tank.status = tankData.status
+			tankModel.addDevice(tank)
+		}
+		tryCompare(tankModel, "totalCapacity", data.totalCapacity, 1)
+		tankModel.deleteAllAndClear()
+
+		// Update tank values after they have been added to the model.
+		for (tankData of data.tanks) {
+			const tank = createTank()
+			tankModel.addDevice(tank)
+			tank.level = tankData.level
+			tank.capacity = tankData.capacity
+			tank.remaining = tankData.remaining
+			tank.status = tankData.status
+		}
+		tryCompare(tankModel, "totalCapacity", data.totalCapacity, 1)
 		tankModel.deleteAllAndClear()
 	}
 
@@ -127,6 +195,7 @@ TestCase {
 		for (capacity of data.values) {
 			const tank = createTank()
 			tank.capacity = capacity
+			tank.status = VenusOS.Tank_Status_Ok
 			tankModel.addDevice(tank)
 		}
 		tryCompare(tankModel, "totalCapacity", data.total, 1)
@@ -136,6 +205,7 @@ TestCase {
 		for (capacity of data.values) {
 			const tank = createTank()
 			tankModel.addDevice(tank)
+			tank.status = VenusOS.Tank_Status_Ok
 			tank.capacity = capacity
 		}
 		tryCompare(tankModel, "totalCapacity", data.total, 1)
@@ -152,6 +222,7 @@ TestCase {
 		for (remaining of data.values) {
 			const tank = createTank()
 			tank.remaining = remaining
+			tank.status = VenusOS.Tank_Status_Ok
 			tankModel.addDevice(tank)
 		}
 		tryCompare(tankModel, "totalRemaining", data.total, 1)
@@ -161,6 +232,7 @@ TestCase {
 		for (remaining of data.values) {
 			const tank = createTank()
 			tankModel.addDevice(tank)
+			tank.status = VenusOS.Tank_Status_Ok
 			tank.remaining = remaining
 		}
 		tryCompare(tankModel, "totalRemaining", data.total, 1)


### PR DESCRIPTION
Also visualize the status of non-OK tanks in the levels page via dimmed surface color, plus warning-colorized icon.

Contributes to issue #2053