### PR TITLE
VE.Bus: Show VE.Bus device state (not system state) in drilldown

### DIFF
--- a/pages/vebusdevice/PageVeBus.qml
+++ b/pages/vebusdevice/PageVeBus.qml
@@ -25,7 +25,7 @@ DevicePage {
 
 		ListText {
 			text: CommonWords.state
-			secondaryText: Global.system.systemStateToText(Global.system.state)
+			secondaryText: Global.system.systemStateToText(state.value)
 		}
 
 		PrimaryListLabel {
@@ -342,5 +342,10 @@ DevicePage {
 	VeQuickItem {
 		id: firmwareVersion
 		uid: root.bindPrefix + "/FirmwareVersion"
+	}
+
+	VeQuickItem {
+		id: state
+		uid: root.bindPrefix + "/State"
 	}
 }


### PR DESCRIPTION
Previously, the system state was shown in the drilldown device list page for VE.Bus devices, instead of the device-specific state. This commit ensures that the device-specific state is shown.

Contributes to issue #2564