### PR TITLE
Rework QuantityTable and QuantityTableSummary to use QuantityRow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,12 +236,12 @@ set (VENUS_QML_MODULE_SOURCES
     components/PageStack.qml
     components/VeQuickItemsQuotient.qml
     components/ProgressArc.qml
-    components/QuantityTableMetrics.qml
     components/QuantityGroupListHeader.qml
     components/QuantityLabel.qml
     components/QuantityRow.qml
-    components/QuantityTableSummary.qml
     components/QuantityTable.qml
+    components/QuantityTableMetrics.qml
+    components/QuantityTableSummary.qml
     components/RadioButtonListPage.qml
     components/RsSystemAcIODisplay.qml
     components/SolarDeviceModel.qml

--- a/components/QuantityGroupListHeader.qml
+++ b/components/QuantityGroupListHeader.qml
@@ -6,53 +6,56 @@
 import QtQuick
 import Victron.VenusOS
 
-Item {
-	property alias firstColumnText: firstTitleLabel.text
-	property alias quantityTitleModel: titleRepeater.model
+Row {
+	id: root
 
-	width: parent.width
-	height: Theme.geometry_listItem_height
+	property alias headerText: firstTitleLabel.text
+	property alias model: titleRepeater.model
+	property int fontSize: Theme.font_size_caption
+	readonly property int columnCount: titleRepeater.count + 1 // +1 for header column
+
+	// Column sizing parameters
+	property int metricsFontSize: fontSize // the QuantityTableMetrics font size, for calculating column size
+	property real fixedColumnWidth: NaN // if set, use this for column widths, instead of QuantityTableMetrics
+
+	height: Theme.geometry_quantityTable_row_height
+	leftPadding: Theme.geometry_listItem_content_horizontalMargin
+	rightPadding: Theme.geometry_listItem_content_horizontalMargin
+	spacing: Theme.geometry_quantityGroupRow_spacing
 
 	Label {
 		id: firstTitleLabel
-		anchors {
-			bottom: parent.bottom
-			bottomMargin: Theme.geometry_quantityTableSummary_verticalMargin
-		}
-		leftPadding: Theme.geometry_listItem_content_horizontalMargin
-		font.pixelSize: Theme.font_size_caption
+		anchors.verticalCenter: parent.verticalCenter
+		font.pixelSize: root.fontSize
 		color: Theme.color_solarListPage_header_text
 		elide: Text.ElideRight
-		width: parent.width - quantityRow.width - Theme.geometry_quantityGroupRow_spacing
+		width: isNaN(root.fixedColumnWidth)
+			   ? parent.width - parent.leftPadding - parent.rightPadding - quantityRow.width - root.spacing
+			   : root.fixedColumnWidth
 	}
 
 	Row {
 		id: quantityRow
 
-		anchors {
-			bottom: parent.bottom
-			bottomMargin: Theme.geometry_quantityTableSummary_verticalMargin
-			right: parent.right
-			rightMargin: Theme.geometry_listItem_content_horizontalMargin + Theme.geometry_icon_size_medium
-		}
-		width: Theme.geometry_solarListPage_quantityRow_width
+		anchors.verticalCenter: parent.verticalCenter
+		spacing: root.spacing
 
 		Repeater {
 			id: titleRepeater
 
 			delegate: Label {
-				width: quantityMetrics.columnWidth(modelData.unit)
+				width: isNaN(root.fixedColumnWidth)
+					   ? quantityMetrics.columnWidth(modelData.unit, implicitWidth)
+					   : root.fixedColumnWidth
 				text: modelData.text
-				font.pixelSize: Theme.font_size_caption
+				font.pixelSize: root.fontSize
 				color: Theme.color_solarListPage_header_text
 			}
 		}
 
 		QuantityTableMetrics {
 			id: quantityMetrics
-			count: titleRepeater.count
-			availableWidth: quantityRow.width
-			spacing: Theme.geometry_quantityGroupRow_spacing
+			font.pixelSize: root.metricsFontSize
 		}
 	}
 }

--- a/components/QuantityTableMetrics.qml
+++ b/components/QuantityTableMetrics.qml
@@ -6,36 +6,25 @@
 import QtQuick
 import Victron.VenusOS
 
+/*
+	Provides a standardized width for a table column that shows a quantity.
+
+	The width is adjusted depending on the font size and the quantity unit.
+*/
 FontMetrics {
-	property bool smallTextMode
-	property real availableWidth
-	property bool equalWidthColumns
-	property int count
-	property int spacing: Theme.geometry_quantityTable_horizontalSpacing
-
-	// If specified, allows for a custom column width for the 'Units_None' column.
-	// Eg. label columns with cells like "L1", "L2" can be thinner to allow wider columns elsewhere.
-	property int firstColumnWidth
-
-	font.family: Global.fontFamily
-	font.pixelSize: smallTextMode ? Theme.font_size_body2 : Theme.font_size_body3
-
-	function columnWidth(unit) {
-		if (!!firstColumnWidth) {
-			if (unit === VenusOS.Units_None) {
-				return firstColumnWidth
-			}
-			return (availableWidth - firstColumnWidth) / (count - 1)
-		}
-
-		if (equalWidthColumns) {
-			return availableWidth / count
+	function columnWidth(unit, defaultValue) {
+		if (unit === VenusOS.Units_None) {
+			return defaultValue
 		}
 
 		// Give the unit symbol some extra space on the column.
-		const maxTextWidth = unit === VenusOS.Units_Energy_KiloWattHour
-						   ? advanceWidth("9999kWH")
-						   : advanceWidth("9999W")
-		return maxTextWidth + spacing
+		// Due to QTBUG-124588, use tightBoundingRect() instead of advanceWidth().
+		const maxTextRect = unit === VenusOS.Units_Energy_KiloWattHour
+				? tightBoundingRect("99.99kWH")
+				: tightBoundingRect("99.99W")
+		return maxTextRect.width + maxTextRect.x
 	}
+
+	font.family: Global.fontFamily
+	font.pixelSize: Theme.font_size_body3
 }

--- a/components/QuantityTableSummary.qml
+++ b/components/QuantityTableSummary.qml
@@ -6,136 +6,34 @@
 import QtQuick
 import Victron.VenusOS
 
-Row {
+/*
+	A table with a header and a single row.
+
+	This is typically used to show a summary (e.g. the total power and energy) of another table.
+*/
+QuantityTable {
 	id: root
 
-	property var model: []
-	property alias metrics: quantityMetrics
+	property string summaryHeaderText
+	property string bodyHeaderText
+	property var summaryModel
+	property QuantityObjectModel bodyModel
 
-	QuantityTableMetrics {
-		id: quantityMetrics
+	bodyFontSize: Theme.font_size_body3
+	model: 1
+	topMargin: Theme.geometry_quantityTableSummary_verticalMargin
+	bottomMargin: Theme.geometry_quantityTableSummary_verticalMargin
 
-		count: model.length
-		availableWidth: root.width - root.leftPadding
+	header: QuantityTable.TableHeader {
+		headerText: root.summaryHeaderText
+		model: root.summaryModel
 	}
 
-	width: parent ? parent.width : 0
-	height: quantityRow.height + (2 * Theme.geometry_quantityTableSummary_verticalMargin)
-	// Omit the right padding to give the table a little more space.
-	leftPadding: Theme.geometry_listItem_content_horizontalMargin
-
-	Item {
-		id: firstColumn
-
-		anchors.verticalCenter: parent.verticalCenter
-		width: root.width - quantityRow.width - x
-		height: firstColumnSubLabel.y + firstColumnSubLabel.height
-
-		Label {
-			id: firstColumnTitleLabel
-
-			width: parent.width
-			elide: Text.ElideRight
-			rightPadding: Theme.geometry_listItem_content_spacing
-			font.pixelSize: Theme.font_size_caption
-			text: root.model[0].title
-			color: Theme.color_quantityTable_quantityValue
-		}
-
-		Label {
-			id: firstColumnSubLabel
-
-			anchors {
-				top: firstColumnTitleLabel.bottom
-				topMargin: Theme.geometry_quantityTableSummary_verticalSpacing
-			}
-			width: parent.width
-			elide: Text.ElideRight
-			rightPadding: Theme.geometry_listItem_content_spacing
-			font.pixelSize: metrics.smallTextMode ? Theme.font_size_body2 : Theme.font_size_body3
-			text: root.model[0].text
-			color: firstColumnTitleLabel.text ? Theme.color_font_primary : Theme.color_quantityTable_quantityValue
-			opacity: firstColumnTitleLabel.text.length ? 1 : 0
-		}
-
-		// When there is no title for the first column, this larger sub label is shown. Adding this
-		// label (instead of just changing firstColumnSubLabel's font size) allows the text baseline
-		// to be correctly aligned.
-		Label {
-			anchors.baseline: firstColumnSubLabel.baseline
-			width: parent.width
-			elide: Text.ElideRight
-			rightPadding: Theme.geometry_listItem_content_spacing
-			font.pixelSize: Theme.font_size_h1
-			text: firstColumnSubLabel.text
-			color: firstColumnSubLabel.color
-			opacity: firstColumnTitleLabel.text.length ? 0 : 1
-		}
-	}
-
-	Row {
-		id: quantityRow
-
-		anchors.verticalCenter: parent.verticalCenter
-
-		Repeater {
-			id: quantityRepeater
-
-			model: root.model.length - 1
-
-			delegate: Column {
-				width: metrics.columnWidth(root.model[model.index + 1].unit)
-				spacing: Theme.geometry_quantityTableSummary_verticalSpacing
-
-				Label {
-					width: parent.width
-					elide: Text.ElideRight
-					font.pixelSize: Theme.font_size_caption
-					text: root.model[model.index + 1].title
-					color: Theme.color_quantityTable_quantityValue
-					fontSizeMode: Text.HorizontalFit
-				}
-
-				Loader {
-					width: parent.width
-					sourceComponent: root.model[model.index + 1].text !== undefined ? textValueComponent : quantityValueComponent
-
-					Component {
-						id: textValueComponent
-
-						Row {
-							width: parent.width
-							spacing: Theme.geometry_quantityLabel_spacing
-
-							Label {
-								font.pixelSize: firstColumnSubLabel.font.pixelSize
-								text: root.model[model.index + 1].text
-							}
-
-							Label {
-								font.pixelSize: firstColumnSubLabel.font.pixelSize
-								text: root.model[model.index + 1].secondaryText
-								color: Theme.color_font_secondary
-							}
-						}
-					}
-
-					Component {
-						id: quantityValueComponent
-
-						QuantityLabel {
-							width: parent.width
-							height: firstColumnSubLabel.height  // align QuantityLabel with other labels
-							alignment: Qt.AlignLeft
-							font.pixelSize: firstColumnSubLabel.font.pixelSize
-							value: root.model[model.index + 1].value
-							unit: root.model[model.index + 1].unit
-							precision: root.model[model.index + 1].precision || VenusOS.Units_Precision_Default
-							visible: unit !== VenusOS.Units_None
-						}
-					}
-				}
-			}
-		}
+	delegate: QuantityTable.TableRow {
+		color: "transparent"
+		headerText: root.bodyHeaderText
+		headerColor: root.summaryHeaderText.length > 0 ? Theme.color_font_primary : Theme.color_quantityTable_quantityValue
+		model: root.bodyModel
+		valueColor: Theme.color_font_primary
 	}
 }

--- a/components/ThreePhaseIOTable.qml
+++ b/components/ThreePhaseIOTable.qml
@@ -29,7 +29,7 @@ BaseListItem {
 			id: inputTable
 			width: (parent.width - parent.spacing) / 2
 			labelText: CommonWords.ac_in
-			rowCount: root.phaseCount
+			model: root.phaseCount
 			voltPrecision: root.voltPrecision
 		}
 
@@ -37,7 +37,7 @@ BaseListItem {
 			id: outputTable
 			width: (parent.width - parent.spacing) / 2
 			labelText: CommonWords.ac_out
-			rowCount: root.phaseCount
+			model: root.phaseCount
 			voltPrecision: root.voltPrecision
 		}
 	}

--- a/components/ThreePhaseQuantityTable.qml
+++ b/components/ThreePhaseQuantityTable.qml
@@ -14,38 +14,8 @@ QuantityTable {
 	property string labelText
 	property int voltPrecision: Units.defaultUnitPrecision(VenusOS.Units_Volt_AC)
 
-	valueForModelIndex: function(phaseIndex, column) {
-		if (column === 0) {
-			return "L%1".arg(phaseIndex + 1)
-		}
-
-		const phase = phases.objectAt(phaseIndex)
-		if (phase) {
-			switch(column) {
-			case 1:
-				return phase.power
-			case 2:
-				return phase.voltage
-			case 3:
-				return phase.current
-			case 4:
-				return phase.frequency
-			}
-		}
-		return NaN
-	}
-
-	metrics.availableWidth: width - 2*Theme.geometry_listItem_content_horizontalMargin
-	metrics.firstColumnWidth: Theme.geometry_vebusDeviceListPage_quantityTable_firstColumn_width
-	units: [
-		{ unit: VenusOS.Units_None },
-		{ unit: VenusOS.Units_Watt },
-		{ unit: VenusOS.Units_Volt_AC, precision: root.voltPrecision },
-		{ unit: VenusOS.Units_Amp },
-		{ unit: VenusOS.Units_Hertz }
-	]
-	labelHorizontalAlignment: Qt.AlignRight
-	headerComponent: AsymmetricRoundedRectangle {
+	columnSpacing: Theme.geometry_quantityTable_horizontalSpacing_small
+	header: AsymmetricRoundedRectangle {
 		layer.enabled: false // if 'layer.enabled' is true, any child text looks rough on wasm builds
 		width: root.width
 		height: Theme.geometry_vebusDeviceListPage_quantityTable_header_height
@@ -87,12 +57,19 @@ QuantityTable {
 		}
 	}
 
-	Instantiator {
-		id: phases
-		model: root.rowCount
-		delegate: AcPhase {
-			required property int index
-			serviceUid: root.phaseUidPrefix.length ? root.phaseUidPrefix + "/L" + (index + 1) : ""
+	delegate: QuantityTable.TableRow {
+		headerText: `L${index + 1}`
+		labelAlignment: Qt.AlignRight
+		model: QuantityObjectModel {
+			QuantityObject { object: phase; key: "power"; unit: VenusOS.Units_Watt }
+			QuantityObject { object: phase; key: "voltage"; unit: VenusOS.Units_Volt_AC; precision: root.voltPrecision }
+			QuantityObject { object: phase; key: "current"; unit: VenusOS.Units_Amp }
+			QuantityObject { object: phase; key: "frequency"; unit: VenusOS.Units_Hertz }
+		}
+
+		AcPhase {
+			id: phase
+			serviceUid: root.phaseUidPrefix.length ? `${root.phaseUidPrefix}/L${index + 1}` : ""
 		}
 	}
 

--- a/components/dialogs/SolarDailyHistoryDialog.qml
+++ b/components/dialogs/SolarDailyHistoryDialog.qml
@@ -49,9 +49,7 @@ T.Dialog {
 
 	anchors.centerIn: parent
 	implicitWidth: background.implicitWidth
-	implicitHeight: Theme.geometry_solarDailyHistoryDialog_header_height
-					+ tableView.height
-					+ (errorView.visible ? errorView.collapsedHeight + Theme.geometry_solarDetailBox_verticalMargin : 0)
+	implicitHeight: background.implicitHeight
 	verticalPadding: 0
 	horizontalPadding: 0
 	modal: true
@@ -83,7 +81,7 @@ T.Dialog {
 		implicitWidth: Theme.geometry_modalDialog_width
 		implicitHeight: Theme.geometry_solarDailyHistoryDialog_header_height
 					+ tableView.height
-					+ (errorView.visible ? errorView.collapsedHeight + Theme.geometry_solarDetailBox_verticalMargin : 0)
+					+ (errorView.enabled ? errorView.collapsedHeight + Theme.geometry_solarDetailBox_verticalMargin : 0)
 		radius: Theme.geometry_modalDialog_radius
 		color: Theme.color_background_secondary
 
@@ -193,7 +191,8 @@ T.Dialog {
 				const history = root.solarHistory.dailyHistory(root.day)
 				return history ? history.errorModel : null
 			}
-			visible: model && model.count > 0
+			enabled: model?.count > 0
+			visible: enabled
 		}
 	}
 }

--- a/components/widgets/AcWidget.qml
+++ b/components/widgets/AcWidget.qml
@@ -98,7 +98,10 @@ OverviewWidget {
 				id: deviceListView
 
 				header: QuantityGroupListHeader {
-					quantityTitleModel: [
+					width: parent.width
+					metricsFontSize: Theme.font_size_body2 // align columns with those in the delegate
+					rightPadding: Theme.geometry_listItem_content_horizontalMargin + Theme.geometry_icon_size_medium
+					model: [
 						{ text: CommonWords.power_watts, unit: VenusOS.Units_Watt },
 					]
 				}

--- a/components/widgets/DcInputWidget.qml
+++ b/components/widgets/DcInputWidget.qml
@@ -67,7 +67,10 @@ OverviewWidget {
 
 			GradientListView {
 				header: QuantityGroupListHeader {
-					quantityTitleModel: [
+					width: parent.width
+					metricsFontSize: Theme.font_size_body2 // align columns with those in the delegate
+					rightPadding: Theme.geometry_listItem_content_horizontalMargin + Theme.geometry_icon_size_medium
+					model: [
 						{ text: CommonWords.voltage, unit: VenusOS.Units_Volt_DC },
 						{ text: CommonWords.current_amps, unit: VenusOS.Units_Amp },
 						{ text: CommonWords.power_watts, unit: VenusOS.Units_Watt },

--- a/data/common/PvInverter.qml
+++ b/data/common/PvInverter.qml
@@ -24,10 +24,6 @@ Device {
 			phaseCount = Math.max(count, maxPhaseCount)
 		}
 
-		function getPhase(index) {
-			return _phases.objectAt(index)
-		}
-
 		readonly property Instantiator _phases: Instantiator {
 			model: 3
 			delegate: QtObject {

--- a/pages/evcs/EvChargerListPage.qml
+++ b/pages/evcs/EvChargerListPage.qml
@@ -26,24 +26,17 @@ Page {
 				QuantityTableSummary {
 					id: summary
 
-					width: parent.width - Theme.geometry_listItem_content_horizontalMargin
-					model: [
-						{
-							title: "",
-							text: CommonWords.total,
-							unit: VenusOS.Units_None
-						},
-						{
-							title: CommonWords.power_watts,
-							value: Global.evChargers.power,
-							unit: VenusOS.Units_Watt
-						},
-						{
-							title: CommonWords.energy,
-							value: Global.evChargers.energy,
-							unit: VenusOS.Units_Energy_KiloWattHour
-						}
+					width: parent.width
+					rightPadding: Theme.geometry_listItem_content_horizontalMargin + Theme.geometry_icon_size_medium
+					summaryModel: [
+						{ text: CommonWords.power_watts, unit: VenusOS.Units_Watt },
+						{ text: CommonWords.energy, unit: VenusOS.Units_Energy_KiloWattHour },
 					]
+					bodyHeaderText: CommonWords.total
+					bodyModel: QuantityObjectModel {
+						QuantityObject { object: Global.evChargers; key: "power"; unit: VenusOS.Units_Watt }
+						QuantityObject { object: Global.evChargers; key: "energy"; unit: VenusOS.Units_Energy_KiloWattHour }
+					}
 				}
 			}
 		}

--- a/pages/settings/debug/PagePowerDebug.qml
+++ b/pages/settings/debug/PagePowerDebug.qml
@@ -83,33 +83,37 @@ Page {
 			id: validModel
 
 			QuantityTable {
-				rowCount: 3
-				units: [
-					{ title: "Name", unit: VenusOS.Units_None },
-					{ title: "AC Out", unit: VenusOS.Units_Watt },
-					{ title: "AC Out", unit: VenusOS.Units_VoltAmpere },
-					{ title: "Qwacs", unit: VenusOS.Units_Watt },
-					{ title: "Qwacs", unit: VenusOS.Units_VoltAmpere },
-					{ title: "Sensors", unit: VenusOS.Units_Watt },
-					{ title: "Diff", unit: VenusOS.Units_Watt },
-				]
-				valueForModelIndex: function(phaseIndex, column) {
-					const phaseName = `L${phaseIndex + 1}`
-					switch (column) {
-					case 0:
-						return phaseName
-					case 1:
-						return acOut[`power${phaseName}`].value ?? NaN
-					case 2:
-						return acOut[`apparent${phaseName}`].value ?? NaN
-					case 3:
-						return qwacsPvInverter[`power${phaseName}`].value ?? NaN
-					case 4:
-						return qwacsPvInverter[`apparent${phaseName}`].value ?? NaN
-					case 5:
-						return sensorPvInverter[`power${phaseName}`].value ?? NaN
-					case 6:
-						return diffs[`power${phaseName}`]
+				id: quantityTable
+
+				width: parent?.width ?? 0
+				model: 3
+				columnSpacing: Theme.geometry_quantityTable_horizontalSpacing_small
+				equalWidthColumns: true
+
+				header: QuantityTable.TableHeader {
+					headerText: "Name"
+					model: [
+						{ text: "AC Out", unit: VenusOS.Units_Watt },
+						{ text: "AC Out", unit: VenusOS.Units_VoltAmpere },
+						{ text: "Qwacs", unit: VenusOS.Units_Watt },
+						{ text: "Qwacs", unit: VenusOS.Units_VoltAmpere },
+						{ text: "Sensors", unit: VenusOS.Units_Watt },
+						{ text: "Diff", unit: VenusOS.Units_Watt },
+					]
+				}
+				delegate: QuantityTable.TableRow {
+					id: tableRow
+					headerText: `L${index + 1}`
+					model: QuantityObjectModel {
+						id: rowModel
+						readonly property string phaseName: `L${tableRow.index + 1}`
+
+						QuantityObject { object: acOut; key: `power${rowModel.phaseName}`; unit: VenusOS.Units_Watt }
+						QuantityObject { object: acOut; key: `apparent${rowModel.phaseName}`; unit: VenusOS.Units_VoltAmpere }
+						QuantityObject { object: qwacsPvInverter; key: `power${rowModel.phaseName}`; unit: VenusOS.Units_Watt }
+						QuantityObject { object: qwacsPvInverter; key: `apparent${rowModel.phaseName}`; unit: VenusOS.Units_VoltAmpere }
+						QuantityObject { object: sensorPvInverter; key: `power${rowModel.phaseName}`; unit: VenusOS.Units_Watt }
+						QuantityObject { object: diffs; key: `power${rowModel.phaseName}`; unit: VenusOS.Units_Watt }
 					}
 				}
 			}

--- a/pages/settings/devicelist/rs/PageMultiRs.qml
+++ b/pages/settings/devicelist/rs/PageMultiRs.qml
@@ -225,41 +225,24 @@ Page {
 
 				bottomContentChildren: [
 					QuantityTable {
-						headerVisible: false
-						rowCount: root.trackerCount
-						units: [
-							{ unit: VenusOS.Units_None },
-							{ unit: VenusOS.Units_Volt_DC },
-							{ unit: VenusOS.Units_Amp },
-							{ unit: VenusOS.Units_Watt },
-						]
-						valueForModelIndex: function(trackerIndex, column) {
-							const tracker = trackerObjects.objectAt(trackerIndex)
-							if (column === 0) {
-								return Global.solarDevices.formatTrackerName(tracker.name,
-										trackerIndex, root.trackerCount, root.title,
-										VenusOS.TrackerName_NoDevicePrefix)
-							} else if (column === 1) {
-								return tracker.voltage
-							} else if (column === 2) {
-								return tracker.current
-							} else if (column === 3) {
-								return tracker.power
+						width: parent.width
+						model: root.trackerCount
+						delegate: QuantityTable.TableRow {
+							id: tableRow
+							preferredVisible: tracker.enabled
+							headerText: Global.solarDevices.formatTrackerName(
+									  tracker.name, index, root.trackerCount, root.title,
+									  VenusOS.TrackerName_NoDevicePrefix)
+							model: QuantityObjectModel {
+								QuantityObject { object: tracker; key: "voltage"; unit: VenusOS.Units_Volt_DC }
+								QuantityObject { object: tracker; key: "current"; unit: VenusOS.Units_Amp }
+								QuantityObject { object: tracker; key: "power"; unit: VenusOS.Units_Watt }
 							}
-						}
-						rowIsVisible: function(row) {
-							const tracker = trackerObjects.objectAt(row)
-							return tracker.enabled
-						}
 
-						Instantiator {
-							id: trackerObjects
-							model: root.trackerCount
-							delegate: SolarTracker {
-								required property int index
-
+							SolarTracker {
+								id: tracker
 								device: root.solarDevice
-								trackerIndex: index
+								trackerIndex: tableRow.index
 							}
 						}
 					}

--- a/pages/solar/PageSolarCharger.qml
+++ b/pages/solar/PageSolarCharger.qml
@@ -151,38 +151,33 @@ Page {
 
 			QuantityTable {
 				id: trackerTable
-				rowCount: root.trackerCount
-				units: [
-					{ title: CommonWords.tracker, unit: VenusOS.Units_None },
-					{ title: CommonWords.voltage, unit: VenusOS.Units_Volt_DC },
-					{ title: CommonWords.current_amps, unit: VenusOS.Units_Amp },
-					{ title: CommonWords.power_watts, unit: VenusOS.Units_Watt }
-				]
-				valueForModelIndex: function(trackerIndex, column) {
-					const tracker = trackerObjects.objectAt(trackerIndex)
-					if (column === 0) {
-						return Global.solarDevices.formatTrackerName(tracker.name, trackerIndex, root.trackerCount, root.solarDevice.name, VenusOS.TrackerName_NoDevicePrefix)
-					} else if (column === 1) {
-						return tracker.voltage
-					} else if (column === 2) {
-						return tracker.current
-					} else if (column === 3) {
-						return tracker.power
+				width: parent.width
+				model: root.trackerCount > 1 ? root.trackerCount : 0
+				header: QuantityTable.TableHeader {
+					headerText: CommonWords.tracker
+					model: [
+						{ text: CommonWords.voltage, unit: VenusOS.Units_Volt_DC },
+						{ text: CommonWords.current_amps, unit: VenusOS.Units_Amp },
+						{ text: CommonWords.power_watts, unit: VenusOS.Units_Watt }
+					]
+				}
+				delegate: QuantityTable.TableRow {
+					id: tableRow
+
+					preferredVisible: tracker.enabled
+					headerText: Global.solarDevices.formatTrackerName(
+							tracker.name, index, root.trackerCount, root.solarDevice.name,
+							VenusOS.TrackerName_NoDevicePrefix)
+					model: QuantityObjectModel {
+						QuantityObject { object: tracker; key: "voltage"; unit: VenusOS.Units_Volt_DC }
+						QuantityObject { object: tracker; key: "current"; unit: VenusOS.Units_Amp }
+						QuantityObject { object: tracker; key: "power"; unit: VenusOS.Units_Watt }
 					}
-				}
-				rowIsVisible: function(row) {
-					const tracker = trackerObjects.objectAt(row)
-					return tracker.enabled
-				}
 
-				Instantiator {
-					id: trackerObjects
-					model: root.solarDevice.trackerCount
-					delegate: SolarTracker {
-						required property int index
-
+					SolarTracker {
+						id: tracker
 						device: root.solarDevice
-						trackerIndex: index
+						trackerIndex: tableRow.index
 					}
 				}
 			}

--- a/pages/solar/PvInverterPage.qml
+++ b/pages/solar/PvInverterPage.qml
@@ -22,33 +22,22 @@ Page {
 				QuantityTableSummary {
 					id: phaseSummary
 
-					model: [
-						{
-							title: root.pvInverter.statusCode >= 0 ? CommonWords.status : "",
-							text: VenusOS.pvInverter_statusCodeToText(root.pvInverter.statusCode),
-							unit: VenusOS.Units_None,
-						},
-						{
-							title: CommonWords.energy,
-							value: root.pvInverter.energy,
-							unit: VenusOS.Units_Energy_KiloWattHour
-						},
-						{
-							title: CommonWords.voltage,
-							value: root.pvInverter.voltage,
-							unit: VenusOS.Units_Volt_AC
-						},
-						{
-							title: CommonWords.current_amps,
-							value: root.pvInverter.current,
-							unit: VenusOS.Units_Amp
-						},
-						{
-							title: CommonWords.power_watts,
-							value: root.pvInverter.power,
-							unit: VenusOS.Units_Watt
-						},
+					width: parent.width
+					columnSpacing: Theme.geometry_quantityTable_horizontalSpacing_small
+					summaryHeaderText: root.pvInverter.statusCode >= 0 ? CommonWords.status : ""
+					summaryModel: [
+						{ text: CommonWords.energy, unit: VenusOS.Units_Energy_KiloWattHour },
+						{ text: CommonWords.voltage, unit: VenusOS.Units_Volt_AC },
+						{ text: CommonWords.current_amps, unit: VenusOS.Units_Amp },
+						{ text: CommonWords.power_watts, unit: VenusOS.Units_Watt }
 					]
+					bodyHeaderText: VenusOS.pvInverter_statusCodeToText(root.pvInverter.statusCode)
+					bodyModel: QuantityObjectModel {
+						QuantityObject { object: root.pvInverter; key: "energy"; unit: VenusOS.Units_Energy_KiloWattHour }
+						QuantityObject { object: root.pvInverter; key: "voltage"; unit: VenusOS.Units_Volt_AC }
+						QuantityObject { object: root.pvInverter; key: "current"; unit: VenusOS.Units_Amp }
+						QuantityObject { object: root.pvInverter; key: "power"; unit: VenusOS.Units_Watt }
+					}
 				}
 
 				QuantityTable {
@@ -58,21 +47,28 @@ Page {
 						top: phaseSummary.bottom
 						topMargin: Theme.geometry_gradientList_spacing
 					}
+					width: phaseSummary.width
 					visible: root.pvInverter.phases.count > 1
-					headerVisible: false
+					metricsFontSize: phaseSummary.metricsFontSize
+					columnSpacing: phaseSummary.columnSpacing
+					model: root.pvInverter.phases.count > 1 ? root.pvInverter.phases : 0
 
-					rowCount: root.pvInverter.phases.count
-					units: [
-						{ title: CommonWords.phase, unit: VenusOS.Units_None },
-						{ title: CommonWords.energy, unit: VenusOS.Units_Energy_KiloWattHour },
-						{ title: CommonWords.voltage, unit: VenusOS.Units_Volt_AC },
-						{ title: CommonWords.current_amps, unit: VenusOS.Units_Amp },
-						{ title: CommonWords.power_watts, unit: VenusOS.Units_Watt }
-					]
-					valueForModelIndex: function(phaseIndex, column) {
-						const phase = root.pvInverter.phases.getPhase(phaseIndex)
-						const columnProperties = ["name", "energy", "voltage", "current", "power"]
-						return phase[columnProperties[column]]
+					delegate: QuantityTable.TableRow {
+						id: tableRow
+
+						required property string name
+						required property real energy
+						required property real voltage
+						required property real current
+						required property real power
+
+						headerText: name
+						model: QuantityObjectModel {
+							QuantityObject { object: tableRow; key: "energy"; unit: VenusOS.Units_Energy_KiloWattHour }
+							QuantityObject { object: tableRow; key: "voltage"; unit: VenusOS.Units_Volt_AC }
+							QuantityObject { object: tableRow; key: "current"; unit: VenusOS.Units_Amp }
+							QuantityObject { object: tableRow; key: "power"; unit: VenusOS.Units_Watt }
+						}
 					}
 				}
 			}

--- a/pages/solar/SolarInputListPage.qml
+++ b/pages/solar/SolarInputListPage.qml
@@ -53,8 +53,11 @@ Page {
 		section.delegate: QuantityGroupListHeader {
 			required property string section
 
-			firstColumnText: section === "pvinverter" ? CommonWords.pv_inverter : ""
-			quantityTitleModel: [
+			width: parent.width
+			metricsFontSize: Theme.font_size_body2 // align columns with those in the delegate
+			rightPadding: Theme.geometry_listItem_content_horizontalMargin + Theme.geometry_icon_size_medium
+			headerText: section === "pvinverter" ? CommonWords.pv_inverter : ""
+			model: [
 				{ text: section === "pvinverter" ? CommonWords.energy : CommonWords.yield_today, unit: VenusOS.Units_Energy_KiloWattHour },
 				{ text: CommonWords.voltage, unit: section === "pvinverter" ? VenusOS.Units_Volt_AC : VenusOS.Units_Volt_DC },
 				{ text: CommonWords.current_amps, unit: VenusOS.Units_Amp },

--- a/src/quantityobject.cpp
+++ b/src/quantityobject.cpp
@@ -89,6 +89,19 @@ void QuantityObject::setDefaultValue(const QVariant &value)
 	}
 }
 
+bool QuantityObject::hidden() const
+{
+	return m_hidden;
+}
+
+void QuantityObject::setHidden(bool hidden)
+{
+	if (m_hidden != hidden) {
+		m_hidden = hidden;
+		emit hiddenChanged();
+	}
+}
+
 qreal QuantityObject::numberValue() const
 {
 	const QVariant &v = m_value.isValid() ? m_value : m_defaultValue;

--- a/src/quantityobject.h
+++ b/src/quantityobject.h
@@ -42,6 +42,10 @@ class QuantityObject : public QObject
 	Q_PROPERTY(QString textValue READ textValue NOTIFY textValueChanged FINAL)
 	Q_PROPERTY(bool hasValue READ hasValue NOTIFY hasValueChanged FINAL)
 
+	// If hidden=true, the UI should reserve the space for the quantity label in the layout, but
+	// hide the label using opacity=0.
+	Q_PROPERTY(bool hidden READ hidden WRITE setHidden NOTIFY hiddenChanged FINAL)
+
 public:
 	explicit QuantityObject(QObject *parent = nullptr);
 
@@ -60,6 +64,9 @@ public:
 	QVariant defaultValue() const;
 	void setDefaultValue(const QVariant &value);
 
+	bool hidden() const;
+	void setHidden(bool hidden);
+
 	qreal numberValue() const;  // NaN if the value is not a real type
 	QString textValue() const;  // empty if the value is not a string type
 	bool hasValue() const;
@@ -73,6 +80,7 @@ Q_SIGNALS:
 	void numberValueChanged();
 	void textValueChanged();
 	void hasValueChanged();
+	bool hiddenChanged();
 
 private Q_SLOTS:
 	void updateValue();
@@ -89,6 +97,7 @@ private:
 	Victron::VenusOS::Enums::Units_Type m_unit = Victron::VenusOS::Enums::Units_None;
 	int m_precision = Victron::VenusOS::Enums::Units_Precision_Default;
 	bool m_hasValue = false;
+	bool m_hidden = false;
 };
 
 } /* VenusOS */

--- a/themes/geometry/FiveInch.json
+++ b/themes/geometry/FiveInch.json
@@ -352,12 +352,12 @@
 
     "geometry_quantityTable_row_height": 32,
     "geometry_quantityTable_bottomMargin": 14,
-    "geometry_quantityTable_horizontalSpacing": 18,
+    "geometry_quantityTable_horizontalSpacing_small": 12,
+    "geometry_quantityTable_horizontalSpacing_large": 48,
 
     "geometry_quantityTableSummary_verticalMargin": 8,
-    "geometry_quantityTableSummary_verticalSpacing": 4,
 
-    "geometry_quantityGroupRow_spacing": 4,
+    "geometry_quantityGroupRow_spacing": 12,
 
     "geometry_solarHistoryPage_tabBar_width": 260,
 
@@ -417,7 +417,6 @@
     "geometry_settingsListNavigation_height": 64,
 
     "geometry_vebusDeviceListPage_quantityTable_row_spacing": 4,
-    "geometry_vebusDeviceListPage_quantityTable_firstColumn_width": 39,
     "geometry_vebusDeviceListPage_quantityTable_header_height": 58,
 
     "geometry_batteryListPage_item_height": 84,

--- a/themes/geometry/SevenInch.json
+++ b/themes/geometry/SevenInch.json
@@ -352,12 +352,12 @@
 
     "geometry_quantityTable_row_height": 32,
     "geometry_quantityTable_bottomMargin": 14,
-    "geometry_quantityTable_horizontalSpacing": 48,
+    "geometry_quantityTable_horizontalSpacing_small": 48,
+    "geometry_quantityTable_horizontalSpacing_large": 64,
 
     "geometry_quantityTableSummary_verticalMargin": 8,
-    "geometry_quantityTableSummary_verticalSpacing": 4,
 
-    "geometry_quantityGroupRow_spacing": 4,
+    "geometry_quantityGroupRow_spacing": 12,
 
     "geometry_solarHistoryPage_tabBar_width": 260,
 
@@ -417,7 +417,6 @@
     "geometry_settingsListNavigation_height": 64,
 
     "geometry_vebusDeviceListPage_quantityTable_row_spacing": 4,
-    "geometry_vebusDeviceListPage_quantityTable_firstColumn_width": 39,
     "geometry_vebusDeviceListPage_quantityTable_header_height": 58,
 
     "geometry_batteryListPage_item_height": 84,


### PR DESCRIPTION
Remove the duplicated code between QuantityTable, QuantityTableSummary and QuantityRow. In QuantityTable and QuantityTableSummary, instead of providing valueForModelIndex() and rowIsVisible() functions that can be customized to provide the column data for each row, provide TableHeader and TableBody types that can be customized together with QuantityObjectModel to provide the column data.

Also simplify QuantityTableMetrics to remove most of its property configurations, which can be implemented in QuantityTable, QuantityTableSummary and QuantityRow instead.

Fixes #2179