### PR TITLE
Settings: initialise security profile value variables

### DIFF
--- a/pages/settings/PageSettingsAccessAndSecurity.qml
+++ b/pages/settings/PageSettingsAccessAndSecurity.qml
@@ -97,7 +97,8 @@ Page {
 			ListRadioButtonGroup {
 				id: securityProfile
 
-				property int pendingProfile
+				defaultIndex: 0 // i.e. VenusOS.Security_Profile_Secured
+				property int pendingProfile: VenusOS.Security_Profile_Secured
 				property string pendingPassword
 
 				function setProfileAndPassword(profile, password, popPage) {
@@ -175,7 +176,8 @@ Page {
 				optionFooter: SettingsColumn {
 					// Set visible instead of preferredVisible, since this is a footer and not a
 					// list item, so preferredVisible would have no effect.
-					visible: securityProfile.currentIndex !== VenusOS.Security_Profile_Unsecured
+					visible: securityProfile.currentIndex === VenusOS.Security_Profile_Secured
+							|| securityProfile.currentIndex === VenusOS.Security_Profile_Weak
 					width: parent.width
 					topPadding: spacing
 
@@ -226,6 +228,9 @@ Page {
 							case VenusOS.Security_Profile_Unsecured:
 								//% "Select 'Unsecured' profile?"
 								return qsTrId("settings_security_profile_unsecured_title")
+							default:
+								console.warn("Invalid pending profile")
+								return ""
 							}
 						}
 
@@ -240,6 +245,9 @@ Page {
 							case VenusOS.Security_Profile_Unsecured:
 								//% "• Local network services do not need a password\n• Unencrypted access to local websites is enabled as well (HTTP/HTTPS)"
 								return  qsTrId("settings_security_profile_unsecured_description")
+							default:
+								console.warn("Invalid pending profile")
+								return ""
 							}
 						}
 						onAccepted: {


### PR DESCRIPTION
When setting a security profile or security profile password, we need to initialise the defaultIndex in the radio button, because if the VeQuickItem is invalidated for any reason the defaultIndex value is returned as the currentIndex, and that currentIndex is used directly as the value for the security profile.

This commit ensures that the defaultIndex value is initialised to the value of the Secured profile.

It also initialises the pendingProfile value to the same Secured profile value.

Finally, it ensures that the Update Password button is only visible if the currentIndex value is either Secured or Weak, rather than being visible if the currentIndex value is not equal to Unsecured, just in case the currentIndex value somehow gets set to something invalid.

Contributes to issue #2552