### PR TITLE
Switch settings: do not show inputs as -1

### DIFF
--- a/pages/settings/devicelist/PageSwitch.qml
+++ b/pages/settings/devicelist/PageSwitch.qml
@@ -64,6 +64,9 @@ Page {
 							QuantityObject { object: output; key: "typeText" }
 						}
 
+						// Do not show invalid outputs (e.g. those configured as inputs)
+						preferredVisible: output.state >= 0
+
 						SwitchableOutput {
 							id: output
 


### PR DESCRIPTION
If an output has an invalid state (e.g. if it is configured as an input) then do not show it in the list of switch outputs.

Fixes #2083