### PR TITLE
UI Plugins: add secondary text label for device list integration

### DIFF
--- a/pages/settings/PageSettingsIntegrations.qml
+++ b/pages/settings/PageSettingsIntegrations.qml
@@ -299,14 +299,28 @@ Page {
 							if (integrations !== null && integrations.length > 0) {
 								for (let i = 0; i < integrations.length; ++i) {
 									if (integrations[i].type === GuiPluginLoader.PluginSettingsPage) {
-										return integrations[i];
+										return integrations[i]
 									}
 								}
 							}
 							return null
 						}
+						readonly property bool hasDeviceListIntegration: {
+							if (integrations !== null && integrations.length > 0) {
+								for (let i = 0; i < integrations.length; ++i) {
+									if (integrations[i].type === GuiPluginLoader.DeviceListSettingsPage) {
+										return true
+									}
+								}
+							}
+							return false
+						}
 
 						text: switchNavigationItem.name
+						secondaryText: hasDeviceListIntegration
+							   //% "Integrates with the device list"
+							? qsTrId("pagesettingsintegrations_uiplugin_integrates_with_devicelist")
+							: ""
 						indicatorColor: switchNavigationItem.color
 						pageSource: switchNavigationItem.pluginSettingsPageIntegration?.url ?? ""
 						interactive: switchNavigationItem.pluginSettingsPageIntegration !== null


### PR DESCRIPTION
Previously, the delegate in the UI Plugins list within the Settings -> Integrations page would only include the name of the plugin, plus an arrow (allowing drill-down) if the plugin included a custom settings page integration.

If the plugin did NOT include a custom settings page integration, but only included a device list integration, the user could be confused when seeing the entry in the list but being unable to interact with it.

This commit adds a secondary text label to inform the user that the plugin integrates with the device list.

Contributes to issue #1071