### PR TITLE
Switches: support config to show/hide outputs in switch pane

### DIFF
--- a/data/Switches.qml
+++ b/data/Switches.qml
@@ -45,6 +45,7 @@ QtObject {
 				onGroupChanged: outputObject.updateGroupModel()
 				onFormattedNameChanged: outputObject.updateSortToken()
 				onTypeChanged: outputObject.updateGroupModel()
+				onShowUIControlChanged: outputObject.updateGroupModel()
 			}
 
 			function updateGroupModel() {
@@ -60,6 +61,9 @@ QtObject {
 						&& output.type !== VenusOS.SwitchableOutput_Type_Dimmable) {
 					// Only momentary/latching/dimmable outputs are controllable and should appear
 					// in the aux cards, so do not add other types of outputs to the model.
+					return
+				}
+				if (!output.showUIControl) {
 					return
 				}
 

--- a/data/common/SwitchableOutput.qml
+++ b/data/common/SwitchableOutput.qml
@@ -65,6 +65,7 @@ QtObject {
 	readonly property int type: _type.valid ? _type.value : -1
 	readonly property string group: _group.value ?? ""
 	readonly property string customName: _customName.value ?? ""
+	readonly property bool showUIControl: !_showUIControl.valid || _showUIControl.value === 1 // true when setting is not present
 
 	function setDimming(value) {
 		if (hasDimming) {
@@ -104,5 +105,9 @@ QtObject {
 
 	readonly property VeQuickItem _group: VeQuickItem {
 		uid: `${root.uid}/Settings/Group`
+	}
+
+	readonly property VeQuickItem _showUIControl: VeQuickItem {
+		uid: `${root.uid}/Settings/ShowUIControl`
 	}
 }

--- a/data/mock/SwitchesImpl.qml
+++ b/data/mock/SwitchesImpl.qml
@@ -102,6 +102,7 @@ Item {
 
 				for (let i = 0; i < root.inputCount; i++) {
 					const outputId = root.outputId(i)
+					switchDev.setMockValue("/SwitchableOutput/%1/Settings/ShowUIControl".arg(outputId), 1)
 					switchDev.setMockValue("/SwitchableOutput/%1/Name".arg(outputId), `Output ${i+1}`)
 					if (i === 1) {
 						switchDev.setMockValue("/SwitchableOutput/%1/Settings/CustomName".arg(outputId), "function Val sw%1".arg(deviceInstance))

--- a/pages/settings/devicelist/PageSwitchableOutput.qml
+++ b/pages/settings/devicelist/PageSwitchableOutput.qml
@@ -58,6 +58,14 @@ Page {
 				optionModel: validTypesItem.options
 			}
 
+			ListSwitch {
+				//: Whether UI controls should be shown for this output
+				//% "Show controls"
+				text: qsTrId("page_switchable_show_controls")
+				dataItem.uid: root.outputUid + "/Settings/ShowUIControl"
+				preferredVisible: dataItem.valid
+			}
+
 			ListSpinBox {
 				//% "Fuse rating"
 				text:  qsTrId("page_switchable_output_fuse_rating")


### PR DESCRIPTION
Use the output /Settings/ShowUIControl setting to determine whether an output should be shown in the switch pane.

Fixes #2107