### PR TITLE
Overview: show correct drilldown for generic DC source inputs

### DIFF
--- a/components/widgets/DcInputWidget.qml
+++ b/components/widgets/DcInputWidget.qml
@@ -14,7 +14,6 @@ OverviewWidget {
 			? Global.dcInputs.inputType(inputs.firstObject.serviceUid, inputs.firstObject.monitorMode)
 			: -1
 	readonly property string detailUrl: inputType === VenusOS.DcInputs_InputType_Alternator ? "/pages/settings/devicelist/dc-in/PageAlternator.qml"
-			: inputType === VenusOS.DcInputs_InputType_GenericSource ? "/pages/settings/devicelist/PageGenset.qml"
 			: "/pages/settings/devicelist/dc-in/PageDcMeter.qml"
 
 	function _refreshTotalPower() {


### PR DESCRIPTION
When the DC input is a generic source, show the DC meter page, rather than the Genset page which is for AC gensets.

Fixes #2338