### PR TITLE
Brief & Overview: Show gauge colours when current is < 1.0

### DIFF
--- a/components/widgets/AcInputWidget.qml
+++ b/components/widgets/AcInputWidget.qml
@@ -58,7 +58,6 @@ AcWidget {
 		sourceComponent: ThreePhaseBarGauge {
 			valueType: VenusOS.Gauges_ValueType_NeutralPercentage
 			phaseModel: root.input.phases
-			phaseModelProperty: "current"
 			minimumValue: root.inputInfo?.minimumCurrent ?? NaN
 			maximumValue: root.inputInfo?.maximumCurrent ?? NaN
 			inputMode: true

--- a/components/widgets/AcLoadsWidget.qml
+++ b/components/widgets/AcLoadsWidget.qml
@@ -23,7 +23,6 @@ AcWidget {
 		model: root.measurements.phases
 		widgetSize: root.size
 		valueType: VenusOS.Gauges_ValueType_RisingPercentage
-		phaseModelProperty: "current"
 		maximumValue: Global.system.load.maximumAcCurrent
 	}
 	extraContentLoader.active: root.phaseCount > 1 || root.measurements.l2AndL1OutSummed

--- a/components/widgets/EssentialLoadsWidget.qml
+++ b/components/widgets/EssentialLoadsWidget.qml
@@ -19,7 +19,6 @@ AcWidget {
 		model: Global.system.load.acOut.phases
 		widgetSize: root.size
 		valueType: VenusOS.Gauges_ValueType_RisingPercentage
-		phaseModelProperty: "current"
 		maximumValue: Global.system.load.maximumAcCurrent
 	}
 	extraContentLoader.active: root.phaseCount > 1 || Global.system.load.acOut.l2AndL1OutSummed

--- a/components/widgets/InverterChargerWidget.qml
+++ b/components/widgets/InverterChargerWidget.qml
@@ -87,7 +87,6 @@ OverviewWidget {
 		sourceComponent: ThreePhaseBarGauge {
 			valueType: VenusOS.Gauges_ValueType_RisingPercentage
 			phaseModel: Global.system.load.ac.phases
-			phaseModelProperty: "current"
 			maximumValue: Global.system.load.maximumAcCurrent
 			animationEnabled: root.animationEnabled
 			inOverviewWidget: true

--- a/pages/BriefPage.qml
+++ b/pages/BriefPage.qml
@@ -148,8 +148,7 @@ SwipeViewPage {
 				opacity: root._gaugeArcOpacity
 				animationEnabled: root.animationEnabled && !pauseLeftGaugeAnimations.running
 				valueType: VenusOS.Gauges_ValueType_NeutralPercentage
-				phaseModel: Global.acInputs.highlightedInput?.phases
-				phaseModelProperty: "current"
+				phaseModel: Global.acInputs.highlightedInput?.phases ?? null
 				minimumValue: !!Global.acInputs.highlightedInput ? Global.acInputs.highlightedInput.inputInfo.minimumCurrent : NaN
 				maximumValue: !!Global.acInputs.highlightedInput ? Global.acInputs.highlightedInput.inputInfo.maximumCurrent : NaN
 				inputMode: true
@@ -291,7 +290,6 @@ SwipeViewPage {
 				animationEnabled: root.animationEnabled && !pauseRightGaugeAnimations.running
 				valueType: VenusOS.Gauges_ValueType_RisingPercentage
 				phaseModel: Global.system.load.ac.phases
-				phaseModelProperty: "current"
 				maximumValue: Global.system.load.maximumAcCurrent
 
 				ArcGaugeQuantityRow {

--- a/pages/BriefSidePanel.qml
+++ b/pages/BriefSidePanel.qml
@@ -60,7 +60,6 @@ ColumnLayout {
 			height: Theme.geometry_barGauge_vertical_width_large
 			orientation: Qt.Horizontal
 			phaseModel: root.visible ? generatorInput.phases : null
-			phaseModelProperty: "current"
 			minimumValue: generatorInput.inputInfo.minimumCurrent
 			maximumValue: generatorInput.inputInfo.maximumCurrent
 			animationEnabled: root.animationEnabled
@@ -198,7 +197,6 @@ exported power v  0.4 |   /
 			height: Theme.geometry_barGauge_vertical_width_large
 			orientation: Qt.Horizontal
 			phaseModel: root.visible ? nonGeneratorInput.phases : null
-			phaseModelProperty: "current"
 			minimumValue: nonGeneratorInput.inputInfo.minimumCurrent
 			maximumValue: nonGeneratorInput.inputInfo.maximumCurrent
 			animationEnabled: root.animationEnabled
@@ -271,7 +269,6 @@ exported power v  0.4 |   /
 			orientation: Qt.Horizontal
 			valueType: VenusOS.Gauges_ValueType_RisingPercentage
 			phaseModel: root.visible ? Global.system.load.ac.phases : null
-			phaseModelProperty: "current"
 			maximumValue: Global.system.load.maximumAcCurrent
 			animationEnabled: root.animationEnabled
 		}

--- a/pages/boatpage/LoadArc.qml
+++ b/pages/boatpage/LoadArc.qml
@@ -67,7 +67,6 @@ Column {
 			animationEnabled: root.animationEnabled
 			valueType: VenusOS.Gauges_ValueType_RisingPercentage
 			phaseModel: Global.system.load.ac.phases
-			phaseModelProperty: "current"
 			maximumValue: Global.system.load.maximumAcCurrent
 		}
 		onStatusChanged: if (status === Loader.Error) console.warn("Unable to load AC load edge")


### PR DESCRIPTION
There are some checks to guard against showing gauge values if they are between -1.0 and 1.0, in case these values are occurring due to noise signals rather than significant value changes. These checks make sense for power values, which are only significant when < -1.0 or > 1.0, but current values can often be in the -1 to 1.0 range.

The changes are:
- Remove "phaseModelProperty" as it always refers to "current" anyway
- Always require a PhaseModel as the model input, to ensure the "power" and "current" role names are availalable
- Only check for noise/insigificant values for the "power" property, and do not check this for the "current" property

Fixes #2233