### PR TITLE
Switches: update device group name if device is not initially valid

### DIFF
--- a/src/switchableoutputgroupmodel.cpp
+++ b/src/switchableoutputgroupmodel.cpp
@@ -102,14 +102,25 @@ SwitchableOutputGroup *SwitchableOutputGroup::newDeviceGroup(const QString &serv
 		//% "GX device relays"
 		group->setName(qtTrId("gx_device_relays"));
 	} else {
-		if (BaseDevice *device = AllDevicesModel::create()->findDevice(serviceUid)) {
-			connect(device, &BaseDevice::nameChanged, group, [group, device]() {
-				 group->setName(device->name());
-			});
-			group->setName(device->name());
+		if (Device *device = AllDevicesModel::create()->findDevice(serviceUid)) {
+			group->initializeDevice(device);
+		} else {
+			connect(AllDevicesModel::create(), &AllDevicesModel::deviceAdded,
+					group, &SwitchableOutputGroup::initializeDevice);
 		}
 	}
 	return group;
+}
+
+void SwitchableOutputGroup::initializeDevice(Device *device)
+{
+	if (deviceGroupId(device->serviceUid()) == m_groupId) {
+		AllDevicesModel::create()->disconnect(this);
+		connect(device, &BaseDevice::nameChanged, this, [this, device]() {
+			 setName(device->name());
+		});
+		setName(device->name());
+	}
 }
 
 QString SwitchableOutputGroup::namedGroupId(const QString &groupName)

--- a/src/switchableoutputgroupmodel.h
+++ b/src/switchableoutputgroupmodel.h
@@ -23,6 +23,7 @@ namespace VenusOS {
 
 class SwitchableOutput;
 class SwitchableOutputGroupModel;
+class Device;
 
 /*
 	A group of of switchable outputs.
@@ -61,6 +62,7 @@ Q_SIGNALS:
 private:
 	explicit SwitchableOutputGroup(QObject *parent, const QString &groupId);
 	void sortOutputs();
+	void initializeDevice(Device *device);
 
 	QList<SwitchableOutput *> m_outputs;
 	QString m_groupId;

--- a/tests/switchableoutputgroupmodel/tst_switchableoutputgroupmodel.qml
+++ b/tests/switchableoutputgroupmodel/tst_switchableoutputgroupmodel.qml
@@ -341,6 +341,39 @@ TestCase {
 				],
 			},
 			{
+				tag: "Device becomes valid after group is created, which changes the group name",
+				devices: [
+					{
+						uid: "mock/com.victronenergy.solarcharger.a",
+						children: {
+							"SwitchableOutput/0/Name": "a",
+							"SwitchableOutput/0/Settings/Type": 0,
+							"SwitchableOutput/0/Settings/Group": "",
+						},
+					}
+				],
+				initialGroups: [
+					{
+						name: "",
+						outputs: [
+							{ uid: "mock/com.victronenergy.solarcharger.a/SwitchableOutput/0", type: 0, group: "" }
+						]
+					}
+				],
+				changes: {
+					"mock/com.victronenergy.solarcharger.a/DeviceInstance" : 0,
+					"mock/com.victronenergy.solarcharger.a/ProductName" : "new_product_name",
+				},
+				finalGroups: [
+					{
+						name: "new_product_name",
+						outputs: [
+							{ uid: "mock/com.victronenergy.solarcharger.a/SwitchableOutput/0", type: 0, group: "" }
+						]
+					}
+				],
+			},
+			{
 				tag: "Remove output from device group by setting invalid type",
 				devices: [
 					{


### PR DESCRIPTION
If an output is part of a device group, and the device is not available when the group is first created, update the group name when the device becomes available.

This can occur if the ES SmartSwitch is connected but not yet available via VE.Can when the app is started.