### PR TITLE
Integrations: add Shelly Devices page

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -542,6 +542,7 @@ set (VENUS_QML_MODULE_SOURCES
     pages/settings/PageSettingsRvcDevice.qml
     pages/settings/PageSettingsRvcDeviceConfiguration.qml
     pages/settings/PageSettingsRvcDevices.qml
+    pages/settings/PageSettingsShelly.qml
     pages/settings/PageSettingsSignalK.qml
     pages/settings/PageSettingsSupportStatus.qml
     pages/settings/PageSettingsSystem.qml
@@ -948,6 +949,7 @@ qt_add_resources(VictronMock "VictronMock_resources"
         data/mock/conf/services/relays.json
         data/mock/conf/services/ruuvi-fridge.json
         data/mock/conf/services/ruuvi-salon.json
+        data/mock/conf/services/shelly.json
         data/mock/conf/services/skylla-charger.json
         data/mock/conf/services/smartshunt-battery.json
         data/mock/conf/services/smartshunt-dcsource.json

--- a/components/CommonWords.qml
+++ b/components/CommonWords.qml
@@ -171,6 +171,9 @@ QtObject {
 	//% "Disconnected"
 	readonly property string disconnected: qsTrId("common_words_disconnected")
 
+	//% "Discovered devices"
+	readonly property string discovered_devices: qsTrId("common_words_discovered_devices")
+
 	//% "Enable"
 	readonly property string enable: qsTrId("common_words_enable")
 

--- a/data/mock/conf/maximal.json
+++ b/data/mock/conf/maximal.json
@@ -37,6 +37,7 @@
         ":/data/mock/conf/services/ruuvi-fridge.json",
         ":/data/mock/conf/services/ruuvi-salon.json",
         ":/data/mock/conf/services/skylla-charger.json",
+        ":/data/mock/conf/services/shelly.json",
         ":/data/mock/conf/services/smartshunt-battery.json",
         ":/data/mock/conf/services/smartswitch.json",
         ":/data/mock/conf/services/tank-blackwater-error-state.json",

--- a/data/mock/conf/services/shelly.json
+++ b/data/mock/conf/services/shelly.json
@@ -1,0 +1,22 @@
+{
+    "com.victronenergy.shelly": {
+        "/Devices/E465B8B6F444/2/Enabled": 1,
+        "/Devices/E465B8B6F444/1/Enabled": 0,
+        "/Devices/E465B8B6F444/0/Enabled": 1,
+        "/Devices/E465B8B6F444/3/Enabled": 1,
+        "/Devices/E465B8B6F444/4/Enabled": 0,
+        "/Devices/E465B8B6F444/5/Enabled": 1,
+        "/Devices/E465B8B6F444/Mac": "11:22:33:aa:bb:cc",
+        "/Devices/E465B8B6F444/Model": "ShellyPlusPlugS",
+        "/Devices/E465B8B6F444/Name": "",
+        "/Devices/E465B8B6F444/Server": "ShellyPlusPlugS-E465B8B6F444.local",
+        "/Devices/ABC/2/Enabled": 1,
+        "/Devices/ABC/1/Enabled": 0,
+        "/Devices/ABC/0/Enabled": 0,
+        "/Devices/ABC/Mac": "22:22:33:aa:bb:cc",
+        "/Devices/ABC/Model": "X",
+        "/Devices/ABC/Name": "",
+        "/Devices/ABC/Server": "X-ABC.local",
+        "/Refresh": 0
+    }
+}

--- a/pages/settings/PageSettingsIntegrations.qml
+++ b/pages/settings/PageSettingsIntegrations.qml
@@ -52,6 +52,19 @@ Page {
 			}
 
 			ListNavigation {
+				//% "Shelly Devices"
+				text: qsTrId("pagesettingsintegrations_shelly_devices")
+				preferredVisible: shellyDevices.rowCount > 0
+				onClicked: Global.pageManager.pushPage("/pages/settings/PageSettingsShelly.qml", {"title": text})
+
+				VeQItemTableModel {
+					id: shellyDevices
+					uids: [ BackendConnection.serviceUidForType("shelly") + "/Devices" ]
+					flags: VeQItemTableModel.AddChildren | VeQItemTableModel.AddNonLeaves | VeQItemTableModel.DontAddItem
+				}
+			}
+
+			ListNavigation {
 				//% "Bluetooth Sensors"
 				text: qsTrId("pagesettingsintegrations_bluetooth_sensors")
 				preferredVisible: !!hasBluetoothSupport.value

--- a/pages/settings/PageSettingsModbus.qml
+++ b/pages/settings/PageSettingsModbus.qml
@@ -47,8 +47,7 @@ Page {
 			}
 
 			ListNavigation {
-				//% "Discovered devices"
-				text: qsTrId("page_settings_modbus_discovered_devices")
+				text: CommonWords.discovered_devices
 				onClicked: Global.pageManager.pushPage("/pages/settings/PageSettingsModbusDiscovered.qml", {"title": root.title})
 			}
 		}

--- a/pages/settings/PageSettingsShelly.qml
+++ b/pages/settings/PageSettingsShelly.qml
@@ -1,0 +1,104 @@
+/*
+** Copyright (C) 2025 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+Page {
+	id: root
+
+	readonly property string serviceUid: BackendConnection.serviceUidForType("shelly")
+
+	// Get a list of channels from all devices on the shelly service. For example, here we have
+	// a device "E465B8B6F444" with "Mac" and "Name" values, and three channels (0-2) with
+	// "Enabled" states that can be toggled by the delegates in this list view.
+	//  com.victronenergy.shelly/Devices/E465B8B6F444/Mac
+	//  com.victronenergy.shelly/Devices/E465B8B6F444/Name
+	//  com.victronenergy.shelly/Devices/E465B8B6F444/0/Enabled
+	//  com.victronenergy.shelly/Devices/E465B8B6F444/1/Enabled
+	//  com.victronenergy.shelly/Devices/E465B8B6F444/2/Enabled
+	VeQItemSortTableModel {
+		id: channelModel
+		dynamicSortFilter: true
+		filterFlags: VeQItemSortTableModel.FilterInvalid
+		filterRole: VeQItemTableModel.UniqueIdRole
+		filterRegExp: "\/Devices\/(?:\\w+)\/\\w+/Enabled$"
+		model: VeQItemTableModel {
+			uids: [ root.serviceUid + "/Devices" ]
+			// Ideally we could set depth=1 to only add the channel paths, but this is fine
+			// for now, and there are not too many paths below the /Devices level anyway.
+			flags: VeQItemTableModel.AddAllChildren | VeQItemTableModel.AddNonLeaves | VeQItemTableModel.DontAddItem
+		}
+	}
+
+	VeQItemSortTableModel {
+		id: sortedChannelModel
+
+		filterRole: VeQItemTableModel.ValueRole
+		sortColumn: childValues.sortValueColumn
+		dynamicSortFilter: true
+
+		model: VeQItemChildModel {
+			id: childValues
+			model: channelModel
+			sortDelegate: VeQItemSortDelegate {
+				id: channelSortDelegate
+
+				readonly property string channelUid: buddy.itemParent()?.uid ?? ""
+				readonly property string channelId: channelUid.substr(channelUid.lastIndexOf('/') + 1)
+				readonly property string deviceUid: buddy.itemParent()?.itemParent()?.uid ?? ""
+				readonly property string name: nameItem.value || "%1 [%2]".arg(modelItem.value).arg(macItem.value)
+
+				sortValue: buddy.valid ? "" : (channelModel.rowCount === 1 ? name : "%1 - %2".arg(name).arg(channelId))
+
+				VeQuickItem {
+					id: macItem
+					uid: channelSortDelegate.deviceUid + "/Mac"
+				}
+
+				VeQuickItem {
+					id: modelItem
+					uid: channelSortDelegate.deviceUid + "/Model"
+				}
+
+				VeQuickItem {
+					id: nameItem
+					uid: channelSortDelegate.deviceUid + "/Name"
+				}
+			}
+		}
+	}
+
+	GradientListView {
+		id: shellyListView
+
+		header: SettingsColumn {
+			width: parent?.width ?? 0
+
+			ListButton {
+				//% "Refresh devices"
+				text: qsTrId("settings_shelly_refresh_devices")
+				//% "Press to refresh"
+				secondaryText: qsTrId("settings_shelly_press_to_refresh")
+				onClicked: refreshItem.setValue(1)
+
+				VeQuickItem {
+					id: refreshItem
+					uid: root.serviceUid + "/Refresh"
+				}
+			}
+
+			SectionHeader {
+				text: CommonWords.discovered_devices
+				opacity: shellyListView.count > 0 ? 1 : 0 // set opacity instead of visible to avoid binding loop
+			}
+		}
+		model: sortedChannelModel
+		delegate: ListSwitch {
+			text: sortValue
+			dataItem.uid: buddy.uid
+		}
+	}
+}


### PR DESCRIPTION
Add Settings > Integrations > Shelly Devices, to scan for and show available shelly devices and their channels.

Fixes #2301