### PR TITLE
attempt to show charge current when an energy meter used to measure an EV charger

### DIFF
--- a/pages/evcs/EvChargerPage.qml
+++ b/pages/evcs/EvChargerPage.qml
@@ -26,10 +26,10 @@ DevicePage {
 				id: chargerSummary
 
 				readonly property string currentSummaryText: {
-					if (root.energyMeterMode) {
-						return "--"
-					}
 					const actual = isNaN(evCharger.current) ? "--" : Math.round(evCharger.current)
+					if (root.energyMeterMode) {
+						return actual
+					}
 					const max = isNaN(evCharger.maxCurrent) ? "--" : Math.round(evCharger.maxCurrent)
 					return actual + "/" + max
 				}


### PR DESCRIPTION
When an energy meter masquerades for an EV charger, show the charge current if available, even if there is no max defined.

The charge current will be added to the energy meter drivers, see: https://github.com/victronenergy/venus/issues/1541