### PR TITLE
Brief: update centre gauge tank source when tanks are reconnected

### DIFF
--- a/components/GaugeModel.qml
+++ b/components/GaugeModel.qml
@@ -215,23 +215,32 @@ ListModel {
 				id: tankIdSource
 
 				GaugeSource {
-					readonly property Tank _device: _findTank()
+					property Tank _device
+					readonly property int totalTankCount: Global.tanks.totalTankCount
 
-					function _findTank() {
+					function _updateTank() {
+						if (_device?.valid) {
+							return
+						}
 						const tankIdInfo = BackendConnection.portableIdInfo(gaugeObject.modelData.value)
 						for (const tankModel of Global.tanks.allTankModels) {
 							const tank = tankModel.deviceForDeviceInstance(tankIdInfo.instance)
 							if (tank) {
-								return tank
+								_device = tank
+								break
 							}
 						}
-						return null
 					}
 
 					name: _device?.name || ""
 					type: _device?.type ?? -1
 					level: _device?.level ?? NaN
 					remaining: Units.convert(_device?.remaining ?? NaN, VenusOS.Units_Volume_CubicMeter, Global.systemSettings.volumeUnit)
+
+					// Set tank on initialization, or when tanks are updated, in case the tank is
+					// disconnected and reconnected.
+					onTotalTankCountChanged: _updateTank()
+					Component.onCompleted: _updateTank()
 				}
 			}
 		}


### PR DESCRIPTION
If the tank is not available on startup, check again when more tanks are connected.

Update the mock TanksImpl to simulate disconnection and reconnection of tanks when the Levels page is toggled off and on, by reusing the service uids of previously disconnected tanks, instead of creating new ones.

Fixes #2230