### PR TITLE
Do not set reuse ListView items

### DIFF
--- a/components/BaseListView.qml
+++ b/components/BaseListView.qml
@@ -28,7 +28,6 @@ ListView {
 	highlightFollowsCurrentItem: true
 	highlightMoveDuration: Theme.animation_listView_highlightMoveDuration
 	focus: Global.keyNavigationEnabled
-	reuseItems: true
 
 	// Pass the Utils.acceptsKeyNavigation() test to receive focus during key navigation when this
 	// list view is within another container.


### PR DESCRIPTION
Set BaseListView::reuseItems to false. It may be more performant to reuse ListView items, but this should be done on a case-by-case basis, instead of applying it to all list views.

One issue it has caused, is that the inverter/charger card shows invalid "-" current limit numbers after the card is scrolled in and out of view multiple times. This is because the AcInputSettingsModel in the card is discarded and then is not repopulated when scrolled back into view.

Fixes #2307