### PR TITLE
Remove convertFromCelsius()

### DIFF
--- a/components/BriefCenterDisplay.qml
+++ b/components/BriefCenterDisplay.qml
@@ -33,6 +33,8 @@ Column {
 			}
 			return ""
 		}
+		sourceUnit: Units.unitToVeUnit(VenusOS.Units_Temperature_Celsius)
+		displayUnit: Units.unitToVeUnit(Global.systemSettings.temperatureUnit)
 	}
 
 	Row {
@@ -77,9 +79,7 @@ Column {
 			}
 		}
 		unit: root._useTemperature ? Global.systemSettings.temperatureUnit : VenusOS.Units_Percentage
-		value: root._useTemperature
-			   ? Global.systemSettings.convertFromCelsius(temperature.value ?? NaN)
-			   : Global.system.battery.stateOfCharge
+		value: root._useTemperature ? (temperature.value ?? NaN) : Global.system.battery.stateOfCharge
 
 		FontMetrics {
 			id: centerLabelMetrics

--- a/components/EnvironmentGaugePanel.qml
+++ b/components/EnvironmentGaugePanel.qml
@@ -54,8 +54,8 @@ BaseListItem {
 		value: Math.round(root.temperature)
 		unit: Global.systemSettings.temperatureUnit
 
-		minimumValue: Global.systemSettings.convertFromCelsius(Global.environmentInputs.temperatureGaugeMinimum(root.temperatureType))
-		maximumValue: Global.systemSettings.convertFromCelsius(Global.environmentInputs.temperatureGaugeMaximum(root.temperatureType))
+		minimumValue: Global.environmentInputs.temperatureGaugeMinimum(root.temperatureType)
+		maximumValue: Global.environmentInputs.temperatureGaugeMaximum(root.temperatureType)
 		stepSize: Global.environmentInputs.temperatureGaugeStepSize(root.temperatureType)
 		highlightedValue: Theme.geometry_levelsPage_environment_temperatureGauge_highlightedValue
 		minimumValueColor: Theme.color_blue

--- a/components/SystemBatteryDelegate.qml
+++ b/components/SystemBatteryDelegate.qml
@@ -36,10 +36,6 @@ BaseListItem {
 			}
 
 			QuantityRow {
-				id: measurementsRow
-
-				readonly property real temperature: Global.systemSettings.convertFromCelsius(root.device.temperature)
-
 				height: nameLabel.height
 				showFirstSeparator: true    // otherwise this row does not align with the battery name
 				model: QuantityObjectModel {
@@ -48,7 +44,7 @@ BaseListItem {
 					QuantityObject { object: root.device; key: "voltage"; unit: VenusOS.Units_Volt_DC; defaultValue: "--" }
 					QuantityObject { object: root.device; key: "current"; unit: VenusOS.Units_Amp }
 					QuantityObject { object: root.device; key: "power"; unit: VenusOS.Units_Watt }
-					QuantityObject { object: measurementsRow; key: "temperature"; unit: Global.systemSettings.temperatureUnit }
+					QuantityObject { object: root.device; key: "temperature"; unit: Global.systemSettings.temperatureUnit }
 				}
 
 				// Show additional separator at the end, to balance with the first separator.

--- a/components/SystemBatteryDeviceModel.qml
+++ b/components/SystemBatteryDeviceModel.qml
@@ -84,6 +84,9 @@ DeviceModel {
 
 		function setValueIfValid(propertyName, value) {
 			if (value !== undefined) {
+				if (propertyName === "temperature") {
+					value = Units.convert(value, VenusOS.Units_Temperature_Celsius, Global.systemSettings.temperatureUnit)
+				}
 				battery[propertyName] = value
 			}
 		}

--- a/components/TemperatureRelaySettings.qml
+++ b/components/TemperatureRelaySettings.qml
@@ -68,8 +68,8 @@ SettingsColumn {
 		dataItem.uid: "%1/%2/SetValue".arg(root.settingsBindPrefix).arg(root.relayNumber)
 		dataItem.sourceUnit: Units.unitToVeUnit(VenusOS.Units_Temperature_Celsius)
 		dataItem.displayUnit: Units.unitToVeUnit(Global.systemSettings.temperatureUnit)
-		from: Global.systemSettings.convertFromCelsius(-50)
-		to: Global.systemSettings.convertFromCelsius(100)
+		from: Units.convert(-50, VenusOS.Units_Temperature_Celsius, Global.systemSettings.temperatureUnit)
+		to: Units.convert(100, VenusOS.Units_Temperature_Celsius, Global.systemSettings.temperatureUnit)
 		suffix: Global.systemSettings.temperatureUnitSuffix
 
 		onValueChanged: {

--- a/components/widgets/BatteryWidget.qml
+++ b/components/widgets/BatteryWidget.qml
@@ -166,7 +166,7 @@ OverviewWidget {
 			rightMargin: Theme.geometry_overviewPage_widget_content_horizontalMargin
 		}
 
-		value: Global.systemSettings.convertFromCelsius(batteryData.temperature)
+		value: batteryData.temperature
 		unit: Global.systemSettings.temperatureUnit
 		font.pixelSize: Theme.font_size_body2
 		alignment: Qt.AlignRight

--- a/data/EnvironmentInputs.qml
+++ b/data/EnvironmentInputs.qml
@@ -78,15 +78,17 @@ QtObject {
 	}
 
 	function temperatureGaugeMinimum(temperatureType) {
-		return _validTemperatureType(temperatureType)
+		const temp = _validTemperatureType(temperatureType)
 				? (_temperatureDetails.get(temperatureType).temperatureGaugeMinimum)
 				: (_temperatureDetails.get(VenusOS.Temperature_DeviceType_Generic).temperatureGaugeMinimum)
+		return Units.convert(temp, VenusOS.Units_Temperature_Celsius, Global.systemSettings.temperatureUnit)
 	}
 
 	function temperatureGaugeMaximum(temperatureType) {
-		return _validTemperatureType(temperatureType)
+		const temp = _validTemperatureType(temperatureType)
 				? (_temperatureDetails.get(temperatureType).temperatureGaugeMaximum)
 				: (_temperatureDetails.get(VenusOS.Temperature_DeviceType_Generic).temperatureGaugeMaximum)
+		return Units.convert(temp, VenusOS.Units_Temperature_Celsius, Global.systemSettings.temperatureUnit)
 	}
 
 	function temperatureGaugeStepSize(temperatureType) {

--- a/data/SystemSettings.qml
+++ b/data/SystemSettings.qml
@@ -92,10 +92,6 @@ QtObject {
 		}
 	}
 
-	function convertFromCelsius(celsius_value) {
-		return Units.convert(celsius_value, VenusOS.Units_Temperature_Celsius, temperatureUnit)
-	}
-
 	function networkStatusToText(status) {
 		switch (status) {
 		case VenusOS.Link_NetworkStatus_Slave:

--- a/data/common/ActiveSystemBattery.qml
+++ b/data/common/ActiveSystemBattery.qml
@@ -37,6 +37,8 @@ QtObject {
 
 	readonly property VeQuickItem _temperature: VeQuickItem {
 		uid: root.systemServiceUid + "/Dc/Battery/Temperature"
+		sourceUnit: Units.unitToVeUnit(VenusOS.Units_Temperature_Celsius)
+		displayUnit: Units.unitToVeUnit(Global.systemSettings.temperatureUnit)
 	}
 
 	readonly property VeQuickItem _timeToGo: VeQuickItem {

--- a/data/common/DcInput.qml
+++ b/data/common/DcInput.qml
@@ -10,14 +10,9 @@ DcDevice {
 	id: input
 
 	readonly property int inputType: Global.dcInputs.inputType(serviceUid, monitorMode)
-	readonly property real temperature: _temperature.valid ? _temperature.value : NaN
 	readonly property int monitorMode: _monitorMode.valid ? _monitorMode.value : -1
 
 	property bool _completed
-
-	readonly property VeQuickItem _temperature: VeQuickItem {
-		uid: input.serviceUid + "/Dc/0/Temperature"
-	}
 
 	readonly property VeQuickItem _monitorMode: VeQuickItem {
 		uid: input.serviceUid + "/Settings/MonitorMode"

--- a/data/common/EnvironmentInput.qml
+++ b/data/common/EnvironmentInput.qml
@@ -15,6 +15,8 @@ Device {
 
 	readonly property VeQuickItem _temperature: VeQuickItem {
 		uid: serviceUid + "/Temperature"
+		sourceUnit: Units.unitToVeUnit(VenusOS.Units_Temperature_Celsius)
+		displayUnit: Units.unitToVeUnit(Global.systemSettings.temperatureUnit)
 	}
 	readonly property VeQuickItem _humidity: VeQuickItem {
 		uid: serviceUid + "/Humidity"

--- a/data/common/Tank.qml
+++ b/data/common/Tank.qml
@@ -9,15 +9,10 @@ import Victron.VenusOS
 BaseTankDevice {
 	id: tank
 
-	readonly property real temperature: _temperature.valid ? _temperature.value : NaN
-
 	property TankModel _tankModel
 
 	readonly property VeQuickItem _status: VeQuickItem {
 		uid: serviceUid + "/Status"
-	}
-	readonly property VeQuickItem _temperature: VeQuickItem {
-		uid: serviceUid + "/Temperature"
 	}
 	readonly property VeQuickItem _type: VeQuickItem {
 		uid: serviceUid + "/FluidType"

--- a/data/mock/TanksImpl.qml
+++ b/data/mock/TanksImpl.qml
@@ -57,6 +57,12 @@ QtObject {
 		Tank {
 			id: tank
 
+			readonly property VeQuickItem _temperature: VeQuickItem {
+				uid: tank.serviceUid + "/Temperature"
+				sourceUnit: Units.unitToVeUnit(VenusOS.Units_Temperature_Celsius)
+				displayUnit: Units.unitToVeUnit(Global.systemSettings.temperatureUnit)
+			}
+
 			onTypeChanged: {
 				if (type >= 0) {
 					_device._customName.setValue("Custom " + Gauges.tankProperties(type).name + " tank")

--- a/pages/EnvironmentTab.qml
+++ b/pages/EnvironmentTab.qml
@@ -21,7 +21,7 @@ LevelsTab {
 		height: Gauges.height(Global.pageManager?.expandLayout)
 		animationEnabled: root.animationEnabled
 		title: device?.name ?? ""
-		temperature: Global.systemSettings.convertFromCelsius(device?.temperature ?? NaN)
+		temperature: device?.temperature ?? NaN
 		temperatureType: device?.temperatureType ?? NaN
 		humidity: device?.humidity ?? NaN
 		temperatureGaugeGradient: temperatureGradient

--- a/pages/settings/devicelist/battery/BatteryDetails.qml
+++ b/pages/settings/devicelist/battery/BatteryDetails.qml
@@ -73,10 +73,14 @@ QtObject {
 		VeQuickItem {
 			id: minCellTemperature
 			uid: root.bindPrefix + "/System/MinCellTemperature"
+			sourceUnit: Units.unitToVeUnit(VenusOS.Units_Temperature_Celsius)
+			displayUnit: Units.unitToVeUnit(Global.systemSettings.temperatureUnit)
 		},
 		VeQuickItem {
 			id: maxCellTemperature
 			uid: root.bindPrefix + "/System/MaxCellTemperature"
+			sourceUnit: Units.unitToVeUnit(VenusOS.Units_Temperature_Celsius)
+			displayUnit: Units.unitToVeUnit(Global.systemSettings.temperatureUnit)
 		},
 		VeQuickItem {
 			id: minVoltageCellId

--- a/pages/settings/devicelist/battery/PageBatteryDetails.qml
+++ b/pages/settings/devicelist/battery/PageBatteryDetails.qml
@@ -12,13 +12,6 @@ Page {
 	property string bindPrefix
 	property BatteryDetails details
 
-	QtObject {
-		id: temperatureData
-
-		readonly property real minCellTemperature: Global.systemSettings.convertFromCelsius(details.minCellTemperature.value)
-		readonly property real maxCellTemperature: Global.systemSettings.convertFromCelsius(details.maxCellTemperature.value)
-	}
-
 	GradientListView {
 		model: VisibleItemModel {
 			ListQuantityGroup {
@@ -46,7 +39,7 @@ Page {
 				text: qsTrId("batterydetails_minimum_cell_temperature")
 				model: QuantityObjectModel {
 					QuantityObject { object: details.minTemperatureCellId; precision: details.minTemperatureCellId.decimals }
-					QuantityObject { object: temperatureData; key: "minCellTemperature"; unit: Global.systemSettings.temperatureUnit }
+					QuantityObject { object: details.minCellTemperature; unit: Global.systemSettings.temperatureUnit }
 				}
 				preferredVisible: details.allowsMinimumCellTemperature
 			}
@@ -56,7 +49,7 @@ Page {
 				text: qsTrId("batterydetails_maximum_cell_temperature")
 				model: QuantityObjectModel {
 					QuantityObject { object: details.maxTemperatureCellId; precision: details.maxTemperatureCellId.decimals }
-					QuantityObject { object: temperatureData; key: "maxCellTemperature"; unit: Global.systemSettings.temperatureUnit }
+					QuantityObject { object: details.maxCellTemperature; unit: Global.systemSettings.temperatureUnit }
 				}
 				preferredVisible: details.allowsMaximumCellTemperature
 			}

--- a/pages/settings/devicelist/battery/PageLynxIonSystem.qml
+++ b/pages/settings/devicelist/battery/PageLynxIonSystem.qml
@@ -67,21 +67,23 @@ Page {
 				//% "Min/max cell temperature"
 				text: qsTrId("lynxionsystem_min_max_cell_temperature")
 				model: QuantityObjectModel {
-					QuantityObject { object: minCellTemperature; key: "convertedValue"; unit: Global.systemSettings.temperatureUnit }
-					QuantityObject { object: maxCellTemperature; key: "convertedValue"; unit: Global.systemSettings.temperatureUnit }
+					QuantityObject { object: minCellTemperature; unit: Global.systemSettings.temperatureUnit }
+					QuantityObject { object: maxCellTemperature; unit: Global.systemSettings.temperatureUnit }
 				}
 				preferredVisible: minCellTemperature.valid && maxCellTemperature.valid
 
 				VeQuickItem {
 					id: minCellTemperature
-					readonly property real convertedValue: Global.systemSettings.convertFromCelsius(value)
 					uid: root.bindPrefix + "/System/MinCellTemperature"
+					dataItem.sourceUnit: Units.unitToVeUnit(VenusOS.Units_Temperature_Celsius)
+					dataItem.displayUnit: Units.unitToVeUnit(Global.systemSettings.temperatureUnit)
 				}
 
 				VeQuickItem {
 					id: maxCellTemperature
-					readonly property real convertedValue: Global.systemSettings.convertFromCelsius(value)
 					uid: root.bindPrefix + "/System/MaxCellTemperature"
+					dataItem.sourceUnit: Units.unitToVeUnit(VenusOS.Units_Temperature_Celsius)
+					dataItem.displayUnit: Units.unitToVeUnit(Global.systemSettings.temperatureUnit)
 				}
 			}
 


### PR DESCRIPTION
Cherry-pick Bea's changes into v3.60 branch.

Use VeQuickItem unit conversion features where possible, or use Units.convert() where a direct conversion is required.

Remove DcInput and Tank 'temperature' properties as they are unused.