### PR TITLE
Local Webpage: Support WASM download from VRM via query parameter

### DIFF
--- a/wasm/index.html
+++ b/wasm/index.html
@@ -254,6 +254,31 @@
                 // but the downloaded size is shown as uncompressed size, since the browser decompresses it
                 const sizeResp = await fetch('venus-gui-v2.wasm.size');
 
+                // check if query parameter download is set to 'vrm'
+                const searchParams = new URLSearchParams(window.location.search);
+                if (searchParams.has('download') && searchParams.get('download').toLowerCase() === 'vrm') {
+
+                    console.log("Download from VRM server forced by URL parameter");
+
+                    // Download hash file from GX device
+                    const wasmHash = await fetch('venus-gui-v2.wasm.sha256');
+                    // Extract the hash from the file
+                    const hash = (await wasmHash.text()).trim().split(' ')[0];
+
+                    // Check if file is available on VRM server
+                    // It fetches automatically the gzipped version
+                    const vrmWasmUrl = "https://updates.victronenergy.com/venus-gui/" + hash + "/venus-gui-v2.wasm"
+
+                    const vrmResp = await fetch(vrmWasmUrl, { method: 'HEAD' });
+                    if (!vrmResp.ok) {
+                        console.warn(`WASM file not found on VRM server (HTTP ${vrmResp.status}), falling back to local download`);
+                    } else {
+                        // If available, change the url to the VRM download url
+                        url = vrmWasmUrl;
+
+                    }
+                }
+
                 // Load WASM after the size is fetched, else the size is not downloaded
                 const response = await fetch(url);
                 if (!response.ok) throw new Error("Failed to fetch WASM");

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -30,6 +30,12 @@
         color: #FAF9F5;
         font-family: "Roboto", sans-serif;
       }
+      a,
+      a:visited,
+      a:hover,
+      a:active {
+        color: #387DC5;
+      }
       #mockup {
         display: none;
         z-index: 0;
@@ -316,13 +322,33 @@
                 // Show error message in wrapper_inner
                 const wrapper_inner = document.querySelector('#wrapper-inner');
                 wrapper_inner.innerHTML = `
-                  <div style="color: red; font-size: 20px; margin-top: 20px;">
-                    <b>Error loading application!</b><br><br>
-                    <b>URL:</b> <i>${window.location.href}</i><br>
-                    <b>User Agent:</b> <i>${navigator.userAgent}</i><br>
-                    <b>${e.name}:</b> <i>${e.message}</i><br>
-                    <b>Stack:</b> <i>${e.stack}</i>
-                  </div>`;
+                    <div style="color: red; font-size: 20px; margin: 20px 25px 0;">
+                      <b>Error pre-loading application!</b><br><br>
+                      <b>URL:</b> <i>${window.location.href}</i><br>
+                      <b>User Agent:</b> <i>${navigator.userAgent}</i><br>
+                      <b>${e.name}:</b> <i>${e.message}</i><br>
+                      <b>Stack:</b> <i>${e.stack}</i>
+                    </div>`;
+
+                // show button to reload the page and try downloading from VRM server
+                if ((
+                    e.message.toLowerCase().includes('network')
+                    || e.message.toLowerCase().includes('error in input stream')
+                ) && !window.location.search.includes('download=vrm')) {
+                    const params = new URLSearchParams(window.location.search);
+                    params.set('download', 'vrm');
+                    const link = `${window.location.pathname}?${params.toString()}`;
+                    wrapper_inner.innerHTML += `
+                        <div style="margin: 20px 50px 0;">
+                          It looks like the network connection is too slow or unstable to download the UI.<br><br>
+                          <a href="${link}">Click here</a> to try downloading the UI web application from the VRM servers on the internet,
+                          instead from the GX device. The data connection will still be direct to the GX device: no connection between the VRM Portal
+                          and the GX device is required.<br>
+                          <br>
+                          This split-method (download UI from internet & direct data connection) is for systems with a limited network connection
+                          between the GX device and the internet. For example a GX device with a GSM connection and a client connected over VPN.
+                        </div>`;
+                }
 
                 class PreloadWasmError extends Error {
                     constructor(message) {
@@ -439,14 +465,34 @@
                     // If the error is from preloadWasm, we already showed the error
                     console.warn("PreloadWasmError caught, no need to show again");
                 } else {
-                    wrapper_inner.innerHTML += `
-                      <div style="color: red; font-size: 20px; margin-top: 20px;">
-                        <b>Error loading application!</b><br><br>
-                        <b>URL:</b> <i>${window.location.href}</i><br>
-                        <b>User Agent:</b> <i>${navigator.userAgent}</i><br>
-                        <b>${e.name}:</b> <i>${e.message}</i><br>
-                        <b>Stack:</b> <i>${e.stack}</i>
-                      </div>`;
+                    wrapper_inner.innerHTML = `
+                        <div style="color: red; font-size: 20px; margin: 20px 25px 0;">
+                          <b>Error loading application!</b><br><br>
+                          <b>URL:</b> <i>${window.location.href}</i><br>
+                          <b>User Agent:</b> <i>${navigator.userAgent}</i><br>
+                          <b>${e.name}:</b> <i>${e.message}</i><br>
+                          <b>Stack:</b> <i>${e.stack}</i>
+                        </div>`;
+
+                    // show button to reload the page and try downloading from VRM server
+                    if ((
+                        e.message.toLowerCase().includes('network')
+                        || e.message.toLowerCase().includes('error in input stream')
+                    ) && !window.location.search.includes('download=vrm')) {
+                        const params = new URLSearchParams(window.location.search);
+                        params.set('download', 'vrm');
+                        const link = `${window.location.pathname}?${params.toString()}`;
+                        wrapper_inner.innerHTML += `
+                            <div style="margin: 20px 50px 0;">
+                              It looks like the network connection is too slow or unstable to download the UI.<br><br>
+                              <a href="${link}">Click here</a> to try downloading the UI web application from the VRM servers on the internet,
+                              instead from the GX device. The data connection will still be direct to the GX device: no connection between the VRM Portal
+                              and the GX device is required.<br>
+                              <br>
+                              This split-method (download UI from internet & direct data connection) is for systems with a limited network connection
+                              between the GX device and the internet. For example a GX device with a GSM connection and a client connected over VPN.
+                            </div>`;
+                    }
                 }
             }
         }


### PR DESCRIPTION
When the URL parameter `download=vrm` is set, the loading script checks if the WASM file is available on the VRM caching server using its hash. If found, it downloads the WASM file from the VRM else it falls back to the local download.

Should the network be unstable propose to the user to download the GUIv2 from the VRM server instead of the GX device.