### PR TITLE
Settings: improve Integrations text strings

### DIFF
--- a/pages/SettingsPage.qml
+++ b/pages/SettingsPage.qml
@@ -71,7 +71,7 @@ SwipeViewPage {
 			SettingsListNavigation {
 				//% "Integrations"
 				text: qsTrId("settings_integrations")
-				//% "Relays, Sensors, Tanks, PV Inverters, Modbus, MQTT…"
+				//% "Relays, Sensors, PV Inverters, Modbus, Node-RED"
 				secondaryText: qsTrId("settings_relays_sensors_tanks")
 				pageSource: "/pages/settings/PageSettingsIntegrations.qml"
 				iconSource: "qrc:/images/icon_integration_32.png"

--- a/pages/settings/PageSettingsIntegrations.qml
+++ b/pages/settings/PageSettingsIntegrations.qml
@@ -218,10 +218,12 @@ Page {
 
 			SettingsListHeader {
 				id: osLargeFeatures
-
-				//% "Venus OS Large Features"
-				text: qsTrId("pagesettingsintegrations_venus_os_large_features")
-				visible: signalk.preferredVisible || nodeRed.preferredVisible
+				readonly property bool largeEnabled: signalk.preferredVisible || nodeRed.preferredVisible
+				text: largeEnabled
+					//% "Venus OS Large Features"
+					? qsTrId("pagesettingsintegrations_venus_os_large_features")
+					//% "Enable the Venus OS Large firmware to use Node-RED or Signal-K"
+					: qsTrId("pagesettingsintegrations_venus_os_enable_large_features")
 			}
 
 			ListNavigation {
@@ -271,14 +273,14 @@ Page {
 				//% "Venus OS Large Documentation"
 				text: qsTrId("settings_venusos_large_documentation")
 				url: "https://ve3.nl/vol"
-				preferredVisible: osLargeFeatures.visible
+				preferredVisible: osLargeFeatures.largeEnabled
 			}
 
 			ListLink {
 				//% "Victron Community"
 				text: qsTrId("settings_large_victron_community")
 				url: "https://community.victronenergy.com"
-				preferredVisible: osLargeFeatures.visible
+				preferredVisible: osLargeFeatures.largeEnabled
 			}
 		}
 	}


### PR DESCRIPTION
Improve the secondary text for the Integrations entry. Also point users toward the Venus OS Large firmware if they want to use Node-RED or Signal-K.

Contributes to issue #2198