### PR TITLE
Add support for Injected Notifications

### DIFF
--- a/data/Notifications.qml
+++ b/data/Notifications.qml
@@ -44,9 +44,10 @@ QtObject {
 
 		function requestToastForNotification(notif: BaseNotification) {
 
-			// the notification must be active and unAcknowledged at the point of being updated
+			// the notification must be acknowledged: false at the point of being updated
+			// (this is because injected notifications' active is always false)
 			// for a toast to be considered for raising (and preempting existing ones)
-			if (notif.active && !notif.acknowledged) {
+			if (!notif.acknowledged) {
 				toastedNotif.checkAndRemoveExistingToast(notif)
 				if (!toastedNotif.toast) {
 					let createdToast = Global.notificationLayer?.showToastNotification(notif.type, "")


### PR DESCRIPTION
Injected notifications are the result of the following VenusOS issue:
https://github.com/victronenergy/venus/issues/1433
which was though to need Gui-v2 Issue (but actually needs no change)
https://github.com/victronenergy/gui-v2/issues/2073

This PR makes it possible to inject notifications into the existing notification models in addition to those already supported by the /Notifications 0-19 API.
The NotificationsPage shows the "normal" notifications and the injected notifications in the same list, sorted correctly.

Injected notifications also have acknowledged and active properties which can be adjusted at run time which changes the model (NotificationsPage) and any on-screen counters or icon/button indicators, even though these notifications are not backed by any path. 

Injected notifications are created active: true; acknowledged: false by default.
Injected notification can be acknowledged by either clicking on individual items in the NotificationPage list or by pressing the "Silence Alarm" button which performs an acknowledgeAll on both "normal" and "injected" notifications.

Since Injected notifications don't have the concept of becoming inactive (from the /Injected path), the code makes them inactive as soon as they are acknowledged. If this needs to be separated, then the active and acknowledged should be considered to be present in the /Inject string value such that an injected notification could be made active/inactive and acknowledged or unacknowledged from the backend.  If this be the case, it may also be prudent to consider a unique notification identifier in the format also. For now, the implementation is kept very simple.

Toasts are handled for injected notifications like any "normal" notification (including priority pre-emption) hence why #2073 is not needed.

Mock mode is also supported by adding COMMAND (or CTRL) to the existing "N" command as noted in the MockDataSimulator.qml file.

There is no limit on the number of Injected Notifications. They are not deleted until Gui-v2 is stopped.

The implementation is designed to adapt to any further extensions of the string-based /Inject format with little effort.

Fixes #2073