### PR TITLE
Show used sensor in DVCC settings as expected

### DIFF
--- a/pages/settings/PageSettingsDvcc.qml
+++ b/pages/settings/PageSettingsDvcc.qml
@@ -122,7 +122,7 @@ Page {
 				dataItem.uid: Global.system.serviceUid + "/AutoSelectedTemperatureService"
 				preferredVisible: sharedTempSense.checked
 					&& commonSettings.dvccActive
-					&& temperatureServiceRadioButtons.secondaryText === "default"
+					&& temperatureServiceRadioButtons.dataItem.value === "default"
 			}
 
 			ListSwitch {


### PR DESCRIPTION
The "Used sensor" setting should be shown when
/Settings/SystemSetup/TemperatureService = "default", not when the "/AvailableTemperatureServices" selected value is "default". The latter will never be true.