### PR TITLE
Ensure generators are controllable from settings page

### DIFF
--- a/data/Generators.qml
+++ b/data/Generators.qml
@@ -10,8 +10,8 @@ QtObject {
 	id: root
 
 	readonly property ServiceDeviceModel model: ServiceDeviceModel {
-		serviceTypes: ["generators"]
-		modelId: "generators"
+		serviceTypes: ["generator"]
+		modelId: "generator"
 		sortBy: BaseDeviceModel.SortByDeviceInstance
 	}
 


### PR DESCRIPTION
Fix Global.generators.model to use the correct service uid, which is 'generator' instead of 'generators'. This was causing a bug where GensetStartStop1Finder would not find the available generators.

Regression from 6610c08038c0acf38c89eabbdb7552127aa5e588.

Fixes #2317