### PR TITLE
Settings: allow user-access to open settings menu items on local UI

### DIFF
--- a/components/listitems/core/ListItem.qml
+++ b/components/listitems/core/ListItem.qml
@@ -81,7 +81,7 @@ BaseListItem {
 	function activate() {
 		if (root.interactive) {
 			// Issue #1964: userHasWriteAccess is ignored for ListNavigation
-			if (root instanceof ListNavigation || root.userHasWriteAccess) {
+			if (root.__is_venus_gui_list_navigation__ === true || root.userHasWriteAccess) {
 				root.clicked()
 			} else {
 				pressArea.toast?.close(true) // close immediately

--- a/components/listitems/core/ListNavigation.qml
+++ b/components/listitems/core/ListNavigation.qml
@@ -14,6 +14,8 @@ ListItem {
 	property alias secondaryLabel: secondaryLabel
 	property alias icon: icon
 
+	readonly property bool __is_venus_gui_list_navigation__: true
+
 	interactive: true
 	Keys.onRightPressed: root.activate()
 


### PR DESCRIPTION
The (instanceof ListNavigation) condition in ListItem fails when running on device, which means none of the ListNavigation items can be opened. This seems to be an issue with the Qt 6.8.3 device build, as it works fine on Wasm and Desktop.

Use a test for a hardcoded property name instead. It's not ideal but it also avoids the need to add yet another read/write/visibility configuration property to ListItem.

Fixes #2526