### PR TITLE
Cleanup: bind list items to 'interactive' instead of 'enabled'

### DIFF
--- a/components/listitems/core/ListDateSelector.qml
+++ b/components/listitems/core/ListDateSelector.qml
@@ -15,7 +15,7 @@ ListButton {
 	property var date: dataItem.valid ? new Date(dataItem.value * 1000) : null
 
 	secondaryText: date == null ? "--" : Qt.formatDate(date, "yyyy-MM-dd")
-	enabled: userHasWriteAccess && (dataItem.uid === "" || dataItem.valid)
+	interactive: (dataItem.uid === "" || dataItem.valid)
 
 	onClicked: Global.dialogLayer.open(dateSelectorComponent, {
 		year: date ? date.getFullYear() : ClockTime.year,

--- a/pages/settings/NetworkSettingsPageModel.qml
+++ b/pages/settings/NetworkSettingsPageModel.qml
@@ -124,7 +124,7 @@ VisibleItemModel {
 	}
 
 	ListIpAddressField {
-		enabled: method.userHasWriteAccess && networkServices.manual
+		interactive: networkServices.manual
 		textField.text: networkServices.ipAddress
 		saveInput: function() { networkServices.setServiceProperty("Address", textField.text) }
 	}

--- a/pages/settings/PageSettingsGenerator.qml
+++ b/pages/settings/PageSettingsGenerator.qml
@@ -126,7 +126,6 @@ Page {
 				//% "Alarm if DC generator is not providing power"
 				text: qsTrId("page_settings_generator_detect_generator_at_dc")
 				dataItem.uid: settingsBindPrefix + "/Alarms/NoGeneratorAtDcIn"
-				enabled: dataItem.valid
 				preferredVisible: noGeneratorAtDcInAlarm.valid
 				onClicked: {
 					if (!checked) {

--- a/pages/settings/PageSettingsIntegrations.qml
+++ b/pages/settings/PageSettingsIntegrations.qml
@@ -216,7 +216,7 @@ Page {
 				//% "Signal K"
 				text: qsTrId("settings_large_signal_k")
 				dataItem.uid: Global.venusPlatform.serviceUid + "/Services/SignalK/Enabled"
-				enabled: userHasWriteAccess && root.allModificationsEnabled
+				interactive: userHasWriteAccess && root.allModificationsEnabled
 				preferredVisible: dataItem.valid
 			}
 

--- a/pages/settings/PageSettingsNodeRed.qml
+++ b/pages/settings/PageSettingsNodeRed.qml
@@ -28,7 +28,7 @@ Page {
 
 				text: qsTrId("settings_large_node_red")
 				dataItem.uid: Global.venusPlatform.serviceUid + "/Services/NodeRed/Mode"
-				enabled: userHasWriteAccess && root.allModificationsEnabled
+				interactive: userHasWriteAccess && root.allModificationsEnabled
 				preferredVisible: dataItem.valid
 				optionModel: [
 					{ display: CommonWords.disabled, value: VenusOS.NodeRed_Mode_Disabled },


### PR DESCRIPTION
As per 911f826df2019739c99759695d65cec60e979dc0.