### PR TITLE
Battery settings: allow System menu to be opened

### DIFF
--- a/pages/settings/devicelist/battery/PageLynxIonSystem.qml
+++ b/pages/settings/devicelist/battery/PageLynxIonSystem.qml
@@ -75,15 +75,15 @@ Page {
 				VeQuickItem {
 					id: minCellTemperature
 					uid: root.bindPrefix + "/System/MinCellTemperature"
-					dataItem.sourceUnit: Units.unitToVeUnit(VenusOS.Units_Temperature_Celsius)
-					dataItem.displayUnit: Units.unitToVeUnit(Global.systemSettings.temperatureUnit)
+					sourceUnit: Units.unitToVeUnit(VenusOS.Units_Temperature_Celsius)
+					displayUnit: Units.unitToVeUnit(Global.systemSettings.temperatureUnit)
 				}
 
 				VeQuickItem {
 					id: maxCellTemperature
 					uid: root.bindPrefix + "/System/MaxCellTemperature"
-					dataItem.sourceUnit: Units.unitToVeUnit(VenusOS.Units_Temperature_Celsius)
-					dataItem.displayUnit: Units.unitToVeUnit(Global.systemSettings.temperatureUnit)
+					sourceUnit: Units.unitToVeUnit(VenusOS.Units_Temperature_Celsius)
+					displayUnit: Units.unitToVeUnit(Global.systemSettings.temperatureUnit)
 				}
 			}
 


### PR DESCRIPTION
The dataItem property does not exist here.

Fixes #2391