### PR TITLE
Move access keyboard shortcuts into user access radio button list

### DIFF
--- a/pages/settings/PageSettingsAccessAndSecurity.qml
+++ b/pages/settings/PageSettingsAccessAndSecurity.qml
@@ -13,9 +13,7 @@ Page {
 
 	onIsCurrentPageChanged: {
 		if (isCurrentPage) {
-			keyEvents.repeatCount = 0
-			keyEvents.upCount = 0
-			keyEvents.downCount = 0
+			keyEvents.enabled = false
 		}
 	}
 
@@ -27,12 +25,9 @@ Page {
 		property int downCount
 
 		target: Global
+		enabled: false
 
 		function onKeyPressed(event) {
-			if (!root.isCurrentPage) {
-				repeatCount = 0
-				return
-			}
 			if (event.key === Qt.Key_Right) {
 				// change to super user mode if the right button is pressed for a while
 				if (Global.systemSettings.accessLevel.value !== VenusOS.User_AccessType_SuperUser && ++repeatCount > 60) {
@@ -89,6 +84,14 @@ Page {
 					}
 					//% "Incorrect password"
 					return Utils.validationResult(VenusOS.InputValidation_Result_Error, qsTrId("settings_access_incorrect_password"))
+				}
+				onClicked: {
+					// When the access options list is open, enable the key shortcuts for changing
+					// the access level.
+					keyEvents.repeatCount = 0
+					keyEvents.upCount = 0
+					keyEvents.downCount = 0
+					keyEvents.enabled = true
 				}
 			}
 


### PR DESCRIPTION
These shortcuts should only be enabled in the access radio button list, rather than in the page with the list of security options, to align with the gui-v1 behaviour.

This also prepares for the key navigation feature, by ensuring that the right arrow key can be used for key navigation, without conflicting with the right arrow key shortcut for changing user access.

Part of #1030