### PR TITLE
Allow user to update the security profile password easily

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,6 +321,7 @@ set (VENUS_QML_MODULE_SOURCES
     components/dialogs/ModalDialog.qml
     components/dialogs/ModalWarningDialog.qml
     components/dialogs/NumberSelectorDialog.qml
+    components/dialogs/SecurityProfilePasswordDialog.qml
     components/dialogs/SolarDailyHistoryDialog.qml
     components/dialogs/TimeSelectorDialog.qml
 

--- a/components/RadioButtonListPage.qml
+++ b/components/RadioButtonListPage.qml
@@ -21,6 +21,8 @@ Page {
 	property var popDestination: null
 	property var validatePassword
 
+	property alias footer: optionsListView.footer
+
 	signal optionClicked(index: int, value : var)
 	signal aboutToPop()
 

--- a/components/dialogs/SecurityProfilePasswordDialog.qml
+++ b/components/dialogs/SecurityProfilePasswordDialog.qml
@@ -1,0 +1,158 @@
+/*
+** Copyright (C) 2025 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import QtQuick.Layouts
+import Victron.VenusOS
+
+ModalDialog {
+	id: root
+
+	property string password
+
+	function validate() : bool {
+
+		root.password = ""
+
+		if (firstPassword.length < 8) {
+
+			// First, validate that the firstPassword is at least 8 characters long.
+			// If not, the border of both firstPassword AND secondPassword turn red and
+			// the passwordHint warning about length, becomes visible.
+
+			firstPassword.borderColor = Theme.color_critical
+			secondPassword.borderColor = Theme.color_critical
+			passwordHint.visible = true
+			//% "Password needs to be at least 8 characters long"
+			passwordHint.text = qsTrId("settings_security_profile_password_incorrect_length")
+
+			return false
+		}
+
+		if (firstPassword.text !== secondPassword.text) {
+			// Secondly, validate that the passwords in both firstPassword AND secondPassword are equal.
+			// If not, the border of both firstPassword AND secondPassword turn red and
+			// the passwordHint warning about mismatch, becomes visible.
+
+			firstPassword.borderColor = Theme.color_critical
+			secondPassword.borderColor = Theme.color_critical
+			passwordHint.visible = true
+			//% "Passwords do not match, please check"
+			passwordHint.text = qsTrId("settings_security_profile_password_mismatch")
+
+			return false
+		}
+
+		resetValidation()
+
+		root.password = firstPassword.text
+
+		return true
+	}
+
+	function resetValidation() {
+
+		// As soon as the input in any input field changes,
+		// the borderColor turns back to blue and the red passwordHint turns invisible.
+		// This is also this is ths default "validated" state
+
+		firstPassword.borderColor = Theme.color_ok
+		secondPassword.borderColor = Theme.color_ok
+		passwordHint.visible = false
+		passwordHint.text = ""
+	}
+
+	//% "Changing the GX Password"
+	title: qsTrId("settings_security_profile_change_password_title")
+
+	//% "Confirm"
+	acceptText: qsTrId("modaldialog_confirm")
+
+	dialogDoneOptions: VenusOS.ModalDialog_DoneOptions_OkAndCancel
+
+	Component.onCompleted: resetValidation()
+
+	contentItem: Item {
+		id: passwordEntryItem
+
+		ColumnLayout {
+			anchors {
+				top: parent.top
+				topMargin: Theme.geometry_modalWarningDialog_title_spacing
+				horizontalCenter: parent.horizontalCenter
+			}
+
+			spacing: Theme.geometry_modalWarningDialog_title_spacing
+
+			Label {
+				id: description
+
+				Layout.fillWidth: true
+
+				//% "Please assign a new GX password\nby entering it twice:"
+				text: qsTrId("settings_security_profile_change_password_description")
+
+				font.pixelSize: Theme.font_size_body2
+				horizontalAlignment: Label.AlignHCenter
+				wrapMode: Text.Wrap
+			}
+
+			TextField {
+				id: firstPassword
+
+				Layout.fillWidth: true
+
+				focus: true
+
+				//% "Enter new password"
+				placeholderText: qsTrId("settings_security_profile_enter_new_password")
+				echoMode: TextInput.Password
+
+				// As soon as the input in any input field changes,
+				// the borderColors turns back to blue and the red passwordHint turns invisible.
+				onTextEdited: root.resetValidation()
+
+				// When Return/Enter key is pressed (and as per current behaviour onFocusLost),
+				// the passwords shall be validated
+				onAccepted: root.acceptButton?.clicked()
+				onActiveFocusChanged: if(!focus) root.valiate()
+			}
+
+			TextField {
+				id: secondPassword
+
+				Layout.fillWidth: true
+
+				//% "Confirm new password"
+				placeholderText: qsTrId("settings_security_profile_confirm_new_password")
+				echoMode: TextInput.Password
+
+				// As soon as the input in any input field changes,
+				// the borderColors turns back to blue and the red passwordHint turns invisible.
+				onTextEdited: root.resetValidation()
+
+				// When Return/Enter key is pressed (and as per current behaviour onFocusLost),
+				// the passwords shall be validated
+				onAccepted: root.acceptButton?.clicked()
+				onActiveFocusChanged: if(!focus) root.validate()
+			}
+
+			Label {
+				id: passwordHint
+
+				Layout.fillWidth: true
+				font.pixelSize: Theme.font_size_caption
+				color: Theme.color_red
+				horizontalAlignment: Label.AlignHCenter
+				wrapMode: Text.Wrap
+			}
+		}
+	}
+
+	tryAccept: function() {
+		// When “Confirm” is tapped the passwords shall be validated
+		return root.validate()
+	}
+}

--- a/components/dialogs/SecurityProfilePasswordDialog.qml
+++ b/components/dialogs/SecurityProfilePasswordDialog.qml
@@ -19,28 +19,13 @@ ModalDialog {
 		if (firstPassword.length < 8) {
 
 			// First, validate that the firstPassword is at least 8 characters long.
-			// If not, the border of both firstPassword AND secondPassword turn red and
-			// the passwordHint warning about length, becomes visible.
+			// If not, the border turns red the passwordHint warning about length
+			// becomes visible.
 
 			firstPassword.borderColor = Theme.color_critical
-			secondPassword.borderColor = Theme.color_critical
 			passwordHint.visible = true
 			//% "Password needs to be at least 8 characters long"
 			passwordHint.text = qsTrId("settings_security_profile_password_incorrect_length")
-
-			return false
-		}
-
-		if (firstPassword.text !== secondPassword.text) {
-			// Secondly, validate that the passwords in both firstPassword AND secondPassword are equal.
-			// If not, the border of both firstPassword AND secondPassword turn red and
-			// the passwordHint warning about mismatch, becomes visible.
-
-			firstPassword.borderColor = Theme.color_critical
-			secondPassword.borderColor = Theme.color_critical
-			passwordHint.visible = true
-			//% "Passwords do not match, please check"
-			passwordHint.text = qsTrId("settings_security_profile_password_mismatch")
 
 			return false
 		}
@@ -59,7 +44,6 @@ ModalDialog {
 		// This is also this is ths default "validated" state
 
 		firstPassword.borderColor = Theme.color_ok
-		secondPassword.borderColor = Theme.color_ok
 		passwordHint.visible = false
 		passwordHint.text = ""
 	}
@@ -91,7 +75,7 @@ ModalDialog {
 
 				Layout.fillWidth: true
 
-				//% "Please assign a new GX password\nby entering it twice:"
+				//% "Please enter a new GX password:"
 				text: qsTrId("settings_security_profile_change_password_description")
 
 				font.pixelSize: Theme.font_size_body2
@@ -115,26 +99,7 @@ ModalDialog {
 				onTextEdited: root.resetValidation()
 
 				// When Return/Enter key is pressed (and as per current behaviour onFocusLost),
-				// the passwords shall be validated
-				onAccepted: root.acceptButton?.clicked()
-				onActiveFocusChanged: if(!focus) root.valiate()
-			}
-
-			TextField {
-				id: secondPassword
-
-				Layout.fillWidth: true
-
-				//% "Confirm new password"
-				placeholderText: qsTrId("settings_security_profile_confirm_new_password")
-				echoMode: TextInput.Password
-
-				// As soon as the input in any input field changes,
-				// the borderColors turns back to blue and the red passwordHint turns invisible.
-				onTextEdited: root.resetValidation()
-
-				// When Return/Enter key is pressed (and as per current behaviour onFocusLost),
-				// the passwords shall be validated
+				// the password shall be validated
 				onAccepted: root.acceptButton?.clicked()
 				onActiveFocusChanged: if(!focus) root.validate()
 			}

--- a/components/listitems/core/ListRadioButtonGroup.qml
+++ b/components/listitems/core/ListRadioButtonGroup.qml
@@ -43,6 +43,8 @@ ListNavigation {
 	//% "Unknown"
 	property string defaultSecondaryText: qsTrId("settings_radio_button_group_unknown")
 
+	property Component optionFooter
+
 	signal optionClicked(index: int)
 	signal aboutToPop()
 
@@ -65,6 +67,7 @@ ListNavigation {
 		id: optionsPageComponent
 
 		RadioButtonListPage {
+			footer: root.optionFooter
 			optionModel: root.optionModel
 			currentIndex: root.currentIndex
 			updateCurrentIndexOnClick: root.updateCurrentIndexOnClick

--- a/pages/settings/PageSettingsAccessAndSecurity.qml
+++ b/pages/settings/PageSettingsAccessAndSecurity.qml
@@ -192,7 +192,7 @@ Page {
 								id: securityProfilePasswordDialog
 
 								onAccepted: {
-									setProfileAndPassword(securityProfile.currentIndex, password, false)
+									securityProfile.setProfileAndPassword(securityProfile.currentIndex, password, false)
 								}
 							}
 						}
@@ -242,7 +242,7 @@ Page {
 							const profile = securityProfile.pendingProfile
 							if (profile === VenusOS.Security_Profile_Unsecured)
 								password = "";
-							setProfileAndPassword(profile, password, true)
+							securityProfile.setProfileAndPassword(profile, password, true)
 						}
 						dialogDoneOptions: VenusOS.ModalDialog_DoneOptions_OkAndCancel
 						height: securityProfile.pendingProfile === VenusOS.Security_Profile_Secured


### PR DESCRIPTION
Add a button which allows the user to update the password without changing the security profile selection.

Contributes to issue #1993