### PR TITLE
SpinBox: display correct decimal number

### DIFF
--- a/components/SpinBoxDecimalConverter.qml
+++ b/components/SpinBoxDecimalConverter.qml
@@ -19,7 +19,8 @@ QtObject {
 	readonly property int decimalFactor: Math.pow(10, decimals)
 
 	function decimalToInt(value) {
-		return value * decimalFactor
+		// Round the number to adjust for loss of precision in values reported from the backend
+		return Math.round(value * decimalFactor)
 	}
 
 	function intToDecimal(value) {


### PR DESCRIPTION
Round the initial SpinBox floating-point value when converting to int. When writing the float to the backend, the backend may report a slightly different value due to floating point conversion: for example, writing '24.9' as an Inverter/Charger current limit may cause it to be written as 24.899999618530273. In this case, if the number is not rounded to 249 before the int conversion, the SpinBox will show it as 24.8 instead of 24.9.

Regression from 0a7e80ec6d6503fb343056eecb6b763f722ea953.

Fixes #2459