### PR TITLE
Main: Rotate display to landscape

### DIFF
--- a/Main.qml
+++ b/Main.qml
@@ -92,12 +92,31 @@ Window {
 		// show the GUI always centered in the window
 		transformOrigin: Item.Center
 
+		// Automatically decide if rotation is required (portrait -> landscape)
+		readonly property bool requiresRotation: Global.isGxDevice && root.height > root.width
+
+		// Apply rotation
+		transform: Rotation {
+			origin.x: root.width / 2
+			origin.y: root.height / 2
+			angle: requiresRotation ? 90 : 0
+		}
+
+		// Adjust scale depending on the rotation
+		readonly property real rotatedScale: requiresRotation ?
+			Math.min(root.width / Theme.geometry_screen_height, root.height / Theme.geometry_screen_width) :
+			Math.min(root.width / Theme.geometry_screen_width, root.height / Theme.geometry_screen_height)
+		scale: rotatedScale
+
+		// Center only if rotated
+		x: requiresRotation ? (root.width - Theme.geometry_screen_height * scale) / 2 : 0
+		y: requiresRotation ? (root.height - Theme.geometry_screen_width * scale) / 2 : 0
+
 		// In WebAssembly builds, if we are displaying on a low-dpi mobile
 		// device, it may not have enough pixels to display the UI natively.
 		// To fix, we need to downscale everything by the appropriate factor,
 		// and take into account browser chrome stealing real-estate also.
 		onScaleChanged: Global.scalingRatio = contentItem.scale
-		scale: Math.min(root.width/Theme.geometry_screen_width, root.height/Theme.geometry_screen_height)
 
 		Keys.onPressed: function(event) {
 			// If a key press is not handled by an item higher up in the hierarchy:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -536,7 +536,7 @@ int main(int argc, char *argv[])
 #if defined(VENUS_DESKTOP_BUILD)
 	const bool desktop(true);
 #else
-	const bool desktop(QGuiApplication::primaryScreen()->availableSize().height() > 600);
+	const bool desktop(false);
 #endif
 
 	window->setProperty("scaleFactor", scaleFactor);


### PR DESCRIPTION
Always rotate the display to landscape. The particular use case is for Raspberry Pi Touch Display 2 on Raspberry Pi 5.

Venus OS operates without a windowing system such as X11 or Wayland and relies on the Linux framebuffer. As a result, the standard methods for rotating the display with or without a desktop, do not work for gui-v2 and rotation must be handled directly from the app.

Update `src/main.cpp` to set the `desktop` variable, used in QML for `Global.isGxDevice`, based on `VENUS_DESKTOP_BUILD` rather than screen height. Raspberry Pi Touch Display 2 has a resolution of 720x1280 pixels so the check for 600 pixels height didn't make sense for it.