### PR TITLE
Always show DC Loads when matching services are present

### DIFF
--- a/data/System.qml
+++ b/data/System.qml
@@ -29,7 +29,11 @@ QtObject {
 	}
 
 	readonly property QtObject dc: QtObject {
-		readonly property real power: (_hasDcSystem.valid && _hasDcSystem.value && _dcSystemPower.valid) ? _dcSystemPower.value : NaN
+		// Regardless of the actual power value, regard the system as having DC power (and show
+		// DC Loads in the UI) if any dc system services are present or if /HasDcSystem=1.
+		readonly property bool hasPower: Global.allDevicesModel.combinedDcLoadDevices.count > 0 || _hasDcSystem.value === 1
+
+		readonly property real power: hasPower ? _dcSystemPower.value || 0 : NaN
 		readonly property real current: (isNaN(power) || isNaN(voltage) || voltage === 0) ? NaN : power / voltage
 		readonly property real voltage: _dcBatteryVoltage.valid ? _dcBatteryVoltage.value : NaN
 		readonly property real maximumPower: _maximumDcPower.valid ? _maximumDcPower.value : NaN

--- a/pages/BriefPage.qml
+++ b/pages/BriefPage.qml
@@ -307,7 +307,7 @@ SwipeViewPage {
 
 			width: Theme.geometry_briefPage_edgeGauge_width
 			height: active ? Gauges.gaugeHeight(root._rightGaugeCount) : 0
-			active: !isNaN(Global.system.dc.power) && root.state !== "panelOpened"
+			active: Global.system.dc.hasPower && root.state !== "panelOpened"
 			sourceComponent: SideGauge {
 				readonly property var gaugeParams: Gauges.rightGaugeParameters(1, _rightGaugeCount)
 

--- a/pages/BriefSidePanel.qml
+++ b/pages/BriefSidePanel.qml
@@ -280,7 +280,7 @@ exported power v  0.4 |   /
 		//% "DC Loads"
 		title: qsTrId("brief_dc_loads")
 		icon.source: "qrc:/images/dcloads.svg"
-		loadersActive: !isNaN(Global.system.dc.power)
+		loadersActive: Global.system.dc.hasPower
 		visible: loadersActive
 		quantityLabel.dataObject: Global.system.dc
 		sideComponent: LoadGraph {

--- a/pages/OverviewPage.qml
+++ b/pages/OverviewPage.qml
@@ -46,7 +46,7 @@ SwipeViewPage {
 			+ (Global.acInputs.input2?.operational ? 1 : 0)
 			+ (Global.system.showInputLoads ? 1 : 0)
 			+ (Global.system.hasAcOutSystem ? 1 : 0)
-			+ (Global.allDevicesModel.combinedDcLoadDevices.count > 0 || !isNaN(Global.system.dc.power) ? 1 : 0)
+			+ (Global.system.dc.hasPower ? 1 : 0)
 			+ (Global.solarInputs.inputCount === 0 ? 0 : 1)
 			+ (Global.evChargers.model.count === 0 ? 0 : 1)
 			+ Global.evChargers.acInputPositionCount
@@ -353,7 +353,7 @@ SwipeViewPage {
 		} else {
 			essentialLoadsWidget.size = VenusOS.OverviewWidget_Size_Zero
 		}
-		if (Global.allDevicesModel.combinedDcLoadDevices.count > 0 || !isNaN(Global.system.dc.power)) {
+		if (Global.system.dc.hasPower) {
 			widgets.push(_createWidget(VenusOS.OverviewWidget_Type_DcLoads))
 		}
 		_rightWidgets = widgets

--- a/pages/boatpage/LoadArc.qml
+++ b/pages/boatpage/LoadArc.qml
@@ -77,7 +77,7 @@ Column {
 
 		width: Theme.geometry_briefPage_edgeGauge_width
 		height: active ? Gauges.gaugeHeight(root._rightGaugeCount) : 0
-		active: !motorDriveLoadGauge.active && !isNaN(Global.system.dc.power)
+		active: !motorDriveLoadGauge.active && Global.system.dc.hasPower
 		sourceComponent: SideGauge {
 			readonly property var gaugeParams: Gauges.rightGaugeParameters(1, _rightGaugeCount,)
 			// DC load gauge progresses in counter-clockwise direction (i.e. upwards).


### PR DESCRIPTION
The Brief and Overview pages should show DC Loads when dc system services are present, and not only when the /SystemSetup/HasDcSystem setting is true.

Use Global.system.dc.hasPower to determine whether DC Loads should be shown, instead of checking the power value.

Fixes #2219