### PR TITLE
UI Controls: reduce use of transparent colours and reduce colour set

### DIFF
--- a/components/widgets/BatteryWidget.qml
+++ b/components/widgets/BatteryWidget.qml
@@ -88,6 +88,7 @@ OverviewWidget {
 
 	quantityLabel.value: batteryData.stateOfCharge
 	quantityLabel.unit: VenusOS.Units_Percentage
+	quantityLabel.unitColor: Theme.color_overviewPage_widget_battery_font_secondary
 
 	color: "transparent"
 
@@ -168,6 +169,7 @@ OverviewWidget {
 
 		value: batteryData.temperature
 		unit: Global.systemSettings.temperatureUnit
+		unitColor: Theme.color_overviewPage_widget_battery_font_secondary
 		font.pixelSize: Theme.font_size_body2
 		alignment: Qt.AlignRight
 		visible: !isNaN(batteryData.temperature)
@@ -187,7 +189,7 @@ OverviewWidget {
 				font.pixelSize: Theme.font_size_body1
 				width: parent.width
 				elide: Text.ElideRight
-				color: Theme.color_font_secondary
+				color: Theme.color_overviewPage_widget_battery_font_secondary
 			}
 			Label {
 				text: Global.system.battery.timeToGo == 0 ? "" : Utils.secondsToString(Global.system.battery.timeToGo)
@@ -228,6 +230,7 @@ OverviewWidget {
 
 			value: batteryData.voltage
 			unit: VenusOS.Units_Volt_DC
+			unitColor: Theme.color_overviewPage_widget_battery_font_secondary
 			font.pixelSize: root._useSmallFont ? Theme.font_size_body1 : Theme.font_size_body2
 			alignment: Qt.AlignLeft
 		},
@@ -242,6 +245,7 @@ OverviewWidget {
 			}
 			value: batteryData.current
 			unit: VenusOS.Units_Amp
+			unitColor: Theme.color_overviewPage_widget_battery_font_secondary
 			font.pixelSize: root._useSmallFont ? Theme.font_size_body1 : Theme.font_size_body2
 		},
 
@@ -270,6 +274,7 @@ OverviewWidget {
 			}
 			value: batteryData.power
 			unit: VenusOS.Units_Watt
+			unitColor: Theme.color_overviewPage_widget_battery_font_secondary
 			font.pixelSize: root._useSmallFont ? Theme.font_size_body1 : Theme.font_size_body2
 			alignment: Qt.AlignRight
 		}

--- a/themes/color/Dark.json
+++ b/themes/color/Dark.json
@@ -23,7 +23,7 @@
     "color_critical_background": "#AA403E",
 
     "color_font_primary": "color_white",
-    "color_font_secondary": "color_dimWhite2",
+    "color_font_secondary": "color_gray5",
     "color_font_disabled": "color_gray4",
 
     "color_background_primary": "color_black",
@@ -109,12 +109,13 @@
     "color_solarDetailBox_quantityTitle": "color_gray5",
     "color_solarDetailBox_columnTitle": "color_gray6",
 
-    "color_solarListPage_header_text": "color_gray4",
+    "color_solarListPage_header_text": "color_gray5",
 
     "color_overviewPage_widget_background": "color_darkBlue",
     "color_overviewPage_widget_border": "color_ok",
     "color_overviewPage_widget_solar_graph_bar": "color_ok",
     "color_overviewPage_widget_battery_background": "color_blue",
+    "color_overviewPage_widget_battery_font_secondary": "color_dimWhite2",
 
     "color_boatPage_background": "color_black",
 

--- a/themes/color/Light.json
+++ b/themes/color/Light.json
@@ -23,7 +23,7 @@
     "color_critical_background": "#F58B87",
 
     "color_font_primary": "color_gray2",
-    "color_font_secondary": "color_dimGray2",
+    "color_font_secondary": "color_gray5",
     "color_font_disabled": "color_gray4",
 
     "color_background_primary": "color_white",
@@ -62,7 +62,7 @@
     "color_listItem_down_forwardIcon": "color_button_icon_down",
     "color_listItem_separator": "color_gray5",
     "color_listItem_secondaryText": "color_gray4",
-    "color_listItem_highAccessLevel": "#66F0962E",
+    "color_listItem_highAccessLevel": "color_darkOrange",
 
     "color_scrollBar_bar": "color_gray5",
 
@@ -115,6 +115,7 @@
     "color_overviewPage_widget_border": "color_ok",
     "color_overviewPage_widget_solar_graph_bar": "color_ok",
     "color_overviewPage_widget_battery_background": "color_lightBlue",
+    "color_overviewPage_widget_battery_font_secondary": "color_dimGray2",
 
     "color_boatPage_background": "color_gray9",
 


### PR DESCRIPTION
Only use transparent colours where necessary - for example, in BatteryWidget where the fill animation may partly cover the text.