### PR TITLE
Avoid binding loop for uid property

### DIFF
--- a/data/SystemSettings.qml
+++ b/data/SystemSettings.qml
@@ -187,7 +187,8 @@ QtObject {
 				flags: VeQItemTableModel.AddChildren | VeQItemTableModel.AddNonLeaves | VeQItemTableModel.DontAddItem
 			}
 			delegate: VeQuickItem {
-				uid: model.uid
+				required property string id
+				uid: root.serviceUid + "/Settings/Gui2/BriefView/Level/" + id
 				onValueChanged: Qt.callLater(root.briefView._refreshCentralGauges)
 			}
 		}


### PR DESCRIPTION
Setting "uid: model.uid" is causing a binding loop, so work around this by referring to the item id instead of the uid.