### PR TITLE
Add menu for additional PV-inverter modbus settings

### DIFF
--- a/cmake/ModuleVenus_Sources.cmake
+++ b/cmake/ModuleVenus_Sources.cmake
@@ -373,8 +373,10 @@ set (VictronVenusOS_QML_MODULE_SOURCES
     pages/settings/PageSettingsFirmwareOffline.qml
     pages/settings/PageSettingsFirmwareOnline.qml
     pages/settings/PageSettingsFronius.qml
+    pages/settings/PageSettingsFroniusAddLocation.qml
     pages/settings/PageSettingsFroniusInverter.qml
     pages/settings/PageSettingsFroniusInverters.qml
+    pages/settings/PageSettingsFroniusModbus.qml
     pages/settings/PageSettingsFroniusSetIpAddresses.qml
     pages/settings/PageSettingsFroniusShowIpAddresses.qml
     pages/settings/PageSettingsGeneral.qml

--- a/pages/settings/PageSettingsFronius.qml
+++ b/pages/settings/PageSettingsFronius.qml
@@ -61,6 +61,12 @@ Page {
 				text: CommonWords.automatic_scanning
 				dataItem.uid: Global.systemSettings.serviceUid + "/Settings/Fronius/AutoScan"
 			}
+
+			ListNavigation {
+				//% "Modbus port and unit ID settings"
+				text: qsTrId("page_settings_fronius_modbus_settings")
+				onClicked: Global.pageManager.pushPage("/pages/settings/PageSettingsFroniusModbus.qml", {"title": text})
+			}
 		}
 	}
 }

--- a/pages/settings/PageSettingsFroniusAddLocation.qml
+++ b/pages/settings/PageSettingsFroniusAddLocation.qml
@@ -1,0 +1,64 @@
+/*
+** Copyright (C) 2025 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+Page {
+	id: root
+
+	property VeQuickItem locations
+
+	//% "Add Modbus port and unit ID"
+	title: qsTrId("page_settings_fronius_add_modbus_location")
+
+	GradientListView {
+		model: VisibleItemModel {
+
+			ListPortField {
+				id: port
+				secondaryText: "1502"
+			}
+
+			ListIntField {
+				id: unit
+
+				//% "Unit ID"
+				text: qsTrId("page_settings_fronius_add_modbus_unitid")
+				secondaryText: "1"
+				validateInput: function() {
+					const valueAsInt = parseInt(textField.text)
+					if (isNaN(valueAsInt) || valueAsInt <= 0 || valueAsInt > 247) {
+						//% "%1 is not a valid unit number. Use a number between 1-247."
+						return Utils.validationResult(VenusOS.InputValidation_Result_Error, qsTrId("page_settings_fronius_unitid_invalid").arg(textField.text))
+					}
+					return Utils.validationResult(VenusOS.InputValidation_Result_OK, "", valueAsInt)
+				}
+			}
+
+			ListButton {
+				//% "Add"
+				secondaryText: qsTrId("page_settings_fronius_add_modbus_location_button")
+				onClicked: {
+					const fields = [port, unit]
+					for (let i = 0; i < fields.length; ++i) {
+						const resultStatus = fields[i].runValidation(VenusOS.InputValidation_ValidateAndSave)
+						if (resultStatus !== VenusOS.InputValidation_Result_OK) {
+							return
+						}
+					}
+
+					let s = [port.secondaryText, unit.secondaryText].join(':');
+					if (locations.value && locations.value.length) {
+						s = locations.value + ',' + s;
+					}
+
+					locations.setValue(s);
+					Global.pageManager.popPage()
+				}
+			}
+		}
+	}
+}

--- a/pages/settings/PageSettingsFroniusModbus.qml
+++ b/pages/settings/PageSettingsFroniusModbus.qml
@@ -1,0 +1,112 @@
+/*
+** Copyright (C) 2025 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+Page {
+	id: root
+
+	property string settings: Global.systemSettings.serviceUid
+
+	topRightButton: Global.systemSettings.canAccess(VenusOS.User_AccessType_Installer)
+			? VenusOS.StatusBar_RightButton_Add
+			: VenusOS.StatusBar_RightButton_None
+
+	Connections {
+		target: Global.mainView?.statusBar ?? null
+		enabled: root.isCurrentPage
+
+		function onRightButtonClicked() {
+			Global.pageManager.pushPage("/pages/settings/PageSettingsFroniusAddLocation.qml", { locations: _locations } )
+		}
+	}
+
+	VeQuickItem {
+		id: _locations
+
+		uid: root.settings + "/Settings/Fronius/ModbusAlternates"
+		// eg: [[1501,1],[1502,2]]
+	}
+
+
+	GradientListView {
+		header: PrimaryListLabel {
+			horizontalAlignment: Text.AlignHCenter
+			//% "The default modbus port is 502 and the default unit ID is 126.\n"
+			//% "Here you can add additional ports and unit IDs to scan for PV inverters."
+			text: qsTrId("page_settings_fronius_modbus_locations_note")
+		}
+		model: _locations.value ? _locations.value.split(',') : []
+		delegate: ListItem {
+			id: locationDelegate
+
+			property int locationNumber: index + 1
+			property var modbusAlternates: modelData.split(':')
+
+			//% "Port/Unit ID %1"
+			text: qsTrId("page_settings_fronius_modbus_location_number").arg(locationNumber)
+			content.spacing: 30
+			content.children: [
+				Label {
+					id: portNumber
+
+					anchors.verticalCenter: parent?.verticalCenter
+					text: modbusAlternates[0].toUpperCase() // eg. '1501'
+				},
+				Label {
+					id: unitAddress
+
+					anchors.verticalCenter: parent?.verticalCenter
+					text: modbusAlternates[1] // unit address
+				},
+				RemoveButton {
+					id: removeButton
+					visible: locationDelegate.clickable
+					onClicked: {
+						Global.dialogLayer.open(removeLocationDialog, {
+							modbusLocation: modelData,
+							//% "Port: %1 (Unit %2)"
+							description: qsTrId("page_settings_fronius_modbus_remove_location_description")
+									.arg(portNumber.text)
+									.arg(unitAddress.text)
+						})
+					}
+				}
+			]
+
+			interactive: true
+			writeAccessLevel: VenusOS.User_AccessType_Installer
+			onClicked: removeButton.clicked()
+		}
+	}
+
+	Component {
+		id: removeLocationDialog
+
+		ModalWarningDialog {
+
+			property var modbusLocation
+
+			//% "Remove Modbus port and unit ID?"
+			title: qsTrId("page_settings_fronius_modbus_remove_location")
+			dialogDoneOptions: VenusOS.ModalDialog_DoneOptions_OkAndCancel
+			height: Theme.geometry_modalDialog_height_small
+			icon.color: Theme.color_orange
+			acceptText: CommonWords.remove
+
+			onAccepted: {
+				const locations = _locations.value ? _locations.value.split(',') : []
+				for (let i = 0; i < locations.length; ++i) {
+					if (locations[i] === modbusLocation) {
+						locations.splice(i, 1)
+						_locations.setValue(locations.join(','))
+						break
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
This adds a menu for adding additional port and unit ID settings for PV-inverters.

Please feel free to make any improvements you feel is necessary.

https://github.com/victronenergy/venus/issues/1531