### PR TITLE
Ensure animations continue to run while page is visible

### DIFF
--- a/components/Page.qml
+++ b/components/Page.qml
@@ -16,7 +16,7 @@ FocusScope {
 	readonly property bool isCurrentPage: !!Global.mainView && Global.mainView.currentPage === root
 	readonly property bool defaultAnimationEnabled: !!Global.mainView && Global.mainView.allowPageAnimations
 			&& !Global.mainView.screenIsBlanked
-	property bool animationEnabled: defaultAnimationEnabled && isCurrentPage
+	property bool animationEnabled: defaultAnimationEnabled && visible
 
 	property int topLeftButton: VenusOS.StatusBar_LeftButton_None
 	property int topRightButton: VenusOS.StatusBar_RightButton_None


### PR DESCRIPTION
A page will be visible for some time after it is no longer the current page in the page stack (i.e. during its transition-out animation).

Contributes to issue #853