### PR TITLE
ESS: show toast when changing away from External Control mode 

### DIFF
--- a/data/common/EssData.qml
+++ b/data/common/EssData.qml
@@ -41,6 +41,13 @@ QtObject {
 		target: Global.ess
 
 		function onSetStateRequested(essState) {
+			if (root.state === VenusOS.Ess_State_ExternalControl) {
+				// When changing away from External Control, /CGwacs/Hub4Mode is reset, so user
+				// should verify the settings changes.
+				//% "Make sure to check the Multiphase regulation setting"
+				Global.showToastNotification(VenusOS.Notification_Info, qsTrId("ess_check_multiphase_regulation_setting"), 10000)
+			}
+
 			// Hub 4 mode
 			if (essState === VenusOS.Ess_State_ExternalControl && veHub4Mode.value !== VenusOS.Ess_Hub4ModeState_Disabled) {
 				veHub4Mode.setValue(VenusOS.Ess_Hub4ModeState_Disabled)

--- a/data/mock/EssImpl.qml
+++ b/data/mock/EssImpl.qml
@@ -6,22 +6,4 @@
 import QtQuick
 import Victron.VenusOS
 
-QtObject {
-	id: root
-
-	Component.onCompleted: {
-		Global.ess.minimumStateOfCharge = 10
-	}
-
-	property Connections essConn: Connections {
-		target: Global.ess
-
-		function onSetStateRequested(s) {
-			Global.ess.state = s
-		}
-
-		function onSetMinimumStateOfChargeRequested(soc) {
-			Global.ess.minimumStateOfCharge = soc
-		}
-	}
-}
+EssData {}


### PR DESCRIPTION
Also updated the ESS mock backend to use the same backend as that for dbus/mqtt, so that the toast will appear in mock mode as well.