### PR TITLE
Add Ruuvi Air support

### DIFF
--- a/pages/settings/devicelist/delegates/DeviceListDelegate_temperature.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_temperature.qml
@@ -12,8 +12,15 @@ DeviceListDelegate {
 	quantityModel: QuantityObjectModel {
 		filterType: QuantityObjectModel.HasValue
 
-		QuantityObject { object: temperature; unit: Global.systemSettings.temperatureUnit }
-		QuantityObject { object: humidity; unit: VenusOS.Units_Percentage }
+		// Show air quality data if CO2 is available, otherwise show temperature/humidity
+		QuantityObject {
+			object: co2.value !== undefined ? co2 : temperature
+			unit: co2.value !== undefined ? VenusOS.Units_PartsPerMillion : Global.systemSettings.temperatureUnit
+		}
+		QuantityObject {
+			object: co2.value !== undefined ? pm25 : humidity
+			unit: co2.value !== undefined ? VenusOS.Units_MicrogramPerCubicMeter : VenusOS.Units_Percentage
+		}
 	}
 
 	onClicked: {
@@ -31,5 +38,15 @@ DeviceListDelegate {
 	VeQuickItem {
 		id: humidity
 		uid: root.device.serviceUid + "/Humidity"
+	}
+
+	VeQuickItem {
+		id: co2
+		uid: root.device.serviceUid + "/CO2"
+	}
+
+	VeQuickItem {
+		id: pm25
+		uid: root.device.serviceUid + "/PM25"
 	}
 }

--- a/pages/settings/devicelist/temperature/PageTemperatureSensor.qml
+++ b/pages/settings/devicelist/temperature/PageTemperatureSensor.qml
@@ -65,6 +65,46 @@ DevicePage {
 			preferredVisible: dataItem.valid
 		}
 
+		ListQuantity {
+			//% "PM2.5"
+			text: qsTrId("temperature_pm25")
+			dataItem.uid: bindPrefix + "/PM25"
+			unit: VenusOS.Units_MicrogramPerCubicMeter
+			preferredVisible: dataItem.valid
+		}
+
+		ListQuantity {
+			//% "CO₂"
+			text: qsTrId("temperature_co2")
+			dataItem.uid: bindPrefix + "/CO2"
+			unit: VenusOS.Units_PartsPerMillion
+			preferredVisible: dataItem.valid
+		}
+
+		ListQuantity {
+			//% "VOC index"
+			text: qsTrId("temperature_voc")
+			dataItem.uid: bindPrefix + "/VOC"
+			unit: VenusOS.Units_None
+			preferredVisible: dataItem.valid
+		}
+
+		ListQuantity {
+			//% "NOx index"
+			text: qsTrId("temperature_nox")
+			dataItem.uid: bindPrefix + "/NOX"
+			unit: VenusOS.Units_None
+			preferredVisible: dataItem.valid
+		}
+
+		ListQuantity {
+			//% "Luminosity"
+			text: qsTrId("temperature_luminosity")
+			dataItem.uid: bindPrefix + "/Luminosity"
+			unit: VenusOS.Units_Lux
+			preferredVisible: dataItem.valid
+		}
+
 		ListItem {
 			id: sensorBattery
 

--- a/src/enums.h
+++ b/src/enums.h
@@ -93,7 +93,10 @@ public:
 		Units_Time_Hour,
 		Units_Time_Minute,
 		Units_Altitude_Metre,
-		Units_Altitude_Foot
+		Units_Altitude_Foot,
+		Units_PartsPerMillion,
+		Units_MicrogramPerCubicMeter,
+		Units_Lux
 	};
 	Q_ENUM(Units_Type)
 

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -104,6 +104,8 @@ int Units::defaultUnitPrecision(VenusOS::Enums::Units_Type unit) const
 	case VenusOS::Enums::Units_PowerFactor:          return 3;
 	case VenusOS::Enums::Units_Volume_CubicMetre:    return 3;
 	case VenusOS::Enums::Units_Volt_DC:              return 2;
+	case VenusOS::Enums::Units_MicrogramPerCubicMeter: return 1;
+	case VenusOS::Enums::Units_Lux:                    return 0;
 	case VenusOS::Enums::Units_Volt_AC:                // fall through
 	case VenusOS::Enums::Units_Volume_Litre:           // fall through
 	case VenusOS::Enums::Units_Volume_GallonImperial:  // fall through
@@ -121,6 +123,7 @@ int Units::defaultUnitPrecision(VenusOS::Enums::Units_Type unit) const
 	case VenusOS::Enums::Units_Time_Minute:            // fall through
 	case VenusOS::Enums::Units_Altitude_Metre:         // fall through
 	case VenusOS::Enums::Units_Altitude_Foot:          // fall through
+	case VenusOS::Enums::Units_PartsPerMillion:        // fall through
 		return 0;
 	default:
 		// VoltAmpere
@@ -201,6 +204,12 @@ QString Units::defaultUnitString(VenusOS::Enums::Units_Type unit, int formatHint
 		return QStringLiteral("m");
 	case VenusOS::Enums::Units_Altitude_Foot:
 		return QStringLiteral("ft");
+	case VenusOS::Enums::Units_PartsPerMillion:
+		return QStringLiteral("ppm");
+	case VenusOS::Enums::Units_MicrogramPerCubicMeter:
+		return QStringLiteral("µg/m³");
+	case VenusOS::Enums::Units_Lux:
+		return QStringLiteral("lux");
 	default:
 		qWarning() << "No unit label known for unit:" << unit;
 		return QString();

--- a/tests/units/tst_units.qml
+++ b/tests/units/tst_units.qml
@@ -297,4 +297,51 @@ TestCase {
 		expect(VenusOS.Units_None, 123, "123", "")
 		expect(VenusOS.Units_None, 12345678, "12345678", "")
 	}
+
+	function test_partsPerMillion() {
+		const unit = VenusOS.Units_PartsPerMillion
+		const unitString = Units.defaultUnitString(unit)
+
+		expect(unit, NaN, "--", unitString)
+		expect(unit, 0, "0", unitString)
+		expect(unit, 400, "400", unitString)
+		expect(unit, 425, "425", unitString)
+		expect(unit, 1000, "1000", unitString)
+		expect(unit, 5000, "5000", unitString)
+		expect(unit, 40000, "40000", unitString)
+	}
+
+	function test_microgramPerCubicMeter() {
+		const unit = VenusOS.Units_MicrogramPerCubicMeter
+		const unitString = Units.defaultUnitString(unit)
+
+		expect(unit, NaN, "--", unitString)
+		expect(unit, 0, "0.0", unitString)
+		expect(unit, 0.4, "0.4", unitString)
+		expect(unit, 0.54, "0.5", unitString)
+		expect(unit, 0.55, "0.6", unitString)
+		expect(unit, 2.2, "2.2", unitString)
+		expect(unit, 10.5, "10.5", unitString)
+		expect(unit, 100, "100", unitString)
+		expect(unit, 250.7, "251", unitString)
+		expect(unit, 999.9, "1000", unitString)
+		expect(unit, 1000, "1000", unitString)
+	}
+
+	function test_lux() {
+		const unit = VenusOS.Units_Lux
+		const unitString = Units.defaultUnitString(unit)
+
+		expect(unit, NaN, "--", unitString)
+		expect(unit, 0, "0", unitString)
+		expect(unit, 1, "1", unitString)
+		expect(unit, 10, "10", unitString)
+		expect(unit, 100, "100", unitString)
+		expect(unit, 244, "244", unitString)
+		expect(unit, 1000, "1000", unitString)
+		expect(unit, 10472, "10472", unitString)
+		expect(unit, 13026.67, "13027", unitString)
+		expect(unit, 65535, "65535", unitString)
+		expect(unit, 144284, "144284", unitString)
+	}
 }


### PR DESCRIPTION
Add basic support for the Ruuvi Air sensor, which is an Air Quality BLE sensor. 

Documentation has been updated on https://github.com/victronenergy/venus/wiki/dbus#temperatures with information on the new paths.

Settings -> Devices shows the CO2 concentration and the PM2.5. 
<img width="1200" height="91" alt="image" src="https://github.com/user-attachments/assets/80c74321-cb69-4127-8fa1-d963d0f1b389" />

What is not part of this PR and might need some work from you is to add an air quality specific card on the _Levels -> Environment_ page. The range isn't linear for the PM2.5 (taken from [samenmeten.rivml.nl/dataportaal/](https://samenmeten.rivm.nl/dataportaal/)):
<img width="136" height="288" alt="image" src="https://github.com/user-attachments/assets/290660cd-99c4-42e9-bcfe-19b867d275ab" />
I'll leave it up to you to do that in a seperate issue or leave that as part of this PR. 

Note: pulled `tests/units/tst_units.qml` through dos2unix to get rid of the ^M's. The actual change is adding 3 functions at the end of the file.

A site running with the Ruuvi Air (and a patched dbus-ble-sensors that supports this) is `469902`, where you already have access to. If you need more context or info, ping me on Slack.

Reference and more info on the status via https://github.com/victronenergy/venus-private/issues/601