### PR TITLE
Hide solar trackers with /Enabled=0

### DIFF
--- a/components/QuantityTable.qml
+++ b/components/QuantityTable.qml
@@ -13,6 +13,7 @@ Column {
 	property var units: []
 	property int rowCount
 	property var valueForModelIndex  // function(row,column) -> data value for this row/column
+	property var rowIsVisible   // TODO remove when QuantityObjectModel is used as model instead.
 	property bool headerVisible: true
 	property Component headerComponent: defaultHeaderComponent
 	property int labelHorizontalAlignment: Qt.AlignLeft
@@ -83,7 +84,23 @@ Column {
 		sourceComponent: headerVisible ? headerComponent : null
 	}
 
+
 	Repeater {
+		id: rowRepeater
+
+		function resetRowColors() {
+			let visibleRowCount = 0
+			for (let i = 0; i < count; ++i) {
+				const row = itemAt(i)
+				if (row && row.visible) {
+					row.color = visibleRowCount % 2 === 0
+						? Theme.color_quantityTable_row_alternateBackground
+						: Theme.color_quantityTable_row_background
+					visibleRowCount++
+				}
+			}
+		}
+
 		model: root.rowCount
 
 		delegate: Rectangle {
@@ -93,9 +110,9 @@ Column {
 
 			width: parent.width
 			height: valueRow.height
-			color: model.index % 2 === 0
-				   ? Theme.color_quantityTable_row_alternateBackground
-				   : Theme.color_quantityTable_row_background
+			visible: !root.rowIsVisible || root.rowIsVisible(rowIndex)
+			onVisibleChanged: rowRepeater.resetRowColors()
+			Component.onCompleted: rowRepeater.resetRowColors()
 
 			Row {
 				id: valueRow

--- a/data/common/SolarTracker.qml
+++ b/data/common/SolarTracker.qml
@@ -17,6 +17,10 @@ QtObject {
 	readonly property real voltage: _voltage.valid ? _voltage.value : NaN
 	readonly property real current: !power || !voltage ? NaN : power / voltage
 
+	// Whether the tracker is enabled, i.e. it should appear in the UI.
+	// This is true if the /Enabled setting is not present, for compatibility with older systems.
+	readonly property bool enabled: !_enabled.valid || _enabled.value === 1
+
 	// If there is only 1 tracker (e.g. all common MPPTs), the voltage and power are provided via
 	// /Pv/V and /Yield/Power instead of /Pv/0/V and /Pv/0/P.
 	readonly property VeQuickItem _voltage: VeQuickItem {
@@ -29,5 +33,9 @@ QtObject {
 
 	readonly property VeQuickItem _name: VeQuickItem {
 		uid: root.device.trackerCount <= 1 ? "" : `${root.device.serviceUid}/Pv/${root.trackerIndex}/Name`
+	}
+
+	readonly property VeQuickItem _enabled: VeQuickItem {
+		uid: root.device.trackerCount <= 1 ? "" : `${root.device.serviceUid}/Pv/${root.trackerIndex}/Enabled`
 	}
 }

--- a/data/mock/SolarDevicesImpl.qml
+++ b/data/mock/SolarDevicesImpl.qml
@@ -81,12 +81,18 @@ QtObject {
 				setMockValue("/NrOfTrackers", trackerCount)
 				let trackerIndex = 0
 
-				// Sometimes trackers have names. If available, they should show up in the UI.
+				// Sometimes trackers have names. If available, they should show up in the UI,
+				// unless /Enabled=0 for the tracker.
 				if (trackerCount > 1 && Math.random() < 0.5) {
 					const charCode = 'A'.charCodeAt(0)
 					for (trackerIndex = 0; trackerIndex < trackerCount; ++trackerIndex) {
-						const nextTrackerName = "Tracker %1".arg(String.fromCharCode(charCode + trackerIndex))
-						setMockValue("/Pv/" + trackerIndex + "/Name", nextTrackerName)
+						if (trackerIndex === trackerCount - 1) {
+							setMockValue("/Pv/" + trackerIndex + "/Enabled", 0)
+							setMockValue("/Pv/" + trackerIndex + "/Name", "Disabled tracker, should not be in UI tracker lists")
+						} else {
+							const nextTrackerName = "Tracker %1".arg(String.fromCharCode(charCode + trackerIndex))
+							setMockValue("/Pv/" + trackerIndex + "/Name", nextTrackerName)
+						}
 					}
 				}
 

--- a/pages/settings/devicelist/rs/PageMultiRs.qml
+++ b/pages/settings/devicelist/rs/PageMultiRs.qml
@@ -247,6 +247,10 @@ Page {
 								return tracker.power
 							}
 						}
+						rowIsVisible: function(row) {
+							const tracker = trackerObjects.objectAt(row)
+							return tracker.enabled
+						}
 
 						Instantiator {
 							id: trackerObjects

--- a/pages/solar/PageSolarCharger.qml
+++ b/pages/solar/PageSolarCharger.qml
@@ -170,6 +170,10 @@ Page {
 						return tracker.power
 					}
 				}
+				rowIsVisible: function(row) {
+					const tracker = trackerObjects.objectAt(row)
+					return tracker.enabled
+				}
 
 				Instantiator {
 					id: trackerObjects

--- a/pages/solar/SolarDevicePage.qml
+++ b/pages/solar/SolarDevicePage.qml
@@ -92,6 +92,10 @@ Page {
 							return tracker.power
 						}
 					}
+					rowIsVisible: function(row) {
+						const tracker = trackerObjects.objectAt(row)
+						return tracker.enabled
+					}
 
 					Instantiator {
 						id: trackerObjects

--- a/pages/solar/SolarInputListPage.qml
+++ b/pages/solar/SolarInputListPage.qml
@@ -84,16 +84,9 @@ Page {
 					}
 					readonly property string formattedName: Global.solarDevices.formatTrackerName(
 							name, index, device.trackerCount, device.name, VenusOS.TrackerName_WithDevicePrefix)
+					property bool initialized
 
-					device: solarDeviceDelegate.device
-					trackerIndex: index
-
-					onTodaysYieldChanged: solarInputModel.setInputValue(device.serviceUid, SolarInputModel.TodaysYieldRole, todaysYield, trackerIndex)
-					onPowerChanged: solarInputModel.setInputValue(device.serviceUid, SolarInputModel.PowerRole, power, trackerIndex)
-					onCurrentChanged: solarInputModel.setInputValue(device.serviceUid, SolarInputModel.CurrentRole, current, trackerIndex)
-					onVoltageChanged: solarInputModel.setInputValue(device.serviceUid, SolarInputModel.VoltageRole, voltage, trackerIndex)
-
-					onFormattedNameChanged: {
+					function addToModel() {
 						const values = {
 							group: "generic",
 							name: formattedName,
@@ -104,10 +97,43 @@ Page {
 						}
 						solarInputModel.addInput(device.serviceUid, values, trackerIndex)
 					}
+
+					function removeFromModel() {
+						const modelIndex = solarInputModel.indexOf(solarDeviceDelegate.device.serviceUid, index)
+						if (modelIndex >= 0) {
+							solarInputModel.removeAt(modelIndex)
+						}
+					}
+
+					function updateModel() {
+						if (initialized) {
+							removeFromModel()
+							if (enabled) {
+								addToModel()
+							}
+						}
+					}
+
+					device: solarDeviceDelegate.device
+					trackerIndex: index
+
+					onTodaysYieldChanged: solarInputModel.setInputValue(device.serviceUid, SolarInputModel.TodaysYieldRole, todaysYield, trackerIndex)
+					onPowerChanged: solarInputModel.setInputValue(device.serviceUid, SolarInputModel.PowerRole, power, trackerIndex)
+					onCurrentChanged: solarInputModel.setInputValue(device.serviceUid, SolarInputModel.CurrentRole, current, trackerIndex)
+					onVoltageChanged: solarInputModel.setInputValue(device.serviceUid, SolarInputModel.VoltageRole, voltage, trackerIndex)
+
+					onFormattedNameChanged: updateModel()
+					onEnabledChanged: updateModel()
 				}
 
+				onObjectAdded: (index, object) => {
+					if (object.enabled) {
+						object.addToModel()
+					}
+					object.initialized = true
+				}
 				onObjectRemoved: (index, object) => {
-					solarInputModel.removeAt(solarInputModel.indexOf(device.serviceUid, object.index))
+					object.removeFromModel()
 				}
 			}
 		}


### PR DESCRIPTION
A solarcharger, multi or inverter service may set /Pv/<x>/Enabled = 0 (where <x> is the solar tracker identifier) to indicate that the solar tracker is disabled. If this is the case, hide the tracker in the UI display.

Ideally QuantityTable would use a filtered model instead of resetting its colours depending on the row count, but that will be fixed in future.

Fixes #2051