### PR TITLE
 ESS: show self-consume from battery more often

### DIFF
--- a/pages/settings/PageSettingsHub4.qml
+++ b/pages/settings/PageSettingsHub4.qml
@@ -70,7 +70,7 @@ Page {
 			//% "Self-consumption from battery"
 			text: qsTrId("settings_ess_self_consumption_battery")
 			dataItem.uid: Global.systemSettings.serviceUid + "/Settings/CGwacs/BatteryUse"
-			preferredVisible: withoutGridMeter.currentIndex === 0 && hasAcOutSystemItem.value === 1
+			preferredVisible: withoutGridMeter.currentIndex === 0 && (hasAcOutSystemItem.value === 1 || dataItem.value === 1)
 			optionModel: [
 				//% "All system loads"
 				{ display: qsTrId("settings_ess_all_system_loads"), value: 0 },


### PR DESCRIPTION
The Self-consumption from battery option makes little sense in a system that has no loads on the output, so it is right that the option to set Self-consumption from battery to Only critical loads should not be shown in that case.

<img width="815" height="483" alt="image" src="https://github.com/user-attachments/assets/edb42145-1e29-4bde-84b7-1eea3ec8833d" />

It is however possible to set this option, and then later change the AC input config so that there are only loads input-side.

<img width="815" height="483" alt="image" src="https://github.com/user-attachments/assets/661daa6d-3555-4d68-9f9b-039708b6cca5" />

Unfortunately this setting still affects how hub4control regulates energy, so there has to be a way to turn it off when enabled. I did not want to make hub4control follow a setting that affects how things are displayed, so instead, this change will always show the option if it is enabled, but if it is disabled, only show it when it would make sense to enable it.

Venus issue: https://github.com/victronenergy/venus-private/issues/568