### PR TITLE
Animate negative DC Loads on Overview page

### DIFF
--- a/pages/OverviewPage.qml
+++ b/pages/OverviewPage.qml
@@ -833,11 +833,13 @@ SwipeViewPage {
 				animationEnabled: root.animationEnabled
 
 				// If load power is positive (i.e. consumed energy), energy flows to load.
+				// If load power is negative (i.e. devices generating power but not directly managed by GX), energy flows to battery.
 				animationMode: root.isCurrentPage
-						&& !isNaN(Global.system.dc.power)
-						&& Global.system.dc.power > 0
-						&& Math.abs(Global.system.dc.power) > Theme.geometry_overviewPage_connector_animationPowerThreshold
-							? VenusOS.WidgetConnector_AnimationMode_StartToEnd
+								&& !isNaN(Global.system.dc.power)
+								&& (Math.abs(Global.system.dc.power) > Theme.geometry_overviewPage_connector_animationPowerThreshold)
+							? (Global.system.dc.power > 0
+								? VenusOS.WidgetConnector_AnimationMode_StartToEnd
+								: VenusOS.WidgetConnector_AnimationMode_EndToStart)
 							: VenusOS.WidgetConnector_AnimationMode_NotAnimated
 			}
 		}


### PR DESCRIPTION
There are some systems which include power generating devices connected to the battery, where those devices are not directly managed by the GX (i.e. they are not registered as generators etc).

In these cases, the measured DC Loads can be negative (i.e. the power generating devices are producing more power than is consumed by actual loads), and thus the battery will be being charged.

We therefore should animate negative DC Loads as power flows from the DC Loads widget to the Battery widget.

Contributes to issue #2087