### PR TITLE
Settings: use stepSize of 0.1 for temperature sensor scale setup

### DIFF
--- a/pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml
+++ b/pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml
@@ -54,6 +54,7 @@ Page {
 				preferredVisible: dataItem.valid
 				from: 0
 				to: 10
+				stepSize: 0.1
 				decimals: 1
 			}
 


### PR DESCRIPTION
Allows setting scaling to non-integer values between 0 to 10.

Contributes to issue #2188