### PR TITLE
MotorDrive: add Sevcon setup page

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -633,6 +633,7 @@ set (VENUS_QML_MODULE_SOURCES
     pages/settings/devicelist/delegates/GensetDeviceListDelegate.qml
     pages/settings/devicelist/inverter/PageInverter.qml
     pages/settings/devicelist/inverter/PageSolarStats.qml
+    pages/settings/devicelist/motordrive/PageSevconSetup.qml
     pages/settings/devicelist/rs/PageMultiRs.qml
     pages/settings/devicelist/rs/PageRsAlarms.qml
     pages/settings/devicelist/rs/PageRsAlarmSettings.qml

--- a/i18n/venus-gui-v2_af.ts
+++ b/i18n/venus-gui-v2_af.ts
@@ -7393,6 +7393,11 @@ Let daarop dat hierdie indekslys slegs Carlo Gavazzi-meters wys wat oor RS485 ge
       <source>Controller Temperature</source>
       <translation>Kontroleerder temperatuur</translation>
     </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/motordrive/PageSevconSetup.qml" line="24"/>
+      <source>Motor Direction Inverted</source>
+      <translation>Motorrigting Omgekeer</translation>
+    </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
       <source>Active cycle</source>

--- a/i18n/venus-gui-v2_ar.ts
+++ b/i18n/venus-gui-v2_ar.ts
@@ -7397,6 +7397,11 @@ Note that this menu only shows Carlo Gavazzi meters connected over RS485. For an
       <source>Controller Temperature</source>
       <translation>درجة الحرارة المتحكم</translation>
     </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/motordrive/PageSevconSetup.qml" line="24"/>
+      <source>Motor Direction Inverted</source>
+      <translation>اتجاه المحرك معكوس</translation>
+    </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
       <source>Active cycle</source>

--- a/i18n/venus-gui-v2_cs.ts
+++ b/i18n/venus-gui-v2_cs.ts
@@ -7394,6 +7394,11 @@ Všimněte si, že tato nabídka zobrazuje pouze měřiče Carlo Gavazzi připoj
       <source>Controller Temperature</source>
       <translation>Teplota ovladače</translation>
     </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/motordrive/PageSevconSetup.qml" line="24"/>
+      <source>Motor Direction Inverted</source>
+      <translation>Směr motoru je obrácen</translation>
+    </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
       <source>Active cycle</source>

--- a/i18n/venus-gui-v2_da.ts
+++ b/i18n/venus-gui-v2_da.ts
@@ -7394,6 +7394,11 @@ Bemærk, at denne menu kun viser Carlo Gavazzi-målere, der er tilsluttet via RS
       <source>Controller Temperature</source>
       <translation>Controller temperatur</translation>
     </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/motordrive/PageSevconSetup.qml" line="24"/>
+      <source>Motor Direction Inverted</source>
+      <translation>Motordrejning omvendt</translation>
+    </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
       <source>Active cycle</source>

--- a/i18n/venus-gui-v2_de.ts
+++ b/i18n/venus-gui-v2_de.ts
@@ -7393,6 +7393,11 @@ Beachten Sie, dass dieses Menü nur Carlo Gavazzi Zähler anzeigt, die über RS4
       <source>Controller Temperature</source>
       <translation>Steuergerättemperatur</translation>
     </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/motordrive/PageSevconSetup.qml" line="24"/>
+      <source>Motor Direction Inverted</source>
+      <translation>Motordrehrichtung umgekehrt</translation>
+    </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
       <source>Active cycle</source>

--- a/i18n/venus-gui-v2_es.ts
+++ b/i18n/venus-gui-v2_es.ts
@@ -7392,6 +7392,11 @@ Tenga en cuenta que este menú solo muestra contadores de Carlo Gavazzi conectad
       <source>Controller Temperature</source>
       <translation>Temperatura controlador</translation>
     </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/motordrive/PageSevconSetup.qml" line="24"/>
+      <source>Motor Direction Inverted</source>
+      <translation>Dirección del motor invertida</translation>
+    </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
       <source>Active cycle</source>

--- a/i18n/venus-gui-v2_fr.ts
+++ b/i18n/venus-gui-v2_fr.ts
@@ -7393,6 +7393,11 @@ Notez que ce menu n'affiche que les compteurs Carlo Gavazzi connectés par RS485
       <source>Controller Temperature</source>
       <translation>Température du contrôleur</translation>
     </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/motordrive/PageSevconSetup.qml" line="24"/>
+      <source>Motor Direction Inverted</source>
+      <translation>Sens du moteur inversé</translation>
+    </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
       <source>Active cycle</source>

--- a/i18n/venus-gui-v2_it.ts
+++ b/i18n/venus-gui-v2_it.ts
@@ -7391,6 +7391,11 @@ Notare che questo menu mostra solo i contatori Carlo Gavazzi collegati tramite R
       <source>Controller Temperature</source>
       <translation>Temperatura regolatore</translation>
     </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/motordrive/PageSevconSetup.qml" line="24"/>
+      <source>Motor Direction Inverted</source>
+      <translation>Direzione del motore invertita</translation>
+    </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
       <source>Active cycle</source>

--- a/i18n/venus-gui-v2_nl.ts
+++ b/i18n/venus-gui-v2_nl.ts
@@ -7390,6 +7390,11 @@ Let op: dit menu toont alleen Carlo Gavazzi meters die zijn aangesloten via RS48
       <source>Controller Temperature</source>
       <translation>Temperatuur besturing</translation>
     </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/motordrive/PageSevconSetup.qml" line="24"/>
+      <source>Motor Direction Inverted</source>
+      <translation>Motorrichting omgekeerd</translation>
+    </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
       <source>Active cycle</source>

--- a/i18n/venus-gui-v2_pl.ts
+++ b/i18n/venus-gui-v2_pl.ts
@@ -7394,6 +7394,11 @@ Należy pamiętać, że to menu pokazuje tylko liczniki Carlo Gavazzi podłączo
       <source>Controller Temperature</source>
       <translation>Temperatura Sterownika</translation>
     </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/motordrive/PageSevconSetup.qml" line="24"/>
+      <source>Motor Direction Inverted</source>
+      <translation>Kierunek silnika odwrócony</translation>
+    </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
       <source>Active cycle</source>

--- a/i18n/venus-gui-v2_ro.ts
+++ b/i18n/venus-gui-v2_ro.ts
@@ -7394,6 +7394,11 @@ Rețineți că acest meniu afișează doar contoarele Carlo Gavazzi conectate pr
       <source>Controller Temperature</source>
       <translation>Temperatura controller</translation>
     </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/motordrive/PageSevconSetup.qml" line="24"/>
+      <source>Motor Direction Inverted</source>
+      <translation>Direcția motorului inversată</translation>
+    </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
       <source>Active cycle</source>

--- a/i18n/venus-gui-v2_ru.ts
+++ b/i18n/venus-gui-v2_ru.ts
@@ -7394,6 +7394,11 @@ Note that this menu only shows Carlo Gavazzi meters connected over RS485. For an
       <source>Controller Temperature</source>
       <translation>Температура контроллера</translation>
     </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/motordrive/PageSevconSetup.qml" line="24"/>
+      <source>Motor Direction Inverted</source>
+      <translation>Направление двигателя инвертировано</translation>
+    </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
       <source>Active cycle</source>

--- a/i18n/venus-gui-v2_sv.ts
+++ b/i18n/venus-gui-v2_sv.ts
@@ -7393,6 +7393,11 @@ Observera att denna meny endast visar Carlo Gavazzi-mätare anslutna över RS485
       <source>Controller Temperature</source>
       <translation>Controllertemperatur</translation>
     </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/motordrive/PageSevconSetup.qml" line="24"/>
+      <source>Motor Direction Inverted</source>
+      <translation>Motorns riktning omvänd</translation>
+    </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
       <source>Active cycle</source>

--- a/i18n/venus-gui-v2_th.ts
+++ b/i18n/venus-gui-v2_th.ts
@@ -7392,6 +7392,11 @@ Note that this menu only shows Carlo Gavazzi meters connected over RS485. For an
       <source>Controller Temperature</source>
       <translation>อุณหภูมิตัวควบคุม</translation>
     </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/motordrive/PageSevconSetup.qml" line="24"/>
+      <source>Motor Direction Inverted</source>
+      <translation>ทิศทางของมอเตอร์กลับด้าน</translation>
+    </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
       <source>Active cycle</source>

--- a/i18n/venus-gui-v2_tr.ts
+++ b/i18n/venus-gui-v2_tr.ts
@@ -7393,6 +7393,11 @@ Bu menünün sadece RS485 üzerinden bağlı Carlo Gavazzi sayaçlarını göste
       <source>Controller Temperature</source>
       <translation>Kontrolör sıcaklığı</translation>
     </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/motordrive/PageSevconSetup.qml" line="24"/>
+      <source>Motor Direction Inverted</source>
+      <translation>Motor yönü tersine çevrildi</translation>
+    </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
       <source>Active cycle</source>

--- a/i18n/venus-gui-v2_uk.ts
+++ b/i18n/venus-gui-v2_uk.ts
@@ -7394,6 +7394,11 @@ Note that this menu only shows Carlo Gavazzi meters connected over RS485. For an
       <source>Controller Temperature</source>
       <translation>Температура Контролера</translation>
     </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/motordrive/PageSevconSetup.qml" line="24"/>
+      <source>Motor Direction Inverted</source>
+      <translation>Напрямок двигуна змінено</translation>
+    </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
       <source>Active cycle</source>

--- a/i18n/venus-gui-v2_zh_CN.ts
+++ b/i18n/venus-gui-v2_zh_CN.ts
@@ -7392,6 +7392,11 @@ Note that this menu only shows Carlo Gavazzi meters connected over RS485. For an
       <source>Controller Temperature</source>
       <translation>控制器温度</translation>
     </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/motordrive/PageSevconSetup.qml" line="24"/>
+      <source>Motor Direction Inverted</source>
+      <translation>电机方向已反转</translation>
+    </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
       <source>Active cycle</source>

--- a/pages/settings/devicelist/PageMotorDrive.qml
+++ b/pages/settings/devicelist/PageMotorDrive.qml
@@ -18,6 +18,11 @@ Page {
 		serviceUid: root.bindPrefix
 	}
 
+	VeQuickItem {
+		id: productId
+		uid: root.bindPrefix + "/ProductId"
+	}
+
 	GradientListView {
 		model: VisibleItemModel {
 			ListQuantity {
@@ -69,6 +74,15 @@ Page {
 				text: qsTrId("devicelist_motordrive_controllertemperature")
 				dataItem.uid: root.bindPrefix + "/Controller/Temperature"
 				preferredVisible: dataItem.valid
+			}
+
+			ListNavigation {
+				text: CommonWords.setup
+				onClicked: {
+					Global.pageManager.pushPage("/pages/settings/devicelist/motordrive/PageSevconSetup.qml",
+							{ "title": text, "bindPrefix": root.bindPrefix })
+				}
+				preferredVisible: productId.value == ProductInfo.ProductId_MotorDrive_Sevcon
 			}
 
 			ListNavigation {

--- a/pages/settings/devicelist/motordrive/PageSevconSetup.qml
+++ b/pages/settings/devicelist/motordrive/PageSevconSetup.qml
@@ -1,0 +1,32 @@
+/*
+** Copyright (C) 2025 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+Page {
+	id: root
+
+	property string bindPrefix
+
+	title: device.name
+
+	Device {
+		id: device
+		serviceUid: root.bindPrefix
+	}
+
+	GradientListView {
+		model: VisibleItemModel {
+			ListSwitch {
+				//% "Motor Direction Inverted"
+				text: qsTrId("devicelist_motordrive_motordirectioninverted")
+				dataItem.uid: root.bindPrefix + "/Motor/DirectionInverted"
+				dataItem.invalidate: false
+				preferredVisible: dataItem.valid
+			}
+		}
+	}
+}

--- a/src/productinfo.h
+++ b/src/productinfo.h
@@ -61,6 +61,7 @@ public:
 		ProductId_PvInverter_Fronius = 0xA142, // VE_PROD_ID_PV_INVERTER_FRONIUS
 		ProductId_TankSensor_Generic = 0xA160,
 		ProductId_MeteoSensor_Imt = 0xB030, // VE_PROD_ID_IMT_SI_RS485_SOLAR_IRRADIANCE_SENSOR
+		ProductId_MotorDrive_Sevcon = 0xB064, // VE_PROD_ID_CITOLEN_SEVCON
 	};
 	Q_ENUM(ProductId_Misc)
 


### PR DESCRIPTION
Adds a new page to control the settings of a Sevcon motor controller.

The page can be navigated to from the motordrive device's page when the `ProductId` matches the one from a Sevcon controller.

Driver: https://github.com/citolen/dbus-sevcon

<img width="912" height="620" alt="Screenshot 2025-07-13 at 15 41 36" src="https://github.com/user-attachments/assets/41b9406e-b00e-47e3-83fb-09b16399b09b" />  
<img width="912" height="620" alt="Screenshot 2025-07-13 at 15 41 48" src="https://github.com/user-attachments/assets/a30429ad-55a8-4270-b425-8694ac910013" />
