### PR TITLE
ESS: conditional spinboxes for some old settings

### DIFF
--- a/pages/settings/PageSettingsHub4.qml
+++ b/pages/settings/PageSettingsHub4.qml
@@ -313,6 +313,34 @@ Page {
 				Global.pageManager.pushPage("/pages/settings/PageHub4Debug.qml")
 			}
 		}
+
+		SettingsListHeader {
+			//% "Deprecated settings"
+			text: qsTrId("settings_ess_deprecated")
+			preferredVisible: maxChargePowerPercentage.preferredVisible || maxDischargePowerPercentage.preferredVisible
+		}
+
+		ListSpinBox {
+			id: maxChargePowerPercentage
+			//% "Battery charge limit (% of CCL)"
+			text: qsTrId("settings_ess_max_charge_percentage")
+			preferredVisible: dataItem.value < 100.0
+			dataItem.uid: Global.systemSettings.serviceUid + "/Settings/CGwacs/MaxChargePercentage"
+			suffix: Units.defaultUnitString(VenusOS.Units_Percentage)
+			from: 0
+			to: 100
+		}
+
+		ListSpinBox {
+			id: maxDischargePowerPercentage
+			//% "Battery discharge limit (% of DCL)"
+			text: qsTrId("settings_ess_max_discharge_percentage")
+			preferredVisible: dataItem.value < 100.0
+			dataItem.uid: Global.systemSettings.serviceUid + "/Settings/CGwacs/MaxDischargePercentage"
+			suffix: Units.defaultUnitString(VenusOS.Units_Percentage)
+			from: 0
+			to: 100
+		}
 	}
 
 	GradientListView {


### PR DESCRIPTION
A long time ago, this is before even my own time here, there were settings that would limit the battery charge and discharge as a percentage of the battery's advertised capabilities. These settings have long been deprecated and removed from the GUI, but are still available over modbus, and cannot easily be removed for that reason.

Occasionally users get themselves in trouble by setting them, or using some piece of software that sets it. They then need support from us to get the system working again, as these settings are completely under the water.

By adding these settings, but only make them show when they are set to the non-default value of 100%, and clearly under a heading of deprecated settings, these users can help themselves, and lower support load at the same time.

More detail in the venus issue: https://github.com/victronenergy/venus-private/issues/498