### PR TITLE
Add support for CANopen motordrive

### DIFF
--- a/pages/settings/CanbusProfile.qml
+++ b/pages/settings/CanbusProfile.qml
@@ -78,6 +78,18 @@ QtObject {
 			display: qsTrId("settings_up_but_no_services_500"),
 			value: VenusOS.CanBusProfile_None500,
 			readOnly: true
+		},
+		{
+			//% "CANopen Motor drive (250 kbit/s)"
+			display: qsTrId("settings_canopen_motordrive_250"),
+			value: VenusOS.CanBusProfile_CanOpenMotordrive250,
+			readOnly: isReadOnly(VenusOS.CanBusProfile_CanOpenMotordrive250)
+		},
+		{
+			//% "CANopen Motor drive (500 kbit/s)"
+			display: qsTrId("settings_canopen_motordrive_500"),
+			value: VenusOS.CanBusProfile_CanOpenMotordrive500,
+			readOnly: isReadOnly(VenusOS.CanBusProfile_CanOpenMotordrive500)
 		}
 	]
 

--- a/src/enums.h
+++ b/src/enums.h
@@ -530,7 +530,9 @@ public:
 		CanBusProfile_None250,
 		CanBusProfile_RvC,
 		CanBusProfile_HighVoltage,
-		CanBusProfile_None500
+		CanBusProfile_None500,
+		CanBusProfile_CanOpenMotordrive250,
+		CanBusProfile_CanOpenMotordrive500
 	};
 	Q_ENUM(CanBusProfile_Type)
 


### PR DESCRIPTION
We're adding a new service soon to read Sevcon/Curtis motorcontrollers via CANopen. This requires two new CAN profiles, one for 250kbit/s and one for 500 kbit/s. 

Inclusion of this PR must be synced with venus-platform that includes the setting and the addition of the dbus-canopen-motordrive to VenusOS.

Additionally, a settings page for this service must be add to hold at least a scan button. This is still work in progress.

<img width="1174" height="783" alt="image" src="https://github.com/user-attachments/assets/f9274a2a-33a7-44a9-81cd-85dab385a7a4" />

