### PR TITLE
Update CAN-bus profiles

### DIFF
--- a/pages/settings/CanbusProfile.qml
+++ b/pages/settings/CanbusProfile.qml
@@ -44,6 +44,12 @@ QtObject {
 			readOnly: isReadOnly(VenusOS.CanBusProfile_VecanAndCanBms)
 		},
 		{
+			//% "VE.Can & CANopen E-drive (250 kbit/s)"
+			display: qsTrId("settings_canopen_motordrive_250"),
+			value: VenusOS.CanBusProfile_CanOpenMotordrive250,
+			readOnly: isReadOnly(VenusOS.CanBusProfile_CanOpenMotordrive250)
+		},
+		{
 			//% "CAN-bus BMS LV (500 kbit/s)"
 			display: qsTrId("settings_canbus_bms"),
 			value: VenusOS.CanBusProfile_CanBms500,
@@ -80,13 +86,7 @@ QtObject {
 			readOnly: true
 		},
 		{
-			//% "CANopen Motor drive (250 kbit/s)"
-			display: qsTrId("settings_canopen_motordrive_250"),
-			value: VenusOS.CanBusProfile_CanOpenMotordrive250,
-			readOnly: isReadOnly(VenusOS.CanBusProfile_CanOpenMotordrive250)
-		},
-		{
-			//% "CANopen Motor drive (500 kbit/s)"
+			//% "CANopen E-drive (500 kbit/s)"
 			display: qsTrId("settings_canopen_motordrive_500"),
 			value: VenusOS.CanBusProfile_CanOpenMotordrive500,
 			readOnly: isReadOnly(VenusOS.CanBusProfile_CanOpenMotordrive500)


### PR DESCRIPTION
The `VE.Can & Lynx Ion BMS (250 kbit/s)` profile was renamed to `VE.Can`.
The `CANopen Motor drive (250 kbit/s)` profile now also adds the VE.Can service, so add that to the name.

While at it, also change motor drive to E-drive, as that is what we use for marketing. Besides, "motor drive" doesn't fit on the screen when using the classic UI.

<img width="1031" height="611" alt="image" src="https://github.com/user-attachments/assets/d2fd568c-9f27-42af-b956-1756546ffe38" />

