### PR TITLE
Notifications: ensure injected notifications are shown

### DIFF
--- a/data/Notifications.qml
+++ b/data/Notifications.qml
@@ -47,7 +47,7 @@ QtObject {
 			// the notification must be acknowledged: false at the point of being updated
 			// (this is because injected notifications' active is always false)
 			// for a toast to be considered for raising (and preempting existing ones)
-			if (!notif.acknowledged && notif.active) {
+			if (!notif.acknowledged) {
 				toastedNotif.checkAndRemoveExistingToast(notif)
 				if (!toastedNotif.toast) {
 					let createdToast = Global.notificationLayer?.showToastNotification(notif.type, "")


### PR DESCRIPTION
Regression from 7886c8c. Injected notifications have active=false, so do not avoid showing toast popups for inactive notifications.

Fixes #2516