### PR TITLE
PageSettingsCanbus: Add reverse current polarity settings for RV-C

### DIFF
--- a/pages/settings/PageSettingsCanbus.qml
+++ b/pages/settings/PageSettingsCanbus.qml
@@ -64,6 +64,15 @@ Page {
 				preferredVisible: root._isVecan
 			}
 
+			ListSwitch {
+				//% "Reverse current polarity"
+				text: qsTrId("settings_canbus_rvc_reverse_current_polarity")
+				dataItem.uid: root._rvcSettingsPrefix + "/ReverseCurrent"
+				preferredVisible: root._isRvc && dataItem.valid
+				//% "When enabled, the current polarity in the CHARGER_AC_STATUS_1, CHARGER_STATUS_2, INVERTER_AC_STATUS_1, and SOLAR_CONTROLLER_BATTERY_STATUS DGNs is reversed."
+				caption: qsTrId("settings_canbus_rvc_reverse_current_polarity_description")
+			}
+
 			ListSpinBox {
 				//% "Unique identity number selector"
 				text: qsTrId("settings_canbus_unique_id_select")


### PR DESCRIPTION
For RV-C we accidentally used the wrong polarity from some messages. This has been like this since the introduction of RV-C support. Since many OEMs already build systems using this wrong values, we have introduced a setting that reverses the polarity of the current in the affected messages.

<img width="1034" height="607" alt="image" src="https://github.com/user-attachments/assets/b46881b7-6c0d-4877-b212-e5dc51a93420" />

Can be tested on https://vrm.victronenergy.com/installation/177534/dashboard.
Should be hidden for systems that are on an older VenusOS without the setting and when RV-C is not enabled.