### PR TITLE
Temp Sensor: Use product name if custom name is unavailable

### DIFF
--- a/components/listitems/ListTemperatureRelay.qml
+++ b/components/listitems/ListTemperatureRelay.qml
@@ -16,8 +16,8 @@ ListNavigation {
 	readonly property string settingsBindPrefix: Global.systemSettings.serviceUid + "/Settings/TempSensorRelay/" + sensorId
 
 	function getTitle() {
-		if (customName.valid && customName.value !== "") {
-			return customName.value
+		if (device.name) {
+			return device.name
 		}
 		const inputNumber = devInstance.valid ? devInstance.value : ""
 
@@ -77,9 +77,9 @@ ListNavigation {
 		uid: bindPrefix + "/TemperatureType"
 	}
 
-	VeQuickItem {
-		id: customName
-		uid: bindPrefix + "/CustomName"
+	Device {
+		id: device
+		serviceUid: bindPrefix
 	}
 
 	VeQuickItem {


### PR DESCRIPTION
Use device name to ensure the product name is shown if the custom name is unavailable for the temperature sensor.

Fixes #2277