### PR TITLE
Disable key navigation temporarily

### DIFF
--- a/Main.qml
+++ b/Main.qml
@@ -82,25 +82,26 @@ Window {
 		onScaleChanged: Global.scalingRatio = contentItem.scale
 		scale: Math.min(root.width/Theme.geometry_screen_width, root.height/Theme.geometry_screen_height)
 
-		Keys.onPressed: function(event) {
-			// When a navigation key is pressed and it is not handled by an item higher up in the
-			// UI item hierarchy, enable key navigation to allow guiLoader to get focus and receive
-			// key events.
-			if (!Global.keyNavigationEnabled) {
-				switch (event.key) {
-				case Qt.Key_Left:
-				case Qt.Key_Right:
-				case Qt.Key_Up:
-				case Qt.Key_Down:
-				case Qt.Key_Tab:
-				case Qt.Key_Backtab:
-					Global.keyNavigationEnabled = true
-					event.accepted = true
-					return
-				}
-			}
-			event.accepted = false
-		}
+		// #2161 Key nav is disabled for now
+		// Keys.onPressed: function(event) {
+		//     // When a navigation key is pressed and it is not handled by an item higher up in the
+		//     // UI item hierarchy, enable key navigation to allow guiLoader to get focus and receive
+		//     // key events.
+		//     if (!Global.keyNavigationEnabled) {
+		//         switch (event.key) {
+		//         case Qt.Key_Left:
+		//         case Qt.Key_Right:
+		//         case Qt.Key_Up:
+		//         case Qt.Key_Down:
+		//         case Qt.Key_Tab:
+		//         case Qt.Key_Backtab:
+		//             Global.keyNavigationEnabled = true
+		//             event.accepted = true
+		//             return
+		//         }
+		//     }
+		//     event.accepted = false
+		// }
 	}
 
 	Loader {

--- a/components/StatusBar.qml
+++ b/components/StatusBar.qml
@@ -343,6 +343,7 @@ FocusScope {
 	// not focusable. So, find the first available button and focus that instead.
 	Connections {
 		target: Global.main
+		enabled: Global.keyNavigationEnabled
 		function onActiveFocusItemChanged() {
 			if (Global.main.activeFocusItem === root) {
 				for (const button of [leftButton, auxButton, breadcrumbs, alarmButton, rightButton, sleepButton]) {

--- a/components/dialogs/ModalDialog.qml
+++ b/components/dialogs/ModalDialog.qml
@@ -142,7 +142,7 @@ T.Dialog {
 		}
 	}
 
-	footer: FocusScope {
+	footer: Item { // #2161 make this a FocusScope when key nav is re-enabled
 		visible: root.dialogDoneOptions !== VenusOS.ModalDialog_DoneOptions_NoOptions
 		height: visible ? Theme.geometry_modalDialog_footer_height : 0
 		focus: false


### PR DESCRIPTION
This is disabled until the feature details are finalized.

Remove the FocusScope from the ModalDialog footer so that down keys do not focus the OK/Cancel buttons. There are many other cases where KeyNavigation will still allow focus to be moved, but items will not be focusable unless a TextField is focused with a click, or unless the Tab/ShiftTab keys are used to move focus. Even if items are focused, they will not be highlighted.

Fixes #2161