### PR TITLE
Fix resetCounter for PulseMeter inputs

### DIFF
--- a/pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml
+++ b/pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml
@@ -33,12 +33,31 @@ Page {
 			ListButton {
 				//% "Reset counter"
 				text: qsTrId("pulsecounter_setup_reset_counter")
-				secondaryText: itemCount.value || 0
+				secondaryText: itemCount_readonly.value || 0
 				onClicked: itemCount.setValue(0)
+				interactive: itemCount.valid
+
+				VeQuickItem {
+					id: itemCount_readonly
+					uid: root.bindPrefix + "/Count"
+				}
 
 				VeQuickItem {
 					id: itemCount
-					uid: root.bindPrefix + "/Count"
+					uid: Global.systemSettings.serviceUid + "/Settings/DigitalInput/"
+						+ (mgmtConnection.ioextId.length > 0 ? mgmtConnection.ioextId : root.inputNumber)
+						+ "/Count"
+				}
+
+				// Determine settings prefix for GX I/O Extender paths, see #2139
+				VeQuickItem {
+					id: mgmtConnection
+					uid: root.bindPrefix + "/Mgmt/Connection"
+					readonly property string inputPath: mgmtConnection.valid ? mgmtConnection.value : ""
+					readonly property string ioextPrefix: "/run/io-ext/"
+					readonly property string ioextId: (inputPath.length > 0 && inputPath.indexOf(ioextPrefix) >= 0)
+						? inputPath.substring(ioextPrefix.length).replace("/", "_")
+						: ""
 				}
 			}
 		}


### PR DESCRIPTION
Write to the system settings prefixed input specific /Count path, instead of the pulse meter path.

In future, the /Count path could be added to the proxied settings paths, to simplify this (see issue #2139).

Contributes to issue #2189