### PR TITLE
Get service name when battery service is used for dbus-tempsensor-relay.

### DIFF
--- a/pages/settings/PageSettingsRelayTempSensors.qml
+++ b/pages/settings/PageSettingsRelayTempSensors.qml
@@ -48,6 +48,8 @@ Page {
 				// is ruuvi_f00f00d00001
 				if (service.indexOf(".temperature.") > -1) {
 					return service.split(".temperature.")[1]
+				} else if (service.indexOf(".battery.") > -1) {
+					return service.split(".battery.")[1]
 				}
 				return ""
 			}


### PR DESCRIPTION
Needed for https://github.com/victronenergy/venus/issues/1448