### PR TITLE
Modify power flow indicator display

### DIFF
--- a/components/ObjectAcConnection.qml
+++ b/components/ObjectAcConnection.qml
@@ -52,7 +52,7 @@ QtObject {
 
 	readonly property bool singlePhaseCurrentValid: _phaseCount.value === 1 && currentL1.valid
 	// multi-phase systems don't have a total current
-	readonly property real current: singlePhaseCurrentValid ? currentL1.value : NaN
+	readonly property real current: singlePhaseCurrentValid && currentL1.value !== undefined ? currentL1.value : NaN
 	readonly property int preferredUnit: Global.systemSettings.electricalQuantity === VenusOS.Units_Amp && singlePhaseCurrentValid ? VenusOS.Units_Amp : VenusOS.Units_Watt
 	readonly property real preferredQuantity: preferredUnit === VenusOS.Units_Amp ? current : power
 

--- a/components/widgets/WidgetConnector.qml
+++ b/components/widgets/WidgetConnector.qml
@@ -214,6 +214,7 @@ Item {
 				delegate: Image {
 					opacity: 0.0
 					source: animationEnabled ? "qrc:/images/electron.svg" : "qrc:/images/electron_arrow.svg"
+					visible: root.animationMode !== VenusOS.WidgetConnector_AnimationMode_NotAnimated
 
 					Behavior on opacity {
 						enabled: root._animated

--- a/components/widgets/WidgetConnector.qml
+++ b/components/widgets/WidgetConnector.qml
@@ -215,6 +215,7 @@ Item {
 					opacity: 0.0
 					source: animationEnabled ? "qrc:/images/electron.svg" : "qrc:/images/electron_arrow.svg"
 					visible: root.animationMode !== VenusOS.WidgetConnector_AnimationMode_NotAnimated
+					rotation: animationEnabled ? 0.0 : pathUpdater.angleForArrow(pathUpdater.progress, pathUpdater.startToEnd)
 
 					Behavior on opacity {
 						enabled: root._animated

--- a/pages/OverviewPage.qml
+++ b/pages/OverviewPage.qml
@@ -370,8 +370,8 @@ SwipeViewPage {
 
 			// For AC inputs, positive power means energy is flowing towards inverter/charger,
 			// and negative power means energy is flowing towards the input.
-			return power > Theme.geometry_overviewPage_connector_animationPowerThreshold
-					? VenusOS.WidgetConnector_AnimationMode_StartToEnd
+			return Math.abs(power) < Theme.geometry_overviewPage_connector_animationPowerThreshold ? VenusOS.WidgetConnector_AnimationMode_NotAnimated
+					: power > 0.0 ? VenusOS.WidgetConnector_AnimationMode_StartToEnd
 					: VenusOS.WidgetConnector_AnimationMode_EndToStart
 		} else if (connectorWidget.endWidget === batteryWidget) {
 			// For DC inputs, positive power means energy is flowing towards battery.

--- a/src/widgetconnectorpathupdater.cpp
+++ b/src/widgetconnectorpathupdater.cpp
@@ -71,3 +71,15 @@ void WidgetConnectorPathUpdater::update() const {
 		electron->setProperty("opacity", normalizedProgress > fadeOutThreshold ? 0 : 1);
 	}
 }
+
+qreal WidgetConnectorPathUpdater::angleForArrow(qreal progress, bool startToEnd)
+{
+	if (!path) {
+		qmlDebug(this) << "Cannot animate electrons without a specified path";
+		return qQNaN();
+	}
+
+	qreal angle = 0;
+	const QPointF position = path->sequentialPointAt(progress, &angle);
+	return startToEnd ? 360.0 - angle : 180 - angle;
+}

--- a/src/widgetconnectorpathupdater.h
+++ b/src/widgetconnectorpathupdater.h
@@ -33,6 +33,7 @@ public:
 	Q_INVOKABLE void remove(QQuickItem *electron);
 
 	Q_INVOKABLE void update() const;
+	Q_INVOKABLE qreal angleForArrow(qreal progress, bool startToEnd);
 
 signals:
 	void progressChanged();


### PR DESCRIPTION
Modify how the animated energy flow is displayed.
When not animated, only show an arrow when power is above 30 in either direction.

Fixes #2395