### PR TITLE
Boat page: always show AC load quantity label

### DIFF
--- a/pages/boatpage/ConsumptionGauge.qml
+++ b/pages/boatpage/ConsumptionGauge.qml
@@ -46,7 +46,7 @@ Column {
 		unit: Global.systemSettings.electricalQuantity
 		icon.source: "qrc:/images/acloads.svg"
 		icon.width: Theme.geometry_widgetHeader_icon_size
-		visible: !motorDriveLoad.visible && !isNaN(value)
+		visible: !motorDriveLoad.visible // && !isNaN(value) once #2159 is resolved
 	}
 
 	QuantityLabelIconRow {


### PR DESCRIPTION
Until #2159 is resolved, we should always show the AC load quantity label, even if the value is NaN (in that case, show "--" as the value), otherwise the gauge will be drawn but with no hint as to what the gauge is displaying.

Contributes to issue #2184