### PR TITLE
Remove import Qt.Quick.Controls

### DIFF
--- a/ApplicationContent.qml
+++ b/ApplicationContent.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import QtQuick.Window
-import QtQuick.Controls as C
 import Victron.VenusOS
 
 FocusScope {
@@ -138,7 +137,7 @@ FocusScope {
 		source: Global.isGxDevice
 				? "qrc:/qt/qml/Victron/VenusOS/components/InputPanel.qml"
 				: "qrc:/qt/qml/Victron/VenusOS/components/WasmVirtualKeyboardHandler.qml"
-		parent: C.Overlay.overlay
+		parent: Overlay.overlay
 		z: 1
 	}
 

--- a/ApplicationContent.qml
+++ b/ApplicationContent.qml
@@ -5,7 +5,7 @@
 
 import QtQuick
 import QtQuick.Window
-import QtQuick.Controls as QtQuickControls
+import QtQuick.Controls as C
 import Victron.VenusOS
 
 FocusScope {
@@ -138,7 +138,7 @@ FocusScope {
 		source: Global.isGxDevice
 				? "qrc:/qt/qml/Victron/VenusOS/components/InputPanel.qml"
 				: "qrc:/qt/qml/Victron/VenusOS/components/WasmVirtualKeyboardHandler.qml"
-		parent: QtQuickControls.Overlay.overlay
+		parent: C.Overlay.overlay
 		z: 1
 	}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -855,6 +855,7 @@ qt_add_qml_module(VenusQMLModule
     URI Victron.VenusOS
     VERSION 2.0
     STATIC
+    IMPORTS QtQuick.Controls.Basic
     OUTPUT_DIRECTORY Victron/VenusOS
     QML_FILES ${VENUS_QML_MODULE_SOURCES}
     SOURCES ${VenusQMLModule_CPP_SOURCES}

--- a/components/ControlCard.qml
+++ b/components/ControlCard.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import QtQuick.Controls.impl as CP
-import QtQuick.Controls as C
 import Victron.VenusOS
 
 BaseListItem {

--- a/components/GeneratorIconLabel.qml
+++ b/components/GeneratorIconLabel.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import QtQuick.Controls as C
 import QtQuick.Controls.impl as CP
 import Victron.VenusOS
 

--- a/components/GeneratorManualControlButton.qml
+++ b/components/GeneratorManualControlButton.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import QtQuick.Controls.impl as CP
 
 ListItemButton {
 	id: root

--- a/components/NavButton.qml
+++ b/components/NavButton.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import QtQuick.Controls as C
 import Victron.VenusOS
 
 Button {
@@ -13,7 +12,7 @@ Button {
 	icon.width: Theme.geometry_navigationBar_button_icon_width
 	icon.height: Theme.geometry_navigationBar_button_icon_height
 	spacing: Theme.geometry_navigationBar_button_spacing
-	display: C.AbstractButton.TextUnderIcon
+	display: Button.TextUnderIcon
 	radius: 0
 
 	color: down

--- a/components/Page.qml
+++ b/components/Page.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import QtQuick.Controls as C
 import Victron.VenusOS
 
 FocusScope {

--- a/components/PageStack.qml
+++ b/components/PageStack.qml
@@ -4,10 +4,9 @@
 */
 
 import QtQuick
-import QtQuick.Controls as C
 import Victron.VenusOS
 
-C.StackView {
+StackView {
 	id: root
 
 	property var pageUrls: []
@@ -89,7 +88,7 @@ C.StackView {
 
 			if (root.depth === 0) {
 				// When the first page is added to the stack, move the stack into view.
-				root.push(objectOrUrl, properties, C.StackView.Immediate)
+				root.push(objectOrUrl, properties, StackView.Immediate)
 				fakePushAnimation.duration = _animationDuration(operation)
 				fakePushAnimation.start()
 			} else {
@@ -121,11 +120,11 @@ C.StackView {
 		}
 
 		function _animationDuration(operation) {
-			return Global.allPagesLoaded && operation !== C.StackView.Immediate ? root.animationDuration : 0
+			return Global.allPagesLoaded && operation !== StackView.Immediate ? root.animationDuration : 0
 		}
 
 		function _adjustedStackOperation(operation) {
-			return Global.allPagesLoaded && operation !== C.StackView.Immediate ? operation : C.StackView.Immediate
+			return Global.allPagesLoaded && operation !== StackView.Immediate ? operation : StackView.Immediate
 		}
 	}
 
@@ -148,7 +147,7 @@ C.StackView {
 		onStopped: {
 			// When leaving the page stack destroy all the pages
 			while (root.depth > 1) {
-				const page = root.pop(duration > 0 ? C.StackView.PopTransition : C.StackView.Immediate)
+				const page = root.pop(duration > 0 ? StackView.PopTransition : StackView.Immediate)
 				if (page && !Theme.objectHasQObjectParent(page)) {
 					page.destroy()
 				}

--- a/components/RadioButtonListPage.qml
+++ b/components/RadioButtonListPage.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import QtQuick.Controls as C
 import Victron.VenusOS
 
 Page {
@@ -78,7 +77,7 @@ Page {
 			showAccessLevel: root.showAccessLevel
 			writeAccessLevel: root.writeAccessLevel
 			checked: optionsListView.selectedIndex === model.index
-			C.ButtonGroup.group: radioButtonGroup
+			ButtonGroup.group: radioButtonGroup
 
 			bottomContent.z: model.index === optionsListView.selectedIndex ? 1 : -1
 			bottomContentChildren: Loader {
@@ -195,7 +194,7 @@ Page {
 			}
 		}
 
-		C.ButtonGroup {
+		ButtonGroup {
 			id: radioButtonGroup
 		}
 	}

--- a/components/SegmentedButtonRow.qml
+++ b/components/SegmentedButtonRow.qml
@@ -4,8 +4,6 @@
 */
 
 import QtQuick
-import QtQuick.Controls as C
-import QtQuick.Controls.impl as CP
 import QtQuick.Templates as T
 import Victron.VenusOS
 

--- a/components/SolarYieldGauge.qml
+++ b/components/SolarYieldGauge.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import QtQuick.Controls.impl as CP
 
 Item {
 	id: root

--- a/components/StatusBar.qml
+++ b/components/StatusBar.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import QtQuick.Controls as C
 import QtQuick.Controls.impl as CP
 import Victron.VenusOS
 
@@ -57,7 +56,7 @@ FocusScope {
 		width: Theme.geometry_statusBar_button_height
 		height: Theme.geometry_statusBar_button_height
 		backgroundColor: "transparent"  // don't show background when disabled
-		display: C.AbstractButton.IconOnly
+		display: Button.IconOnly
 		color: Theme.color_ok
 		opacity: enabled && Global.pageManager?.interactivity === VenusOS.PageManager_InteractionMode_Interactive ? 1.0 : 0.0
 		onActiveFocusChanged: {

--- a/components/SwipeViewPage.qml
+++ b/components/SwipeViewPage.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import QtQuick.Controls as C
 import Victron.VenusOS
 
 /*

--- a/components/controls/Button.qml
+++ b/components/controls/Button.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import QtQuick.Templates as CT
-import QtQuick.Controls as C
 import QtQuick.Controls.impl as CP
 import Victron.VenusOS
 

--- a/components/controls/Button.qml
+++ b/components/controls/Button.qml
@@ -4,11 +4,11 @@
 */
 
 import QtQuick
-import QtQuick.Templates as CT
+import QtQuick.Templates as T
 import QtQuick.Controls.impl as CP
 import Victron.VenusOS
 
-CT.Button {
+T.Button {
 	id: root
 
 	property color color: !showEnabled ? Theme.color_font_disabled

--- a/components/controls/ComboBox.qml
+++ b/components/controls/ComboBox.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import QtQuick.Templates as CT
-import QtQuick.Controls as C
 import QtQuick.Controls.impl as CP
 import Victron.VenusOS
 

--- a/components/controls/ComboBox.qml
+++ b/components/controls/ComboBox.qml
@@ -4,11 +4,11 @@
 */
 
 import QtQuick
-import QtQuick.Templates as CT
+import QtQuick.Templates as T
 import QtQuick.Controls.impl as CP
 import Victron.VenusOS
 
-CT.ComboBox {
+T.ComboBox {
 	id: root
 
 	implicitWidth: contentItem.implicitWidth + root.leftPadding + root.rightPadding
@@ -20,7 +20,7 @@ CT.ComboBox {
 	bottomPadding: Theme.geometry_comboBox_verticalPadding
 	spacing: Theme.geometry_comboBox_spacing
 
-	delegate: CT.ItemDelegate {
+	delegate: T.ItemDelegate {
 		id: optionDelegate
 
 		width: root.width
@@ -91,7 +91,7 @@ CT.ComboBox {
 			   : Theme.color_background_disabled
 	}
 
-	popup: CT.Popup {
+	popup: T.Popup {
 		width: root.width
 		implicitHeight: contentItem.implicitHeight
 

--- a/components/controls/Label.qml
+++ b/components/controls/Label.qml
@@ -4,10 +4,10 @@
 */
 
 import QtQuick
-import QtQuick.Templates as CT
+import QtQuick.Templates as T
 import Victron.VenusOS
 
-CT.Label {
+T.Label {
 	color: Theme.color_font_primary
 	font.family: Global.fontFamily
 	font.pixelSize: Theme.font_size_body1

--- a/components/controls/ProgressBar.qml
+++ b/components/controls/ProgressBar.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import QtQuick.Templates as T
-import QtQuick.Controls as C
 import Victron.VenusOS
 import QtQuick.Effects as Effects
 

--- a/components/controls/RadioButton.qml
+++ b/components/controls/RadioButton.qml
@@ -4,10 +4,10 @@
 */
 
 import QtQuick
-import QtQuick.Templates as CT
+import QtQuick.Templates as T
 import Victron.VenusOS
 
-CT.RadioButton {
+T.RadioButton {
 	id: root
 
 	implicitWidth: Math.max(

--- a/components/controls/RangeSlider.qml
+++ b/components/controls/RangeSlider.qml
@@ -4,15 +4,24 @@
 */
 
 import QtQuick
-import QtQuick.Controls as C
+import QtQuick.Templates as T
 import QtQuick.Controls.impl as CP
 import Victron.VenusOS
 
-C.RangeSlider {
+T.RangeSlider {
 	id: root
 
 	property color firstColor: "transparent"
 	property color secondColor: "transparent"
+
+	implicitWidth: Math.max(implicitBackgroundWidth + leftInset + rightInset,
+							first.implicitHandleWidth + leftPadding + rightPadding,
+							second.implicitHandleWidth + leftPadding + rightPadding)
+	implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset,
+							 first.implicitHandleHeight + topPadding + bottomPadding,
+							 second.implicitHandleHeight + topPadding + bottomPadding)
+
+	padding: 6
 
 	background: Rectangle {
 		anchors {

--- a/components/controls/ScrollBar.qml
+++ b/components/controls/ScrollBar.qml
@@ -4,10 +4,10 @@
 */
 
 import QtQuick
-import QtQuick.Templates as CT
+import QtQuick.Templates as T
 import Victron.VenusOS
 
-CT.ScrollBar {
+T.ScrollBar {
 	id: root
 
 	implicitWidth: Math.max(

--- a/components/controls/Slider.qml
+++ b/components/controls/Slider.qml
@@ -5,8 +5,6 @@
 
 import QtQuick
 import QtQuick.Templates as T
-import QtQuick.Controls as C
-import QtQuick.Controls.impl as CP
 import Victron.VenusOS
 import QtQuick.Effects as Effects
 

--- a/components/controls/SpinBox.qml
+++ b/components/controls/SpinBox.qml
@@ -4,7 +4,7 @@
 */
 
 import QtQuick
-import QtQuick.Templates as CT
+import QtQuick.Templates as T
 import QtQuick.Layouts
 import Victron.VenusOS
 
@@ -12,7 +12,7 @@ import Victron.VenusOS
 // When the button is released, 'stepSize' reverts to its original value.
 // TODO - find a way to do this without exposing the changes to 'stepSize', as it may surprise developers when the value changes unexpectedly.
 
-CT.SpinBox {
+T.SpinBox {
 	id: root
 
 	property alias textInput: primaryTextInput

--- a/components/controls/SpinBox.qml
+++ b/components/controls/SpinBox.qml
@@ -4,9 +4,7 @@
 */
 
 import QtQuick
-import QtQuick.Controls as C
 import QtQuick.Templates as CT
-import QtQuick.Controls.impl as CP
 import QtQuick.Layouts
 import Victron.VenusOS
 

--- a/components/controls/Switch.qml
+++ b/components/controls/Switch.qml
@@ -4,10 +4,10 @@
 */
 
 import QtQuick
-import QtQuick.Templates as CT
+import QtQuick.Templates as T
 import Victron.VenusOS
 
-CT.Switch {
+T.Switch {
 	id: root
 
 	checkable: false

--- a/components/controls/Switch.qml
+++ b/components/controls/Switch.qml
@@ -4,9 +4,7 @@
 */
 
 import QtQuick
-import QtQuick.Controls as C
 import QtQuick.Templates as CT
-import QtQuick.Controls.impl as CP
 import Victron.VenusOS
 
 CT.Switch {

--- a/components/controls/TextField.qml
+++ b/components/controls/TextField.qml
@@ -4,10 +4,10 @@
 */
 
 import QtQuick
-import QtQuick.Templates as CT
+import QtQuick.Templates as T
 import Victron.VenusOS
 
-CT.TextField {
+T.TextField {
 	id: root
 
 	property color borderColor: Theme.color_ok

--- a/components/dialogs/VrmInstanceSwapDialog.qml
+++ b/components/dialogs/VrmInstanceSwapDialog.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import QtQuick.Controls as C
 
 ModalWarningDialog {
 	id: root
@@ -134,7 +133,7 @@ ModalWarningDialog {
 				? Theme.color_red
 				: Theme.color_green
 
-	closePolicy: _busy ? C.Popup.NoAutoClose : (C.Popup.CloseOnEscape | C.Popup.CloseOnPressOutside)
+	closePolicy: _busy ? Popup.NoAutoClose : (Popup.CloseOnEscape | Popup.CloseOnPressOutside)
 	footer.enabled: !_busy
 	footer.opacity: _busy ? 0 : 1
 

--- a/components/listitems/ListRebootButton.qml
+++ b/components/listitems/ListRebootButton.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import QtQuick.Controls.impl as CP
 import Victron.VenusOS
 import QtQuick.Templates as T
 

--- a/components/listitems/core/ListButton.qml
+++ b/components/listitems/core/ListButton.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import QtQuick.Controls.impl as CP
 import Victron.VenusOS
 
 ListItem {

--- a/components/listitems/core/ListRadioButton.qml
+++ b/components/listitems/core/ListRadioButton.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import QtQuick.Controls as C
 import Victron.VenusOS
 
 ListItem {

--- a/components/listitems/core/ListTextField.qml
+++ b/components/listitems/core/ListTextField.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import QtQuick.Controls.impl as CP
 import Victron.VenusOS
 
 ListItem {

--- a/components/widgets/DcLoadsWidget.qml
+++ b/components/widgets/DcLoadsWidget.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import QtQuick.Controls.impl as CP
 import Victron.VenusOS
 
 OverviewWidget {

--- a/pages/LevelsPage.qml
+++ b/pages/LevelsPage.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import QtQuick.Controls.impl as CP
 
 SwipeViewPage {
 	id: root

--- a/pages/NotificationsPage.qml
+++ b/pages/NotificationsPage.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import QtQuick.Controls.impl as CP
 
 SwipeViewPage {
 	id: root

--- a/pages/PageManager.qml
+++ b/pages/PageManager.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQml
-import QtQuick.Controls as C
 import Victron.VenusOS
 
 QtObject {
@@ -52,10 +51,10 @@ QtObject {
 
 	function popToAbovePage(page, operation = PageStack.PopTransition) {
 		if (page) {
-			const stackView = page.C.StackView.view
+			const stackView = page.StackView.view
 			for (let i = stackView.depth - 1; i >= 0; --i) {
-				if (stackView.get(i, C.StackView.DontLoad) === page) {
-					const targetPage = i === 0 ? null : stackView.get(i - 1, C.StackView.DontLoad)
+				if (stackView.get(i, StackView.DontLoad) === page) {
+					const targetPage = i === 0 ? null : stackView.get(i - 1, StackView.DontLoad)
 					if (targetPage) {
 						root.popPage(targetPage)
 						return

--- a/pages/boatpage/BoatPage.qml
+++ b/pages/boatpage/BoatPage.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.BoatPageComponents as BoatPageComponents
-import QtQuick.Controls.impl as CP
 import Victron.VenusOS
 
 SwipeViewPage {

--- a/pages/boatpage/Gear.qml
+++ b/pages/boatpage/Gear.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.BoatPageComponents as BoatPageComponents
-import QtQuick.Controls.impl as CP
 import Victron.VenusOS
 import Victron.Gauges
 

--- a/pages/boatpage/TemperatureGauges.qml
+++ b/pages/boatpage/TemperatureGauges.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.BoatPageComponents as BoatPageComponents
-import QtQuick.Controls.impl as CP
 import Victron.VenusOS
 import Victron.Gauges
 

--- a/pages/boatpage/TimeToGo.qml
+++ b/pages/boatpage/TimeToGo.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import QtQuick.Controls.impl as CP
 import Victron.VenusOS
 import Victron.Gauges
 

--- a/pages/controlcards/ESSCard.qml
+++ b/pages/controlcards/ESSCard.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import QtQuick.Controls as C
 import QtQuick.Controls.impl as CP
 
 ControlCard {
@@ -21,7 +20,7 @@ ControlCard {
 		}
 		width: parent.width
 
-		C.ButtonGroup {
+		ButtonGroup {
 			id: stateRadioButtonGroup
 		}
 
@@ -37,7 +36,7 @@ ControlCard {
 					text: modelData.display
 					flat: true
 					checked: Global.systemSettings.ess.state === modelData.value
-					C.ButtonGroup.group: stateRadioButtonGroup
+					ButtonGroup.group: stateRadioButtonGroup
 					onClicked: Global.systemSettings.ess.setState(modelData.value)
 				}
 

--- a/pages/controlcards/EVCSCard.qml
+++ b/pages/controlcards/EVCSCard.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import QtQuick.Controls.impl as CP
 import Victron.VenusOS
 
 ControlCard {

--- a/pages/controlcards/GeneratorCard.qml
+++ b/pages/controlcards/GeneratorCard.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import QtQuick.Controls.impl as CP
 import Victron.VenusOS
 
 ControlCard {

--- a/pages/evcs/EvChargerSetupPage.qml
+++ b/pages/evcs/EvChargerSetupPage.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import QtQuick.Controls.impl as CP
 
 Page {
 	id: root

--- a/pages/settings/IpAddressListView.qml
+++ b/pages/settings/IpAddressListView.qml
@@ -4,8 +4,6 @@
 */
 
 import QtQuick
-import QtQuick.Controls as C
-import QtQuick.Controls.impl as CP
 import Victron.VenusOS
 
 GradientListView {

--- a/pages/settings/PageDeviceInfo.qml
+++ b/pages/settings/PageDeviceInfo.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import QtQuick.Controls.impl as CP
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsDvcc.qml
+++ b/pages/settings/PageSettingsDvcc.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import QtQuick.Controls as C
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsFroniusSetIpAddresses.qml
+++ b/pages/settings/PageSettingsFroniusSetIpAddresses.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import QtQuick.Controls as C
 import Victron.VenusOS
 
 Page {

--- a/pages/settings/PageSettingsFroniusShowIpAddresses.qml
+++ b/pages/settings/PageSettingsFroniusShowIpAddresses.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import QtQuick.Controls as C
 import Victron.VenusOS
 
 Page {

--- a/pages/settings/PageSettingsModbusAddDevice.qml
+++ b/pages/settings/PageSettingsModbusAddDevice.qml
@@ -6,7 +6,6 @@
 import QtQuick
 import Victron.VenusOS
 import QtQuick.Controls as C
-import QtQuick.Controls.impl as CP
 
 Page {
 	id: root

--- a/pages/settings/PageSettingsModbusAddDevice.qml
+++ b/pages/settings/PageSettingsModbusAddDevice.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import QtQuick.Controls as C
 
 Page {
 	id: root
@@ -15,7 +14,7 @@ Page {
 	//% "Add Modbus TCP/UDP device"
 	title: qsTrId("add_modbus_tcp_udp_device")
 
-	C.ButtonGroup {
+	ButtonGroup {
 		id: radioButtonGroup
 	}
 

--- a/pages/settings/PageSettingsModbusDevices.qml
+++ b/pages/settings/PageSettingsModbusDevices.qml
@@ -5,8 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import QtQuick.Controls as C
-import QtQuick.Controls.impl as CP
 
 Page {
 	id: root

--- a/pages/settings/PageVrmDeviceInstances.qml
+++ b/pages/settings/PageVrmDeviceInstances.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import QtQuick.Controls as C
 import Victron.VenusOS
 
 // Allows VRM instances to be changed for devices on the system.
@@ -336,7 +335,7 @@ Page {
 
 				if (BackendConnection.type === BackendConnection.DBusSource) {
 					// Reboot takes a while to execute, so prevent any user activity until that happens.
-					closePolicy = C.Popup.NoAutoClose
+					closePolicy = Popup.NoAutoClose
 					footer.enabled = false
 					footer.opacity = 0
 				}

--- a/pages/solar/SolarHistoryPage.qml
+++ b/pages/solar/SolarHistoryPage.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import QtQuick.Controls as C
 
 Page {
 	id: root

--- a/pages/vebusdevice/PageVeBusSerialNumbers.qml
+++ b/pages/vebusdevice/PageVeBusSerialNumbers.qml
@@ -5,7 +5,6 @@
 
 import QtQuick
 import Victron.VenusOS
-import QtQuick.Controls.impl as CP
 
 Page {
 	id: root

--- a/pages/welcome/WelcomeView.qml
+++ b/pages/welcome/WelcomeView.qml
@@ -4,7 +4,6 @@
 */
 
 import QtQuick
-import QtQuick.Controls as C
 import Victron.VenusOS
 
 Rectangle {
@@ -152,12 +151,12 @@ Rectangle {
 		}
 		onObjectAdded: (index, object) => {
 			if (index === 0) {
-				stackView.push(object, {}, C.StackView.Immediate)
+				stackView.push(object, {}, StackView.Immediate)
 			}
 		}
 	}
 
-	C.StackView {
+	StackView {
 		id: stackView
 		anchors {
 			left: parent.left


### PR DESCRIPTION
This PR is to:
- remove redundant ```import QtQuick.Controls``` and ```import QtQuick.Controls.impl```
- remove the **run-time** style selection (we want to use the style from Victron.VenusOS (components) as a **faster** [compile-time style selection](https://doc.qt.io/qt-6/qtquickcontrols-styles.html#compile-time-style-selection) which helps the code model immensely as well. 
- remove the possibility of visual inconsistencies on different platforms when using the "fallback" [default style](https://doc.qt.io/qt-6/qtquickcontrols-styles.html#default-styles)
- make sure that when you ```import Victron.VenusOS``` you can know exactly what you are getting: 
      Priority 1: all the components that are defined in Victron.VenusOS and _only then:_
      Priority 2: where such is not available (e.g. Page, Pane etc) you get is absolutely prescribed - the controls from the **QtQuick.Controls.Basic style**
- ensure that all Victron.VenusOS components use QtQuick.Controls.Templates and avoid type name clashes (RangeSlider)
- Only the Qt.Quick.Controls.Basic style library needs to be shipped to target - all the others if provided can be eliminated.
- a contrived palette can be added to the ApplicationWindow component such that "purple" is used for all palette roles. This means that if any Control be present from the QtQuick.Controls.Basic library, they will immediately look purple and alert to attention - i.e. a potential new customised addition to the Victron.VenusOS component set.