### PR TITLE
Inverter/Charger: Update microgrid page

### DIFF
--- a/pages/vebusdevice/PageMicrogrid.qml
+++ b/pages/vebusdevice/PageMicrogrid.qml
@@ -14,10 +14,15 @@ Page {
 	//% "Microgrid"
 	title: qsTrId("microgrid")
 
-	component MicrogridModeListText : ListText {
+	component MicrogridModeListText: ListText {
 		//% "Active mode"
 		text: qsTrId("page_microgrid_active_mode")
 		secondaryText: VenusOS.microgridModeToText(mode.value)
+	}
+
+	component MicrogridListQuantity: ListQuantity {
+		textFormat: Text.RichText
+		precision: 2
 	}
 
 	component ListValueRange: ListText {
@@ -27,10 +32,10 @@ Page {
 		property alias quantityInfoFrom: fromInfo
 		property alias quantityInfoTo: toInfo
 
-		//: Describes a range from one quantity to another, e.g. "30 W to 60 W".
+		//: Describes a range from one quantity to another, e.g. "30W to 60W".
 		//: The first argument is the first quantity, the second argument is the units of the first quantity,
 		//: the third argument is the second quantity, the fourth argument is the units of the second quantity.
-		//% "%1 %2 to %3 %4"
+		//% "%1%2 to %3%4"
 		secondaryText: qsTrId("page_microgrid_from_p1_to_p2").arg(fromInfo.number).arg(Units.defaultUnitString(unitType)).arg(toInfo.number).arg(Units.defaultUnitString(unitType))
 
 		QuantityInfo {
@@ -38,6 +43,7 @@ Page {
 
 			unitType: parent && parent.unitType ? parent.unitType : VenusOS.Units_None
 			value: dataItemFrom.valid ? dataItemFrom.value : NaN
+			precision: 2
 		}
 
 		QuantityInfo {
@@ -45,6 +51,7 @@ Page {
 
 			unitType: parent && parent.unitType ? parent.unitType : VenusOS.Units_None
 			value: dataItemTo.valid ? dataItemTo.value : NaN
+			precision: 2
 		}
 
 		VeQuickItem {
@@ -92,58 +99,46 @@ Page {
 					text: qsTrId("page_microgrid_hybrid_droop_parameters")
 				}
 
-				ListQuantity {
+				MicrogridListQuantity {
 					dataItem.uid: root.bindPrefix + "/MicroGrid/DroopModeParameters/P0/Value"
-					textFormat: Text.RichText
 					//% "Reference active power (P<sub>0</sub>)"
 					text: qsTrId("page_microgrid_reference_active_power_p0")
 					unit: VenusOS.Units_Percentage
-					precision: 1
 				}
 
-				ListQuantity {
+				MicrogridListQuantity {
 					dataItem.uid: root.bindPrefix + "/MicroGrid/DroopModeParameters/F0/Value"
-					textFormat: Text.RichText
 					//% "Reference frequency (f<sub>0</sub>)"
 					text: qsTrId("page_microgrid_reference_frequency_f0")
 					unit: VenusOS.Units_Hertz
-					precision: 1
 				}
 
-				ListQuantity {
+				MicrogridListQuantity {
 					dataItem.uid: root.bindPrefix + "/MicroGrid/DroopModeParameters/FPDroop/Value"
-					textFormat: Text.RichText
 					//% "Frequency droop slope (droop<sub>fP</sub>)"
 					text: qsTrId("page_microgrid_frequency_droop_slope")
 					unit: VenusOS.Units_Percentage
-					precision: 1
 				}
 
-				ListQuantity {
+				MicrogridListQuantity {
 					dataItem.uid: root.bindPrefix + "/MicroGrid/DroopModeParameters/Q0/Value"
-					textFormat: Text.RichText
 					//% "Reference reactive power (Q<sub>0</sub>)"
 					text: qsTrId("page_microgrid_reference_reactive_power")
 					unit: VenusOS.Units_Percentage
-					precision: 1
 				}
 
-				ListQuantity {
+				MicrogridListQuantity {
 					dataItem.uid: root.bindPrefix + "/MicroGrid/DroopModeParameters/U0/Value"
-					textFormat: Text.RichText
 					//% "Reference Voltage (U<sub>0</sub>)"
 					text: qsTrId("page_microgrid_reference_voltage")
 					unit: VenusOS.Units_Volt_AC
-					precision: 1
 				}
 
-				ListQuantity {
+				MicrogridListQuantity {
 					dataItem.uid: root.bindPrefix + "/MicroGrid/DroopModeParameters/UQDroop/Value"
-					textFormat: Text.RichText
 					//% "Voltage droop slope (droop<sub>UQ</sub>)"
 					text: qsTrId("page_microgrid_voltage_droop_slope")
 					unit: VenusOS.Units_Percentage
-					precision: 1
 				}
 
 				SettingsListHeader {
@@ -154,7 +149,7 @@ Page {
 				ListValueRange {
 					//% "Allowed active power range"
 					text: qsTrId("page_microgrid_allowed_active_power_range")
-					unitType: VenusOS.Units_Watt
+					unitType: VenusOS.Units_Percentage
 					dataItemFrom.uid: root.bindPrefix + "/MicroGrid/DroopModeParameters/Pmin/Value"
 					dataItemTo.uid: root.bindPrefix + "/MicroGrid/DroopModeParameters/Pmax/Value"
 				}
@@ -162,7 +157,7 @@ Page {
 				ListValueRange {
 					//% "Allowed reactive power range"
 					text: qsTrId("page_microgrid_allowed_reactive_power_range")
-					unitType: VenusOS.Units_VoltAmpereReactive
+					unitType: VenusOS.Units_Percentage
 					dataItemFrom.uid: root.bindPrefix + "/MicroGrid/DroopModeParameters/QMin/Value"
 					dataItemTo.uid: root.bindPrefix + "/MicroGrid/DroopModeParameters/QMax/Value"
 				}
@@ -181,20 +176,18 @@ Page {
 					text: qsTrId("page_microgrid_p_q_direct_drive_settings")
 				}
 
-				ListQuantity {
+				MicrogridListQuantity {
 					//% "Active power setpoint (P)"
 					text: qsTrId("page_microgrid_active_power_setpoint_p")
 					dataItem.uid: root.bindPrefix + "/MicroGrid/DirectDrivePQ/P"
 					unit: VenusOS.Units_Percentage
-					precision: 0
 				}
 
-				ListQuantity {
+				MicrogridListQuantity {
 					//% "Reactive power setpoint (Q)"
 					text: qsTrId("page_microgrid_reactive_power_setpoint_q")
 					dataItem.uid: root.bindPrefix + "/MicroGrid/DirectDrivePQ/Q"
 					unit: VenusOS.Units_Percentage
-					precision: 0
 				}
 
 				ListValueRange {
@@ -227,20 +220,18 @@ Page {
 					text: qsTrId("page_microgrid_v_f_direct_drive_settings")
 				}
 
-				ListQuantity {
+				MicrogridListQuantity {
 					//% "Voltage setpoint (U)"
 					text: qsTrId("page_microgrid_voltage_setpoint")
 					dataItem.uid: root.bindPrefix + "/MicroGrid/DirectDriveVf/U"
 					unit: VenusOS.Units_Volt_AC
-					precision: 1
 				}
 
-				ListQuantity {
+				MicrogridListQuantity {
 					//% "Frequency setpoint (f)"
 					text: qsTrId("page_microgrid_frequency_setpoint")
 					dataItem.uid: root.bindPrefix + "/MicroGrid/DirectDriveVf/F"
 					unit: VenusOS.Units_Hertz
-					precision: 1
 				}
 			}
 		}


### PR DESCRIPTION
Display values with two decimals.
Change units for "Allowed active power range" and "Allowed reactive power range" to "%".

Fixes #2597