### PR TITLE
Show quantity number even when unit is Units_None

### DIFF
--- a/data/mock/BatteriesImpl.qml
+++ b/data/mock/BatteriesImpl.qml
@@ -102,6 +102,10 @@ QtObject {
 			"/TimeToGo": (24 * 60 * 60) + 190 * 60, // 1d 3h 10m
 			"/Settings/HasSettings": 1,
 			"/Settings/Battery/PeukertExponent": 1.03999999,
+			"/System/MinTemperatureCellId": 201,
+			"/System/MinCellTemperature": 14.5,
+			"/System/NrOfModulesBlockingCharge": 20,
+			"/System/NrOfModulesBlockingDischarge": 21,
 		}
 		for (var propName in props) {
 			Global.mockDataSimulator.setMockValue(battery.serviceUid + propName, props[propName])

--- a/pages/settings/devicelist/battery/PageBatteryDetails.qml
+++ b/pages/settings/devicelist/battery/PageBatteryDetails.qml
@@ -25,7 +25,7 @@ Page {
 				//% "Lowest cell voltage"
 				text: qsTrId("batterydetails_lowest_cell_voltage")
 				model: QuantityObjectModel {
-					QuantityObject { object: details.minVoltageCellId }
+					QuantityObject { object: details.minVoltageCellId; precision: details.minVoltageCellId.decimals }
 					QuantityObject { object: details.minCellVoltage; unit: VenusOS.Units_Volt_DC; precision: 3 }
 				}
 				preferredVisible: details.allowsLowestCellVoltage
@@ -35,7 +35,7 @@ Page {
 				//% "Highest cell voltage"
 				text: qsTrId("batterydetails_highest_cell_voltage")
 				model: QuantityObjectModel {
-					QuantityObject { object: details.maxVoltageCellId }
+					QuantityObject { object: details.maxVoltageCellId; precision: details.maxVoltageCellId.decimals }
 					QuantityObject { object: details.maxCellVoltage; unit: VenusOS.Units_Volt_DC; precision: 3 }
 				}
 				preferredVisible: details.allowsHighestCellVoltage
@@ -45,7 +45,7 @@ Page {
 				//% "Minimum cell temperature"
 				text: qsTrId("batterydetails_minimum_cell_temperature")
 				model: QuantityObjectModel {
-					QuantityObject { object: details.minTemperatureCellId }
+					QuantityObject { object: details.minTemperatureCellId; precision: details.minTemperatureCellId.decimals }
 					QuantityObject { object: temperatureData; key: "minCellTemperature"; unit: Global.systemSettings.temperatureUnit }
 				}
 				preferredVisible: details.allowsMinimumCellTemperature
@@ -55,7 +55,7 @@ Page {
 				//% "Maximum cell temperature"
 				text: qsTrId("batterydetails_maximum_cell_temperature")
 				model: QuantityObjectModel {
-					QuantityObject { object: details.maxTemperatureCellId }
+					QuantityObject { object: details.maxTemperatureCellId; precision: details.maxTemperatureCellId.decimals }
 					QuantityObject { object: temperatureData; key: "maxCellTemperature"; unit: Global.systemSettings.temperatureUnit }
 				}
 				preferredVisible: details.allowsMaximumCellTemperature
@@ -85,8 +85,8 @@ Page {
 				//% "Number of modules blocking charge / discharge"
 				text: qsTrId("batterydetails_number_of_modules_blocking_charge_discharge")
 				model: QuantityObjectModel {
-					QuantityObject { object: details.nrOfModulesBlockingCharge }
-					QuantityObject { object: details.nrOfModulesBlockingDischarge }
+					QuantityObject { object: details.nrOfModulesBlockingCharge; precision: details.nrOfModulesBlockingCharge.decimals }
+					QuantityObject { object: details.nrOfModulesBlockingDischarge; precision: details.nrOfModulesBlockingDischarge.decimals }
 				}
 				preferredVisible: details.allowsNumberOfModulesBlockingChargeDischarge
 			}

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -130,6 +130,8 @@ int Units::defaultUnitPrecision(VenusOS::Enums::Units_Type unit) const
 QString Units::defaultUnitString(VenusOS::Enums::Units_Type unit, int formatHints) const
 {
 	switch (unit) {
+	case VenusOS::Enums::Units_None:
+		return QString();
 	case VenusOS::Enums::Units_Watt:
 		return QStringLiteral("W");
 	case VenusOS::Enums::Units_Volt_AC: // fall through
@@ -268,14 +270,6 @@ quantityInfo Units::getDisplayTextWithHysteresis(VenusOS::Enums::Units_Type unit
 	qreal unitMatchValue,
 	int formatHints) const
 {
-	// unit unknown
-	if (unit == VenusOS::Enums::Units_None) {
-		//qWarning() << "getDisplayText(): unknown unit " << unit << " with value " << value;
-		quantityInfo qty;
-		qty.number = QStringLiteral("--");
-		return qty;
-	}
-
 	// value unknown
 	if (qIsNaN(value)) {
 		quantityInfo qty;

--- a/tests/units/tst_units.qml
+++ b/tests/units/tst_units.qml
@@ -291,4 +291,10 @@ TestCase {
 		quantity = Units.getDisplayText(unit, 1.9612345, 4)
 		compare(quantity.number, "1.9612")
 	}
+
+	function test_unitNone() {
+		expect(VenusOS.Units_None, NaN, "--", "")
+		expect(VenusOS.Units_None, 123, "123", "")
+		expect(VenusOS.Units_None, 12345678, "12345678", "")
+	}
 }


### PR DESCRIPTION
It is valid for a number value to not have a unit (i.e. unit is Units_None). In this case, show the number without a unit suffix, instead of showing "--".

This bug was causing "--" to be shown on the battery details page under "Number of modules blocking charge / discharge", instead of showing the number value.

Also, set the decimals for the QuantityObject so that the number is not shown with unnecessary decimals. Do this for the cell id values in PageBatteryDetails.qml as well.

Fixes #2208