### PR TITLE
Show correct AC input number in when changing current limit

### DIFF
--- a/components/CommonWords.qml
+++ b/components/CommonWords.qml
@@ -13,6 +13,9 @@ QtObject {
 	//% "AC In"
 	readonly property string ac_in: qsTrId("common_words_ac_in")
 
+	//% "AC Input"
+	readonly property string ac_input: qsTrId("common_words_ac_input")
+
 	//% "Add device"
 	readonly property string add_device: qsTrId("common_words_add_device")
 
@@ -528,13 +531,14 @@ QtObject {
 	//% "This feature is disabled, since \"All modifications enabled\" under \"Settings -> General -> Modification checks\" is disabled."
 	readonly property string all_modifications_disabled: qsTrId("common_words_large_features_currently_disabled")
 
-	function acInput(index) {
-			   //% "AC Input 1"
-		return index === 0 ? qsTrId("common_words_ac_input_1")
-			   //% "AC Input 2"
-			 : index === 1 ? qsTrId("common_words_ac_input_2")
-			   //% "AC Input"
-			 : qsTrId("common_words_ac_input")
+	function acInputFromIndex(index) {
+		return acInputFromNumber(index + 1)
+	}
+
+	function acInputFromNumber(number) {
+		//: %1 = number of the AC input
+		//% "AC input %1"
+		return qsTrId("common_words_ac_input_number").arg(number)
 	}
 
 	function onOrOff(value) {

--- a/components/listitems/ListActiveAcInput.qml
+++ b/components/listitems/ListActiveAcInput.qml
@@ -19,13 +19,7 @@ ListText {
 
 	//% "Active AC Input"
 	text: qsTrId("vebus_device_active_ac_input")
-	secondaryText: {
-		switch (acActiveInput.value) {
-		case 0:
-		case 1:
-			return CommonWords.acInput(acActiveInput.value)
-		default:
-			return CommonWords.disconnected
-		}
-	}
+
+	// ActiveInput value is 0-based index.
+	secondaryText: acActiveInput.valid ? CommonWords.acInputFromIndex(acActiveInput.value) : CommonWords.disconnected
 }

--- a/components/listitems/ListCurrentLimitButton.qml
+++ b/components/listitems/ListCurrentLimitButton.qml
@@ -10,7 +10,7 @@ ListButton {
 	id: root
 
 	required property string serviceUid
-	required property int inputNumber
+	required property int inputNumber // note this is 1-based, i.e. first AC input has inputNumber=1, not 0
 	required property int inputType
 
 	readonly property string serviceType: BackendConnection.serviceTypeFromUid(serviceUid)
@@ -73,7 +73,7 @@ ListButton {
 		CurrentLimitDialog {
 			productId: productIdItem.valid ? productIdItem.value : 0
 			title: Global.acInputs.currentLimitTypeToText(root.inputType)
-			secondaryTitle: CommonWords.acInput(root.inputNumber)
+			secondaryTitle: CommonWords.acInputFromNumber(root.inputNumber)
 			onAccepted: currentLimitItem.setValue(value)
 		}
 	}

--- a/components/listitems/ListEvChargerPositionRadioButtonGroup.qml
+++ b/components/listitems/ListEvChargerPositionRadioButtonGroup.qml
@@ -11,7 +11,7 @@ ListRadioButtonGroup {
 	//% "Position"
 	text: qsTrId("evcs_ac_position")
 	optionModel: [
-		{ display: CommonWords.acInput(), value: VenusOS.Evcs_Position_ACInput },
+		{ display: CommonWords.ac_input, value: VenusOS.Evcs_Position_ACInput },
 		{ display: CommonWords.ac_output, value: VenusOS.Evcs_Position_ACOutput }
 	]
 }

--- a/components/listitems/ListPvInverterPositionRadioButtonGroup.qml
+++ b/components/listitems/ListPvInverterPositionRadioButtonGroup.qml
@@ -9,8 +9,8 @@ import Victron.VenusOS
 ListRadioButtonGroup {
 	text: CommonWords.position_ac
 	optionModel: [
-		{ display: CommonWords.acInput(0), value: VenusOS.PvInverter_Position_ACInput },
-		{ display: CommonWords.acInput(1), value: VenusOS.PvInverter_Position_ACInput2 },
+		{ display: CommonWords.acInputFromNumber(1), value: VenusOS.PvInverter_Position_ACInput },
+		{ display: CommonWords.acInputFromNumber(2), value: VenusOS.PvInverter_Position_ACInput2 },
 		{ display: CommonWords.ac_output, value: VenusOS.PvInverter_Position_ACOutput },
 	]
 }

--- a/data/AcInputs.qml
+++ b/data/AcInputs.qml
@@ -101,7 +101,7 @@ QtObject {
 
 	function sourceToText(source) {
 		if (source === undefined) {
-			return CommonWords.acInput()
+			return CommonWords.ac_input
 		}
 		switch (source) {
 		case VenusOS.AcInputs_InputSource_NotAvailable:

--- a/data/common/AcInputSettings.qml
+++ b/data/common/AcInputSettings.qml
@@ -6,6 +6,9 @@
 import QtQuick
 import Victron.VenusOS
 
+/*
+	Provides AC input type data for inputs on a vebus or acsystem service.
+*/
 QtObject {
 	id: root
 
@@ -25,11 +28,14 @@ QtObject {
 	}
 
 	property VeQuickItem _systemSetupType: VeQuickItem {
+		// The setting path is 1-based: setting for first AC input is under /AcInput1
 		uid: Global.systemSettings.serviceUid + "/Settings/SystemSetup/AcInput" + inputNumber
 	}
 
 	property VeQuickItem _type: VeQuickItem {
 		// The /Type setting is only available for acsystem services.
+		// The setting path is 1-based: setting for first AC input is under /Ac/In/1, unlike the
+		// com.victronenergy.system setting path for the first AC input, which is /Ac/In/0.
 		uid: root.serviceType === "acsystem" ? root.serviceUid + "/Ac/In/" + inputNumber + "/Type" : ""
 	}
 }

--- a/pages/settings/PageGeneratorConditions.qml
+++ b/pages/settings/PageGeneratorConditions.qml
@@ -85,8 +85,8 @@ Page {
 							  ? 2 : 0
 				optionModel: [
 					{ display: CommonWords.disabled, value: 0 },
-					{ display: CommonWords.acInput(0), value: 1 },
-					{ display: CommonWords.acInput(1), value: 2, readOnly: !(capabilities.value & 1) },
+					{ display: CommonWords.acInputFromNumber(1), value: 1 },
+					{ display: CommonWords.acInputFromNumber(2), value: 2, readOnly: !(capabilities.value & 1) },
 				]
 
 				onOptionClicked: function(index) {

--- a/pages/settings/PageSettingsDisplayMinMax.qml
+++ b/pages/settings/PageSettingsDisplayMinMax.qml
@@ -73,12 +73,12 @@ Page {
 								if (inputInfo.source === VenusOS.AcInputs_InputSource_NotAvailable) {
 									//: %1 = 'AC input 1' or 'AC input 2'
 									//% "%1 (not available)"
-									return qsTrId("settings_minmax_ac_in_not_available").arg(CommonWords.acInput(index))
+									return qsTrId("settings_minmax_ac_in_not_available").arg(CommonWords.acInputFromIndex(index))
 								}
 								//: %1 = 'AC input 1' or 'AC input 2', %2 = name of connected input (e.g. Grid, Shore)
 								//% "%1 (%2)"
 								return qsTrId("settings_minmax_ac_in_header_with_source")
-										.arg(CommonWords.acInput(index))
+										.arg(CommonWords.acInputFromIndex(index))
 										.arg(Global.acInputs.sourceToText(inputInfo.source))
 							}
 						}


### PR DESCRIPTION
The digit used to represent an AC input may be 0-based or 1-based depending on the context. For example, the first AC input current limit is configured by com.victronenergy.vebus.<suffix>/Ac/In/1/CurrentLimit while the same input's service name is available as com.victronenergy.system/Ac/In/0/ServiceName.

The current limit dialog showed a 0-based AC input title string instead of the correct 1-based number. Fix this and replace CommonWords.acInput() with acInputFromIndex() and acInputFromNumber() to make it more explicit as to whether a 0-based or 1-based text string should be returned.

Fixes #2095