### PR TITLE
MainView: avoid re-animation of initial page

### DIFF
--- a/components/SwipePageModel.qml
+++ b/components/SwipePageModel.qml
@@ -19,7 +19,7 @@ ObjectModel {
 	readonly property VeQuickItem showBoatPage: VeQuickItem {
 		uid: !!Global.systemSettings ? Global.systemSettings.serviceUid + "/Settings/Gui/ElectricPropulsionUI/Enabled" : ""
 		onValueChanged: {
-			if (!_completed) {
+			if (!completed) {
 				return
 			}
 
@@ -38,7 +38,7 @@ ObjectModel {
 	}
 	property LevelsPage levelsPage
 
-	property bool _completed: false
+	property bool completed: false
 
 	BriefPage {
 		view: root.view
@@ -78,11 +78,11 @@ ObjectModel {
 			insert(0, boatPage.createObject(parent))
 		}
 
-		_completed = true
+		completed = true
 	}
 
 	onShowLevelsPageChanged: {
-		if (!_completed) {
+		if (!completed) {
 			return
 		}
 

--- a/pages/MainView.qml
+++ b/pages/MainView.qml
@@ -42,6 +42,7 @@ FocusScope {
 	property int _loadedPages: 0
 
 	readonly property bool _readyToInit: Global.dataManagerLoaded && !Global.needPageReload
+			&& swipeViewLoader.readyToLoad
 	on_ReadyToInitChanged: {
 		if (_readyToInit && swipeViewLoader.active == false) {
 			console.info("MainView: data sources ready, loading swipe view pages")
@@ -135,6 +136,8 @@ FocusScope {
 
 			property bool blockItemFocus
 			property bool refreshBlockItemFocus: Global.keyNavigationEnabled
+			readonly property bool readyToLoad: swipePageModel.completed
+					&& Global.notifications && Global.notificationLayer // checked by onLoaded handler
 
 			anchors {
 				top: parent.top
@@ -151,7 +154,7 @@ FocusScope {
 			onLoaded: {
 				// If there is an active alarm, the notifications page will be shown; otherwise, show the
 				// application start page, if set.
-				if (Global.notifications?.alarms.hasActive ?? false) {
+				if (Global.notifications?.alarms.hasActive) {
 					Global.notificationLayer.popAndGoToNotifications()
 				} else {
 					root.loadStartPage()


### PR DESCRIPTION
Ensure the SwipePageModel is initialized before the SwipeView is loaded. Otherwise, the model changes in the SwipePageModel initialization (where pages may be inserted or removed depending on the Levels page models or the Boat configuration) confuse the SwipeView, causing its currentIndex to change between -1 and 0. These currentIndex changes also cause the SwipeView to animate its currentPage unnecessarily and re-animate in the first page even when it is already the current page.