### PR TITLE
Fix missing fields in vebus Device page

### DIFF
--- a/pages/vebusdevice/PageVeBusDeviceInfo.qml
+++ b/pages/vebusdevice/PageVeBusDeviceInfo.qml
@@ -10,39 +10,30 @@ import QtQuick.Controls.impl as CP
 PageDeviceInfo {
 	id: root
 
-	Component.onCompleted: {
-		settingsListView.model.append(veBusDeviceInfoComponent.createObject(root))
-	}
+	settingsListView.footer: SettingsColumn {
+		width: parent ? parent.width : 0
+		topPadding: spacing
+		preferredVisible: deviceInfoModel.count > 0
 
-	Component {
-		id: veBusDeviceInfoComponent
-		SettingsColumn {
-			width: parent ? parent.width : 0
-			preferredVisible: deviceInfoModel.count > 0
+		Repeater {
+			model: VeBusDeviceInfoModel { id: deviceInfoModel }
 
-			Repeater {
-				model: VeBusDeviceInfoModel { id: deviceInfoModel }
-
-				ListText {
-					text: displayText
-					dataItem.uid: root.bindPrefix + pathSuffix
-				}
+			ListText {
+				text: displayText
+				dataItem.uid: root.bindPrefix + pathSuffix
 			}
+		}
 
-			// TODO: this crashes when running with '--mock'
-			ListNavigation {
-				//% "Serial numbers"
-				text: qsTrId("vebus_device_serial_numbers")
-				onClicked: {
-					Global.pageManager.pushPage("/pages/vebusdevice/PageVeBusSerialNumbers.qml", {
-													//% "Serial numbers"
-													"title": qsTrId("vebus_device_serial_numbers"),
-													"bindPrefix": root.bindPrefix
-												}
-												)
-				}
+		ListNavigation {
+			//% "Serial numbers"
+			text: qsTrId("vebus_device_serial_numbers")
+			onClicked: {
+				Global.pageManager.pushPage("/pages/vebusdevice/PageVeBusSerialNumbers.qml", {
+					//% "Serial numbers"
+					"title": qsTrId("vebus_device_serial_numbers"),
+					"bindPrefix": root.bindPrefix
+				})
 			}
 		}
 	}
-
 }


### PR DESCRIPTION
VisibleItemModel does not have an append() function as expected, unlike ObjectModel that was previously used.

Set the extra vebus-specific info as a footer of the main view instead of appending it to the model.

Fixes #2132