### PR TITLE
UI Controls: Restrict ListSwitch and ListButton touch area

### DIFF
--- a/components/controls/Switch.qml
+++ b/components/controls/Switch.qml
@@ -48,9 +48,9 @@ T.Switch {
 
 	indicator: Image {
 		x: root.checked
-		   ? parent.width - width + Theme.geometry_switch_indicator_shadowOffset
-		   : parent.width - indicatorBackground.width - Theme.geometry_switch_indicator_shadowOffset
-		y: parent.height/2 - height/2
+		   ? root.background.width - width + Theme.geometry_switch_indicator_shadowOffset + root.leftInset
+		   : root.background.width - indicatorBackground.width - Theme.geometry_switch_indicator_shadowOffset + root.leftInset
+		y: root.topInset + root.background.height/2 - height/2
 		width: Theme.geometry_switch_indicator_width
 		height: Theme.geometry_switch_indicator_width
 		source: "qrc:/images/switch_indicator.png"

--- a/components/listitems/core/ListButton.qml
+++ b/components/listitems/core/ListButton.qml
@@ -13,6 +13,7 @@ ListItem {
 	property alias secondaryText: button.text
 
 	interactive: true
+	pressAreaEnabled: false
 
 	content.children: [
 		ListItemButton {

--- a/components/listitems/core/ListItem.qml
+++ b/components/listitems/core/ListItem.qml
@@ -72,6 +72,7 @@ BaseListItem {
 				: VenusOS.ListItem_BottomContentSizeMode_Stretch
 
 	property bool interactive: false
+	property bool pressAreaEnabled: true
 	readonly property bool clickable: enabled && interactive && userHasWriteAccess
 
 	signal clicked()
@@ -121,6 +122,7 @@ BaseListItem {
 
 		anchors.fill: parent
 		radius: root.background.radius
+		enabled: root.pressAreaEnabled
 		effectEnabled: root.interactive
 		onClicked: root.activate()
 

--- a/components/listitems/core/ListSwitch.qml
+++ b/components/listitems/core/ListSwitch.qml
@@ -25,47 +25,56 @@ ListItem {
 	// switch is toggled directly.
 	signal toggled
 
-	interactive: (dataItem.uid === "" || dataItem.valid)
+	// Override ListItem right padding to give Switch a larger touch area for users
+	rightPadding: 0
 
+	interactive: (dataItem.uid === "" || dataItem.valid)
+	pressAreaEnabled: false
+
+	content.spacing: 0
 	content.children: [
 		Label {
 			id: secondaryLabel
+			rightPadding: 0
 			anchors.verticalCenter: switchItem.verticalCenter
 			color: Theme.color_font_secondary
 			font.pixelSize: Theme.font_size_body2
-			width: Math.min(implicitWidth, root.maximumContentWidth - switchItem.width - root.content.spacing)
+			width: Math.min(implicitWidth, root.maximumContentWidth - switchItem.width - Theme.geometry_listItem_content_spacing)
 			wrapMode: Text.Wrap
 		},
 		Switch {
 			id: switchItem
 
+			topInset: Theme.geometry_listItem_content_verticalMargin
+			bottomInset: Theme.geometry_listItem_content_verticalMargin
+			leftInset: Theme.geometry_listItem_content_spacing
+			rightInset: root.flat ? Theme.geometry_listItem_flat_content_horizontalMargin : Theme.geometry_listItem_content_horizontalMargin
 			enabled: root.clickable
 			checked: invertSourceValue ? dataItem.value === valueFalse : dataItem.value === valueTrue
 			checkable: false
 			focusPolicy: Qt.NoFocus
 
-			onClicked: root.clicked()
+			onClicked: {
+				if (root.updateDataOnClick) {
+					if (root.dataItem.uid.length > 0) {
+						// Note: this logic only holds so long as checkable is false so we can use
+						// the current unmodified checked state at the point of onClicked.
+						// (dataItem might not be valid until the first write so we can't simply use
+						// the comparison of dataItem.value === valueFalse) and forget invertSourceValue).
+						// Note that an malformed uid will result in it being empty when inspected.
+						root._updatingValue = true
+						if (root.invertSourceValue) {
+							root.dataItem.setValue(checked ? valueTrue : valueFalse)
+						} else {
+							root.dataItem.setValue(checked ? valueFalse : valueTrue)
+						}
+					}
+				}
+				root.clicked()
+			}
 			onToggled: root.toggled()
 		}
 	]
-
-	onClicked: {
-		if (switchItem.enabled && updateDataOnClick) {
-			if (root.dataItem.uid.length > 0) {
-				// Note: this logic only holds so long as checkable is false so we can use
-				// the current unmodified checked state at the point of onClicked.
-				// (dataItem might not be valid until the first write so we can't simply use
-				// the comparison of dataItem.value === valueFalse) and forget invertSourceValue).
-				// Note that an malformed uid will result in it being empty when inspected.
-				root._updatingValue = true
-				if (invertSourceValue) {
-					dataItem.setValue(switchItem.checked ? valueTrue : valueFalse)
-				} else {
-					dataItem.setValue(switchItem.checked ? valueFalse : valueTrue)
-				}
-			}
-		}
-	}
 
 	VeQuickItem {
 		id: dataItem


### PR DESCRIPTION
Restrict the touch area of ListSwitch and ListButton from the entirety of ListItem to an area around the Switch/Button.

Fixes #2471