### PR TITLE
add an Auto setting for ESS meter selection

### DIFF
--- a/pages/settings/PageSettingsHub4.qml
+++ b/pages/settings/PageSettingsHub4.qml
@@ -59,6 +59,8 @@ Page {
 			dataItem.uid: Global.systemSettings.serviceUid + "/Settings/CGwacs/RunWithoutGridMeter"
 			preferredVisible: essMode.value !== VenusOS.Ess_Hub4ModeState_Disabled
 			optionModel: [
+				//% "Auto"
+				{ display: qsTrId("settings_ess_auto_meter"), value: 2 },
 				//% "External meter"
 				{ display: qsTrId("settings_ess_external_meter"), value: 0 },
 				//% "Inverter/Charger"


### PR DESCRIPTION
This allows the system to use an energy meter if present, but fall back to using the Inverter/Charger if the meter is lost. Or in other words, it automatically uses a meter if available, otherwise the internal measurement.

https://github.com/victronenergy/venus-private/issues/595