### PR TITLE
Shaders: ensure qsb files are found in wasm build

### DIFF
--- a/cmake/BuildQt6AddShaders.cmake
+++ b/cmake/BuildQt6AddShaders.cmake
@@ -27,7 +27,7 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Emscripten" AND NOT COMMAND qt6_add_shaders)
 
         # Process each shader file
         foreach(shader_file ${SHADER_FILES})
-            get_filename_component(shader_name ${shader_file} NAME_WE)
+            get_filename_component(shader_name ${shader_file} NAME)
             get_filename_component(shader_dir ${shader_file} DIRECTORY)
 
             # Output file
@@ -47,8 +47,16 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Emscripten" AND NOT COMMAND qt6_add_shaders)
 
             # Add to target
             target_sources(${target} PRIVATE ${output_file})
-            set_source_files_properties(${output_file} PROPERTIES QT_RESOURCE_ALIAS "${shader_name}.qsb")
+            set_source_files_properties(${output_file} PROPERTIES QT_RESOURCE_ALIAS "${shader_file}.qsb")
+
+            # Add to resource files
+            list(APPEND qsb_files "${output_file}")
         endforeach()
+
+        # Add resource file containing the qsb files
+        qt6_add_resources(${target} "${target}_resources"
+            FILES "${qsb_files}"
+        )
     endfunction()
 
     message(STATUS "Created custom qt6_add_shaders function")


### PR DESCRIPTION
Fix some issues in the custom qt6_add_shaders() function used by build-wasm.sh:

- add the resource file containing the qsb files, otherwise qrc:/components/shaders/presseffect.frag.qsb cannot be found by BasePressEffect.qml
- use NAME_WE instead of NAME_ to get shader_name, as it needs to include the .frag suffix, so that output_file is presseffect.frag.qsb rather than presseffect.qsb
- the qrc alias to the qsb file needs to be shader_file (which includes the path) rather than just shader_name