### PR TITLE
Brief: reduce font size of center text

### DIFF
--- a/components/BriefCenterDisplay.qml
+++ b/components/BriefCenterDisplay.qml
@@ -63,7 +63,8 @@ Column {
 
 	FittedQuantityLabel {
 		id: centerLabel
-		width: parent.width
+		anchors.horizontalCenter: parent.horizontalCenter
+		width: parent.width - (2 * Theme.geometry_briefPage_centerGauge_centerText_horizontalSpacing)
 		unit: root._useTemperature ? Global.systemSettings.temperatureUnit : VenusOS.Units_Percentage
 		value: root._useTemperature ? (temperature.value ?? NaN) : Global.system.battery.stateOfCharge
 		minimumPixelSize: Theme.font_briefPage_battery_percentage_minimumPixelSize


### PR DESCRIPTION
Add horizontal margins to the center SOC/temperature text so that the text is not so close to the gauges around it.

Before:

<img width="2040" height="1186" alt="image" src="https://github.com/user-attachments/assets/bf962c3c-b00b-4d99-8349-9c36c805a1d9" />

After:

<img width="2040" height="1186" alt="image" src="https://github.com/user-attachments/assets/e8fb4c6d-390f-4e94-98fc-8dd30b9ccac5" />
