### PR TITLE
Fix rendering issues on the Mobile Network page

### DIFF
--- a/pages/settings/PageSettingsGsm.qml
+++ b/pages/settings/PageSettingsGsm.qml
@@ -30,255 +30,265 @@ Page {
 	GradientListView {
 		id: settingsListView
 
-		model: simStatus.valid ? modemConnected : notConnected
+		model: loader.status === Loader.Ready ? loader.item : null
 
-		VisibleItemModel {
+		Loader {
+			id: loader
+
+			sourceComponent: simStatus.valid ? modemConnected : notConnected
+		}
+
+		Component {
 			id: notConnected
+			VisibleItemModel {
 
-			ListItem {
-				//% "Connect a Victron Energy GX GSM or GX LTE 4G modem to enable mobile network connectivity."
-				text: qsTrId("page_settings_connect_cellular_modem")
+				ListItem {
+					//% "Connect a Victron Energy GX GSM or GX LTE 4G modem to enable mobile network connectivity."
+					text: qsTrId("page_settings_connect_cellular_modem")
+				}
 			}
 		}
 
-		VisibleItemModel {
+		Component {
 			id: modemConnected
 
-			ListText {
-				id: status
+			VisibleItemModel {
+				ListText {
+					id: status
 
-				//% "Internet"
-				text: qsTrId("page_settings_gsm_internet")
-				secondaryText: dataItem.value ? CommonWords.online : CommonWords.offline
-				dataItem.uid: bindPrefix + "/Connected"
-			}
+					//% "Internet"
+					text: qsTrId("page_settings_gsm_internet")
+					secondaryText: dataItem.value ? CommonWords.online : CommonWords.offline
+					dataItem.uid: bindPrefix + "/Connected"
+				}
 
-			ListText {
-				id: carrier
+				ListText {
+					id: carrier
 
-				//% "Carrier"
-				text: qsTrId("page_settings_gsm_carrier")
-				secondaryText: dataItem.valid ? dataItem.value + " " + Utils.simplifiedNetworkType(networkType.value) : "--"
-				dataItem.uid: bindPrefix + "/NetworkName"
-			}
+					//% "Carrier"
+					text: qsTrId("page_settings_gsm_carrier")
+					secondaryText: dataItem.valid ? dataItem.value + " " + Utils.simplifiedNetworkType(networkType.value) : "--"
+					dataItem.uid: bindPrefix + "/NetworkName"
+				}
 
-			ListItem {
-				preferredVisible: gsmStatusIcon.valid
-				text: CommonWords.signal_strength
+				ListItem {
+					preferredVisible: gsmStatusIcon.valid
+					text: CommonWords.signal_strength
 
-				content.children: [
-					Item {
-						anchors.verticalCenter: parent.verticalCenter
-						width: Theme.geometry_settings_gsmModem_icon_container_width
-						height: Theme.geometry_settings_gsmModem_icon_container_height
+					content.children: [
+						Item {
+							anchors.verticalCenter: parent.verticalCenter
+							width: Theme.geometry_settings_gsmModem_icon_container_width
+							height: Theme.geometry_settings_gsmModem_icon_container_height
 
-						GsmStatusIcon {
-							id: gsmStatusIcon
-							height: Theme.geometry_settings_gsmModem_icon_height
-							anchors.centerIn: parent
+							GsmStatusIcon {
+								id: gsmStatusIcon
+								height: Theme.geometry_settings_gsmModem_icon_height
+								anchors.centerIn: parent
+							}
+						}
+					]
+				}
+
+				ListItem {
+					//% "It may be necessary to configure the APN settings below in this page, contact your operator for details.\nIf that doesn't work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data."
+					text: qsTrId("page_settings_gsm_error_message")
+					preferredVisible: status.dataItem.value === 0 && carrier.dataItem.valid && simStatus.value === 1000
+				}
+
+				ListSwitch {
+					//% "Allow roaming"
+					text: qsTrId("page_settings_gsm_allow_roaming")
+					dataItem.uid: settingsBindPrefix + "/RoamingPermitted"
+					writeAccessLevel: VenusOS.User_AccessType_User
+				}
+
+				ListText {
+					//% "Sim status"
+					text: qsTrId("page_settings_gsm_sim_status")
+					secondaryText: {
+						switch (dataItem.value) {
+						case 10:
+							//% "SIM not inserted"
+							return qsTrId("page_settings_gsm_sim_not_inserted")
+						case 11:
+							//% "PIN required"
+							return qsTrId("page_settings_gsm_pin_required")
+						case 12:
+							//% "PUK required"
+							return qsTrId("page_settings_gsm_puk_required")
+						case 13:
+							//% "SIM failure"
+							return qsTrId("page_settings_gsm_sim_failure")
+						case 14:
+							//% "SIM busy"
+							return qsTrId("page_settings_gsm_sim_busy")
+						case 15:
+							//% "Wrong SIM"
+							return qsTrId("page_settings_gsm_wrong_sim")
+						case 16:
+							//% "Wrong PIN"
+							return qsTrId("page_settings_gsm_wrong_pin")
+						case 1000:
+							//% "OK"
+							return qsTrId("page_settings_gsm_ok")
+						default:
+							//% "Unknown error"
+							return qsTrId("page_settings_gsm_unknown_error")
 						}
 					}
-				]
-			}
-
-			ListItem {
-				//% "It may be necessary to configure the APN settings below in this page, contact your operator for details.\nIf that doesn't work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data."
-				text: qsTrId("page_settings_gsm_error_message")
-				preferredVisible: status.dataItem.value === 0 && carrier.dataItem.valid && simStatus.value === 1000
-			}
-
-			ListSwitch {
-				//% "Allow roaming"
-				text: qsTrId("page_settings_gsm_allow_roaming")
-				dataItem.uid: settingsBindPrefix + "/RoamingPermitted"
-				writeAccessLevel: VenusOS.User_AccessType_User
-			}
-
-			ListText {
-				//% "Sim status"
-				text: qsTrId("page_settings_gsm_sim_status")
-				secondaryText: {
-					switch (dataItem.value) {
-					case 10:
-						//% "SIM not inserted"
-						return qsTrId("page_settings_gsm_sim_not_inserted")
-					case 11:
-						//% "PIN required"
-						return qsTrId("page_settings_gsm_pin_required")
-					case 12:
-						//% "PUK required"
-						return qsTrId("page_settings_gsm_puk_required")
-					case 13:
-						//% "SIM failure"
-						return qsTrId("page_settings_gsm_sim_failure")
-					case 14:
-						//% "SIM busy"
-						return qsTrId("page_settings_gsm_sim_busy")
-					case 15:
-						//% "Wrong SIM"
-						return qsTrId("page_settings_gsm_wrong_sim")
-					case 16:
-						//% "Wrong PIN"
-						return qsTrId("page_settings_gsm_wrong_pin")
-					case 1000:
-						//% "OK"
-						return qsTrId("page_settings_gsm_ok")
-					default:
-						//% "Unknown error"
-						return qsTrId("page_settings_gsm_unknown_error")
-					}
+					dataItem.uid: bindPrefix + "/SimStatus"
 				}
-				dataItem.uid: bindPrefix + "/SimStatus"
-			}
 
-			ListText {
-				//% "Registration status"
-				text: qsTrId("page_settings_gsm_registration_status")
-				secondaryText: {
-					switch (dataItem.value) {
-					case 0:
-						//% "Not registered, not searching for operator"
-						return qsTrId("page_settings_gsm_not_registered_not_searching")
-					case 1:
-						//% "Registered, home network"
-						return qsTrId("page_settings_gsm_registered_home_network")
-					case 2:
-						//% "Not registered, searching for operator"
-						return qsTrId("page_settings_gsm_not_registered_searching")
-					case 3:
-						//% "Registration denied"
-						return qsTrId("page_settings_gsm_registration_denied")
-					case 4:
-						//% "Unknown"
-						return qsTrId("page_settings_gsm_unknown_state")
-					case 5:
-						//% "Registered, roaming"
-						return qsTrId("page_settings_gsm_registered_roaming")
-					default:
-						//% "Unknown"
-						return qsTrId("page_settings_gsm_unknown_value")
+				ListText {
+					//% "Registration status"
+					text: qsTrId("page_settings_gsm_registration_status")
+					secondaryText: {
+						switch (dataItem.value) {
+						case 0:
+							//% "Not registered, not searching for operator"
+							return qsTrId("page_settings_gsm_not_registered_not_searching")
+						case 1:
+							//% "Registered, home network"
+							return qsTrId("page_settings_gsm_registered_home_network")
+						case 2:
+							//% "Not registered, searching for operator"
+							return qsTrId("page_settings_gsm_not_registered_searching")
+						case 3:
+							//% "Registration denied"
+							return qsTrId("page_settings_gsm_registration_denied")
+						case 4:
+							//% "Unknown"
+							return qsTrId("page_settings_gsm_unknown_state")
+						case 5:
+							//% "Registered, roaming"
+							return qsTrId("page_settings_gsm_registered_roaming")
+						default:
+							//% "Unknown"
+							return qsTrId("page_settings_gsm_unknown_value")
+						}
 					}
+					dataItem.uid: bindPrefix + "/RegStatus"
+					preferredVisible: dataItem.valid
 				}
-				dataItem.uid: bindPrefix + "/RegStatus"
-				preferredVisible: dataItem.valid
-			}
 
-			ListText {
-				//% "Data link (PPP) status"
-				text: qsTrId("page_settings_gsm_data_link_status")
-				secondaryText: {
-					switch (dataItem.value) {
-					case 0:
-						//% "Offline"
-						return qsTrId("page_settings_gsm_offline")
-					case 1:
-						//% "Connecting"
-						return qsTrId("page_settings_gsm_connecting")
-					case 2:
-						//% "Connected"
-						return qsTrId("page_settings_gsm_connected")
-					default:
-						//% "Unknown"
-						return qsTrId("page_settings_gsm_unknown_value")
+				ListText {
+					//% "Data link (PPP) status"
+					text: qsTrId("page_settings_gsm_data_link_status")
+					secondaryText: {
+						switch (dataItem.value) {
+						case 0:
+							//% "Offline"
+							return qsTrId("page_settings_gsm_offline")
+						case 1:
+							//% "Connecting"
+							return qsTrId("page_settings_gsm_connecting")
+						case 2:
+							//% "Connected"
+							return qsTrId("page_settings_gsm_connected")
+						default:
+							//% "Unknown"
+							return qsTrId("page_settings_gsm_unknown_value")
+						}
 					}
+					dataItem.uid: bindPrefix + "/PPPStatus"
+					preferredVisible: dataItem.valid
 				}
-				dataItem.uid: bindPrefix + "/PPPStatus"
-				preferredVisible: dataItem.valid
-			}
 
-			ListTextField {
-				//% "PIN"
-				text: qsTrId("page_settings_gsm_pin")
-				textField.maximumLength: 35
-				dataItem.uid: settingsBindPrefix + "/PIN"
-				writeAccessLevel: VenusOS.User_AccessType_User
-				// Show only when PIN required
-				preferredVisible: dataItem.valid && [11, 16].indexOf(simStatus.value)  > -1
-			}
+				ListTextField {
+					//% "PIN"
+					text: qsTrId("page_settings_gsm_pin")
+					textField.maximumLength: 35
+					dataItem.uid: settingsBindPrefix + "/PIN"
+					writeAccessLevel: VenusOS.User_AccessType_User
+					// Show only when PIN required
+					preferredVisible: dataItem.valid && [11, 16].indexOf(simStatus.value)  > -1
+				}
 
-			ListText {
-				text: CommonWords.ip_address
-				dataItem.uid: bindPrefix + "/IP"
-				preferredVisible: status.dataItem.value === 1
-			}
+				ListText {
+					text: CommonWords.ip_address
+					dataItem.uid: bindPrefix + "/IP"
+					preferredVisible: status.dataItem.value === 1
+				}
 
-			ListNavigation {
-				//% "APN"
-				text: qsTrId("page_settings_gsm_apn")
-				//% "Default"
-				secondaryText: (!apnSetting.valid || apnSetting.value === "") ? qsTrId("page_settings_gsm_default") : apnSetting.value
-				onClicked: Global.pageManager.pushPage(apnPage, { title: text })
-				Component {
-					id: apnPage
+				ListNavigation {
+					//% "APN"
+					text: qsTrId("page_settings_gsm_apn")
+					//% "Default"
+					secondaryText: (!apnSetting.valid || apnSetting.value === "") ? qsTrId("page_settings_gsm_default") : apnSetting.value
+					onClicked: Global.pageManager.pushPage(apnPage, { title: text })
+					Component {
+						id: apnPage
 
-					Page {
+						Page {
 
-						GradientListView {
+							GradientListView {
 
-							model: VisibleItemModel {
+								model: VisibleItemModel {
 
-								ListSwitch {
-									id: useDefaultApn
-									//% "Use default APN"
-									text: qsTrId("page_settings_gsm_use_default_apn")
-									checked: apnSetting.value === ""
-									checkable: true
-									onCheckedChanged: {
-										if (apnSetting.valid && checked) {
-											apnSetting.setValue("")
+									ListSwitch {
+										id: useDefaultApn
+										//% "Use default APN"
+										text: qsTrId("page_settings_gsm_use_default_apn")
+										checked: apnSetting.value === ""
+										checkable: true
+										onCheckedChanged: {
+											if (apnSetting.valid && checked) {
+												apnSetting.setValue("")
+											}
 										}
 									}
-								}
 
-								ListTextField {
-									//% "APN name"
-									text: qsTrId("page_settings_gsm_apn_name")
-									dataItem.uid: root.settingsBindPrefix + "/APN"
-									preferredVisible: !useDefaultApn.checked
-									textField.maximumLength: 50
+									ListTextField {
+										//% "APN name"
+										text: qsTrId("page_settings_gsm_apn_name")
+										dataItem.uid: root.settingsBindPrefix + "/APN"
+										preferredVisible: !useDefaultApn.checked
+										textField.maximumLength: 50
+									}
 								}
 							}
 						}
 					}
 				}
-			}
 
-			ListSwitch {
-				id: useAuth
-				//% "Use authentication"
-				text: qsTrId("page_settings_gsm_use_authentication")
-				checked: authUser.dataItem.value !== "" || authPass.dataItem.value !== ""
-				checkable: true
-				onCheckedChanged: {
-					if (!checked) {
-						authUser.dataItem.setValue("")
-						authPass.dataItem.setValue("")
+				ListSwitch {
+					id: useAuth
+					//% "Use authentication"
+					text: qsTrId("page_settings_gsm_use_authentication")
+					checked: authUser.dataItem.value !== "" || authPass.dataItem.value !== ""
+					checkable: true
+					onCheckedChanged: {
+						if (!checked) {
+							authUser.dataItem.setValue("")
+							authPass.dataItem.setValue("")
+						}
 					}
 				}
-			}
 
-			ListTextField {
-				id: authUser
+				ListTextField {
+					id: authUser
 
-				//% "User name"
-				text: qsTrId("page_settings_gsm_user_name")
-				dataItem.uid: settingsBindPrefix + "/User"
-				preferredVisible: useAuth.checked
-			}
+					//% "User name"
+					text: qsTrId("page_settings_gsm_user_name")
+					dataItem.uid: settingsBindPrefix + "/User"
+					preferredVisible: useAuth.checked
+				}
 
-			ListTextField {
-				id: authPass
+				ListTextField {
+					id: authPass
 
-				text: CommonWords.password
-				dataItem.uid: settingsBindPrefix + "/Password"
-				preferredVisible: useAuth.checked
-			}
+					text: CommonWords.password
+					dataItem.uid: settingsBindPrefix + "/Password"
+					preferredVisible: useAuth.checked
+				}
 
-			ListText {
-				//% "IMEI"
-				text: qsTrId("page_settings_gsm_imei")
-				dataItem.uid: bindPrefix + "/IMEI"
-				preferredVisible: dataItem.valid
+				ListText {
+					//% "IMEI"
+					text: qsTrId("page_settings_gsm_imei")
+					dataItem.uid: bindPrefix + "/IMEI"
+					preferredVisible: dataItem.valid
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #2467.

Prior to this fix, if `simStatus.valid` flicked back and forth, both `VisibleItemModels` would be created and displayed on top of each other. If I used `ObejctModel` instead of `VisibleItemModel` for `modemConnected` and `notConnected`, the GradientListView would behave correctly, making me think that the 'real' bug is in in `VisibleItemModel` somewhere.

Fixing `VisibleItemModel` to behave properly, like `ObjectModel` is likely to be difficult. This fix is easy, and works fine.
