### PR TITLE
Mock: fix saving of floating-point numbers

### DIFF
--- a/src/mockmanager.cpp
+++ b/src/mockmanager.cpp
@@ -155,7 +155,12 @@ void MockManager::setServiceValues(const QJsonObject &object)
 				qInfo() << "Warning: changing value of" << path << "from" << value(path)
 						<< "to" << valueIterator.value().toVariant();
 			}
-			setValue(path, valueIterator.value().toVariant());
+			// Store all parsed numbers as doubles. Otherwise, if a number can be floating-point but
+			// is written without a decimal in the JSON, it will be stored as an int, and then
+			// veutil will prevent it from being saved as a double in order to preserve the original
+			// type.
+			const QJsonValue jsonValue = valueIterator.value();
+			setValue(path, jsonValue.isDouble() ? jsonValue.toDouble() : jsonValue.toVariant());
 		}
 	}
 }


### PR DESCRIPTION
Store numbers as doubles so that a value can be saved as a float even if the original JSON value was an int.

This fixes a bug where if a CurrentLimit was specified without a decimal in a mock json configuration, then the user attempted to change the limit in the UI, the value would not save as expected.