### PR TITLE
Don't display AC Loads gauge or widget if no AC loads exist

### DIFF
--- a/data/System.qml
+++ b/data/System.qml
@@ -13,7 +13,10 @@ QtObject {
 	readonly property int state: _systemState.valid ? _systemState.value : VenusOS.System_State_Off
 
 	readonly property bool hasGridMeter: _gridDeviceType.valid
-	readonly property bool hasAcOutSystem: _hasAcOutSystem.valid && _hasAcOutSystem.value === 1
+	readonly property bool hasAcOutSystem: _hasAcOutSystem.valid && _hasAcOutSystem.value === 1 // i.e. Essential loads
+	readonly property bool hasAcLoads: showInputLoads
+				? (load.acIn !== null && load.acIn !== undefined && !isNaN(load.acIn.power))
+				: (load.ac !== null && load.ac !== undefined && !isNaN(load.ac.power))
 	readonly property bool hasVebusEss: _systemType.value === "ESS" || _systemType.value === "Hub-4"
 	readonly property bool hasEss: hasVebusEss || _systemType.value === "AC System"
 	readonly property bool showInputLoads: load.acIn.hasPower

--- a/pages/OverviewPage.qml
+++ b/pages/OverviewPage.qml
@@ -345,7 +345,10 @@ SwipeViewPage {
 	}
 
 	function _resetRightWidgets() {
-		let widgets = [acLoadsWidget]
+		let widgets = []
+		if (acLoadsWidget.visible) {
+			widgets.push(acLoadsWidget)
+		}
 		if (Global.evChargers.model.count > 0) {
 			widgets.push(_createWidget(VenusOS.OverviewWidget_Type_Evcs))
 		}
@@ -683,6 +686,8 @@ SwipeViewPage {
 	WidgetConnector {
 		id: inverterToAcLoadsConnector
 
+		visible: acLoadsWidget.visible
+
 		startWidget: inverterChargerWidget
 		startLocation: VenusOS.WidgetConnector_Location_Right
 		straighten: _rightWidgets.length === 1 ? VenusOS.WidgetConnector_Straighten_None : VenusOS.WidgetConnector_Straighten_EndToStart
@@ -743,6 +748,10 @@ SwipeViewPage {
 
 	AcLoadsWidget {
 		id: acLoadsWidget
+
+		visible: Global.system.hasAcLoads
+				|| Global.evChargers.model.count > 0
+				|| (Global.system.showInputLoads && Global.system.hasAcOutSystem)
 
 		expanded: root._expandLayout
 		animateGeometry: root._animateGeometry

--- a/pages/boatpage/LoadArc.qml
+++ b/pages/boatpage/LoadArc.qml
@@ -15,8 +15,9 @@ Column {
 	required property MotorDrive motorDrive
 
 	readonly property int _rightGaugeCount: gps.valid && motorDrive.dcConsumption.valid ? 1 // just the motor drive
-											: dcLoadGauge.active ? 2 // both AC & DC
-											: 1  // just AC. The AC load gauge is always active
+											: dcLoadGauge.active && acLoadGauge.active ? 2 // both AC & DC
+											: dcLoadGauge.active || acLoadGauge.active ? 1 // one of AC or DC
+											: 0
 
 	readonly property bool showing3Phases: acLoadGauge.active && Global.system.load.ac.phases.count === 3
 
@@ -47,7 +48,7 @@ Column {
 
 		width: Theme.geometry_briefPage_edgeGauge_width
 		height: active ? Gauges.gaugeHeight(root._rightGaugeCount) : 0
-		active: !motorDriveLoadGauge.active
+		active: !motorDriveLoadGauge.active && Global.system.hasAcLoads
 
 		sourceComponent: SideMultiGauge {
 			readonly property var gaugeParams: Gauges.rightGaugeParameters(0, _rightGaugeCount, phaseModel.count > 1)
@@ -80,7 +81,7 @@ Column {
 		height: active ? Gauges.gaugeHeight(root._rightGaugeCount) : 0
 		active: !motorDriveLoadGauge.active && !isNaN(Global.system.dc.power)
 		sourceComponent: SideGauge {
-			readonly property var gaugeParams: Gauges.rightGaugeParameters(1, _rightGaugeCount,)
+			readonly property var gaugeParams: Gauges.rightGaugeParameters(acLoadGauge.active ? 1 : 0, _rightGaugeCount, false)
 			// DC load gauge progresses in counter-clockwise direction (i.e. upwards).
 			direction: PathArc.Counterclockwise
 			startAngle: gaugeParams.end


### PR DESCRIPTION
Affects both the Boat Page and the Overview Page.

Contributes to issue #2159