### PR TITLE
Do not report active AC input as '241' when inverting

### DIFF
--- a/components/listitems/ListActiveAcInput.qml
+++ b/components/listitems/ListActiveAcInput.qml
@@ -21,5 +21,7 @@ ListText {
 	text: qsTrId("vebus_device_active_ac_input")
 
 	// ActiveInput value is 0-based index.
-	secondaryText: acActiveInput.valid ? CommonWords.acInputFromIndex(acActiveInput.value) : CommonWords.disconnected
+	secondaryText: acActiveInput.valid && acActiveInput.value !== VenusOS.AcInputs_InputSource_Inverting
+			? CommonWords.acInputFromIndex(acActiveInput.value)
+			: CommonWords.disconnected
 }


### PR DESCRIPTION
When the Multi RS is in inverter-only mode, /Ac/ActiveIn/ActiveInput will be 240, which means the AC input is not connected. In this case, do not assume ActiveInput refers to the input index.

Fixes #2269