### PR TITLE
Only set switchable output dimming value if path is valid

### DIFF
--- a/data/common/SwitchableOutput.qml
+++ b/data/common/SwitchableOutput.qml
@@ -67,7 +67,9 @@ QtObject {
 	readonly property string customName: _customName.value ?? ""
 
 	function setDimming(value) {
-		_dimming.setValue(value)
+		if (hasDimming) {
+			_dimming.setValue(value)
+		}
 	}
 
 	function setState(value) {
@@ -89,7 +91,7 @@ QtObject {
 	}
 
 	readonly property VeQuickItem _dimming: VeQuickItem {
-		uid: `${root.uid}/Dimming`
+		uid: root.type === VenusOS.SwitchableOutput_Type_Dimmable ? `${root.uid}/Dimming` : ""
 	}
 
 	readonly property VeQuickItem _customName: VeQuickItem {


### PR DESCRIPTION
Some switchable outputs are e.g. latchable only, so don't support dimming values.