### PR TITLE
Switch pane: implement Dropdown control

### DIFF
--- a/components/SwitchableOutputDelegate.qml
+++ b/components/SwitchableOutputDelegate.qml
@@ -386,7 +386,88 @@ BaseListItem {
 	Component {
 		id: dropdownComponent
 
-		PlaceholderDelegate {}
+		ComboBox {
+			id: dropdown
+
+			function handlePress(key) {
+				// Enter edit mode (i.e. allow ComboBox to handle key events) when space is pressed.
+				switch (key) {
+				case Qt.Key_Space:
+					focus = true
+					return true
+				default:
+					return false
+				}
+			}
+
+			width: root._buttonWidth
+			enabled: !dropdownSync.busy
+			onActivated: (index) => dropdownSync.writeValue(index)
+
+			// Process key events in edit mode.
+			Keys.onPressed: (event) => {
+				switch (event.key) {
+				case Qt.Key_Enter:
+				case Qt.Key_Return:
+					// Save highlighted index as the currentIndex, and exit edit mode.
+					if (highlightedIndex >= 0 && highlightedIndex < count) {
+						currentIndex = highlightedIndex
+						activated(highlightedIndex)
+					}
+					focus = false
+					event.accepted = true
+					return
+				case Qt.Key_Escape:
+					// Exit edit mode. If the popup was open, it will be closed without changing the
+					// current index.
+					focus = false
+					event.accepted = true
+					return
+				case Qt.Key_Left:
+				case Qt.Key_Right:
+					// When in edit mode, prevent left/right from moving focus to another item in
+					// the grid view.
+					event.accepted = true
+					return
+				default:
+					break
+				}
+				event.accepted = false
+			}
+
+			SettingSync {
+				id: dropdownSync
+				backendValue: dropdownSelection.value
+				onUpdateToBackend: (value) => { dropdownSelection.setValue(Math.floor(value)) }
+				onBackendValueChanged: {
+					if (backendValue >= 0 && backendValue < dropdown.count) {
+						dropdown.currentIndex = Math.floor(backendValue)
+					}
+				}
+			}
+
+			VeQuickItem {
+				uid: root.outputUid + "/Settings/Labels"
+				onValueChanged: {
+					if (value === undefined) {
+						dropdown.model = []
+					} else {
+						let items = []
+						for (const key in value) {
+							items.push({ text: value[key] })
+						}
+						dropdown.model = items
+						dropdown.currentIndex = Math.floor(dropdownSync.backendValue)
+					}
+				}
+			}
+
+			// The /DimmingValue holds the selected dropdwon index.
+			VeQuickItem {
+				id: dropdownSelection
+				uid: root.outputUid + "/Dimming"
+			}
+		}
 	}
 
 	Component {

--- a/components/controls/ComboBox.qml
+++ b/components/controls/ComboBox.qml
@@ -31,7 +31,18 @@ CT.ComboBox {
 		contentItem: Rectangle {
 			anchors.fill: parent
 			radius: Theme.geometry_button_radius
-			color: optionDelegate.pressed ? Theme.color_ok : "transparent"
+			color: optionDelegate.highlighted ? Theme.color_ok : "transparent"
+
+			// Add another rectangle to fill out the bottom and/or top corners to pretend this is
+			// showing a half-rounded rect for the first/last options, and no rounded corners for
+			// the other options in between.
+			Rectangle {
+				y: index === 0 ? height : 0
+				width: parent.width
+				height: index === 0 || index === root.count - 1 ? parent.height / 2 : parent.height
+				color: parent.color
+				visible: root.count > 0
+			}
 
 			Label {
 				anchors.fill: parent
@@ -41,18 +52,7 @@ CT.ComboBox {
 				verticalAlignment: Text.AlignVCenter
 				elide: Text.ElideRight
 				text: modelData.text
-				color: optionDelegate.pressed ? Theme.color_button_down_text : Theme.color_font_primary
-			}
-
-			CP.ColorImage {
-				anchors {
-					right: parent.right
-					rightMargin: 8
-					verticalCenter: parent.verticalCenter
-				}
-				source: "qrc:/images/icon_checkmark_32.svg"
-				color: optionDelegate.pressed ? Theme.color_button_down_text : Theme.color_ok
-				visible: root.currentIndex === index
+				color: optionDelegate.highlighted ? Theme.color_button_down_text : Theme.color_font_primary
 			}
 		}
 
@@ -66,7 +66,9 @@ CT.ComboBox {
 		y: root.topPadding + (root.availableHeight - height) / 2
 		source: "qrc:/images/icon_arrow_32.svg"
 		rotation: 270
-		color: root.pressed ? Theme.color_primary : Theme.color_ok
+		color: root.enabled
+			   ? (root.pressed ? Theme.color_primary : Theme.color_ok)
+			   : Theme.color_font_disabled
 	}
 
 	contentItem: Label {
@@ -76,14 +78,18 @@ CT.ComboBox {
 		verticalAlignment: Text.AlignVCenter
 		elide: Text.ElideRight
 		text: root.displayText
-		color: root.pressed ? Theme.color_button_down_text : Theme.color_font_primary
+		color: root.enabled
+			   ? (root.pressed ? Theme.color_button_down_text : Theme.color_font_primary)
+			   : Theme.color_font_disabled
 	}
 
 	background: Rectangle {
-		border.color: Theme.color_ok
+		border.color: root.enabled ? Theme.color_ok : Theme.color_font_disabled
 		border.width: Theme.geometry_button_border_width
 		radius: Theme.geometry_button_radius
-		color: root.pressed ? Theme.color_ok : Theme.color_darkOk
+		color: root.enabled
+			   ? (root.pressed ? Theme.color_ok : Theme.color_darkOk)
+			   : Theme.color_background_disabled
 	}
 
 	popup: CT.Popup {
@@ -109,6 +115,8 @@ CT.ComboBox {
 			Rectangle {
 				anchors.fill: parent
 				radius: Theme.geometry_button_radius
+				border.width: Theme.geometry_button_border_width
+				border.color: Theme.color_ok
 				color: Theme.color_darkOk
 			}
 		}
@@ -118,5 +126,6 @@ CT.ComboBox {
 		onOpenedChanged: Qt.callLater(_updateVisibility)
 	}
 
+	Keys.enabled: Global.keyNavigationEnabled
 	KeyNavigationHighlight.active: root.activeFocus
 }


### PR DESCRIPTION
The Dropdown control is essentially a ComboBox that allows the user to select from a list of options.

/SwitchableOutput/<x>/Settings/Labels sets the JSON map of options. /SwitchableOutput/<x>/Dimming sets the index of the selected option.

This change also updates the ComboBox control to follow the updated ComboBox design:
- highlight the selected option, instead of showing a check/tick icon next to it
- change the control colours when it is disabled
- show a border around the popup

Part of #2303