### PR TITLE
Replace 'Language' with 'Firmware' in General settings menu item

### DIFF
--- a/pages/SettingsPage.qml
+++ b/pages/SettingsPage.qml
@@ -40,8 +40,8 @@ SwipeViewPage {
 			SettingsListNavigation {
 				//% "General"
 				text: qsTrId("settings_general")
-				//% "Access control, Display, Language, Support"
-				secondaryText: qsTrId("settings_access_control_display_language")
+				//% "Access control, Display, Firmware, Support"
+				secondaryText: qsTrId("settings_access_control_display_firmware")
 				pageSource: "/pages/settings/PageSettingsGeneral.qml"
 				iconSource: "qrc:/images/icon_general_32.png"
 			}


### PR DESCRIPTION
"Firmware" is a commonly-accessed page so it needs to be easy to find. "Language" is not really needed as "Display" already indicates the sub-page is likely to contain language settings.

Fixes #2124