### PR TITLE
Key navigation: ensure space key activates toggle switches

### DIFF
--- a/components/listitems/core/ListSwitch.qml
+++ b/components/listitems/core/ListSwitch.qml
@@ -25,6 +25,11 @@ ListItem {
 	interactive: (dataItem.uid === "" || dataItem.valid)
 	pressAreaEnabled: false
 
+	// Since pressAreaEnabled=false (to ensure only the internal Switch is clickable, rather than
+	// the whole item), the key events must be forwarded to the internal Switch so that the Space
+	// key activates the Switch onClicked() handler.
+	Keys.forwardTo: [switchItem, root]
+
 	content.spacing: 0
 	content.children: [
 		Label {


### PR DESCRIPTION
For toggle switches that directly affect a data item value, ensure the value is updated by the internal Switch in ListSwitch when the space key is pressed while the item is focused.

Fixes #2622