### PR TITLE
Start page: fix reference to pageManager

### DIFF
--- a/data/StartPageConfiguration.qml
+++ b/data/StartPageConfiguration.qml
@@ -56,7 +56,7 @@ QtObject {
 	]
 
 	// Changes the application view to show the start page.
-	function loadStartPage(navBar, swipeView, topStackPageUrl) {
+	function loadStartPage(pageManager, navBar, swipeView, topStackPageUrl) {
 		if (!hasStartPage) {
 			return
 		}
@@ -88,10 +88,10 @@ QtObject {
 			// Looks like the stack is already showing the correct page, so there's nothing to do.
 			return
 		}
-		Global.pageManager.popAllPages(PageStack.Immediate)
+		pageManager.popAllPages(PageStack.Immediate)
 		for (let i = 0; i < stackPages.length; ++i) {
 			if (stackPages[i].page) {
-				Global.pageManager.pushPage(stackPages[i].page, stackPages[i].properties || {})
+				pageManager.pushPage(stackPages[i].page, stackPages[i].properties || {})
 			}
 		}
 	}

--- a/pages/MainView.qml
+++ b/pages/MainView.qml
@@ -54,7 +54,7 @@ FocusScope {
 			: swipeViewAndNavBarContainer
 
 	function loadStartPage() {
-		Global.systemSettings.startPageConfiguration.loadStartPage(navBar, swipeView, pageStack.topPageUrl)
+		Global.systemSettings.startPageConfiguration.loadStartPage(pageManager, navBar, swipeView, pageStack.topPageUrl)
 	}
 
 	function clearUi() {


### PR DESCRIPTION
It may be invalid if the start page is loaded before all Global references are initialized.