### PR TITLE
Adjust nav button width and fix Levels re-insertion

### DIFF
--- a/components/NavBar.qml
+++ b/components/NavBar.qml
@@ -55,10 +55,10 @@ FocusScope {
 	}
 
 	Row {
+		id: buttonRow
 		x: Theme.geometry_page_content_horizontalMargin
 		width: parent.width - 2*Theme.geometry_page_content_horizontalMargin
 		height: parent.height
-		spacing: (width - (buttonRepeater.count * Theme.geometry_navigationBar_button_width)) / Math.max(buttonRepeater.count - 1, 1)
 
 		Repeater {
 			id: buttonRepeater
@@ -73,7 +73,7 @@ FocusScope {
 
 				readonly property var _modelData: root.model.get(index)
 				height: root.height
-				width: Theme.geometry_navigationBar_button_width
+				width: buttonRow.width / buttonRepeater.count
 				text: _modelData.navButtonText
 				icon.source: _modelData.navButtonIcon
 				checked: root.currentIndex === model.index

--- a/components/SwipePageModel.qml
+++ b/components/SwipePageModel.qml
@@ -31,11 +31,12 @@ ObjectModel {
 		}
 	}
 
-	readonly property Component levelsPage: Component {
+	readonly property Component levelsComponent: Component {
 		LevelsPage {
 			view: root.view
 		}
 	}
+	property LevelsPage levelsPage
 
 	property bool _completed: false
 
@@ -59,6 +60,7 @@ ObjectModel {
 	}
 
 	NotificationsPage {
+		id: notificationsPage
 		view: root.view
 	}
 
@@ -68,7 +70,8 @@ ObjectModel {
 
 	Component.onCompleted: {
 		if (showLevelsPage) {
-			insert(2, levelsPage.createObject(parent))
+			levelsPage = levelsComponent.createObject(parent)
+			insert(2, levelsPage) // ideally the index would not be hardcoded, but the view is not initialized yet
 		}
 
 		if (showBoatPage.value) {
@@ -84,9 +87,15 @@ ObjectModel {
 		}
 
 		if (showLevelsPage) {
-			root.view.insertItem(2, levelsPage.createObject(parent))
+			for (let i = 0; i < root.view.count; ++i) {
+				if (root.view.itemAt(i) === notificationsPage) {
+					root.levelsPage = levelsComponent.createObject(parent)
+					root.view.insertItem(i, root.levelsPage)
+					break
+				}
+			}
 		} else {
-			root.view.removeItem(view.itemAt(2))
+			root.view.removeItem(root.levelsPage)
 		}
 	}
 }

--- a/data/mock/config/MockDataSimulator.qml
+++ b/data/mock/config/MockDataSimulator.qml
@@ -120,6 +120,11 @@ QtObject {
 			root.animationEnabled = !root.animationEnabled
 			event.accepted = true
 			break
+		case Qt.Key_B:
+			root.setMockValue(Global.systemSettings.serviceUid + "/Settings/Gui/ElectricPropulsionUI/Enabled",
+				root.mockValue(Global.systemSettings.serviceUid + "/Settings/Gui/ElectricPropulsionUI/Enabled") == 0 ? 1 : 0)
+			event.accepted = true
+			break
 		case Qt.Key_C:
 			Theme.colorScheme = Theme.colorScheme == Theme.Dark ? Theme.Light : Theme.Dark
 			event.accepted = true

--- a/themes/geometry/FiveInch.json
+++ b/themes/geometry/FiveInch.json
@@ -98,7 +98,6 @@
 
     "geometry_navigationBar_initialize_margin": 12,
     "geometry_navigationBar_height": 72,
-    "geometry_navigationBar_button_width": 144,
     "geometry_navigationBar_button_icon_width": 32,
     "geometry_navigationBar_button_icon_height": 32,
     "geometry_navigationBar_button_spacing": "geometry_button_spacing",

--- a/themes/geometry/SevenInch.json
+++ b/themes/geometry/SevenInch.json
@@ -98,7 +98,6 @@
 
     "geometry_navigationBar_initialize_margin": 12,
     "geometry_navigationBar_height": 72,
-    "geometry_navigationBar_button_width": 176,
     "geometry_navigationBar_button_icon_width": 32,
     "geometry_navigationBar_button_icon_height": 32,
     "geometry_navigationBar_button_spacing": "geometry_button_spacing",


### PR DESCRIPTION
- Set nav button width according to the number of items in the bar
- If Levels page is removed and reinserted while Boat page is visible, ensure the Levels page is removed rather than the Overview page, and always insert Levels before Notifications page