### PR TITLE
Device List: use custom name for GPS devices if available

### DIFF
--- a/pages/settings/PageGps.qml
+++ b/pages/settings/PageGps.qml
@@ -34,6 +34,13 @@ Page {
 		}
 	}
 
+	title: device.name
+
+	Device {
+		id: device
+		serviceUid: root.bindPrefix
+	}
+
 	GradientListView {
 		model: VisibleItemModel {
 			ListText {

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_gps.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_gps.qml
@@ -9,11 +9,9 @@ import Victron.VenusOS
 DeviceListDelegate {
 	id: root
 
-	text: productName.valid ? productName.value : "--"
-
 	onClicked: {
 		Global.pageManager.pushPage("/pages/settings/PageGps.qml",
-									{"title": text, bindPrefix: root.device.serviceUid })
+									{ bindPrefix: root.device.serviceUid })
 	}
 
 	VeQuickItem {


### PR DESCRIPTION
In DeviceListDelegate_gps, remove the text customization and use the default device.name value, which refers to the custom name if it is available.

Also set the device page title dynamically, so that the title is updated if the custom name of the device is changed.

Fixes #2213