### PR TITLE
Improve UI text related to cellular modems

### DIFF
--- a/pages/settings/PageSettingsConnectivity.qml
+++ b/pages/settings/PageSettingsConnectivity.qml
@@ -51,8 +51,8 @@ Page {
 			ListNavigation {
 				//% "Mobile Network"
 				text: qsTrId("pagesettingsconnectivity_mobile_network")
-				//% "No GSM modem connected"
-				secondaryText: simStatus.valid ? networkServices.mobileNetworkName : qsTrId("page_settings_no_gsm_modem_connected")
+				//% "No cellular modem connected"
+				secondaryText: simStatus.valid ? networkServices.mobileNetworkName : qsTrId("page_settings_no_cellular_modem_connected")
 				onClicked: Global.pageManager.pushPage("/pages/settings/PageSettingsGsm.qml", {"title": text})
 
 				VeQuickItem {

--- a/pages/settings/PageSettingsGsm.qml
+++ b/pages/settings/PageSettingsGsm.qml
@@ -36,8 +36,8 @@ Page {
 			id: notConnected
 
 			ListItem {
-				//% "No GSM modem connected"
-				text: qsTrId("page_settings_no_gsm_modem_connected")
+				//% "Connect a Victron Energy GX GSM or GX LTE 4G modem to enable mobile network connectivity."
+				text: qsTrId("page_settings_connect_cellular_modem")
 			}
 		}
 


### PR DESCRIPTION
Refer to "cellular modem" rather than "GSM modem" as cellular modems can be based on newer tech rather than GSM (e.g. LTE etc).

Contributes to issue #2147