### PR TITLE
Brief: allow side panel to be closed when Brief is the Start Page

### DIFF
--- a/pages/BriefPage.qml
+++ b/pages/BriefPage.qml
@@ -454,7 +454,6 @@ SwipeViewPage {
 		Transition {
 			to: "panelOpening"
 			from: "initialized"
-			enabled: Global.allPagesLoaded
 			SequentialAnimation {
 				NumberAnimation {
 					target: root
@@ -473,7 +472,6 @@ SwipeViewPage {
 		Transition {
 			to: "initialized"
 			from: "panelOpened"
-			enabled: Global.allPagesLoaded
 			SequentialAnimation {
 				NumberAnimation {
 					target: sidePanel


### PR DESCRIPTION
The side panel can only be closed when state="panelOpened", and this state is set by the ScriptAction in the "initialized" -> "panelOpening" transition. So this transition must be run whenever the state becomes "panelOpening", regardless of whether Global.allPagesLoaded is true; otherwise, it is possible to get stuck in the "panelOpening" state without moving onto the "panelOpened" state.

This was happening when the Start Page was "Brief (side panel open)", where Brief was loaded as the Start Page while Global.allPagesLoaded was  still false; therefore the transition was not run, the state remained in  "panelOpening" and the side panel could not be closed.

Also remove the Global.allPagesLoaded condition from the "panelOpened" -> "initialized" transition, which should always be run to ensure its ScriptAction is executed.

Fixes #2374