### PR TITLE
Main: Detect Raspberry Pi Touch Display 2

### DIFF
--- a/Main.qml
+++ b/Main.qml
@@ -92,12 +92,30 @@ Window {
 		// show the GUI always centered in the window
 		transformOrigin: Item.Center
 
+		// Rotate for Raspberry Pi Touch Display 2
+		transform: Rotation {
+			origin.x: root.width / 2
+			origin.y: root.height / 2
+			angle: Theme.requiredRotation
+		}
+
+		// Adjust scale depending on the rotation
+		property real rotatedScale: (Theme.requiredRotation == 90.0)
+			? Math.min(root.width / Theme.geometry_screen_height,
+				root.height / Theme.geometry_screen_width)
+			: Math.min(root.width / Theme.geometry_screen_width,
+				root.height / Theme.geometry_screen_height)
+		scale: rotatedScale
+
+		// Center the content only if rotated
+		x: requiresRotation ? (root.width - Theme.geometry_screen_height * scale) / 2 : 0
+		y: requiresRotation ? (root.height - Theme.geometry_screen_width * scale) / 2 : 0
+
 		// In WebAssembly builds, if we are displaying on a low-dpi mobile
 		// device, it may not have enough pixels to display the UI natively.
 		// To fix, we need to downscale everything by the appropriate factor,
 		// and take into account browser chrome stealing real-estate also.
 		onScaleChanged: Global.scalingRatio = contentItem.scale
-		scale: Math.min(root.width/Theme.geometry_screen_width, root.height/Theme.geometry_screen_height)
 
 		Keys.onPressed: function(event) {
 			// If a key press is not handled by an item higher up in the hierarchy:

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -152,6 +152,19 @@ QString Theme::applicationVersion() const
 	return QStringLiteral("v%1.%2.%3").arg(PROJECT_VERSION_MAJOR).arg(PROJECT_VERSION_MINOR).arg(PROJECT_VERSION_PATCH);
 }
 
+qreal Theme::requiredRotation() const
+{
+	return m_requiredRotation;
+}
+
+void Theme::setRequiredRotation(qreal rotation)
+{
+	if (!qFuzzyCompare(m_requiredRotation, rotation)) {
+		m_requiredRotation = rotation;
+		emit requiredRotationChanged();
+	}
+}
+
 #if defined(VENUS_WEBASSEMBLY_BUILD)
 
 // Called from JavaScript when theme changes

--- a/src/theme.h
+++ b/src/theme.h
@@ -26,6 +26,7 @@ class Theme : public QObject
 	Q_PROPERTY(SystemColorScheme systemColorScheme READ systemColorScheme WRITE setSystemColorScheme NOTIFY systemColorSchemeChanged)
 	Q_PROPERTY(ForcedColorScheme forcedColorScheme READ forcedColorScheme WRITE setForcedColorScheme NOTIFY forcedColorSchemeChanged)
 	Q_PROPERTY(QString applicationVersion READ applicationVersion CONSTANT)
+	Q_PROPERTY(qreal requiredRotation READ requiredRotation WRITE setRequiredRotation NOTIFY requiredRotationChanged)
 
 public:
 	enum ScreenSize {
@@ -83,6 +84,10 @@ public:
 
 	QString applicationVersion() const;
 
+	qreal requiredRotation() const;
+
+	void setRequiredRotation(qreal rotation);
+
 Q_SIGNALS:
 	void screenSizeChanged(Victron::VenusOS::Theme::ScreenSize screenSize);
 	void screenSizeChanged_parameterless();
@@ -91,12 +96,14 @@ Q_SIGNALS:
 	void systemColorSchemeChanged(Victron::VenusOS::Theme::SystemColorScheme systemColorScheme);
 	void systemColorSchemeChanged_parameterless();
 	void forcedColorSchemeChanged(Victron::VenusOS::Theme::ForcedColorScheme forcedColorScheme);
+	void requiredRotationChanged();
 
 protected:
 	ScreenSize m_screenSize = SevenInch;
 	ColorScheme m_colorScheme = Dark;
 	SystemColorScheme m_systemColorScheme = SystemColorSchemeDark;
 	ForcedColorScheme m_forcedColorScheme = ForcedColorSchemeDefault;
+	qreal m_requiredRotation = 0.0;
 };
 
 }


### PR DESCRIPTION
Detect whether the device tree binary overlay for the Raspberry Pi Touch Display 2 has been automatically loaded on Raspberry Pi 5, and if so, rotate the screen. By default, the Raspberry Pi Touch Display 2 operates in portrait mode, but gui-v2 runs in landscape mode. This check runs only if no HDMI is connected.

Venus OS operates without a windowing system such as X11 or Wayland and relies on the Linux framebuffer. As a result, the standard methods for rotating the display [with](https://www.raspberrypi.com/documentation/accessories/touch-display-2.html#with-a-desktop) or [without a desktop](https://www.raspberrypi.com/documentation/accessories/touch-display-2.html#without-a-desktop), do not work for gui-v2 and rotation must be handled directly from the app.