### PR TITLE
Use pulse counter /Count path for reset writes

### DIFF
--- a/pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml
+++ b/pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml
@@ -33,31 +33,13 @@ Page {
 			ListButton {
 				//% "Reset counter"
 				text: qsTrId("pulsecounter_setup_reset_counter")
-				secondaryText: itemCount_readonly.value || 0
+				secondaryText: itemCount.value || 0
 				onClicked: itemCount.setValue(0)
 				interactive: itemCount.valid
 
 				VeQuickItem {
-					id: itemCount_readonly
-					uid: root.bindPrefix + "/Count"
-				}
-
-				VeQuickItem {
 					id: itemCount
-					uid: Global.systemSettings.serviceUid + "/Settings/DigitalInput/"
-						+ (mgmtConnection.ioextId.length > 0 ? mgmtConnection.ioextId : root.inputNumber)
-						+ "/Count"
-				}
-
-				// Determine settings prefix for GX I/O Extender paths, see #2139
-				VeQuickItem {
-					id: mgmtConnection
-					uid: root.bindPrefix + "/Mgmt/Connection"
-					readonly property string inputPath: mgmtConnection.valid ? mgmtConnection.value : ""
-					readonly property string ioextPrefix: "/run/io-ext/"
-					readonly property string ioextId: (inputPath.length > 0 && inputPath.indexOf(ioextPrefix) >= 0)
-						? inputPath.substring(ioextPrefix.length).replace("/", "_")
-						: ""
+					uid: root.bindPrefix + "/Count"
 				}
 			}
 		}


### PR DESCRIPTION
Previously, the /Count path was not writable, and so we had to find the device-specific settings path to write to.

Recently, the /Count path was made writable, so we can simply write directly to it.

Contributes to issue #2194