### PR TITLE
Alternator settings: rename "Setup" to "Settings"

### DIFF
--- a/pages/settings/devicelist/dc-in/PageAlternatorModel.qml
+++ b/pages/settings/devicelist/dc-in/PageAlternatorModel.qml
@@ -107,7 +107,7 @@ VisibleItemModel {
 	}
 
 	ListNavigation {
-		text: CommonWords.setup
+		text: CommonWords.settings
 		preferredVisible: setupOutputItem.valid
 		onClicked: {
 			Global.pageManager.pushPage(settingsComponent)


### PR DESCRIPTION
This is consistent with the same setting name in the dcdc settings.

Part of #2026