### PR TITLE
Overview: fix table column alignment in AC/Essential loads drilldowns

### DIFF
--- a/components/QuantityTable.qml
+++ b/components/QuantityTable.qml
@@ -28,6 +28,7 @@ ListView {
 	property real rightPadding: Theme.geometry_listItem_content_horizontalMargin
 
 	readonly property real availableWidth: width - leftPadding - rightPadding
+	readonly property real fixedColumnWidth: headerItem?.fixedColumnWidth ?? NaN
 
 	function resetRowColors() {
 		let visibleRowCount = 0
@@ -52,6 +53,7 @@ ListView {
 		property QuantityTable table: ListView.view
 		property alias model: groupHeader.model
 		property alias headerText: groupHeader.headerText
+		readonly property alias fixedColumnWidth: groupHeader.fixedColumnWidth
 
 		implicitWidth: table.width
 		implicitHeight: Theme.geometry_quantityTable_row_height

--- a/pages/loads/AcLoadListPage.qml
+++ b/pages/loads/AcLoadListPage.qml
@@ -18,6 +18,9 @@ Page {
 
 	GradientListView {
 		header: BaseListItem {
+			readonly property alias columnWidth: loadSummary.fixedColumnWidth
+			readonly property alias columnSpacing: loadSummary.columnSpacing
+
 			width: parent?.width ?? 0
 			height: phaseTable.y + phaseTable.height + bottomInset
 			bottomInset: Theme.geometry_gradientList_spacing
@@ -28,9 +31,9 @@ Page {
 				width: parent.width
 				equalWidthColumns: true
 
-				// rightPadding = width of the sub-menu arrow icon, plus margin around it. Needed to
-				// align the "Total power" column with the "Total power" in each list delegate.
-				rightPadding: 32 + (Theme.geometry_listItem_content_horizontalMargin * 2)
+				// rightPadding = 32px width of the sub-menu arrow icon in each list delegate, plus
+				// margin, to align with the columns in the delegates.
+				rightPadding: 32 + Theme.geometry_listItem_content_horizontalMargin
 				summaryModel: [
 					{ text: "", unit: VenusOS.Units_None },
 					{ text: "", unit: VenusOS.Units_None },
@@ -108,6 +111,8 @@ Page {
 
 			name: device.name
 			power: powerItem.value ?? NaN
+			columnWidth: ListView.view.headerItem?.columnWidth ?? NaN
+			columnSpacing: ListView.view.headerItem?.columnSpacing ?? 0
 
 			// Status depends on the service:
 			// - acload, heatpump: /SwitchableOutput/Status

--- a/pages/loads/LoadListDelegate.qml
+++ b/pages/loads/LoadListDelegate.qml
@@ -16,20 +16,25 @@ BaseListItem {
 	property real temperature: NaN
 	property real power: NaN
 
+	property real columnWidth: NaN
+	property real columnSpacing
+
 	signal clicked
 
 	width: parent?.width ?? 0
 	height: Theme.geometry_loadListPage_item_height
 
-	component QuantityColumn : ColumnLayout {
+	component QuantityColumn : Column {
 		property alias title: quantityTitle.text
 		property alias value: quantityLabel.value
 		property alias unit: quantityLabel.unit
 
+		width: root.columnWidth || implicitWidth
 		spacing: Theme.geometry_batteryListPage_item_verticalSpacing
 
 		Label {
 			id: quantityTitle
+			width: parent.width
 			elide: Text.ElideRight
 			color: Theme.color_listItem_secondaryText
 			font.pixelSize: Theme.font_size_caption
@@ -44,11 +49,12 @@ BaseListItem {
 	RowLayout {
 		width: parent.width
 		height: parent.height
+		spacing: 0
 
 		Column {
 			Layout.fillWidth: true
 			Layout.leftMargin: Theme.geometry_listItem_content_horizontalMargin
-			Layout.rightMargin: Theme.geometry_listItem_content_horizontalMargin
+			Layout.rightMargin: root.columnSpacing
 			spacing: Theme.geometry_batteryListPage_item_verticalSpacing
 
 			Label {
@@ -69,7 +75,7 @@ BaseListItem {
 		}
 
 		Loader {
-			Layout.rightMargin: Theme.geometry_listItem_content_horizontalMargin
+			Layout.rightMargin: root.columnSpacing
 			active: !isNaN(root.temperature)
 			sourceComponent: QuantityColumn {
 				title: CommonWords.temperature
@@ -79,7 +85,6 @@ BaseListItem {
 		}
 
 		QuantityColumn {
-			Layout.rightMargin: Theme.geometry_listItem_content_horizontalMargin
 			title: CommonWords.total_power
 			value: root.power
 			unit: VenusOS.Units_Watt


### PR DESCRIPTION
Ensure the last column of each delegate aligns with the last column of the table summary.

Since the table summary uses fixed column widths - rather than a width calculated depending on the unit displayed, which could be calculated independently in each delegate - this width needs to be provided to each delegate.

Contributes to #2311