### PR TITLE
Switch pane: implement auto toggle switch control

### DIFF
--- a/cmake/ModuleVenus.cmake
+++ b/cmake/ModuleVenus.cmake
@@ -23,6 +23,7 @@ target_link_libraries(VictronVenusOS PRIVATE
     Qt6::Quick
     Qt6::Svg
     Qt6::QuickPrivate
+    Qt6::QuickTemplates2Private
     Qt6::Xml
     Qt6::Mqtt
 )

--- a/cmake/ModuleVenus_Sources.cmake
+++ b/cmake/ModuleVenus_Sources.cmake
@@ -130,6 +130,7 @@ set (VictronVenusOS_QML_MODULE_SOURCES
     components/WasmVirtualKeyboardHandler.qml
     components/WifiModel.qml
     components/ClassAndVrmInstance.qml
+    components/controls/AutoToggleButton.qml
     components/controls/Button.qml
     components/controls/ComboBox.qml
     components/controls/DimmingSlider.qml
@@ -555,6 +556,8 @@ list(APPEND VictronVenusOS_CPP_SOURCES
     src/aggregatetankmodel.cpp
     src/visibleitemmodel.h
     src/visibleitemmodel.cpp
+    src/baseautotoggleswitch.h
+    src/baseautotoggleswitch.cpp
     src/basedevice.h
     src/basedevice.cpp
     src/basedevicemodel.h

--- a/components/SwitchableOutputDelegate.qml
+++ b/components/SwitchableOutputDelegate.qml
@@ -566,6 +566,43 @@ BaseListItem {
 	Component {
 		id: threeStateSwitchComponent
 
-		PlaceholderDelegate {}
+		AutoToggleButton {
+			id: autoToggleButton
+
+			function handlePress(key) {
+				switch (key) {
+				case Qt.Key_Space:
+					focus = true
+					return true
+				}
+				return false
+			}
+
+			height: Theme.geometry_switchableoutput_button_height
+			width: root._buttonWidth
+			enabled: !toggleState.busy || !autoToggleState.busy
+			onChecked: toggleState.backendValue === 1
+			autoChecked: autoToggleState.backendValue
+			onOnClicked: toggleState.writeValue(1)
+			onOffClicked: toggleState.writeValue(0)
+			onAutoClicked: autoToggleState.writeValue(autoToggleState.backendValue === 1 ? 0 : 1)
+
+			SettingSync {
+				id: autoToggleState
+				backendValue: autoState.value
+				onUpdateToBackend: (value) => { autoState.setValue(value) }
+			}
+
+			VeQuickItem {
+				id: autoState
+				uid: root.outputUid + "/Auto"
+			}
+
+			SettingSync {
+				id: toggleState
+				backendValue: output.state
+				onUpdateToBackend: (value) => { output.setState(value) }
+			}
+		}
 	}
 }

--- a/components/controls/AutoToggleButton.qml
+++ b/components/controls/AutoToggleButton.qml
@@ -1,0 +1,129 @@
+/*
+** Copyright (C) 2025 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+BaseAutoToggleSwitch {
+	id: root
+
+	property int buttonWidth: (root.width - (Theme.geometry_button_border_width * (root.buttonCount + 2)) - Theme.geometry_autotoggle_button_spacing) / root.buttonCount
+
+	implicitWidth: parent.width
+	implicitHeight: Theme.geometry_segmentedButtonRow_height
+
+	// background is the on/off buttons visual border
+	background: Rectangle {
+		anchors.left: parent.left
+		anchors.top: parent.top
+		anchors.bottom: parent.bottom
+		width: buttonWidth * 2 + Theme.geometry_button_border_width * 3
+		radius: Theme.geometry_button_radius
+		color: root.enabled ? Theme.color_ok : Theme.color_font_disabled
+	}
+
+	function notification() {
+		//% "Function is set on Auto Mode"
+		Global.showToastNotification(VenusOS.Notification_Info, qsTrId("autotoggleswitch_function_auto_mode_info"))
+	}
+
+	contentItem: FocusScope {
+		focus: true
+
+		Button {
+			id: offButton
+
+			anchors {
+				left: parent.left
+				leftMargin: Theme.geometry_button_border_width
+				top: parent.top
+				topMargin: Theme.geometry_button_border_width
+				bottom: parent.bottom
+				bottomMargin: Theme.geometry_button_border_width
+			}
+			width: root.buttonWidth
+			height: parent.height
+			radius: 0
+			topLeftRadius: Theme.geometry_button_radius - Theme.geometry_button_border_width
+			bottomLeftRadius: Theme.geometry_button_radius - Theme.geometry_button_border_width
+			backgroundColor: !root.enabled ? Theme.color_background_disabled
+				: root.onChecked ? Theme.color_darkOk
+				: Theme.color_button_off_background
+
+			text: CommonWords.off
+
+			checked: !root.onChecked
+			onClicked: root.autoChecked ? notification() : root.offClicked()
+			focus: !root.onChecked
+
+			Keys.onSpacePressed: root.autoChecked ? notification() : root.offClicked()
+			KeyNavigation.right: onButton
+		}
+
+		Button {
+			id: onButton
+
+			anchors {
+				left: offButton.right
+				leftMargin: Theme.geometry_button_border_width
+				top: parent.top
+				topMargin: Theme.geometry_button_border_width
+				bottom: parent.bottom
+				bottomMargin: Theme.geometry_button_border_width
+			}
+			width: root.buttonWidth
+			height: parent.height
+			radius: 0
+			topRightRadius: Theme.geometry_button_radius - Theme.geometry_button_border_width
+			bottomRightRadius: Theme.geometry_button_radius - Theme.geometry_button_border_width
+			backgroundColor: !root.enabled ? Theme.color_background_disabled
+				: root.onChecked ? Theme.color_ok
+				: Theme.color_darkOk
+
+			text: CommonWords.on
+
+			checked: root.onChecked
+			onClicked: root.autoChecked ? notification() : root.onClicked()
+			focus: root.onChecked
+
+			Keys.onSpacePressed: root.autoChecked ? notification() : root.onClicked()
+			KeyNavigation.right: autoButton
+		}
+
+		Button {
+			id: autoButton
+
+			anchors {
+				right: parent.right
+				top: parent.top
+				bottom: parent.bottom
+			}
+			width: root.buttonWidth
+			height: parent.height
+
+			radius: Theme.geometry_button_radius
+			backgroundColor: !root.enabled ? Theme.color_background_disabled
+				: root.autoChecked ? Theme.color_ok
+				: Theme.color_darkOk
+			borderWidth: Theme.geometry_button_border_width
+			borderColor: root.enabled ? Theme.color_ok : Theme.color_font_disabled
+
+			text: CommonWords.auto
+
+			checked: root.autoChecked
+			onClicked: root.autoClicked()
+
+			Keys.onSpacePressed: root.autoClicked()
+		}
+	}
+
+	Keys.onEscapePressed: focus = false
+	Keys.onEnterPressed: focus = false
+	Keys.onReturnPressed: focus = false
+	Keys.onUpPressed: {}
+	Keys.onDownPressed: {}
+	Keys.onLeftPressed: {}
+	Keys.onRightPressed: {}
+}

--- a/components/controls/Button.qml
+++ b/components/controls/Button.qml
@@ -20,8 +20,13 @@ T.Button {
 			: Theme.color_darkOk
 	property color downColor: flat ? "transparent"
 			: Theme.color_ok
-	property alias border: backgroundRect.border
-	property alias radius: backgroundRect.radius
+	property color borderColor: showEnabled ? Theme.color_ok : Theme.color_font_disabled
+	property real borderWidth: flat ? 0 : Theme.geometry_button_border_width
+	property real radius: Theme.geometry_button_radius
+	property real topLeftRadius: NaN
+	property real bottomLeftRadius: NaN
+	property real topRightRadius: NaN
+	property real bottomRightRadius: NaN
 	property bool showEnabled: enabled
 
 	onPressed: pressEffect.start(pressX/width, pressY/height)
@@ -45,16 +50,28 @@ T.Button {
 	flat: true
 
 	background: Rectangle {
-		id: backgroundRect
-
 		color: root.backgroundColor
-		border.width: root.flat ? 0 : Theme.geometry_button_border_width
-		border.color: root.showEnabled ? Theme.color_ok : Theme.color_font_disabled
-		radius: Theme.geometry_button_radius
+		border.width: root.borderWidth
+		border.color: root.borderColor
+
+		// Only set the radius if none of the corner radii are set, otherwise each corner will be
+		// rounded even if no radius has been set for that corner.
+		radius: isNaN(root.topLeftRadius)
+				&& isNaN(root.bottomLeftRadius)
+				&& isNaN(root.topRightRadius)
+				&& isNaN(root.bottomRightRadius)
+			? root.radius
+			: 0
+
+		// Clear corner radii values if they are not set.
+		topLeftRadius: isNaN(root.topLeftRadius) ? undefined : root.topLeftRadius
+		bottomLeftRadius: isNaN(root.bottomLeftRadius) ? undefined : root.bottomLeftRadius
+		topRightRadius: isNaN(root.topRightRadius) ? undefined : root.topRightRadius
+		bottomRightRadius: isNaN(root.bottomRightRadius) ? undefined : root.bottomRightRadius
 
 		PressEffect {
 			id: pressEffect
-			radius: backgroundRect.radius
+			radius: root.radius
 			anchors.fill: parent
 		}
 	}

--- a/src/baseautotoggleswitch.cpp
+++ b/src/baseautotoggleswitch.cpp
@@ -1,0 +1,39 @@
+#include "baseautotoggleswitch.h"
+
+BaseAutoToggleSwitch::BaseAutoToggleSwitch(QQuickItem *parent)
+    : QQuickControl(parent)
+{
+	setFlag(ItemIsFocusScope);
+	setFocusPolicy(Qt::StrongFocus);
+}
+
+bool BaseAutoToggleSwitch::onChecked() const
+{
+	return m_onChecked;
+}
+
+void BaseAutoToggleSwitch::setOnChecked(bool checked)
+{
+	if (m_onChecked != checked) {
+		m_onChecked = checked;
+		Q_EMIT onCheckedChanged();
+	}
+}
+
+bool BaseAutoToggleSwitch::autoChecked() const
+{
+	return m_autoChecked;
+}
+
+void BaseAutoToggleSwitch::setAutoChecked(bool checked)
+{
+	if (m_autoChecked != checked) {
+		m_autoChecked = checked;
+		Q_EMIT autoCheckedChanged();
+	}
+}
+
+int BaseAutoToggleSwitch::buttonCount() const
+{
+    return 3;
+}

--- a/src/baseautotoggleswitch.h
+++ b/src/baseautotoggleswitch.h
@@ -1,0 +1,40 @@
+#ifndef BASEAUTOTOGGLESWITCH_H
+#define BASEAUTOTOGGLESWITCH_H
+
+#include <QObject>
+#include <QQmlEngine>
+#include <QtQuickTemplates2/private/qquickcontrol_p.h>
+
+class BaseAutoToggleSwitch : public QQuickControl
+{
+	Q_OBJECT
+	QML_ELEMENT
+	Q_PROPERTY(bool onChecked READ onChecked WRITE setOnChecked NOTIFY onCheckedChanged FINAL)
+	Q_PROPERTY(bool autoChecked READ autoChecked WRITE setAutoChecked NOTIFY autoCheckedChanged FINAL)
+	Q_PROPERTY(int buttonCount READ buttonCount CONSTANT FINAL)
+
+public:
+    BaseAutoToggleSwitch(QQuickItem *parent = nullptr);
+
+	bool onChecked() const;
+	void setOnChecked(bool checked);
+
+	bool autoChecked() const;
+	void setAutoChecked(bool checked);
+
+	int buttonCount() const;
+
+signals:
+	void onCheckedChanged();
+	void autoCheckedChanged();
+
+	void onClicked();
+	void offClicked();
+	void autoClicked();
+
+private:
+	bool m_onChecked = false;
+	bool m_autoChecked = false;
+};
+
+#endif // BASEAUTOTOGGLESWITCH_H

--- a/themes/geometry/FiveInch.json
+++ b/themes/geometry/FiveInch.json
@@ -13,6 +13,8 @@
     "geometry_flickable_maximumFlickVelocity": 2500,
     "geometry_flickable_flickDeceleration": 2500,
 
+    "geometry_autotoggle_button_spacing": 10,
+
     "geometry_barGauge_vertical_width_large": 8,
     "geometry_barGauge_vertical_width_small": 4,
     "geometry_barGauge_horizontal_height": 10,

--- a/themes/geometry/SevenInch.json
+++ b/themes/geometry/SevenInch.json
@@ -13,6 +13,8 @@
     "geometry_flickable_maximumFlickVelocity": 2500,
     "geometry_flickable_flickDeceleration": 2500,
 
+    "geometry_autotoggle_button_spacing": 10,
+
     "geometry_barGauge_vertical_width_large": 8,
     "geometry_barGauge_vertical_width_small": 4,
     "geometry_barGauge_horizontal_height": 10,


### PR DESCRIPTION
The AutoToggleSwitch control is a three way switch controlling two states.

/SwitchableOutput/<x>/State sets the default toggle.
 /SwitchableOutput/<x>/Auto sets the additional toggle.

Contributes to #2303