### PR TITLE
Show center details on Brief Page when 4 gauges are visible

### DIFF
--- a/components/BriefCenterDisplay.qml
+++ b/components/BriefCenterDisplay.qml
@@ -12,7 +12,6 @@ Column {
 	id: root
 
 	property bool showFullDetails
-	property bool smallTextMode
 
 	readonly property bool _useTemperature: BackendConnection.portableIdInfo(centerService.value).type === "temperature"
 
@@ -62,29 +61,22 @@ Column {
 		}
 	}
 
-	QuantityLabel {
+	Label {
 		id: centerLabel
+		width: parent.width
+		horizontalAlignment: Text.AlignHCenter
+		verticalAlignment: Text.AlignVCenter
+		text: quantityLabel.valueText + quantityLabel.unitText
+		font.pixelSize: Theme.font_briefPage_battery_percentage_maximumPixelSize
+		fontSizeMode: Text.HorizontalFit
+	}
 
+	QuantityLabel {
+		id: quantityLabel
+		visible: false
 		anchors.horizontalCenter: parent.horizontalCenter
-		height: root.smallTextMode ? centerLabelMetrics.ascent : implicitHeight
-		font.pixelSize: {
-			if (root._useTemperature) {
-				return root.smallTextMode
-					? Theme.font_briefPage_battery_temperature_minimumPixelSize
-					: Theme.font_briefPage_battery_temperature_maximumPixelSize
-			} else {
-				return root.smallTextMode
-					? Theme.font_briefPage_battery_percentage_minimumPixelSize
-					: Theme.font_briefPage_battery_percentage_maximumPixelSize
-			}
-		}
 		unit: root._useTemperature ? Global.systemSettings.temperatureUnit : VenusOS.Units_Percentage
 		value: root._useTemperature ? (temperature.value ?? NaN) : Global.system.battery.stateOfCharge
-
-		FontMetrics {
-			id: centerLabelMetrics
-			font: centerLabel.font
-		}
 	}
 
 	Loader {

--- a/pages/BriefPage.qml
+++ b/pages/BriefPage.qml
@@ -74,6 +74,7 @@ SwipeViewPage {
 		id: multiGauge
 
 		CircularMultiGauge {
+			id: circularMultiGauge
 			model: gaugeModel
 			animationEnabled: root.animationEnabled
 			labelOpacity: root._gaugeLabelOpacity
@@ -82,10 +83,8 @@ SwipeViewPage {
 
 			BriefCenterDisplay {
 				anchors.centerIn: parent
-				width: parent.width
-				visible: gaugeModel.count <= 3
+				width: parent.width - (gaugeModel.count * circularMultiGauge._stepSize) + Theme.geometry_circularMultiGauge_spacing
 				showFullDetails: gaugeModel.count === 1
-				smallTextMode: gaugeModel.count === 3
 			}
 		}
 	}

--- a/themes/typography/FiveInch.json
+++ b/themes/typography/FiveInch.json
@@ -1,8 +1,5 @@
 {
-    "font_briefPage_battery_percentage_minimumPixelSize": "font_size_h3",
     "font_briefPage_battery_percentage_maximumPixelSize": "font_size_h4",
-    "font_briefPage_battery_temperature_minimumPixelSize": "font_size_h2",
-    "font_briefPage_battery_temperature_maximumPixelSize": "font_size_h4",
     "font_briefPage_battery_timeToGo_pixelSize": "font_size_body1",
     "font_briefPage_battery_voltage_pixelSize": "font_size_body3",
     "font_briefPage_quantityLabel_size": "font_size_body3",

--- a/themes/typography/SevenInch.json
+++ b/themes/typography/SevenInch.json
@@ -1,8 +1,5 @@
 {
-    "font_briefPage_battery_percentage_minimumPixelSize": "font_size_h5",
     "font_briefPage_battery_percentage_maximumPixelSize": "font_size_h5",
-    "font_briefPage_battery_temperature_minimumPixelSize": "font_size_h4",
-    "font_briefPage_battery_temperature_maximumPixelSize": "font_size_h5",
     "font_briefPage_battery_timeToGo_pixelSize": "font_size_body2",
     "font_briefPage_battery_voltage_pixelSize": "font_size_h1",
     "font_briefPage_quantityLabel_size": "font_size_h2",


### PR DESCRIPTION
Use a normal Label with font fitting to ensure that the text is sized appropriately to the available space.

Contributes to issue #2218