### PR TITLE
Switch device page: migrate setup to individual items

### DIFF
--- a/pages/settings/devicelist/PageSwitch.qml
+++ b/pages/settings/devicelist/PageSwitch.qml
@@ -11,14 +11,6 @@ Page {
 
 	required property string serviceUid
 
-	function switchableOutputDisplayName(output) {
-		if (output.customName) {
-			return "%1: %2".arg(output.name).arg(output.customName)
-		} else {
-			return output.name
-		}
-	}
-
 	VeQItemTableModel {
 		id: switchableOutputModel
 		uids: [ root.serviceUid + "/SwitchableOutput" ]
@@ -49,13 +41,15 @@ Page {
 
 				Repeater {
 					model: switchableOutputModel
-					delegate: ListQuantityGroup {
+					delegate: ListQuantityGroupNavigation {
 						id: outputQuantities
 
 						required property string uid
 
-						text: root.switchableOutputDisplayName(output)
-						model: QuantityObjectModel {
+						text: output.customName
+								? "%1: %2".arg(output.name).arg(output.customName)
+								: output.name
+						quantityModel: QuantityObjectModel {
 							filterType: QuantityObjectModel.HasValue
 
 							QuantityObject { object: outputCurrent; unit: VenusOS.Units_Amp }
@@ -66,6 +60,13 @@ Page {
 
 						// Do not show invalid outputs (e.g. those configured as inputs)
 						preferredVisible: output.state >= 0
+
+						onClicked: {
+							Global.pageManager.pushPage("/pages/settings/devicelist/PageSwitchableOutput.qml", {
+								outputUid: output.uid,
+								title: Qt.binding(function() { return outputQuantities.text })
+							})
+						}
 
 						SwitchableOutput {
 							id: output
@@ -88,61 +89,10 @@ Page {
 			}
 
 			ListNavigation {
-				text: CommonWords.setup
-				onClicked: {
-					Global.pageManager.pushPage(outputListComponent)
-				}
-			}
-
-			ListNavigation {
 				text: CommonWords.device_info_title
 				onClicked: {
 					Global.pageManager.pushPage("/pages/settings/PageDeviceInfo.qml",
 							{ "bindPrefix": root.serviceUid })
-				}
-			}
-		}
-	}
-
-	Component {
-		id: outputListComponent
-
-		Page {
-			title: CommonWords.setup
-
-			GradientListView {
-				model: switchableOutputModel
-				delegate: ListQuantityGroupNavigation {
-					id: outputQuantities
-
-					required property string uid
-
-					text: root.switchableOutputDisplayName(output)
-					quantityModel: QuantityObjectModel {
-						filterType: QuantityObjectModel.HasValue
-
-						QuantityObject { object: output; key: "group" }
-						QuantityObject { object: output; key: "typeText" }
-						QuantityObject { object: outputFuseRating; unit: VenusOS.Units_Amp }
-					}
-
-					onClicked: {
-						Global.pageManager.pushPage("/pages/settings/devicelist/PageSwitchableOutput.qml", {
-							outputUid: output.uid,
-							title: Qt.binding(function() { return root.switchableOutputDisplayName(output) })
-						})
-					}
-
-					SwitchableOutput {
-						id: output
-						readonly property string typeText: VenusOS.switchableOutput_typeToText(type, name)
-						uid: outputQuantities.uid
-					}
-
-					VeQuickItem {
-						id: outputFuseRating
-						uid: outputQuantities.uid + "/Settings/FuseRating"
-					}
 				}
 			}
 		}


### PR DESCRIPTION
On the main Switch page, make the switchable output items clickable, and remove the separate "Setup" page.

Fixes #2283