### PR TITLE
WASM: improve watchdog and initialized variables

### DIFF
--- a/src/backendconnection.cpp
+++ b/src/backendconnection.cpp
@@ -269,13 +269,13 @@ void BackendConnection::openUrl(const QString &url)
 
 void BackendConnection::hitWatchdog()
 {
-	// 'watchdogHit' and 'initialized' are defined in index.html.
-	// After this function sets 'initialized' to true, a timer in index.html periodically:
+	// 'watchdogHit' and 'guiv2initialized' are defined in index.html.
+	// After this function sets 'guiv2initialized' to true, a timer in index.html periodically:
 	//	1. checks watchdogHit - if false, reloads the page.
 	//	2. sets 'watchdogHit' to false.
 
-	emscripten_run_script("watchdogHit = true");
-	emscripten_run_script("initialized = true");
+	emscripten_run_script("if (typeof watchdogHit !== 'undefined') watchdogHit = true");
+	emscripten_run_script("if (typeof guiv2initialized !== 'undefined') guiv2initialized = true");
 }
 
 #else

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -181,7 +181,9 @@
     <script src="venus-gui-v2.js"></script>
     <script type="text/javascript" src="qtloader.js"></script>
     <script type="text/javascript">
-        var initialized = false
+        // Note: VRM does not use this index.html, so if you add some
+        // control variables here, make sure you coordinate with VRM.
+        var guiv2initialized = false
         var watchdogHit = false // this gets set to 'true' by a timer via BackendConnection::hitWatchdog()
         var reloadTriggered = false // this gets set to 'true' if reload() is called to prevent multiple reload calls
         console.log("starting watchdog timer")
@@ -189,7 +191,7 @@
 
         function checkWatchdog()
         {
-            if (!watchdogHit && !reloadTriggered && initialized) {
+            if (!watchdogHit && !reloadTriggered && guiv2initialized) {
                 console.error("Watchdog timer expired - reloading page")
                 reload()
                 reloadTriggered = true


### PR DESCRIPTION
Use a prefixed name for the initialized variable to avoid clashes. Check that the variables are defined in the JS environment before attempting to set them, in case they are not provided by VRM, as VRM does not use our index.html.