### PR TITLE
Add relay options: Manual polarity and disabled

### DIFF
--- a/pages/settings/PageSettingsRelay.qml
+++ b/pages/settings/PageSettingsRelay.qml
@@ -68,12 +68,14 @@ Page {
 			}
 
 			ListRadioButtonGroup {
-				id: alarmPolaritySwitch
-
-				//% "Alarm relay polarity"
-				text: qsTrId("settings_relay_alarm_polarity")
+				id: relayPolaritySwitch
+				text: relay1State.valid
+					  //% "Polarity (Relay 1)"
+					? qsTrId("settings_relay_polarity_relay1")
+					  //% "Polarity"
+					: qsTrId("settings_relay_polarity")
 				dataItem.uid: Global.systemSettings.serviceUid + "/Settings/Relay/Polarity"
-				preferredVisible: relayFunction.currentValue === VenusOS.Relay_Function_Alarm
+				preferredVisible: [VenusOS.Relay_Function_Alarm, VenusOS.Relay_Function_Manual].indexOf(relayFunction.currentValue) >= 0
 				optionModel: [
 					//% "Normally open"
 					{ display: qsTrId("settings_relay_normally_open"), value: 0 },
@@ -97,6 +99,15 @@ Page {
 				onOptionClicked: function(index) {
 					root.notifyRelayFunctionChange(optionModel[index].value)
 				}
+			}
+
+			ListRadioButtonGroup {
+				id: relay1PolaritySwitch
+				//% "Polarity (Relay 2)"
+				text: qsTrId("settings_relay_polarity_relay2")
+				dataItem.uid: Global.systemSettings.serviceUid + "/Settings/Relay/1/Polarity"
+				preferredVisible: relay1Function.currentValue === VenusOS.Relay_Function_Manual
+				optionModel: relayPolaritySwitch.optionModel
 			}
 
 			ListNavigation {

--- a/pages/settings/PageSettingsRelay.qml
+++ b/pages/settings/PageSettingsRelay.qml
@@ -43,13 +43,15 @@ Page {
 			ListRadioButtonGroup {
 				id: relayFunction
 
-				text: relay1State.valid
+				text: relay1State.seen
 					  //% "Function (Relay 1)"
 					? qsTrId("settings_relay_function_relay1")
 					  //% "Function"
 					: qsTrId("settings_relay_function")
 				dataItem.uid: Global.systemSettings.serviceUid + "/Settings/Relay/Function"
 				optionModel: [
+					//% "Disabled"
+					{ display: qsTrId("settings_relay_disabled"), value: VenusOS.Relay_Function_Disabled },
 					//% "Alarm relay"
 					{ display: qsTrId("settings_relay_alarm_relay"), value: VenusOS.Relay_Function_Alarm },
 					//% "Genset start/stop"
@@ -69,7 +71,7 @@ Page {
 
 			ListRadioButtonGroup {
 				id: relayPolaritySwitch
-				text: relay1State.valid
+				text: relay1State.seen
 					  //% "Polarity (Relay 1)"
 					? qsTrId("settings_relay_polarity_relay1")
 					  //% "Polarity"
@@ -90,8 +92,10 @@ Page {
 				//% "Function (Relay 2)"
 				text: qsTrId("settings_relay_function_relay2")
 				dataItem.uid: Global.systemSettings.serviceUid + "/Settings/Relay/1/Function"
-				preferredVisible: relay1State.valid
+				preferredVisible: relay1State.seen
 				optionModel: [
+					//% "Disabled"
+					{ display: qsTrId("settings_relay_disabled"), value: VenusOS.Relay_Function_Disabled },
 					//% "Manual"
 					{ display: qsTrId("settings_relay_manual"), value: VenusOS.Relay_Function_Manual },
 					{ display: CommonWords.temperature, value: VenusOS.Relay_Function_Temperature },

--- a/src/enums.h
+++ b/src/enums.h
@@ -566,6 +566,7 @@ public:
 	Q_ENUM(CanBusConfig_Type)
 
 	enum Relay_Function {
+		Relay_Function_Disabled = -1,
 		Relay_Function_Alarm = 0,
 		Relay_Function_GeneratorStartStop,
 		Relay_Function_Manual,


### PR DESCRIPTION
This allows changing the polarity of the GX relays when function is set to manual, instead of just for Alarm relay.

It also allows completely disabling the relay.

Some issues I don't know how to solve: If a manual relay is disabled, it remains on the Device List, and on the Switch Pane.