### PR TITLE
Inverter/Charger widget: wrap on word boundaries + fit font size

### DIFF
--- a/components/widgets/InverterChargerWidget.qml
+++ b/components/widgets/InverterChargerWidget.qml
@@ -50,8 +50,8 @@ OverviewWidget {
 			text: Global.system.systemStateToText(Global.system.state)
 			font.pixelSize: Theme.font_overviewPage_widget_quantityLabel_maximumSize
 			minimumPixelSize: Theme.font_overviewPage_widget_quantityLabel_minimumSize
-			fontSizeMode: Text.VerticalFit
-			wrapMode: Text.Wrap
+			fontSizeMode: Text.Fit
+			wrapMode: Text.WordWrap
 			maximumLineCount: 4
 			elide: Text.ElideRight
 		},


### PR DESCRIPTION
To prevent strange rendering of longer (especially translated) strings, only wrap at word boundaries.  Also, enable both horizontal and vertical font fitting.

We still allow eliding (for very long terms which still don't fit using the minimum-allowed font size).

Contributes to issue #2009