### PR TITLE
Implement UIAnimations system setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1137,6 +1137,7 @@ qt_add_resources(${PROJECT_NAME} "${PROJECT_NAME}_large_resources"
         images/dcloads.svg
         images/dropdown.svg
         images/electron.svg
+        images/electron_arrow.svg
         images/ess.svg
         images/freshWater.svg
         images/key_navigation_highlight_dark.svg

--- a/Global.qml
+++ b/Global.qml
@@ -30,7 +30,7 @@ QtObject {
 	property var notificationLayer
 	property ScreenBlanker screenBlanker
 	property bool displayCpuUsage
-	property bool pauseElectronAnimations
+	readonly property bool animationEnabled: (systemSettings?.animationEnabled ?? true) && BackendConnection.applicationVisible
 
 	// data sources
 	property var acInputs
@@ -58,8 +58,6 @@ QtObject {
 	property bool isDesktop
 	property bool isGxDevice: Qt.platform.os === "linux" && !isDesktop
 	property real scalingRatio: 1.0
-
-	property bool animationEnabled: true // for mock mode only.
 
 	readonly property int int32Max: _intValidator.top
 	readonly property int int32Min: _intValidator.bottom

--- a/components/CardViewLoader.qml
+++ b/components/CardViewLoader.qml
@@ -12,10 +12,11 @@ Loader {
 	required property Item statusBarItem
 	required property Item navBarItem
 	required property Item swipeViewItem
+	required property bool animationEnabled
 	property color backgroundColor: Theme.color_page_background
 	readonly property bool animationRunning: inAnimation.running || outAnimation.running
-	property int animationDuration: Theme.animation_controlCards_slide_duration
 	property bool viewActive: false
+	readonly property int _animationDuration: animationEnabled ? Theme.animation_controlCards_slide_duration : 1
 
 	active: viewActive
 	onActiveChanged: if (active) active = viewActive // remove binding
@@ -31,28 +32,28 @@ Loader {
 				target: root
 				from: root.statusBarItem.height - Theme.geometry_controlCards_slide_distance
 				to: root.statusBarItem.height
-				duration: root.animationDuration
+				duration: root._animationDuration
 				easing.type: Easing.OutSine
 			}
 			OpacityAnimator {
 				target: root
 				from: 0.0
 				to: 1.0
-				duration: root.animationDuration
+				duration: root._animationDuration
 				easing.type: Easing.OutSine
 			}
 			OpacityAnimator {
 				target: root.swipeViewItem
 				from: 1.0
 				to: 0.0
-				duration: root.animationDuration
+				duration: root._animationDuration
 				easing.type: Easing.OutSine
 			}
 			OpacityAnimator {
 				target: root.navBarItem
 				from: 1.0
 				to: 0.0
-				duration: root.animationDuration
+				duration: root._animationDuration
 				easing.type: Easing.OutSine
 			}
 			ColorAnimation {
@@ -60,7 +61,7 @@ Loader {
 				property: "backgroundColor"
 				from: root.backgroundColor
 				to: Theme.color_page_background
-				duration: root.animationDuration
+				duration: root._animationDuration
 				easing.type: Easing.OutSine
 			}
 		}
@@ -75,28 +76,28 @@ Loader {
 				target: root
 				from: root.statusBarItem.height
 				to: root.statusBarItem.height - Theme.geometry_controlCards_slide_distance
-				duration: root.animationDuration
+				duration: root._animationDuration
 				easing.type: Easing.InSine
 			}
 			OpacityAnimator {
 				target: root
 				from: 1.0
 				to: 0.0
-				duration: root.animationDuration
+				duration: root._animationDuration
 				easing.type: Easing.InSine
 			}
 			OpacityAnimator {
 				target: root.swipeViewItem
 				from: 0.0
 				to: 1.0
-				duration: root.animationDuration
+				duration: root._animationDuration
 				easing.type: Easing.InSine
 			}
 			OpacityAnimator {
 				target: root.navBarItem
 				from: 0.0
 				to: 1.0
-				duration: root.animationDuration
+				duration: root._animationDuration
 				easing.type: Easing.InSine
 			}
 			ColorAnimation {
@@ -104,7 +105,7 @@ Loader {
 				property: "backgroundColor"
 				from: Theme.color_page_background
 				to: root.backgroundColor
-				duration: root.animationDuration
+				duration: root._animationDuration
 				easing.type: Easing.InSine
 			}
 			PropertyAction {

--- a/components/LoadGraph.qml
+++ b/components/LoadGraph.qml
@@ -20,7 +20,7 @@ Item {
 	property color horizontalGradientColor1: Theme.color_briefPage_background
 	property color horizontalGradientColor2: "transparent"
 	property bool zeroCentered
-	property alias active: graphAnimation.running
+	property alias animationEnabled: graphAnimation.running
 
 	signal nextValueRequested()
 
@@ -34,6 +34,18 @@ Item {
 	clip: Global.isGxDevice // we have to clip if we don't use a layer in LoadGraphShapePath.
 	implicitWidth: Theme.geometry_briefPage_sidePanel_loadGraph_width
 	implicitHeight: Theme.geometry_briefPage_sidePanel_loadGraph_height
+
+	Timer {
+		id: pausedAnimationTimer
+		running: !root.animationEnabled
+		repeat: true
+		interval: Theme.geometry_briefPage_sidePanel_loadGraph_intervalMs
+		onTriggered: {
+			// step the graph and request the next value.
+			root.offsetFraction = 1.0
+			root.nextValueRequested();
+		}
+	}
 
 	SequentialAnimation {
 		id: graphAnimation

--- a/components/Page.qml
+++ b/components/Page.qml
@@ -14,7 +14,8 @@ FocusScope {
 	property color backgroundColor: Theme.color_page_background
 	property bool fullScreenWhenIdle
 	readonly property bool isCurrentPage: !!Global.mainView && Global.mainView.currentPage === root
-	readonly property bool defaultAnimationEnabled: !!Global.mainView && Global.mainView.allowPageAnimations
+	readonly property bool defaultAnimationEnabled: !!Global.mainView
+			&& Global.mainView.allowPageAnimations
 			&& !Global.mainView.screenIsBlanked
 	property bool animationEnabled: defaultAnimationEnabled && isCurrentPage
 

--- a/components/PageStack.qml
+++ b/components/PageStack.qml
@@ -13,6 +13,7 @@ C.StackView {
 	property var pageUrls: []
 	property Page _poppedPage
 
+	readonly property int animationDuration: Global.mainView && Global.mainView.allowPageAnimations ? Theme.animation_page_slide_duration : 0
 	readonly property bool animating: busy || fakePushAnimation.running || fakePopAnimation.running
 	property bool swipeViewVisible: true
 
@@ -21,7 +22,7 @@ C.StackView {
 		XAnimator {
 			from: width
 			to: 0
-			duration: Theme.animation_page_slide_duration
+			duration: root.animationDuration
 			easing.type: Easing.InOutQuad
 		}
 	}
@@ -30,7 +31,7 @@ C.StackView {
 		XAnimator {
 			from: 0
 			to: -width
-			duration: Theme.animation_page_slide_duration
+			duration: root.animationDuration
 			easing.type: Easing.InOutQuad
 		}
 	}
@@ -38,7 +39,7 @@ C.StackView {
 		XAnimator {
 			from: -width
 			to: 0
-			duration: Theme.animation_page_slide_duration
+			duration: root.animationDuration
 			easing.type: Easing.InOutQuad
 		}
 	}
@@ -48,7 +49,7 @@ C.StackView {
 			XAnimator {
 				from: 0
 				to: width
-				duration: Theme.animation_page_slide_duration
+				duration: root.animationDuration
 				easing.type: Easing.InOutQuad
 			}
 			ScriptAction {
@@ -120,7 +121,7 @@ C.StackView {
 		}
 
 		function _animationDuration(operation) {
-			return Global.allPagesLoaded && operation !== C.StackView.Immediate ? Theme.animation_page_slide_duration : 0
+			return Global.allPagesLoaded && operation !== C.StackView.Immediate ? root.animationDuration : 0
 		}
 
 		function _adjustedStackOperation(operation) {

--- a/components/StatusBar.qml
+++ b/components/StatusBar.qml
@@ -29,7 +29,9 @@ FocusScope {
 
 	width: parent.width
 	height: Theme.geometry_statusBar_height
-	opacity: 0
+	opacity: 0.0
+
+	Component.onCompleted: if (!animationEnabled) { root.opacity = 1.0 }
 
 	Rectangle {
 		id: backgroundRect
@@ -83,9 +85,9 @@ FocusScope {
 		font.family: Global.fontFamily
 		font.pixelSize: Theme.font_size_caption
 		Behavior on opacity {
+			enabled: root.animationEnabled
 			OpacityAnimator {
 				id: animator
-
 				duration: Theme.animation_toastNotification_fade_duration
 			}
 		}

--- a/components/ToastNotification.qml
+++ b/components/ToastNotification.qml
@@ -37,7 +37,12 @@ Item {
 	implicitHeight: Math.max(Theme.geometry_toastNotification_minHeight,
 			label.implicitHeight + 2*Theme.geometry_toastNotification_label_padding)
 
-	Behavior on opacity { OpacityAnimator { duration: Theme.animation_toastNotification_fade_duration } }
+	Behavior on opacity {
+		enabled: Global.animationEnabled
+		OpacityAnimator {
+			duration: Theme.animation_toastNotification_fade_duration
+		}
+	}
 	opacity: dismiss.dismissClicked ? 0.0
 		: dismiss.dismissAvailable  ? 1.0
 		: 0.0

--- a/components/controls/SwipeView.qml
+++ b/components/controls/SwipeView.qml
@@ -53,7 +53,8 @@ T.SwipeView {
 		highlightRangeMode: ListView.StrictlyEnforceRange
 		preferredHighlightBegin: 0
 		preferredHighlightEnd: 0
-		highlightMoveDuration: Global.allPagesLoaded ? 250 : 0 // don't animate when loading initial page
+		highlightMoveDuration: Global.allPagesLoaded && Global.mainView && Global.mainView.allowPageAnimations ? 250 : 0 // don't animate when loading initial page, or when animations are disabled.
+		highlightMoveVelocity: Global.allPagesLoaded && Global.mainView && Global.mainView.allowPageAnimations ? 400 : -1
 		maximumFlickVelocity: 4 * (control.orientation === Qt.Horizontal ? width : height)
 
 		Timer {

--- a/components/dialogs/ModalDialog.qml
+++ b/components/dialogs/ModalDialog.qml
@@ -91,9 +91,11 @@ T.Dialog {
 	focus: Global.keyNavigationEnabled
 
 	enter: Transition {
+		enabled: Global.animationEnabled
 		NumberAnimation { property: "opacity"; from: 0.0; to: 1.0; duration: Theme.animation_page_fade_duration }
 	}
 	exit: Transition {
+		enabled: Global.animationEnabled
 		NumberAnimation {
 			loops: Qt.platform.os == "wasm" ? 0 : 1 // workaround wasm crash, see https://bugreports.qt.io/browse/QTBUG-121382
 			property: "opacity"; from: 1.0; to: 0.0; duration: Theme.animation_page_fade_duration
@@ -269,6 +271,7 @@ T.Dialog {
 			transitions: [
 				Transition {
 					to: "*"
+					enabled: Global.animationEnabled
 					NumberAnimation {
 						target: root
 						property: "y"

--- a/components/widgets/OverviewWidget.qml
+++ b/components/widgets/OverviewWidget.qml
@@ -98,7 +98,7 @@ Rectangle {
 	}
 
 	transitions: Transition {
-		enabled: root.animateGeometry
+		enabled: root.animationEnabled && root.animateGeometry
 
 		NumberAnimation {
 			properties: "y,height,verticalMargin"

--- a/components/widgets/WidgetConnector.qml
+++ b/components/widgets/WidgetConnector.qml
@@ -58,7 +58,9 @@ Item {
 		// Sets the distance between electrons (i.e. how often to spawn a new electron)
 		// Use a min value to ensure at least one electron is shown for short connectors
 		const electronTravelDistance = Math.max(Theme.geometry_overviewPage_connector_electron_interval, _electronTravelDistance)
-		const modelCount = Math.floor(electronTravelDistance / Theme.geometry_overviewPage_connector_electron_interval)
+		const modelCount = animationEnabled
+			? Math.floor(electronTravelDistance / Theme.geometry_overviewPage_connector_electron_interval)
+			: 1 // show just one arrow, if animations are disabled.
 
 		if (electronRepeater.count !== modelCount) {
 			electronRepeater.model = modelCount
@@ -211,7 +213,7 @@ Item {
 
 				delegate: Image {
 					opacity: 0.0
-					source: "qrc:/images/electron.svg"
+					source: animationEnabled ? "qrc:/images/electron.svg" : "qrc:/images/electron_arrow.svg"
 
 					Behavior on opacity {
 						enabled: root._animated
@@ -243,7 +245,7 @@ Item {
 		property real normalizedElapsed: 1000 * root.frameAnimation.animationElapsed / pathUpdater.duration
 		readonly property real loopedElapsed: normalizedElapsed - Math.trunc(normalizedElapsed)
 		readonly property bool startToEnd: root.animationMode === VenusOS.WidgetConnector_AnimationMode_StartToEnd
-		progress: root.animationEnabled ? (startToEnd ? loopedElapsed : 1.0 - loopedElapsed) : 0.5
+		progress: root.animationEnabled ? (startToEnd ? loopedElapsed : 1.0 - loopedElapsed) : 0.515
 
 		animationMode: root.animationMode
 

--- a/data/SystemSettings.qml
+++ b/data/SystemSettings.qml
@@ -44,6 +44,8 @@ QtObject {
 		}
 	}
 
+	readonly property bool animationEnabled: _animationEnabled.valid ? _animationEnabled.value : true
+
 	function canAccess(level) {
 		return accessLevel.valid && accessLevel.value >= level
 	}
@@ -405,6 +407,11 @@ QtObject {
 
 	readonly property VeQuickItem _touchEnabled: VeQuickItem {
 		uid: root.serviceUid + "/Settings/Gui/TouchEnabled"
+	}
+
+	// 0 = disabled, 1 = enabled; value is 1 by default.
+	readonly property VeQuickItem _animationEnabled: VeQuickItem {
+		uid: root.serviceUid + "/Settings/Gui2/UIAnimations"
 	}
 
 	function reset() {

--- a/data/mock/SystemSettingsImpl.qml
+++ b/data/mock/SystemSettingsImpl.qml
@@ -122,6 +122,7 @@ QtObject {
 		setMockSettingValue("Gui2/StartPage", VenusOS.StartPage_Mode_AutoSelect)
 		setMockSettingValue("Gui2/StartPageName", "")
 		setMockSettingValue("Gui2/StartPageTimeout", 0)
+		setMockSettingValue("Gui2/UIAnimations", 1)
 
 		setMockPlatformValue("Vebus/Interface/ttyS2/Action", 0)
 		setMockPlatformValue("Vebus/Interface/ttyS2/AvailableBackups", '["MyBackup-ttyS2.rvsc", "AnotherBackup-ttyS2.rvsc"]')

--- a/data/mock/config/MockDataSimulator.qml
+++ b/data/mock/config/MockDataSimulator.qml
@@ -12,7 +12,6 @@ QtObject {
 	property bool timersActive: !Global.splashScreenVisible
 	property int deviceCount
 	property bool levelsEnabled: true
-	property bool animationEnabled: true
 
 	signal setBatteryRequested(config : var)
 	signal setAcInputsRequested(config : var)
@@ -109,7 +108,7 @@ QtObject {
 			}
 			break
 		case Qt.Key_A:
-			root.animationEnabled = !root.animationEnabled
+			root.setMockValue(Global.systemSettings.serviceUid + "/Settings/Gui2/UIAnimations", Global.systemSettings.animationEnabled ? 0 : 1)
 			break
 		case Qt.Key_B:
 			root.setMockValue(Global.systemSettings.serviceUid + "/Settings/Gui/ElectricPropulsionUI/Enabled",
@@ -347,19 +346,5 @@ QtObject {
 		onKeyPressed: (key, modifiers) => {
 			root.keyPressed(key, modifiers)
 		}
-	}
-
-	property Binding _pageAnimationsBinding: Binding {
-		when: !animationEnabled
-		target: !!Global.mainView ? Global.mainView : null
-		property: "allowPageAnimations"
-		value: false
-	}
-
-	property Binding _statusBarAnimationsBinding: Binding {
-		when: !animationEnabled
-		target: !!Global.pageManager ? Global.pageManager.statusBar : null
-		property: "animationEnabled"
-		value: false
 	}
 }

--- a/images/electron_arrow.svg
+++ b/images/electron_arrow.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="8" viewBox="0 0 10 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M 0 0 L 10 4 L 0 8 Z" fill="white" />
+</svg>

--- a/pages/BriefPage.qml
+++ b/pages/BriefPage.qml
@@ -436,16 +436,16 @@ SwipeViewPage {
 					NumberAnimation {
 						target: root
 						properties: "_gaugeArcOpacity,_gaugeArcMargin"
-						duration: Theme.animation_briefPage_gaugeArc_initialize_duration
+						duration: root.animationEnabled ? Theme.animation_briefPage_gaugeArc_initialize_duration : 1
 					}
 					SequentialAnimation {
 						PauseAnimation {
-							duration: Theme.animation_briefPage_gaugeLabel_initialize_delayedStart_duration
+							duration: root.animationEnabled ? Theme.animation_briefPage_gaugeLabel_initialize_delayedStart_duration : 1
 						}
 						NumberAnimation {
 							target: root
 							properties: "_gaugeLabelOpacity,_gaugeLabelMargin"
-							duration: Theme.animation_briefPage_gaugeLabel_initialize_duration
+							duration: root.animationEnabled ? Theme.animation_briefPage_gaugeLabel_initialize_duration : 1
 						}
 					}
 				}
@@ -459,12 +459,12 @@ SwipeViewPage {
 				NumberAnimation {
 					target: root
 					properties: "_gaugeArcOpacity,_gaugeLabelOpacity"
-					duration: Theme.animation_briefPage_edgeGauge_fade_duration
+					duration: root.animationEnabled ? Theme.animation_briefPage_sidePanel_slide_duration : 1
 				}
 				NumberAnimation {
 					target: sidePanel
 					properties: 'x,opacity'
-					duration: Theme.animation_briefPage_sidePanel_slide_duration
+					duration: root.animationEnabled ? Theme.animation_briefPage_sidePanel_slide_duration : 1
 					easing.type: Easing.InQuad
 				}
 				ScriptAction { script: root.state = "panelOpened" }
@@ -478,13 +478,13 @@ SwipeViewPage {
 				NumberAnimation {
 					target: sidePanel
 					properties: 'x,opacity'
-					duration: Theme.animation_briefPage_sidePanel_slide_duration
+					duration: root.animationEnabled ? Theme.animation_briefPage_sidePanel_slide_duration : 1
 					easing.type: Easing.InQuad
 				}
 				NumberAnimation {
 					target: root
 					properties: "_gaugeArcOpacity,_gaugeLabelOpacity"
-					duration: Theme.animation_briefPage_edgeGauge_fade_duration
+					duration: root.animationEnabled ? Theme.animation_briefPage_sidePanel_slide_duration : 1
 				}
 				ScriptAction { script: sidePanel.active = false }
 			}

--- a/pages/BriefSidePanel.qml
+++ b/pages/BriefSidePanel.qml
@@ -147,7 +147,7 @@ exported power v  0.4 |   /
 				}
 			}
 
-			active: root.animationEnabled
+			animationEnabled: root.animationEnabled
 			aboveThresholdFillColor: Theme.color_blue   // warning color is not needed for inputs
 			belowThresholdFillColor: _graphShowsFeedIn ? Theme.color_green : Theme.color_blue
 			initialModelValue: _graphShowsFeedIn ? 0.5 : 0
@@ -216,7 +216,7 @@ exported power v  0.4 |   /
 		visible: loadersActive
 		quantityLabel.dataObject: Global.dcInputs
 		sideComponent: LoadGraph {
-			active: root.animationEnabled
+			animationEnabled: root.animationEnabled
 			threshold: 0    // no threshold needed for inputs
 			aboveThresholdFillColor: Theme.color_blue   // warning color is not needed for inputs
 			onNextValueRequested: addValue(dcInputRange.valueAsRatio)
@@ -256,7 +256,7 @@ exported power v  0.4 |   /
 		quantityLabel.dataObject: Global.system.load.ac
 		loadersActive: true
 		sideComponent: LoadGraph {
-			active: root.animationEnabled
+			animationEnabled: root.animationEnabled
 			onNextValueRequested: addValue(acLoadGraphRange.averagePhaseCurrentAsRatio)
 
 			AcPhasesCurrentRange {
@@ -284,7 +284,7 @@ exported power v  0.4 |   /
 		visible: loadersActive
 		quantityLabel.dataObject: Global.system.dc
 		sideComponent: LoadGraph {
-			active: root.animationEnabled
+			animationEnabled: root.animationEnabled
 			onNextValueRequested: addValue(dcLoadRange.valueAsRatio)
 		}
 

--- a/pages/LevelsPage.qml
+++ b/pages/LevelsPage.qml
@@ -48,12 +48,12 @@ SwipeViewPage {
 				 : 0.0
 
 		Behavior on opacity {
-			enabled: root.isCurrentPage
+			enabled: root.animationEnabled && root.isCurrentPage
 			OpacityAnimator { duration: Theme.animation_page_idleOpacity_duration }
 		}
 
 		Behavior on anchors.topMargin {
-			enabled: root.isCurrentPage
+			enabled: root.animationEnabled && root.isCurrentPage
 			NumberAnimation { duration: Theme.animation_page_idleResize_duration; easing.type: Easing.InOutQuad }
 		}
 

--- a/pages/MainView.qml
+++ b/pages/MainView.qml
@@ -26,7 +26,9 @@ FocusScope {
 	// between pages, or when flicking between the main pages. Note that animations are still
 	// allowed when dragging between the main pages, as it looks odd if animations stop abruptly
 	// when the user drags slowly between pages.
-	property bool allowPageAnimations: mainViewVisible && !pageStack.busy && (!swipeView || !swipeView.flicking)
+	property bool allowPageAnimations: Global.animationEnabled
+									   && mainViewVisible
+									   && !pageStack.busy && (!swipeView || !swipeView.flicking)
 
 	// This SwipeView contains the main application pages (Brief, Overview, Levels, Notifications,
 	// and Settings).
@@ -269,6 +271,7 @@ FocusScope {
 		swipeViewItem : swipeView
 		backgroundColor: root.backgroundColor
 		viewActive: root.cardsActive
+		animationEnabled: root.allowPageAnimations
 		focus: root._focusTarget === cardsLoader
 		KeyNavigation.up: statusBar
 
@@ -303,14 +306,14 @@ FocusScope {
 				target: navBar
 				from: root.height - navBar.height + Theme.geometry_navigationBar_initialize_margin
 				to: root.height - navBar.height
-				duration: Theme.animation_navBar_initialize_fade_duration
+				duration: Global.animationEnabled ? Theme.animation_navBar_initialize_fade_duration : 1
 			}
 			OpacityAnimator {
 				id: opacityAnimator
 				target: navBar
 				from: 0.0
 				to: 1.0
-				duration: Theme.animation_navBar_initialize_fade_duration
+				duration: Global.animationEnabled ? Theme.animation_navBar_initialize_fade_duration : 1
 			}
 		}
 	}
@@ -325,7 +328,7 @@ FocusScope {
 			target: navBar
 			from: root.height
 			to: root.height - navBar.height
-			duration: Theme.animation_page_idleResize_duration
+			duration: Global.animationEnabled ? Theme.animation_page_idleResize_duration : 1
 			easing.type: Easing.InOutQuad
 		}
 		ScriptAction {
@@ -339,7 +342,7 @@ FocusScope {
 			target: navBar
 			from: 0.0
 			to: 1.0
-			duration: Theme.animation_page_idleOpacity_duration
+			duration: Global.animationEnabled ? Theme.animation_page_idleOpacity_duration : 1
 			easing.type: Easing.InOutQuad
 		}
 		ScriptAction {
@@ -361,7 +364,7 @@ FocusScope {
 			target: navBar
 			from: 1.0
 			to: 0.0
-			duration: Theme.animation_page_idleOpacity_duration
+			duration: Global.animationEnabled ? Theme.animation_page_idleOpacity_duration : 1
 			easing.type: Easing.InOutQuad
 		}
 		ScriptAction {
@@ -375,7 +378,7 @@ FocusScope {
 			target: navBar
 			from: root.height - navBar.height
 			to: root.height
-			duration: Theme.animation_page_idleResize_duration
+			duration: Global.animationEnabled ? Theme.animation_page_idleResize_duration : 1
 			easing.type: Easing.InOutQuad
 		}
 		ScriptAction {
@@ -400,7 +403,7 @@ FocusScope {
 			return customButton
 		}
 		rightButton: !!root.currentPage ? root.currentPage.topRightButton : VenusOS.StatusBar_RightButton_None
-		animationEnabled: BackendConnection.applicationVisible
+		animationEnabled: Global.animationEnabled
 		backgroundColor: root.backgroundColor
 
 		onLeftButtonClicked: {

--- a/pages/OverviewPage.qml
+++ b/pages/OverviewPage.qml
@@ -518,6 +518,7 @@ SwipeViewPage {
 				endWidget: inverterChargerWidget
 				endLocation: VenusOS.WidgetConnector_Location_Left
 				expanded: root._expandLayout
+				frameAnimation: overviewPageRootAnimation
 				animateGeometry: root._animateGeometry
 				animationEnabled: root.animationEnabled
 				animationMode: root._inputConnectorAnimationMode(acInputWidgetConnector)
@@ -552,6 +553,7 @@ SwipeViewPage {
 				endWidget: batteryWidget
 				endLocation: VenusOS.WidgetConnector_Location_Left
 				expanded: root._expandLayout
+				frameAnimation: overviewPageRootAnimation
 				animateGeometry: root._animateGeometry
 				animationEnabled: root.animationEnabled
 				animationMode: root._inputConnectorAnimationMode(dcInputConnector)
@@ -570,7 +572,7 @@ SwipeViewPage {
 	FrameAnimation {
 		id: overviewPageRootAnimation
 
-		paused: cpuInfo.overLimit || Global.pauseElectronAnimations
+		paused: cpuInfo.overLimit
 		running: root.animationEnabled
 		property real previousElapsed
 
@@ -615,6 +617,7 @@ SwipeViewPage {
 				endLocation: VenusOS.WidgetConnector_Location_Left
 				visible: defaultVisible && !isNaN(Global.system.solar.acPower)
 				expanded: root._expandLayout
+				frameAnimation: overviewPageRootAnimation
 				animateGeometry: root._animateGeometry
 				animationEnabled: root.animationEnabled
 
@@ -634,6 +637,7 @@ SwipeViewPage {
 				endLocation: VenusOS.WidgetConnector_Location_Left
 				visible: defaultVisible && !isNaN(Global.system.solar.dcPower)
 				expanded: root._expandLayout
+				frameAnimation: overviewPageRootAnimation
 				animateGeometry: root._animateGeometry
 				animationEnabled: root.animationEnabled
 
@@ -686,6 +690,7 @@ SwipeViewPage {
 		endWidget: acLoadsWidget
 		endLocation: VenusOS.WidgetConnector_Location_Left
 		expanded: root._expandLayout
+		frameAnimation: overviewPageRootAnimation
 		animateGeometry: root._animateGeometry
 		animationEnabled: root.animationEnabled
 
@@ -705,6 +710,7 @@ SwipeViewPage {
 		endWidget: batteryWidget
 		endLocation: VenusOS.WidgetConnector_Location_Top
 		expanded: root._expandLayout
+		frameAnimation: overviewPageRootAnimation
 		animateGeometry: root._animateGeometry
 		animationEnabled: root.animationEnabled
 
@@ -781,6 +787,7 @@ SwipeViewPage {
 			endWidget: essentialLoadsWidget
 			endLocation: VenusOS.WidgetConnector_Location_Left
 			expanded: root._expandLayout
+			frameAnimation: overviewPageRootAnimation
 			animateGeometry: root._animateGeometry
 			animationEnabled: root.animationEnabled
 
@@ -826,6 +833,7 @@ SwipeViewPage {
 				endWidget: dcLoadsWidget
 				endLocation: VenusOS.WidgetConnector_Location_Left
 				expanded: root._expandLayout
+				frameAnimation: overviewPageRootAnimation
 				animateGeometry: root._animateGeometry
 				animationEnabled: root.animationEnabled
 
@@ -906,6 +914,7 @@ SwipeViewPage {
 				endOffsetY: acLoadsToEvcsEndAnchor.offsetY
 				midpointOffsetX: -evcsWidget.loadsConnectorsXDistance
 				expanded: root._expandLayout
+				frameAnimation: overviewPageRootAnimation
 				animateGeometry: root._animateGeometry
 				animationEnabled: root.animationEnabled
 				animationMode: root.isCurrentPage
@@ -941,6 +950,7 @@ SwipeViewPage {
 				endOffsetY: essentialLoadsToEvcsEndAnchor.offsetY
 				midpointOffsetX: -evcsWidget.loadsConnectorsXDistance
 				expanded: root._expandLayout
+				frameAnimation: overviewPageRootAnimation
 				animateGeometry: root._animateGeometry
 				animationEnabled: root.animationEnabled
 				animationMode: root.isCurrentPage

--- a/pages/settings/PageSettingsDisplayAndAppearance.qml
+++ b/pages/settings/PageSettingsDisplayAndAppearance.qml
@@ -115,6 +115,16 @@ Page {
 				}
 			}
 
+			ListSwitch {
+				id: animationsEnabled
+				//% "UI Animations"
+				text: qsTrId("settings_ui_animations")
+				//% "Disable to reduce CPU usage"
+				secondaryText: qsTrId("settings_ui_animations_description")
+				dataItem.uid: Global.systemSettings.serviceUid + "/Settings/Gui2/UIAnimations"
+				preferredVisible: dataItem.valid
+			}
+
 			ListRadioButtonGroup {
 				id: runningVersion
 

--- a/pages/settings/debug/PageDebug.qml
+++ b/pages/settings/debug/PageDebug.qml
@@ -71,13 +71,6 @@ Page {
 				preferredVisible: Qt.platform.os === "linux"
 			}
 
-			SwitchItem {
-				//% "Pause electron animations"
-				text: qsTrId("settings_page_debug_pause_electron_animations")
-				checked: Global.pauseElectronAnimations
-				onClicked: Global.pauseElectronAnimations = !Global.pauseElectronAnimations
-			}
-
 			ListNavigation {
 				text: "UI Library"
 				onClicked: Global.pageManager.pushPage("/pages/settings/debug/PageSettingsDemo.qml", { title: text })


### PR DESCRIPTION
When this setting value is 1, all animations (including Overview page electron animations, gauge value change animations, page transition animations, and control card pane or side panel opening and closing animations) will be enabled; otherwise they will be disabled.

Disabling animations greatly reduces CPU usage on device.

Contributes to issue #2226