### PR TITLE
Show center details on Brief Page when 4 gauges are visible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,6 +205,7 @@ set (VENUS_QML_MODULE_SOURCES
     components/EnvironmentGaugePanel.qml
     components/ExpandedTanksView.qml
     components/FirmwareUpdate.qml
+    components/FittedQuantityLabel.qml
     components/FixedWidthLabel.qml
     components/GaugeModel.qml
     components/GaugeHeader.qml

--- a/components/BriefCenterDisplay.qml
+++ b/components/BriefCenterDisplay.qml
@@ -12,7 +12,6 @@ Column {
 	id: root
 
 	property bool showFullDetails
-	property bool smallTextMode
 
 	readonly property bool _useTemperature: BackendConnection.portableIdInfo(centerService.value).type === "temperature"
 
@@ -62,29 +61,13 @@ Column {
 		}
 	}
 
-	QuantityLabel {
+	FittedQuantityLabel {
 		id: centerLabel
-
-		anchors.horizontalCenter: parent.horizontalCenter
-		height: root.smallTextMode ? centerLabelMetrics.ascent : implicitHeight
-		font.pixelSize: {
-			if (root._useTemperature) {
-				return root.smallTextMode
-					? Theme.font_briefPage_battery_temperature_minimumPixelSize
-					: Theme.font_briefPage_battery_temperature_maximumPixelSize
-			} else {
-				return root.smallTextMode
-					? Theme.font_briefPage_battery_percentage_minimumPixelSize
-					: Theme.font_briefPage_battery_percentage_maximumPixelSize
-			}
-		}
+		width: parent.width
 		unit: root._useTemperature ? Global.systemSettings.temperatureUnit : VenusOS.Units_Percentage
 		value: root._useTemperature ? (temperature.value ?? NaN) : Global.system.battery.stateOfCharge
-
-		FontMetrics {
-			id: centerLabelMetrics
-			font: centerLabel.font
-		}
+		minimumPixelSize: Theme.font_briefPage_battery_percentage_minimumPixelSize
+		maximumPixelSize: Theme.font_briefPage_battery_percentage_maximumPixelSize
 	}
 
 	Loader {

--- a/components/FittedQuantityLabel.qml
+++ b/components/FittedQuantityLabel.qml
@@ -1,0 +1,27 @@
+/*
+** Copyright (C) 2025 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+QuantityLabel {
+	id: root
+
+	property int minimumPixelSize: -1
+	property int maximumPixelSize: -1
+
+	readonly property real _maximumWidth: width - Theme.geometry_quantityLabel_spacing
+	readonly property string _combinedText: valueText + unitText
+
+	on_MaximumWidthChanged: Qt.callLater(_calculateFontFitting)
+	on_CombinedTextChanged: Qt.callLater(_calculateFontFitting)
+	onVisibleChanged:       Qt.callLater(_calculateFontFitting)
+
+	function _calculateFontFitting() {
+		if (root.visible) {
+			root.font.pixelSize = FastUtils.fittedPixelSize(root._combinedText, root._maximumWidth, root.minimumPixelSize, root.maximumPixelSize, root.font, Theme)
+		}
+	}
+}

--- a/pages/BriefPage.qml
+++ b/pages/BriefPage.qml
@@ -74,6 +74,7 @@ SwipeViewPage {
 		id: multiGauge
 
 		CircularMultiGauge {
+			id: circularMultiGauge
 			model: gaugeModel
 			animationEnabled: root.animationEnabled
 			labelOpacity: root._gaugeLabelOpacity
@@ -82,10 +83,8 @@ SwipeViewPage {
 
 			BriefCenterDisplay {
 				anchors.centerIn: parent
-				width: parent.width
-				visible: gaugeModel.count <= 3
+				width: parent.width - (gaugeModel.count * circularMultiGauge._stepSize) + Theme.geometry_circularMultiGauge_spacing
 				showFullDetails: gaugeModel.count === 1
-				smallTextMode: gaugeModel.count === 3
 			}
 		}
 	}

--- a/src/fastutils.cpp
+++ b/src/fastutils.cpp
@@ -5,6 +5,8 @@
 
 #include "fastutils.h"
 
+#include <QFontMetricsF>
+
 namespace Victron {
 namespace VenusOS {
 
@@ -31,6 +33,67 @@ QList<qreal> FastUtils::calculateLoadGraphYValues(const QList<qreal> &data, int 
 qreal FastUtils::degreesToRadians(const qreal degrees) const
 {
 	return degrees * 0.017453292519943295;  // Math.PI/180
+}
+
+// Find the largest pixel size for text which will fit in the specified maxWidth.
+// If the Theme singleton is specified, check the various theme values from largest to smallest.
+// Otherwise, use binary search to find an arbitrary font size which works.
+int FastUtils::fittedPixelSize(const QString &text, const qreal maxWidth, int minPixelSize, int maxPixelSize, const QFont &font, ThemeSingleton *theme) const
+{
+	if (maxWidth <= 0 || maxPixelSize <= 0 || minPixelSize == maxPixelSize || text.isEmpty()) {
+		return minPixelSize;
+	}
+
+	int currPixelSize;
+	QFont fittedFont(font);
+
+	if (theme) {
+		static const QList<int> fontSizes {
+			theme->font_size_h5(),
+			theme->font_size_h4(),
+			theme->font_size_h3(),
+			theme->font_size_h2(),
+			theme->font_size_h1(),
+			theme->font_size_body3(),
+			theme->font_size_body2(),
+			theme->font_size_body1(),
+			theme->font_size_caption(),
+			theme->font_size_phase_medium(),
+			theme->font_size_phase_small(),
+			theme->font_size_phase_number(),
+		};
+
+		for (int i = 0; i < fontSizes.size(); ++i) {
+			currPixelSize = fontSizes[i];
+			if (currPixelSize > maxPixelSize) {
+				continue;
+			} else if (currPixelSize <= minPixelSize) {
+				break;
+			}
+			fittedFont.setPixelSize(currPixelSize);
+			const QFontMetricsF fm(fittedFont);
+			const QRectF rect = fm.tightBoundingRect(text);
+			if ((rect.x() + rect.width()) <= maxWidth) {
+				return currPixelSize;
+			}
+		}
+
+		return minPixelSize;
+	}
+
+	// fall back to binary search.
+	while (minPixelSize < maxPixelSize) {
+		currPixelSize = minPixelSize + (maxPixelSize - minPixelSize + 1) / 2;
+		fittedFont.setPixelSize(currPixelSize);
+		const QFontMetricsF fm(fittedFont);
+		const QRectF rect = fm.tightBoundingRect(text);
+		if ((rect.x() + rect.width()) <= maxWidth) {
+			minPixelSize = currPixelSize;
+		} else {
+			maxPixelSize = currPixelSize - 1;
+		}
+	}
+	return minPixelSize;
 }
 
 }

--- a/src/fastutils.h
+++ b/src/fastutils.h
@@ -8,6 +8,9 @@
 
 #include <QQmlEngine>
 #include <QObject>
+#include <QFont>
+
+#include "themeobjects.h"
 
 namespace Victron {
 namespace VenusOS {
@@ -30,6 +33,7 @@ public:
 
 	Q_INVOKABLE QList<qreal> calculateLoadGraphYValues(const QList<qreal> &data, int dataLen, qreal height) const;
 	Q_INVOKABLE qreal degreesToRadians(const qreal degrees) const;
+	Q_INVOKABLE int fittedPixelSize(const QString &text, const qreal maxWidth, int minPixelSize, int maxPixelSize, const QFont &font, ThemeSingleton *theme = nullptr) const;
 };
 
 }

--- a/themes/typography/FiveInch.json
+++ b/themes/typography/FiveInch.json
@@ -1,8 +1,6 @@
 {
-    "font_briefPage_battery_percentage_minimumPixelSize": "font_size_h3",
+    "font_briefPage_battery_percentage_minimumPixelSize": "font_size_body3",
     "font_briefPage_battery_percentage_maximumPixelSize": "font_size_h4",
-    "font_briefPage_battery_temperature_minimumPixelSize": "font_size_h2",
-    "font_briefPage_battery_temperature_maximumPixelSize": "font_size_h4",
     "font_briefPage_battery_timeToGo_pixelSize": "font_size_body1",
     "font_briefPage_battery_voltage_pixelSize": "font_size_body3",
     "font_briefPage_quantityLabel_size": "font_size_body3",

--- a/themes/typography/SevenInch.json
+++ b/themes/typography/SevenInch.json
@@ -1,8 +1,6 @@
 {
-    "font_briefPage_battery_percentage_minimumPixelSize": "font_size_h5",
+    "font_briefPage_battery_percentage_minimumPixelSize": "font_size_body3",
     "font_briefPage_battery_percentage_maximumPixelSize": "font_size_h5",
-    "font_briefPage_battery_temperature_minimumPixelSize": "font_size_h4",
-    "font_briefPage_battery_temperature_maximumPixelSize": "font_size_h5",
     "font_briefPage_battery_timeToGo_pixelSize": "font_size_body2",
     "font_briefPage_battery_voltage_pixelSize": "font_size_h1",
     "font_briefPage_quantityLabel_size": "font_size_h2",


### PR DESCRIPTION
Use a QuantityLabel with font fitting to ensure that the text is sized appropriately to the available space.

Contributes to issue #2218