### PR TITLE
Mock notifications: improve mock impl and test configurations

### DIFF
--- a/data/mock/NotificationsImpl.qml
+++ b/data/mock/NotificationsImpl.qml
@@ -87,11 +87,13 @@ QtObject {
 		uid: Global.notifications.serviceUid + "/AcknowledgeAll"
 		onValueChanged: {
 			if (!isNaN(value) && value === 1) {
-				for (let i = 0 ; i < notifications.length; ++i) {
-					const notif = notifications[i]
+				const model = Global.notifications.allNotificationsModel
+				for (let i = 0 ; i < model.count; ++i) {
+					const notif = model.data(model.index(i, 0), NotificationsModel.Notification)
 					notif.updateAcknowledged(true)
 				}
 				_acknowledgeAll.setValue(0)
+				updateNotifications()
 			}
 		}
 	}

--- a/data/mock/conf/multi-rs.json
+++ b/data/mock/conf/multi-rs.json
@@ -4,7 +4,7 @@
         ":/data/mock/conf/services/pylontech.json",
         ":/data/mock/conf/services/motordrive.json",
         ":/data/mock/conf/services/multirs-smart.json",
-        ":/data/mock/conf/services/network-ethernet.json",
+        ":/data/mock/conf/services/notifications-alarm.json",
         ":/data/mock/conf/setup-common.json"
     ],
     "setup": {

--- a/data/mock/conf/services/notifications-alarm.json
+++ b/data/mock/conf/services/notifications-alarm.json
@@ -1,13 +1,13 @@
 {
     "com.victronenergy.platform": {
-        "/Notifications/0/Acknowledged": false,
-        "/Notifications/0/Active": true,
+        "/Notifications/0/Acknowledged": 0,
+        "/Notifications/0/Active": 0,
         "/Notifications/0/AlarmValue": 2,
         "/Notifications/0/DateTime": 1750230796,
         "/Notifications/0/Description": "Low SOC",
         "/Notifications/0/DeviceName": "SmartShunt",
         "/Notifications/0/Service": "com.victronenergy.battery.ttyS5",
-        "/Notifications/0/Silenced": false,
+        "/Notifications/0/Silenced": 0,
         "/Notifications/0/Trigger": "/Alarms/LowSoc",
         "/Notifications/0/Type": 1,
         "/Notifications/0/Value": "",

--- a/data/mock/conf/services/notifications-no-alarm.json
+++ b/data/mock/conf/services/notifications-no-alarm.json
@@ -1,20 +1,20 @@
 {
     "com.victronenergy.platform": {
-        "/Notifications/0/Acknowledged": 0,
+        "/Notifications/0/Acknowledged": 1,
         "/Notifications/0/Active": 0,
         "/Notifications/0/DateTime": 1751279835,
         "/Notifications/0/Description": "Fuel level low",
         "/Notifications/0/DeviceName": "Fuel tank custom name",
         "/Notifications/0/Type": 0,
         "/Notifications/0/Value": "15%",
-        "/Notifications/1/Acknowledged": 0,
-        "/Notifications/1/Active": 0,
+        "/Notifications/1/Acknowledged": 1,
+        "/Notifications/1/Active": 1,
         "/Notifications/1/DateTime": 1751364675,
         "/Notifications/1/Description": "Software update available",
         "/Notifications/1/DeviceName": "System",
         "/Notifications/1/Type": 2,
         "/Notifications/1/Value": null,
-        "/Notifications/2/Acknowledged": 0,
+        "/Notifications/2/Acknowledged": 1,
         "/Notifications/2/Active": 0,
         "/Notifications/2/DateTime": 1751358435,
         "/Notifications/2/Description": "High temperature",
@@ -23,12 +23,12 @@
         "/Notifications/2/Value": "25C",
         "/Notifications/AcknowledgeAll": null,
         "/Notifications/NumberOfActiveAlarms": 0,
-        "/Notifications/NumberOfActiveInformations": 0,
-        "/Notifications/NumberOfActiveNotifications": 0,
+        "/Notifications/NumberOfActiveInformations": 1,
+        "/Notifications/NumberOfActiveNotifications": 1,
         "/Notifications/NumberOfActiveWarnings": 0,
         "/Notifications/NumberOfNotifications": 3,
         "/Notifications/NumberOfUnAcknowledgedAlarms": 0,
-        "/Notifications/NumberOfUnAcknowledgedInformations": 2,
-        "/Notifications/NumberOfUnAcknowledgedWarnings": 1
+        "/Notifications/NumberOfUnAcknowledgedInformations": 0,
+        "/Notifications/NumberOfUnAcknowledgedWarnings": 0
     }
 }

--- a/data/mock/conf/setup-common.json
+++ b/data/mock/conf/setup-common.json
@@ -5,7 +5,7 @@
     },
     "com.victronenergy.platform": {
         "/Device/Model": "Cerbo GX",
-        "/Device/Time": 1750553847
+        "/Device/Time": 1751358535
     },
     "com.victronenergy.settings": {
         "/Settings/Alarm/System/GridLost": 1,


### PR DESCRIPTION
- setup-common.json: use a system time that is after the most recent notification time, so that the notification times are in the past and the UI can show "5 minutes ago" instead of "now".
- notifications-no-alarm.json: set all notifications here to acknowledged so that the UI doesn't show a toast on startup, as it is annoying for the default maximal configuration.
- multi-rs.json: show an alert notification here, as that is not tested in maximal.json, and remove network-ethernet.json which does not exist.
- NotificationsImpl: allow user to acknowledge notifications created by static mock configurations, instead of only those that were created dynamically by NotificationsImpl.