### PR TITLE
Switches: limit precision for temperature slider popup

### DIFF
--- a/components/controls/TemperatureSlider.qml
+++ b/components/controls/TemperatureSlider.qml
@@ -97,7 +97,7 @@ SwitchableOutputSlider {
 			horizontalAlignment: Text.AlignHCenter
 			verticalAlignment: Text.AlignVCenter
 			font.pixelSize: Theme.font_size_h2
-			text: root.value + "\u00b0"
+			text: root.value.toFixed(root.stepSizeDecimalCount) + Units.degreesSymbol
 			color: Theme.color_button_down_text
 		}
 	}

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -80,6 +80,11 @@ QString Units::numberFormattingLocaleName() const
 	return formattingLocale()->name();
 }
 
+QString Units::degreesSymbol() const
+{
+	return DegreesSymbol;
+}
+
 QString Units::formatNumber(qreal number, int precision) const
 {
 	return formattingLocale()->toString(number, 'f', precision);

--- a/src/units.h
+++ b/src/units.h
@@ -38,6 +38,7 @@ class Units : public QObject
 	QML_ELEMENT
 	QML_SINGLETON
 	Q_PROPERTY(QString numberFormattingLocaleName READ numberFormattingLocaleName CONSTANT FINAL)
+	Q_PROPERTY(QString degreesSymbol READ degreesSymbol CONSTANT FINAL)
 
 public:
 	enum FormatHint {
@@ -52,6 +53,8 @@ public:
 	static QObject* instance(QQmlEngine *engine, QJSEngine *);
 
 	QString numberFormattingLocaleName() const;
+	QString degreesSymbol() const;
+
 	Q_INVOKABLE QString formatNumber(qreal number, int precision = 0) const;
 	Q_INVOKABLE qreal formattedNumberToReal(const QString &s) const;
 


### PR DESCRIPTION
Use the precision specified by the output /Settings/StepSize.

Also use Units::degreesSymbol() instead of a hardcoded symbol.

Contributes to #2303