### PR TITLE
Notifications: show toast pop-up immediately on new notification

### DIFF
--- a/data/Notifications.qml
+++ b/data/Notifications.qml
@@ -16,7 +16,8 @@ QtObject {
 			+ Math.max(informations.activeCount, informations.unAcknowledgedCount)
 
 	readonly property NotificationsModel allNotificationsModel: NotificationsModel {
-		onNotificationUpdated: (notification) => toastedNotification.onNotificationUpdated(notification)
+		onNotificationInserted: (notification) => toastedNotification.queueNotification(notification)
+		onNotificationUpdated: (notification) => toastedNotification.queueNotification(notification)
 		onNotificationRemoved: (notification) => toastedNotification.onNotificationRemoved(notification)
 	}
 
@@ -35,7 +36,7 @@ QtObject {
 			onTriggered: toastedNotif.requestToastForNotification(toastedNotif.pendingNotification)
 		}
 
-		function onNotificationUpdated(notif: BaseNotification) {
+		function queueNotification(notif: BaseNotification) {
 			if (!toastedNotif.pendingNotification || notif.dateTime >= toastedNotif.pendingNotification.dateTime) {
 				toastedNotif.pendingNotification = notif;
 				pendingNotificationTimer.restart();
@@ -43,11 +44,10 @@ QtObject {
 		}
 
 		function requestToastForNotification(notif: BaseNotification) {
-
 			// the notification must be acknowledged: false at the point of being updated
 			// (this is because injected notifications' active is always false)
 			// for a toast to be considered for raising (and preempting existing ones)
-			if (!notif.acknowledged) {
+			if (!notif.acknowledged && notif.active) {
 				toastedNotif.checkAndRemoveExistingToast(notif)
 				if (!toastedNotif.toast) {
 					let createdToast = Global.notificationLayer?.showToastNotification(notif.type, "")


### PR DESCRIPTION
When a new notification is inserted into the model, show the toast pop-up immediately, instead of waiting until a notification property has changed.

Also, check that the notification is still active before showing the toast pop-up. Otherwise, if the toast is acknowledged, and then the notification becomes inactive, the toast is shown again due to the property change.

Fixes #2444