### PR TITLE
Restore key navigation feature and update shortcuts

### DIFF
--- a/Main.qml
+++ b/Main.qml
@@ -24,6 +24,9 @@ Window {
 	property real scaleFactor: 1.0
 	onIsDesktopChanged: Global.isDesktop = root.isDesktop
 
+	// Uncomment for key navigation debugging
+	// onActiveFocusItemChanged: console.info("** Active focused:", activeFocusItem, activeFocusItem?.title ?? activeFocusItem?.text ?? "")
+
 	function skipSplashScreen() {
 		Global.splashScreenVisible = false
 	}
@@ -82,26 +85,31 @@ Window {
 		onScaleChanged: Global.scalingRatio = contentItem.scale
 		scale: Math.min(root.width/Theme.geometry_screen_width, root.height/Theme.geometry_screen_height)
 
-		// #2161 Key nav is disabled for now
-		// Keys.onPressed: function(event) {
-		//     // When a navigation key is pressed and it is not handled by an item higher up in the
-		//     // UI item hierarchy, enable key navigation to allow guiLoader to get focus and receive
-		//     // key events.
-		//     if (!Global.keyNavigationEnabled) {
-		//         switch (event.key) {
-		//         case Qt.Key_Left:
-		//         case Qt.Key_Right:
-		//         case Qt.Key_Up:
-		//         case Qt.Key_Down:
-		//         case Qt.Key_Tab:
-		//         case Qt.Key_Backtab:
-		//             Global.keyNavigationEnabled = true
-		//             event.accepted = true
-		//             return
-		//         }
-		//     }
-		//     event.accepted = false
-		// }
+		Keys.onPressed: function(event) {
+			// If a key press is not handled by an item higher up in the hierarchy:
+			// Enable key navigation when an arrow or tab/backtab key is pressed.
+			// Disable it when the escape key is pressed.
+			if (Global.keyNavigationEnabled) {
+				if (event.key === Qt.Key_Escape) {
+					Global.keyNavigationEnabled = false
+					event.accepted = true
+					return
+				}
+			} else {
+				switch (event.key) {
+				case Qt.Key_Left:
+				case Qt.Key_Right:
+				case Qt.Key_Up:
+				case Qt.Key_Down:
+				case Qt.Key_Tab:
+				case Qt.Key_Backtab:
+					Global.keyNavigationEnabled = true
+					event.accepted = true
+					return
+				}
+			}
+			event.accepted = false
+		}
 	}
 
 	Loader {

--- a/components/dialogs/ModalDialog.qml
+++ b/components/dialogs/ModalDialog.qml
@@ -142,7 +142,7 @@ T.Dialog {
 		}
 	}
 
-	footer: Item { // #2161 make this a FocusScope when key nav is re-enabled
+	footer: FocusScope {
 		visible: root.dialogDoneOptions !== VenusOS.ModalDialog_DoneOptions_NoOptions
 		height: visible ? Theme.geometry_modalDialog_footer_height : 0
 		focus: false

--- a/components/listitems/core/ListNavigation.qml
+++ b/components/listitems/core/ListNavigation.qml
@@ -16,6 +16,8 @@ ListItem {
 
 	interactive: true
 	Keys.onRightPressed: root.activate()
+	Keys.onEnterPressed: root.activate()
+	Keys.onReturnPressed: root.activate()
 
 	// Issue #1964: userHasWriteAccess is ignored for ListNavigation - see ListItem
 

--- a/pages/MainView.qml
+++ b/pages/MainView.qml
@@ -153,10 +153,12 @@ FocusScope {
 				Global.allPagesLoaded = true
 			}
 
+			// When focused during key navigation, show a full-page focus blocker if the current
+			// page has blockInitialFocus=true.
 			onActiveFocusChanged: {
 				if (Global.keyNavigationEnabled) {
-					if (activeFocus && refreshBlockItemFocus && item?.currentItem?.blockInitialFocus) {
-						blockItemFocus = true
+					if (activeFocus && refreshBlockItemFocus) {
+						blockItemFocus = item?.currentItem?.blockInitialFocus
 						refreshBlockItemFocus = false
 					} else if (!activeFocus && (statusBar.activeFocus || navBar.activeFocus)) {
 						// Re-refresh the focus blocker state if navigating back from status or nav bar.
@@ -165,9 +167,18 @@ FocusScope {
 				}
 			}
 
-			KeyNavigation.down: navBar
-			Keys.onSpacePressed: blockItemFocus = false
+			// Space key disables the focus blocker, so that user can focus individual items on the
+			// page; Escape key re-enables the blocker. Ignore the event if no change is necessary.
+			Keys.onSpacePressed: (event) => {
+				event.accepted = blockItemFocus
+				blockItemFocus = false
+			}
+			Keys.onEscapePressed: (event) => {
+				event.accepted = !blockItemFocus
+				blockItemFocus = true
+			}
 			Keys.enabled: Global.keyNavigationEnabled
+			KeyNavigation.down: navBar
 
 			Component {
 				id: swipeViewComponent


### PR DESCRIPTION
As the latest release has been made, restore the key navigation feature. Also add some key shortcuts:

- allow Enter/Return to activate a list item with a sub-menu
- on Settings and Notification pages: allow Escape to enable the full page blocker
- if Escape is pressed and the key is not already handled, disable key navigation

Also fix a bug where the current page would unexpectedly show the full page blocker, if the previously opened page had the blocker enabled.

Fixes #2182