### PR TITLE
Fix relay menu disappearing when relay 1 is disabled

### DIFF
--- a/pages/settings/PageSettingsIntegrations.qml
+++ b/pages/settings/PageSettingsIntegrations.qml
@@ -121,7 +121,7 @@ Page {
 
 				VeQuickItem {
 					id: relay0
-					uid: Global.system.serviceUid + "/Relay/0/State"
+					uid: Global.system.serviceUid + "/SwitchableOutput/0/Name"
 				}
 			}
 


### PR DESCRIPTION
By checking whether the `/Name` path for switchableoutput 0 is valid. The `/State` path will be invalidated when the function is set to disabled. On devices which do not have relays, the `/SwitchableOutput/x` paths won't be created, so the menu won't show.