### PR TITLE
Settings: remove embedded QR code in list items and support key nav

### DIFF
--- a/cmake/ModuleVenus_Sources.cmake
+++ b/cmake/ModuleVenus_Sources.cmake
@@ -126,6 +126,7 @@ set (VictronVenusOS_QML_MODULE_SOURCES
     components/ClassAndVrmInstance.qml
     components/controls/AutoToggleButton.qml
     components/controls/Button.qml
+    components/controls/CloseButton.qml
     components/controls/ComboBox.qml
     components/controls/EditFrame.qml
     components/controls/GlobalKeyNavigationHighlight.qml

--- a/components/controls/CloseButton.qml
+++ b/components/controls/CloseButton.qml
@@ -1,0 +1,14 @@
+/*
+** Copyright (C) 2025 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+IconButton {
+	width: icon.sourceSize.width + (2 * Theme.geometry_closeButton_margins)
+	height: icon.sourceSize.height + (2 * Theme.geometry_closeButton_margins)
+	icon.color: Theme.color_ok
+	icon.source: "qrc:/images/icon_close_32.svg"
+}

--- a/components/dialogs/SolarDailyHistoryDialog.qml
+++ b/components/dialogs/SolarDailyHistoryDialog.qml
@@ -145,17 +145,11 @@ T.Dialog {
 			font.pixelSize: Theme.font_size_body1
 		}
 
-		IconButton {
+		CloseButton {
 			anchors {
 				right: parent.right
 				top: parent.top
 			}
-			width: Theme.geometry_solarDailyHistoryDialog_closeButton_icon_size + (2 * Theme.geometry_solarDailyHistoryDialog_closeButton_icon_margins)
-			height: Theme.geometry_solarDailyHistoryDialog_closeButton_icon_size + (2 * Theme.geometry_solarDailyHistoryDialog_closeButton_icon_margins)
-			icon.sourceSize.height: Theme.geometry_solarDailyHistoryDialog_closeButton_icon_size
-			icon.color: Theme.color_ok
-			icon.source: "qrc:/images/icon_close_32.svg"
-
 			onClicked: root.close()
 		}
 

--- a/themes/geometry/FiveInch.json
+++ b/themes/geometry/FiveInch.json
@@ -25,6 +25,8 @@
     "geometry_button_radius": 8,
     "geometry_button_border_width": 2,
 
+    "geometry_closeButton_margins": 4,
+
     "geometry_focus_highlight_corner_size": 14,
     "geometry_focus_highlight_border_size": 4,
 
@@ -404,8 +406,6 @@
 
     "geometry_solarDailyHistoryDialog_minimumHeight": 216,
     "geometry_solarDailyHistoryDialog_header_height": 50,
-    "geometry_solarDailyHistoryDialog_closeButton_icon_size": 24,
-    "geometry_solarDailyHistoryDialog_closeButton_icon_margins": 12,
     "geometry_solarDailyHistoryDialog_arrow_icon_size": 72,
     "geometry_solarDailyHistoryDialog_arrow_horizontalMargin": 2,
 

--- a/themes/geometry/SevenInch.json
+++ b/themes/geometry/SevenInch.json
@@ -25,6 +25,8 @@
     "geometry_button_radius": 8,
     "geometry_button_border_width": 2,
 
+    "geometry_closeButton_margins": 4,
+
     "geometry_focus_highlight_corner_size": 14,
     "geometry_focus_highlight_border_size": 4,
 
@@ -404,8 +406,6 @@
 
     "geometry_solarDailyHistoryDialog_minimumHeight": 222,
     "geometry_solarDailyHistoryDialog_header_height": 50,
-    "geometry_solarDailyHistoryDialog_closeButton_icon_size": 24,
-    "geometry_solarDailyHistoryDialog_closeButton_icon_margins": 12,
     "geometry_solarDailyHistoryDialog_arrow_icon_size": 72,
     "geometry_solarDailyHistoryDialog_arrow_horizontalMargin": 18,
 


### PR DESCRIPTION
Do not show the QR code within list items, as the QR code image is too small to be scanned on a 5" GX touch screen, especially for longer URLs. Replace the embedded QR code with a text button to make it obvious that the user can click the button to see a large version of the QR code.

Also open the dialog when the Space key is pressed while the list item is focused.

Add CloseButton component for reuse from the QR code dialog and the solar history dialog.

Fixes #2566