### PR TITLE
Fix resetCounter for PulseMeter inputs (excluding GX I/O Ext)

### DIFF
--- a/pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml
+++ b/pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml
@@ -33,12 +33,19 @@ Page {
 			ListButton {
 				//% "Reset counter"
 				text: qsTrId("pulsecounter_setup_reset_counter")
-				secondaryText: itemCount.value || 0
-				onClicked: itemCount.setValue(0)
+				secondaryText: itemCount_readonly.value || 0
+				onClicked: itemCount_internal.setValue(0)
+				interactive: itemCount_internal.valid
 
 				VeQuickItem {
-					id: itemCount
+					id: itemCount_readonly
 					uid: root.bindPrefix + "/Count"
+				}
+
+				// Not valid for GX I/O Extender paths, see #2139
+				VeQuickItem {
+					id: itemCount_internal
+					uid: Global.systemSettings.serviceUid + "/Settings/DigitalInput/" + root.inputNumber + "/Count"
 				}
 			}
 		}


### PR DESCRIPTION
Write to the system settings prefixed input specific /Count path, instead of the pulse meter path.

Note that this does not work for inputs from the GX I/O extender, as the path includes a serial number and not just an input number (see #2139 for more details).  In future, the /Count path should be added to the proxied settings paths, to resolve this.

Contributes to issue #2189