### PR TITLE
Remove Duplicate CustomName ListTextField

### DIFF
--- a/pages/settings/devicelist/PageSwitch.qml
+++ b/pages/settings/devicelist/PageSwitch.qml
@@ -111,20 +111,6 @@ Page {
 			title: CommonWords.setup
 
 			GradientListView {
-				header: SettingsColumn {
-					width: parent.width
-					bottomPadding: spacing
-
-					ListTextField {
-						//% "Name"
-						text: qsTrId("page_switch_device_name")
-						dataItem.uid: root.serviceUid + "/CustomName"
-						dataItem.invalidate: false
-						textField.maximumLength: 32
-						preferredVisible : dataItem.valid
-						placeholderText: CommonWords.custom_name
-					}
-				}
 				model: switchableOutputModel
 				delegate: ListQuantityGroupNavigation {
 					id: outputQuantities


### PR DESCRIPTION
- PageSwitch does not need to show the CustomName as it is already shown in the Breadcrumbs and is already editable from the Device Sub Menu

Fixes #2275