### PR TITLE
Switch pane: allow key navigation when DimmingSlider is selected

### DIFF
--- a/components/SwitchableOutputDelegate.qml
+++ b/components/SwitchableOutputDelegate.qml
@@ -173,8 +173,11 @@ BaseListItem {
 					return true
 				case Qt.Key_Up:
 				case Qt.Key_Down:
-					// Prevent key navigation to other grid delegates while in edit mode.
-					return true
+					if (activeFocus) {
+						// Prevent key navigation to other grid delegates while in edit mode.
+						return true
+					}
+					break
 				}
 				return false
 			}


### PR DESCRIPTION
The user should be prevented from navigation away from the DimmingSlider when the slider is in "edit" mode, but not when the user has highlighted the slider as part of moving around the grid view.