### PR TITLE
Switches: set multi-step and 3-state controls based on expected value

### DIFF
--- a/components/switches/delegates/SwitchableOutputCardDelegate_4.qml
+++ b/components/switches/delegates/SwitchableOutputCardDelegate_4.qml
@@ -62,7 +62,7 @@ FocusScope {
 			top: header.bottom
 		}
 		height: Theme.geometry_switchableoutput_control_height
-		checked: multiStepState.backendValue
+		checked: multiStepState.expectedValue === 1
 		onOnClicked: multiStepState.writeValue(1)
 		onOffClicked: multiStepState.writeValue(0)
 

--- a/components/switches/delegates/SwitchableOutputCardDelegate_9.qml
+++ b/components/switches/delegates/SwitchableOutputCardDelegate_9.qml
@@ -55,9 +55,8 @@ FocusScope {
 			top: header.bottom
 		}
 		height: Theme.geometry_switchableoutput_control_height
-		enabled: !toggleState.busy || !autoToggleState.busy
-		onChecked: toggleState.backendValue === 1
-		autoChecked: autoToggleState.backendValue
+		onChecked: toggleState.expectedValue === 1
+		autoChecked: autoToggleState.expectedValue === 1
 		onOnClicked: toggleState.writeValue(1)
 		onOffClicked: toggleState.writeValue(0)
 		onAutoClicked: autoToggleState.writeValue(autoToggleState.backendValue === 1 ? 0 : 1)


### PR DESCRIPTION
If the backend has not yet updated its value, show the button as checked if it was clicked by the user; it will revert to the unchecked state when SettingsSync times out.

Also, allow the three-state switch to be clicked even while waiting for the backend to update, as the user may want to click to force a value to be set.

Contributes to victronenergy/venus#1561