### PR TITLE
Escape key should selectively enable full-page highlight

### DIFF
--- a/pages/MainView.qml
+++ b/pages/MainView.qml
@@ -174,8 +174,9 @@ FocusScope {
 				blockItemFocus = false
 			}
 			Keys.onEscapePressed: (event) => {
-				event.accepted = !blockItemFocus
-				blockItemFocus = true
+				const shouldBlockFocus = item?.currentItem?.blockInitialFocus
+				event.accepted = shouldBlockFocus && !blockItemFocus
+				blockItemFocus = shouldBlockFocus
 			}
 			Keys.enabled: Global.keyNavigationEnabled
 			KeyNavigation.down: navBar


### PR DESCRIPTION
If an item on the Overview or Levels page is selected via key navigation, and the escape key is pressed, the full-page highlight should not be enabled as these pages do not contain lists.