### PR TITLE
Fix off-by-one in brief page center details selection dialog

### DIFF
--- a/components/listitems/ListBriefCenterDetails.qml
+++ b/components/listitems/ListBriefCenterDetails.qml
@@ -35,7 +35,7 @@ ListNavigation {
 				section: qsTrId("settings_briefview_center_temperature_services")
 			})
 			if (selectedIndex < 0 && portableServiceId === centerService.value) {
-				selectedIndex = i
+				selectedIndex = i+1 // allow for the prepended active battery option
 			}
 		}
 		Global.pageManager.pushPage(deviceOptionsComponent, {


### PR DESCRIPTION
The deviceOptionModel has an activeBatteryName option injected at index 0, so subsequent device indexes should be increased by one.

Contributes to issue #2085