### PR TITLE
Support adding shelly devices by IP

### DIFF
--- a/cmake/ModuleVenus_Sources.cmake
+++ b/cmake/ModuleVenus_Sources.cmake
@@ -409,6 +409,7 @@ set (VictronVenusOS_QML_MODULE_SOURCES
     pages/settings/PageSettingsRvcDeviceConfiguration.qml
     pages/settings/PageSettingsRvcDevices.qml
     pages/settings/PageSettingsShelly.qml
+    pages/settings/PageSettingsShellySetIpAddresses.qml
     pages/settings/PageSettingsSignalK.qml
     pages/settings/PageSettingsSupportStatus.qml
     pages/settings/PageSettingsSystem.qml

--- a/pages/settings/PageSettingsShelly.qml
+++ b/pages/settings/PageSettingsShelly.qml
@@ -82,12 +82,19 @@ Page {
 				text: qsTrId("settings_shelly_refresh_devices")
 				//% "Press to refresh"
 				secondaryText: qsTrId("settings_shelly_press_to_refresh")
+				writeAccessLevel: VenusOS.User_AccessType_User
 				onClicked: refreshItem.setValue(1)
 
 				VeQuickItem {
 					id: refreshItem
 					uid: root.serviceUid + "/Refresh"
 				}
+			}
+
+			ListNavigation {
+				//% "Add IP address manually"
+				text: qsTrId("page_settings_shelly_add_ip_address_manually")
+				onClicked: Global.pageManager.pushPage("/pages/settings/PageSettingsShellySetIpAddresses.qml", {"title": text, bindPrefix: root.serviceUid})
 			}
 
 			SectionHeader {
@@ -99,6 +106,7 @@ Page {
 		delegate: ListSwitch {
 			text: sortValue
 			dataItem.uid: buddy.uid
+			writeAccessLevel: VenusOS.User_AccessType_User
 		}
 	}
 }

--- a/pages/settings/PageSettingsShellySetIpAddresses.qml
+++ b/pages/settings/PageSettingsShellySetIpAddresses.qml
@@ -1,0 +1,47 @@
+/*
+** Copyright (C) 2023 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+Page {
+	id: root
+
+	required property string bindPrefix
+	property var _addDialog
+
+	function _addOrUpdateAddress(ipAddress, index = -1) {
+		let addresses = settingsListView.ipAddresses.value ? settingsListView.ipAddresses.value.split(',') : []
+		if (index >= addresses.length) {
+			console.warn("invalid index", index, "/IPAddresses length is:", addresses.length)
+			return
+		}
+		if (index < 0) {
+			addresses.push(ipAddress)
+		} else {
+			addresses[index] = ipAddress
+		}
+		settingsListView.ipAddresses.setValue(addresses.join(','))
+	}
+
+	topRightButton: VenusOS.StatusBar_RightButton_Add
+
+	IpAddressListView {
+		id: settingsListView
+
+		ipAddresses.uid: bindPrefix + "/IpAddresses"
+		writeAccessLevel: VenusOS.User_AccessType_User
+		onIpAddressUpdated: (index, ipAddress) => { root._addOrUpdateAddress(ipAddress, index) }
+	}
+
+	Connections {
+		target: Global.mainView?.statusBar ?? null
+		enabled: root.isCurrentPage
+
+		function onRightButtonClicked() {
+			root._addOrUpdateAddress("192.168.1.1", -1)
+		}
+	}
+}


### PR DESCRIPTION
Shelly devices sometimes cannot be discovered by mDNS. Users can now add devices manually by entering an IP address.

Contributes to https://github.com/victronenergy/gui-v2/issues/2590

The backend part is already merged.