### PR TITLE
translations: Update translations 20251110 (after fix!)

### DIFF
--- a/i18n/venus-gui-v2_af.ts
+++ b/i18n/venus-gui-v2_af.ts
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="af">
   <context>
-    <name/>
+    <name></name>
     <message id="switchable_output_disabled">
       <location filename="../../src/enums.cpp" line="478"/>
       <source>Disabled</source>
@@ -22,6 +22,7 @@
     <message id="solarchargers_state_off">
       <location filename="../../src/enums.cpp" line="331"/>
       <source>Off</source>
+      <extracomment>Digital input state</extracomment>
       <translation>Af</translation>
     </message>
     <message id="common_words_auto">
@@ -52,18 +53,25 @@
     <message id="settings_startpage_none">
       <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
       <source>None</source>
+      <extracomment>Indicates no phase</extracomment>
       <translation>Geen</translation>
     </message>
     <message id="common_words_position_ac">
       <location filename="../../components/CommonWords.qml" line="416"/>
       <source>Position</source>
-      <extracomment>AC input or output position</extracomment>
+      <extracomment>EVCS AC input/output position</extracomment>
       <translation>Posisie</translation>
     </message>
     <message id="settings_minmax_speed">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="193"/>
       <source>Speed</source>
+      <extracomment>A speed measurement value</extracomment>
       <translation>Spoed</translation>
+    </message>
+    <message id="common_words_state">
+      <location filename="../../components/CommonWords.qml" line="502"/>
+      <source>State</source>
+      <translation>Toestand</translation>
     </message>
     <message id="settings_firmware_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="67"/>
@@ -101,8 +109,8 @@
       <source>Solar yield</source>
       <translation>Sonopbrengs</translation>
     </message>
-    <message id="ess_state_external_control">
-      <location filename="../../data/Ess.qml" line="41"/>
+    <message id="inverters_state_externalccontrol">
+      <location filename="../../data/System.qml" line="183"/>
       <source>External control</source>
       <translation>Eksterne beheer</translation>
     </message>
@@ -140,6 +148,11 @@
       <location filename="../../components/CommonWords.qml" line="203"/>
       <source>ESS</source>
       <translation type="unfinished">ESS</translation>
+    </message>
+    <message id="pagesettingsconnectivity_ethernet">
+      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
+      <source>Ethernet</source>
+      <translation type="unfinished">Ethernet</translation>
     </message>
     <message id="pagesettingsconnectivity_wifi">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="28"/>
@@ -262,11 +275,6 @@
       <source>Name</source>
       <translation>Naam</translation>
     </message>
-    <message id="settings_deviceinfo_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="38"/>
-      <source>Name</source>
-      <translation type="unfinished">Naam</translation>
-    </message>
     <message id="settings_deviceinfo_product_id">
       <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
       <source>Product ID</source>
@@ -327,15 +335,20 @@
       <source>Daily run time</source>
       <translation>Daaglikse looptyd</translation>
     </message>
+    <message id="common_words_value_must_be_greater_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="560"/>
+      <source>Value must be greater than stop value</source>
+      <translation>Waarde moet groter as stopwaarde wees</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="563"/>
+      <source>Value must be lower than start value</source>
+      <translation>Waarde moet laer as beginwaarde wees</translation>
+    </message>
     <message id="settings_minmax_acout_max_power">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="124"/>
       <source>AC output</source>
       <translation>Wisselstroom uitset</translation>
-    </message>
-    <message id="ac_output">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="15"/>
-      <source>AC output</source>
-      <translation type="unfinished">Wisselstroom uitset</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
       <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="25"/>
@@ -382,16 +395,6 @@
       <source>Unavailable monitor, set another</source>
       <translation>Monitor nie-beskikbaar, skakel oor na 'n ander</translation>
     </message>
-    <message id="page_generator_conditions_battery_monitor">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="42"/>
-      <source>Battery monitor</source>
-      <translation type="unfinished">Battery monitor</translation>
-    </message>
-    <message id="page_generator_conditions_unavailable_monitor_set_another">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="44"/>
-      <source>Unavailable monitor, set another</source>
-      <translation type="unfinished">Monitor nie-beskikbaar, skakel oor na 'n ander</translation>
-    </message>
     <message id="page_generator_conditions_on_loss_of_communication">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="68"/>
       <source>On loss of communication</source>
@@ -416,11 +419,6 @@
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="105"/>
       <source>Battery SOC</source>
       <translation type="unfinished">Battery SBS - Sekuriteits Bedryfs Sentrum</translation>
-    </message>
-    <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="173"/>
-      <source>Periodic run</source>
-      <translation type="unfinished">Periodieke bedryf</translation>
     </message>
     <message id="settings_inverter_high_temperature">
       <location filename="../../data/Generators.qml" line="83"/>
@@ -505,7 +503,7 @@
     <message id="settings_gps_speed_kmh">
       <location filename="../../pages/settings/PageGps.qml" line="83"/>
       <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometres per hour</extracomment>
+      <extracomment>GPS speed data, in kilometers per hour</extracomment>
       <translation>%1 km/u</translation>
     </message>
     <message id="settings_gps_speed_mph">
@@ -523,7 +521,7 @@
     <message id="settings_gps_speed_ms">
       <location filename="../../pages/settings/PageGps.qml" line="95"/>
       <source>%1 m/s</source>
-      <extracomment>GPS speed data, in metres per second</extracomment>
+      <extracomment>GPS speed data, in meters per second</extracomment>
       <translation>%1 m/s</translation>
     </message>
     <message id="settings_gps_course">
@@ -580,21 +578,6 @@
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="64"/>
       <source>%1 (Output %2)</source>
       <translation>%1 (Uitset %2)</translation>
-    </message>
-    <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">Aktiewe batterymonitor</translation>
-    </message>
-    <message id="settings_batteries_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="101"/>
-      <source>Name</source>
-      <translation type="unfinished">Naam</translation>
-    </message>
-    <message id="settings_batteries_enter_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="103"/>
-      <source>Enter name</source>
-      <translation type="unfinished">Voer naam in</translation>
     </message>
     <message id="settings_briefview_center_active_battery_monitor">
       <location filename="../../components/listitems/ListBriefCenterDetails.qml" line="27"/>
@@ -656,45 +639,25 @@
       <source>CAN-bus profile</source>
       <translation type="unfinished">CAN-bus profiel  - CAN meaning uncertain</translation>
     </message>
-    <message id="settings_disabled">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="31"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Ontsluit</translation>
-    </message>
-    <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation type="unfinished">VE.Can &amp; Lynx Ion BMS (250 kbit/s)</translation>
-    </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
       <location filename="../../pages/settings/CanbusProfile.qml" line="42"/>
       <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
       <translation type="unfinished">VE.Can &amp; CAN-bus BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
       <source>Oceanvolt (250 kbit/s)</source>
       <translation>Oseaanvolt (250 kbit/s)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
       <source>RV-C (250 kbit/s)</source>
       <translation type="unfinished">RV-C (250 kbit/s)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
       <source>Up, but no services (250 kbit/s)</source>
       <translation>Op, maar geen dienslewering (250 kbit/s)</translation>
-    </message>
-    <message id="settings_canopen_motordrive_250">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
-      <source>CANopen Motor drive (250 kbit/s)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_canopen_motordrive_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
-      <source>CANopen Motor drive (500 kbit/s)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_devices">
       <location filename="../../components/CommonWords.qml" line="166"/>
@@ -731,11 +694,6 @@
       <source>Check Unique id numbers</source>
       <translation>Gaan Unieke ID-nommers na</translation>
     </message>
-    <message id="settings_canbus_unique_id_press_to_check">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Press to check</source>
-      <translation type="unfinished">Druk om na te gaan</translation>
-    </message>
     <message id="settings_canbus_unique_id_conflict">
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="125"/>
       <source>There is another device connected with this unique number, please select a new number.</source>
@@ -745,11 +703,6 @@
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="133"/>
       <source>OK: No other device is connected with this unique number.</source>
       <translation>REG: Geen ander toestel is met hierdie unieke nommer gekoppel nie.</translation>
-    </message>
-    <message id="pagesettingsintegrations_canopenmotordrive">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
-      <source>CANopen motor drives</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_network_status">
       <location filename="../../components/CommonWords.qml" line="349"/>
@@ -884,11 +837,6 @@
       <source>Unavailable sensor, set another</source>
       <translation>Onbeskikbare sensor, stel 'n ander</translation>
     </message>
-    <message id="settings_system_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="81"/>
-      <source>Unavailable sensor, set another</source>
-      <translation type="unfinished">Onbeskikbare sensor, stel 'n ander</translation>
-    </message>
     <message id="settings_dvcc_used_sensor">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="120"/>
       <source>Used sensor</source>
@@ -945,12 +893,6 @@
       <source>Auto selected</source>
       <translation>Outo gekies</translation>
     </message>
-    <message id="settings_dvcc_auto_selected_none">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="208"/>
-      <source>None</source>
-      <extracomment>Indicates no option is selected</extracomment>
-      <translation type="unfinished">Geen</translation>
-    </message>
     <message id="settings_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
       <source>Build date/time</source>
@@ -986,12 +928,6 @@
       <source>Installing %1</source>
       <extracomment>%1 = firmware version</extracomment>
       <translation>Installeer tans %1</translation>
-    </message>
-    <message id="settings_firmware_offline_press_to_install">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">Druk om op te dateer na %1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="90"/>
@@ -1062,12 +998,6 @@
       <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
       <translation>Installeer tans %1 %2%</translation>
     </message>
-    <message id="settings_firmware_online_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="86"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">Installeer tans %1...</translation>
-    </message>
     <message id="settings_firmware_update_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="109"/>
       <source>Update build date/time</source>
@@ -1097,11 +1027,6 @@
       <location filename="../../pages/settings/PageSettingsFronius.qml" line="56"/>
       <source>TCP port</source>
       <translation>TCP-poort</translation>
-    </message>
-    <message id="page_settings_fronius_modbus_settings">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
-      <source>Modbus port and unit ID settings</source>
-      <translation type="unfinished"/>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
       <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
@@ -1153,16 +1078,6 @@
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="64"/>
       <source>AC-Out MP</source>
       <translation type="unfinished">WS-Uit MP</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="52"/>
-      <source>AC-In1 L%1</source>
-      <translation type="unfinished">WS-In1 L%1</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="56"/>
-      <source>AC-In1 --</source>
-      <translation type="unfinished">WS-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="70"/>
@@ -1330,12 +1245,6 @@
       <source>Reset service timer</source>
       <translation>Stel dienstydteller terug</translation>
     </message>
-    <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
-      <source>Volume</source>
-      <extracomment>Title for a list of units of volume (e.g. cubic metres, litres, gallons)</extracomment>
-      <translation type="unfinished">Volume</translation>
-    </message>
     <message id="settings_gps_format">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="69"/>
       <source>Format</source>
@@ -1438,42 +1347,6 @@ As dit nie werk nie, gaan sim-kaart in 'n foon na om seker te maak dat daar kred
       <source>Wrong PIN</source>
       <translation>Verkeerde PIN</translation>
     </message>
-    <message id="page_settings_gsm_ok">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>OK</source>
-      <translation type="unfinished">Reg</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="128"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">Onbekende fout</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_state">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="153"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Onbekend</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_value">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="182"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Onbekend</translation>
-    </message>
-    <message id="page_settings_gsm_offline">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="173"/>
-      <source>Offline</source>
-      <translation type="unfinished">Van lyn af</translation>
-    </message>
-    <message id="page_settings_gsm_connecting">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="176"/>
-      <source>Connecting</source>
-      <translation type="unfinished">Verbind</translation>
-    </message>
-    <message id="page_settings_gsm_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="179"/>
-      <source>Connected</source>
-      <translation type="unfinished">Gekoppel</translation>
-    </message>
     <message id="page_settings_gsm_pin">
       <location filename="../../pages/settings/PageSettingsGsm.qml" line="191"/>
       <source>PIN</source>
@@ -1530,32 +1403,32 @@ As dit nie werk nie, gaan sim-kaart in 'n foon na om seker te maak dat daar kred
       <translation>Roostermeting</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
       <source>External meter</source>
       <translation>Eksterne meter</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="67"/>
       <source>Inverter/Charger</source>
       <translation>Omsetter/laaier</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
       <source>Multiphase regulation</source>
       <translation>Multifase regulering</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="91"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
       <source>Total of all phases</source>
       <translation>Totaal van alle fases</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="95"/>
       <source>Individual phase</source>
       <translation>Individuele fase</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="99"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="101"/>
       <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
@@ -1564,68 +1437,13 @@ CAUTION: Use only if required by the utility provider.</source>
 WAARSKUWING: Gebruik slegs indien dit deur die diensteverskaffer vereis word.</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="104"/>
       <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
       <translation>Die totaal van alle fases word intelligent gereguleer om die roosterstelpunt te bereik (stelseldoeltreffendheid is geoptimaliseer).
 
 Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
-    </message>
-    <message id="settings_ess_min_soc">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation type="unfinished">Minimum SBS (tensy rooster misluk)</translation>
-    </message>
-    <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="129"/>
-      <source>Active SOC limit</source>
-      <translation type="unfinished">Aktiewe SBS limiet</translation>
-    </message>
-    <message id="settings_ess_battery_life_sustain">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
-      <source>Sustain</source>
-      <translation type="unfinished">Onderhou</translation>
-    </message>
-    <message id="settings_ess_battery_life_recharge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="157"/>
-      <source>Recharge</source>
-      <translation type="unfinished">Herlaai</translation>
-    </message>
-    <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <source>Scheduled charge levels</source>
-      <translation type="unfinished">Geskeduleerde heffingsvlakke</translation>
-    </message>
-    <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="257"/>
-      <source>Active (%1)</source>
-      <translation type="unfinished">Aktief (%1)</translation>
-    </message>
-    <message id="settings_ess_inactive">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="259"/>
-      <source>Inactive</source>
-      <translation type="unfinished">Onaktief</translation>
-    </message>
-    <message id="settings_ess_dynamic">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="293"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">Dinamiese WSD</translation>
-    </message>
-    <message id="settings_ess_deprecated">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="319"/>
-      <source>Deprecated settings</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_charge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="326"/>
-      <source>Battery charge limit (% of CCL)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_discharge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="337"/>
-      <source>Battery discharge limit (% of DCL)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_rs_ess_min_soc">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="40"/>
@@ -1637,13 +1455,8 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <source>Active SOC limit</source>
       <translation type="unfinished">Aktiewe SBS limiet</translation>
     </message>
-    <message id="scheduled_charge_inactive">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
-      <source>Inactive</source>
-      <translation type="unfinished">Onaktief</translation>
-    </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="245"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="247"/>
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
       <source>Peak shaving</source>
       <translation type="unfinished">Piek skeer</translation>
@@ -1659,12 +1472,12 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <translation>Altyd</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="151"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
       <source>Discharge disabled</source>
       <translation>Ontlading gedeaktiveer</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
       <source>Slow charge</source>
       <translation>Stadige lading</translation>
     </message>
@@ -1679,32 +1492,32 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <translation>Herlaai</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="165"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="167"/>
       <source>Limit charge power</source>
       <translation>Beperk laaikrag</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="183"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="185"/>
       <source>Maximum charge power</source>
       <translation>Maksimum laaikrag</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="196"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="198"/>
       <source>Limit inverter power</source>
       <translation>Beperk Omsetter krag </translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="214"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="216"/>
       <source>Maximum inverter power</source>
       <translation>Maksimum Omsetter krag</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="225"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="227"/>
       <source>Grid setpoint</source>
       <translation>Rooster stelpunt</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="236"/>
       <source>Grid feed-in</source>
       <translation>Roosterinvoer</translation>
     </message>
@@ -1743,8 +1556,8 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <source>Door alarm</source>
       <translation>Deur alarm</translation>
     </message>
-    <message id="digitalinputs_type_bilgepump">
-      <location filename="../../src/enums.cpp" line="201"/>
+    <message id="switchable_output_bilge_pump">
+      <location filename="../../src/enums.cpp" line="424"/>
       <source>Bilge pump</source>
       <translation type="unfinished">Lenspomp</translation>
     </message>
@@ -1796,11 +1609,6 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <source>Deferred by %1s</source>
       <extracomment>%1 = number of seconds</extracomment>
       <translation>Uitgestel met %1s</translation>
-    </message>
-    <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="75"/>
-      <source>Are you sure?</source>
-      <translation type="unfinished">Is jy seker?</translation>
     </message>
     <message id="settings_vrm_portal_id">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="87"/>
@@ -1939,11 +1747,6 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <source>External storage</source>
       <translation>Eksterne berging</translation>
     </message>
-    <message id="settings_vrm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="308"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">Onbekende fout</translation>
-    </message>
     <message id="settings_vrm_no_error">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="311"/>
       <source>No Error</source>
@@ -2029,37 +1832,10 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <source>Function</source>
       <translation>Funksie</translation>
     </message>
-    <message id="settings_relay_disabled">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="54"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="98"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Ontsluit</translation>
-    </message>
     <message id="settings_relay_alarm_relay">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="56"/>
       <source>Alarm relay</source>
       <translation>Alarm weerstand</translation>
-    </message>
-    <message id="settings_relay_tank_pump">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="62"/>
-      <source>Tank pump</source>
-      <translation type="unfinished">Tenkpomp</translation>
-    </message>
-    <message id="settings_relay_manual">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="64"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="100"/>
-      <source>Manual</source>
-      <translation type="unfinished">Handleiding</translation>
-    </message>
-    <message id="settings_relay_polarity_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
-      <source>Polarity (Relay 1)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_relay_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
-      <source>Polarity</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_normally_open">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="83"/>
@@ -2075,11 +1851,6 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="93"/>
       <source>Function (Relay 2)</source>
       <translation>Funksie (Weerstand 2)</translation>
-    </message>
-    <message id="settings_relay_polarity_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
-      <source>Polarity (Relay 2)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_temp_control_rules">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="119"/>
@@ -2111,12 +1882,6 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
       <source>Press to boot</source>
       <translation>Druk om te begin</translation>
-    </message>
-    <message id="settings_firmware_backup_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
-      <translation type="unfinished">Fermware %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
@@ -2152,6 +1917,7 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
     <message id="nav_boat">
       <location filename="../../pages/boat/BoatPage.qml" line="14"/>
       <source>Boat</source>
+      <extracomment>The 'Boat' page</extracomment>
       <translation>Boot</translation>
     </message>
     <message id="settings_system_name">
@@ -2219,11 +1985,6 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <source>Solar charger current control</source>
       <translation>Sonkraglaaier stroombeheer</translation>
     </message>
-    <message id="settings_system_status_bms_params">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
-      <source>BMS control</source>
-      <translation type="unfinished">BMS beheer</translation>
-    </message>
     <message id="common_words_bms_control">
       <location filename="../../components/CommonWords.qml" line="101"/>
       <source>BMS control</source>
@@ -2238,11 +1999,6 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
       <source>Pump state</source>
       <translation>Pomp toestand</translation>
-    </message>
-    <message id="settings_pump_auto">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="56"/>
-      <source>Auto</source>
-      <translation type="unfinished">Outo</translation>
     </message>
     <message id="settings_tank_sensor">
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
@@ -2271,11 +2027,6 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="35"/>
       <source>Unplugged</source>
       <translation>Ontkoppel</translation>
-    </message>
-    <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="16"/>
-      <source>Name</source>
-      <translation type="unfinished">Naam</translation>
     </message>
     <message id="settings_tcpip_hidden">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="21"/>
@@ -2317,16 +2068,6 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="99"/>
       <source>IP configuration</source>
       <translation>IP-konfigurasie</translation>
-    </message>
-    <message id="settings_tcpip_manual">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="105"/>
-      <source>Manual</source>
-      <translation type="unfinished">Handleiding</translation>
-    </message>
-    <message id="settings_tcpip_off">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="107"/>
-      <source>Off</source>
-      <translation type="unfinished">Af</translation>
     </message>
     <message id="settings_tcpip_fixed">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="109"/>
@@ -2382,21 +2123,6 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="30"/>
       <source>Create access point</source>
       <translation>Skep toegangspunt</translation>
-    </message>
-    <message id="settings_wifi_access_point_enter_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="68"/>
-      <source>Enter password</source>
-      <translation type="unfinished">Sleutel wagwoord in</translation>
-    </message>
-    <message id="page_settings_wifi_invalid_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
-      <source>Password length must be either 0 or between 10 and 63 characters long</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_wifi_password_updated">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
-      <source>Password updated</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_wifi_networks">
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="86"/>
@@ -2539,20 +2265,10 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <extracomment>Network status: Standalone</extracomment>
       <translation>Selfstandig</translation>
     </message>
-    <message id="charger_standalone">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="45"/>
-      <source>Standalone</source>
-      <translation type="unfinished">Selfstandig</translation>
-    </message>
     <message id="charger_charge">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="48"/>
       <source>Charge</source>
       <translation>Laai</translation>
-    </message>
-    <message id="charger_external_control">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="51"/>
-      <source>External control</source>
-      <translation type="unfinished">Eksterne beheer</translation>
     </message>
     <message id="charger_charge_hub_1">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="54"/>
@@ -2584,16 +2300,6 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <source>Master setting</source>
       <translation>Meesterinstelling</translation>
     </message>
-    <message id="charger_slave">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="85"/>
-      <source>Slave</source>
-      <translation type="unfinished">Slaaf</translation>
-    </message>
-    <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation type="unfinished">Laai spanning</translation>
-    </message>
     <message id="systemsettings_networkstatus_slave">
       <location filename="../../data/SystemSettings.qml" line="148"/>
       <source>Slave</source>
@@ -2615,14 +2321,15 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <source>Group &amp; Charge master</source>
       <translation>Groep- &amp; Laaimeester</translation>
     </message>
-    <message id="genset_charge_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="365"/>
+    <message id="charger_charge_voltage">
+      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
       <source>Charge voltage</source>
       <translation>Laai spanning</translation>
     </message>
     <message id="common_words_reset">
       <location filename="../../components/CommonWords.qml" line="448"/>
       <source>Reset</source>
+      <extracomment>Reset the BMS control</extracomment>
       <translation>Herstel</translation>
     </message>
     <message id="solarcharger_load">
@@ -2651,14 +2358,14 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <extracomment>Voltage alarm is at "Warning" level</extracomment>
       <translation>Waarskuwing</translation>
     </message>
-    <message id="listitems_alarm_level_alarm">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="25"/>
+    <message id="digitalinputs_state_alarm">
+      <location filename="../../src/enums.cpp" line="270"/>
       <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
+      <extracomment>Relay function is 'alarm'</extracomment>
       <translation>Alarm</translation>
     </message>
-    <message id="devicelist_tankshape_volume">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="190"/>
+    <message id="components_volumeunit_volume">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
       <source>Volume</source>
       <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
       <translation>Volume</translation>
@@ -2808,26 +2515,10 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <source>Relay function</source>
       <translation>Aflos funksie</translation>
     </message>
-    <message id="batterysettingrelay_alarm">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation type="unfinished">Alarm</translation>
-    </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
       <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
       <source>Charger or generator start/stop</source>
       <translation>Laaier of kragopwekker begin/stop</translation>
-    </message>
-    <message id="batterysettingrelay_manual_control">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
-      <source>Manual control</source>
-      <translation type="unfinished">Handmatige beheer</translation>
-    </message>
-    <message id="batterysettingrelay_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">Sekering geblaas</translation>
     </message>
     <message id="common_words_manual_control">
       <location filename="../../components/CommonWords.qml" line="302"/>
@@ -2853,12 +2544,6 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
       <source>Status LEDs</source>
       <translation>Status LED's</translation>
-    </message>
-    <message id="batterydiagnostics_none">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
-      <source>None</source>
-      <extracomment>Indicates no alarm is set</extracomment>
-      <translation type="unfinished">Geen</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
@@ -2888,7 +2573,7 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
     <message id="common_words_switch">
       <location filename="../../components/CommonWords.qml" line="525"/>
       <source>Switch</source>
-      <extracomment>Change the mode value</extracomment>
+      <extracomment>Change the battery mode</extracomment>
       <translation>Skakel oor</translation>
     </message>
     <message id="devicelist_battery_initializing">
@@ -2956,21 +2641,6 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <source>Top section voltage</source>
       <translation>Top seksie spanning</translation>
     </message>
-    <message id="battery_bank_error_communication">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="96"/>
-      <source>Communication error</source>
-      <translation type="unfinished">Kommunikasie fout</translation>
-    </message>
-    <message id="battery_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="182"/>
-      <source>State of health</source>
-      <translation type="unfinished">Gesondheidstoestand</translation>
-    </message>
-    <message id="battery_bus_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="212"/>
-      <source>Bus voltage</source>
-      <translation type="unfinished">Busspanning</translation>
-    </message>
     <message id="battery_bottom_section_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="228"/>
       <source>Bottom section voltage</source>
@@ -3016,16 +2686,6 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <source>IO</source>
       <translation>IO</translation>
     </message>
-    <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="391"/>
-      <source>System</source>
-      <translation type="unfinished">Stelsel</translation>
-    </message>
-    <message id="battery_press_to_redetect">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="433"/>
-      <source>Press to redetect</source>
-      <translation type="unfinished">Druk om te herken</translation>
-    </message>
     <message id="pagesettingsgeneral_system">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="107"/>
       <source>System</source>
@@ -3066,16 +2726,6 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <source>Low SOC</source>
       <translation>Lae SBS</translation>
     </message>
-    <message id="batteryalarms_high_battery_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
-      <source>High battery voltage</source>
-      <translation type="unfinished">Hoë batteryspanning</translation>
-    </message>
-    <message id="batteryalarms_low_soc">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low SOC</source>
-      <translation type="unfinished">Lae SBS</translation>
-    </message>
     <message id="batteryalarms_low_starter_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="73"/>
       <source>Low starter voltage</source>
@@ -3095,11 +2745,6 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
       <source>Mid-point voltage</source>
       <translation>Middelpuntspanning</translation>
-    </message>
-    <message id="batteryalarms_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">Sekering geblaas</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
@@ -3293,11 +2938,6 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <source>Restore factory defaults</source>
       <translation>Herstel fabrieksinstellings</translation>
     </message>
-    <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation type="unfinished">Druk om te herstel</translation>
-    </message>
     <message id="vebus_backup_press_to_restore">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="362"/>
       <source>Press to restore</source>
@@ -3337,11 +2977,6 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="18"/>
       <source>Capacity</source>
       <translation>Kapasiteit</translation>
-    </message>
-    <message id="batterysettingsbattery_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
-      <source>Capacity</source>
-      <translation type="unfinished">Kapasiteit</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
@@ -3418,11 +3053,6 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <source>No power on busbar</source>
       <translation>Geen krag op busstaaf nie</translation>
     </message>
-    <message id="lynxdistributor_connection_lost">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
-      <source>Connection lost</source>
-      <translation type="unfinished">Konneksie verlore</translation>
-    </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
       <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
       <source>%n fuse(s) blown</source>
@@ -3458,26 +3088,6 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <source>Shutdowns due error</source>
       <translation>Afsluitings weens fout</translation>
     </message>
-    <message id="lynxiondiagnostics_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
-      <source>Last error</source>
-      <translation type="unfinished">Laaste fout</translation>
-    </message>
-    <message id="lynxiondiagnostics_2nd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
-      <source>2nd last error</source>
-      <translation type="unfinished">2de laaste fout</translation>
-    </message>
-    <message id="lynxiondiagnostics_3rd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
-      <source>3rd last error</source>
-      <translation type="unfinished">3de laaste fout</translation>
-    </message>
-    <message id="lynxiondiagnostics_4th_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
-      <source>4th last error</source>
-      <translation type="unfinished">4de laaste fout</translation>
-    </message>
     <message id="lynxionio_system_switch">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
       <source>System Switch</source>
@@ -3497,11 +3107,6 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <location filename="../../components/CommonWords.qml" line="54"/>
       <source>Batteries</source>
       <translation>Batterye</translation>
-    </message>
-    <message id="lynxionsystem_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
-      <source>Capacity</source>
-      <translation type="unfinished">Kapasiteit</translation>
     </message>
     <message id="lynxionsystem_parallel">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="30"/>
@@ -3523,20 +3128,10 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <source>Min/max cell temperature</source>
       <translation>Min/maks seltemperatuur</translation>
     </message>
-    <message id="lynxionsystem_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="92"/>
-      <source>Balancing</source>
-      <translation type="unfinished">Balansering</translation>
-    </message>
     <message id="lynxionsystem_balancer_balancing">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
       <source>Balancing</source>
       <translation>Balansering</translation>
-    </message>
-    <message id="lynxionsystem_balancer_unknown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="117"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Onbekend</translation>
     </message>
     <message id="dc_output">
       <location filename="../../components/listitems/ListDcOutputQuantityGroup.qml" line="16"/>
@@ -3644,11 +3239,6 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <source>Remaining</source>
       <translation>Oorblywende</translation>
     </message>
-    <message id="devicelist_tanksensor_sensor_battery">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="51"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">Sensor battery</translation>
-    </message>
     <message id="temperature_sensor_battery">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="112"/>
       <source>Sensor battery</source>
@@ -3677,7 +3267,7 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
     <message id="devicelist_tanksetup_custom">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="53"/>
       <source>Custom</source>
-      <translation type="unfinished">Pasgemaak</translation>
+      <translation>Pasgemaak</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="59"/>
@@ -3710,34 +3300,34 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <translation>Sensorwaarde</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="75"/>
       <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
       <translation>Geen pasgemaakte vorm gedefinieer nie. Jy kan een definieer met tot tien punte. Let daarop dat 0% en 100% geïmpliseer word.</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="91"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="89"/>
       <source>Point %1</source>
       <extracomment>%1 = the point number</extracomment>
       <translation>Punt %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="133"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="179"/>
       <source>Add point</source>
       <translation>Voeg punt by</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="156"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="205"/>
       <source>Sensor level</source>
       <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
       <translation>Sensor vlak</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="256"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="311"/>
       <source>Duplicate sensor level values are not allowed.</source>
       <translation>Duplikaat sensorvlakwaardes word nie toegelaat nie.</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="262"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="317"/>
       <source>Volume values must be increasing.</source>
       <translation>Volumewaardes moet toeneem.</translation>
     </message>
@@ -3777,11 +3367,6 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <source>Switch position</source>
       <translation>Skakel posisie</translation>
     </message>
-    <message id="ac-in-setup_single_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="142"/>
-      <source>Single phase</source>
-      <translation type="unfinished">Enkelfase</translation>
-    </message>
     <message id="ac-in-setup_two_phase">
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="144"/>
       <source>2-phase</source>
@@ -3791,11 +3376,6 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="146"/>
       <source>3-phase</source>
       <translation>3-fase</translation>
-    </message>
-    <message id="ac-in-setup_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="161"/>
-      <source>Devices</source>
-      <translation type="unfinished">Toestelle</translation>
     </message>
     <message id="ac-in-genset_ac">
       <location filename="../../components/PageGensetModel.qml" line="194"/>
@@ -3889,12 +3469,6 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <extracomment>%1 = CT device number</extracomment>
       <translation>CT %1</translation>
     </message>
-    <message id="smappeect_phase_none">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation type="unfinished">Geen</translation>
-    </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
       <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
       <source>Flashing LED indicates this CT</source>
@@ -3908,11 +3482,13 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
     <message id="common_words_setting_disabled_when_dmc_connected">
       <location filename="../../components/CommonWords.qml" line="355"/>
       <source>This setting is disabled when a Digital Multi Control is connected.</source>
+      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>Hierdie instelling is gedeaktiveer wanneer 'n Digitale Multi Beheer gekoppel is.</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
       <location filename="../../components/CommonWords.qml" line="358"/>
       <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>Hierdie instelling is gedeaktiveer wanneer 'n VE.Bus BMS gekoppel is.</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
@@ -3930,16 +3506,6 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="21"/>
       <source>Inverted</source>
       <translation>Omgeskakel</translation>
-    </message>
-    <message id="digitalinput_enable_alarm">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="48"/>
-      <source>Enable alarm</source>
-      <translation type="unfinished">Aktiveer alarm</translation>
-    </message>
-    <message id="digitalinput_inverted">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="54"/>
-      <source>Inverted</source>
-      <translation type="unfinished">Omgeskakel</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
       <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="60"/>
@@ -3976,16 +3542,6 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <source>Wind speed</source>
       <translation>Wind spoed</translation>
     </message>
-    <message id="page_meteo_battery_voltage">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="99"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">Sensor battery</translation>
-    </message>
-    <message id="meteo_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="120"/>
-      <source>Low</source>
-      <translation type="unfinished">Laag</translation>
-    </message>
     <message id="page_meteo_settings_auto_detect">
       <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
       <source>Auto-detect</source>
@@ -4016,16 +3572,6 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <source>Reset counter</source>
       <translation>Stel teller terug</translation>
     </message>
-    <message id="temperature_short_circuited">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="32"/>
-      <source>Short circuited</source>
-      <translation type="unfinished">Kortsluiting</translation>
-    </message>
-    <message id="temperature_reverse_polarity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="35"/>
-      <source>Reverse polarity</source>
-      <translation type="unfinished">Omgekeerde polariteit</translation>
-    </message>
     <message id="temperature_sensor_battery_low">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
       <source>Sensor battery low</source>
@@ -4040,36 +3586,6 @@ Gebruik tensy dit deur die diensverskaffer verbied word.</translation>
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="62"/>
       <source>Pressure</source>
       <translation>Druk</translation>
-    </message>
-    <message id="temperature_pm25">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
-      <source>PM2.5</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_co2">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>CO₂</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_voc">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
-      <source>VOC index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_nox">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
-      <source>NOx index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_luminosity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
-      <source>Luminosity</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="133"/>
-      <source>Low</source>
-      <translation type="unfinished">Laag</translation>
     </message>
     <message id="temperature_offset">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
@@ -4123,25 +3639,10 @@ LET WEL: Die opdatering kan die stelsel tydelik stop.</translation>
       <source>Updating the MK3, values will reappear after the update is complete</source>
       <translation>Na die MK3 opdatering, sal waardes weer verskyn sodra die opdatering voltooi is</translation>
     </message>
-    <message id="vebus_device_charging_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="78"/>
-      <source>Charging the battery to 100%</source>
-      <translation type="unfinished">Laai die battery tot 100%</translation>
-    </message>
     <message id="vebus_device_charging_the_battery_to_100">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="93"/>
       <source>Charging the battery to 100%</source>
       <translation>Laai die battery tot 100%</translation>
-    </message>
-    <message id="vebus_device_page_microgrid_parameters">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
-      <source>Microgrid parameters</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="vebus_device_page_advanced">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
-      <source>Advanced</source>
-      <translation type="unfinished">Gevorderd</translation>
     </message>
     <message id="vebus_device_in_progress">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="80"/>
@@ -4197,15 +3698,15 @@ Wil jy voortgaan?</translation>
       <source>DC Current</source>
       <translation>DC Stroom</translation>
     </message>
+    <message id="vebus_device_page_advanced">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
+      <source>Advanced</source>
+      <translation>Gevorderd</translation>
+    </message>
     <message id="common_words_alarm_setup">
       <location filename="../../components/CommonWords.qml" line="65"/>
       <source>Alarm setup</source>
       <translation>Alarm opstelling</translation>
-    </message>
-    <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
-      <translation type="unfinished">'n VE.Bus BMS skakel die stelsel outomaties af wanneer dit nodig is om die battery te beskerm. Om die stelsel vanaf die Kleurbeheer te beheer is dus nie moontlik nie.</translation>
     </message>
     <message id="vebus_device_bms_not_found">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="240"/>
@@ -4246,7 +3747,7 @@ Wil jy voortgaan?</translation>
     <message id="vebus_device_starting">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="117"/>
       <source>Starting...</source>
-      <translation type="unfinished">Begin tans …</translation>
+      <translation>Begin tans …</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="120"/>
@@ -4312,16 +3813,6 @@ Wil jy voortgaan?</translation>
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="260"/>
       <source>ESS Relay test</source>
       <translation>WSD Weerstand toets</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_completed">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="266"/>
-      <source>Completed</source>
-      <translation type="unfinished">Voltooi</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_pending">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="268"/>
-      <source>Pending</source>
-      <translation type="unfinished">Hangend</translation>
     </message>
     <message id="cycle_history_completed">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
@@ -4508,6 +3999,7 @@ Wil jy voortgaan?</translation>
     <message id="rssystemalarms_overload">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
       <source>Overload</source>
+      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
       <translation>Oorlading</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
@@ -4520,11 +4012,6 @@ Wil jy voortgaan?</translation>
       <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
       <source>Voltage Sensor</source>
       <translation>Spanning sensor</translation>
-    </message>
-    <message id="vebus_device_phase_rotation">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
-      <source>Phase rotation</source>
-      <translation type="unfinished">Fase rotasie</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
@@ -4556,12 +4043,6 @@ Wil jy voortgaan?</translation>
       <source>VE.Bus BMS version</source>
       <translation>VE.Bus BMS weergawe</translation>
     </message>
-    <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="15"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="52"/>
-      <source>Minimum SOC</source>
-      <translation type="unfinished">Minimum SOC</translation>
-    </message>
     <message id="ess_unless_grid_fails">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="32"/>
       <source>Unless grid fails</source>
@@ -4581,7 +4062,7 @@ Wil jy voortgaan?</translation>
     <message id="common_words_ac_input_role">
       <location filename="../../components/CommonWords.qml" line="24"/>
       <source>Role</source>
-      <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
       <translation>Rol</translation>
     </message>
     <message id="common_words_ac_load">
@@ -4620,18 +4101,6 @@ Wil jy voortgaan?</translation>
       <source>Active</source>
       <extracomment>Status is 'active'</extracomment>
       <translation>Aktief</translation>
-    </message>
-    <message id="common_words_alarm">
-      <location filename="../../components/CommonWords.qml" line="51"/>
-      <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
-      <translation type="unfinished">Alarm</translation>
-    </message>
-    <message id="common_words_alarm_setting_overload">
-      <location filename="../../components/CommonWords.qml" line="58"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation type="unfinished">Oorlading</translation>
     </message>
     <message id="common_words_alarm_status">
       <location filename="../../components/CommonWords.qml" line="68"/>
@@ -4678,8 +4147,8 @@ Wil jy voortgaan?</translation>
       <source>Charge current</source>
       <translation>Laaistroom</translation>
     </message>
-    <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="125"/>
+    <message id="battery_mode_charging">
+      <location filename="../../src/enums.cpp" line="30"/>
       <source>Charging</source>
       <extracomment>"Charging" state</extracomment>
       <translation>Laai</translation>
@@ -4693,7 +4162,7 @@ Wil jy voortgaan?</translation>
     <message id="digitalinputs_state_closed">
       <location filename="../../src/enums.cpp" line="262"/>
       <source>Closed</source>
-      <extracomment>Digital input state</extracomment>
+      <extracomment>Status is 'closed'</extracomment>
       <translation>Gesluit</translation>
     </message>
     <message id="evchargers_status_connected">
@@ -4701,8 +4170,8 @@ Wil jy voortgaan?</translation>
       <source>Connected</source>
       <translation>Gekoppel</translation>
     </message>
-    <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="143"/>
+    <message id="temperature_slider_current">
+      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
       <source>Current</source>
       <extracomment>Electric current, as measured in Amps</extracomment>
       <translation>Huidige</translation>
@@ -4729,9 +4198,10 @@ Wil jy voortgaan?</translation>
       <extracomment>Title for device information</extracomment>
       <translation>Toestel</translation>
     </message>
-    <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="172"/>
+    <message id="battery_mode_discharging">
+      <location filename="../../src/enums.cpp" line="34"/>
       <source>Discharging</source>
+      <extracomment>Battery mode</extracomment>
       <translation>Ontlaai</translation>
     </message>
     <message id="wifimodel_disconnected">
@@ -4817,13 +4287,14 @@ Wil jy voortgaan?</translation>
       <source>%1 Hour(s)</source>
       <translation>%1 uur</translation>
     </message>
-    <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="251"/>
+    <message id="battery_mode_idle">
+      <location filename="../../src/enums.cpp" line="26"/>
       <source>Idle</source>
+      <extracomment>Battery mode</extracomment>
       <translation>Ledig</translation>
     </message>
-    <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="258"/>
+    <message id="scheduled_charge_inactive">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
       <source>Inactive</source>
       <extracomment>Status is 'inactive'</extracomment>
       <translation>Onaktief</translation>
@@ -4925,8 +4396,8 @@ Wil jy voortgaan?</translation>
       <source>Offline</source>
       <translation>Van lyn af</translation>
     </message>
-    <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="17"/>
+    <message id="digitalinputs_state_ok">
+      <location filename="../../src/enums.cpp" line="266"/>
       <source>OK</source>
       <extracomment>Voltage alarm is at "OK" level</extracomment>
       <translation>Reg</translation>
@@ -4934,6 +4405,7 @@ Wil jy voortgaan?</translation>
     <message id="switchable_output_on">
       <location filename="../../src/enums.cpp" line="471"/>
       <source>On</source>
+      <extracomment>Digital input state</extracomment>
       <translation>Aan</translation>
     </message>
     <message id="common_words_online">
@@ -4944,7 +4416,7 @@ Wil jy voortgaan?</translation>
     <message id="digitalinputs_state_open">
       <location filename="../../src/enums.cpp" line="258"/>
       <source>Open</source>
-      <extracomment>Digital input open</extracomment>
+      <extracomment>Status is 'open'</extracomment>
       <translation>Oop</translation>
     </message>
     <message id="common_words_password">
@@ -5004,9 +4476,10 @@ Wil jy voortgaan?</translation>
       <source>Remove</source>
       <translation>Verwyder</translation>
     </message>
-    <message id="switch_state_running">
-      <location filename="../../src/enums.cpp" line="363"/>
+    <message id="switchable_output_running">
+      <location filename="../../src/enums.cpp" line="468"/>
       <source>Running</source>
+      <extracomment>Status = "running"</extracomment>
       <translation>Hardloop</translation>
     </message>
     <message id="common_words_scanning">
@@ -5073,7 +4546,7 @@ Wil jy voortgaan?</translation>
     <message id="pvinverter_statusCode_startup">
       <location filename="../../src/enums.cpp" line="296"/>
       <source>Startup (%1)</source>
-      <extracomment>PV inverter status code. %1 = the startup status number</extracomment>
+      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
       <translation type="unfinished">Opstart (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
@@ -5128,8 +4601,10 @@ Wil jy voortgaan?</translation>
       <source>Unique Identity Number</source>
       <translation>Unieke identiteitsnommer</translation>
     </message>
-    <message id="settings_radio_button_group_unknown">
-      <location filename="../../components/listitems/core/ListRadioButtonGroup.qml" line="44"/>
+    <message id="Unknown">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
       <source>Unknown</source>
       <translation>Onbekend</translation>
     </message>
@@ -5284,11 +4759,6 @@ Wil jy voortgaan?</translation>
       <source>Error while checking for firmware updates</source>
       <translation>Fout terwyl fermware-opdaterings gekontroleur word.</translation>
     </message>
-    <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation type="unfinished">Fout terwyl fermware-opdaterings gekontroleur word.</translation>
-    </message>
     <message id="settings_firmware_downloading_and_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="63"/>
       <source>Downloading and installing firmware %1...</source>
@@ -5315,6 +4785,66 @@ Wil jy voortgaan?</translation>
       <source>No firmware found</source>
       <translation>Geen fermware gevind nie</translation>
     </message>
+    <message id="tank_type_fuel">
+      <location filename="../../src/enums.cpp" line="495"/>
+      <source>Fuel</source>
+      <translation>Brandstof</translation>
+    </message>
+    <message id="tank_type_fresh_water">
+      <location filename="../../src/enums.cpp" line="498"/>
+      <source>Fresh water</source>
+      <translation>Vars water</translation>
+    </message>
+    <message id="tank_type_waste_water">
+      <location filename="../../src/enums.cpp" line="501"/>
+      <source>Waste water</source>
+      <translation>Afvalwater</translation>
+    </message>
+    <message id="tank_type_live_well">
+      <location filename="../../src/enums.cpp" line="504"/>
+      <source>Live well</source>
+      <translation type="unfinished">Leef goed</translation>
+    </message>
+    <message id="tank_type_oil">
+      <location filename="../../src/enums.cpp" line="507"/>
+      <source>Oil</source>
+      <translation>Olie</translation>
+    </message>
+    <message id="tank_type_black_water">
+      <location filename="../../src/enums.cpp" line="510"/>
+      <source>Black water</source>
+      <translation>Swart water</translation>
+    </message>
+    <message id="tank_type_gasoline">
+      <location filename="../../src/enums.cpp" line="513"/>
+      <source>Gasoline</source>
+      <translation>Petrol</translation>
+    </message>
+    <message id="tank_type_diesel">
+      <location filename="../../src/enums.cpp" line="516"/>
+      <source>Diesel</source>
+      <translation>Diesel</translation>
+    </message>
+    <message id="tank_type_lpg">
+      <location filename="../../src/enums.cpp" line="519"/>
+      <source>LPG</source>
+      <translation>VPG</translation>
+    </message>
+    <message id="tank_type_lng">
+      <location filename="../../src/enums.cpp" line="522"/>
+      <source>LNG</source>
+      <translation>VNG</translation>
+    </message>
+    <message id="tank_type_hydraulic_oil">
+      <location filename="../../src/enums.cpp" line="525"/>
+      <source>Hydraulic oil</source>
+      <translation>Hidroliese olie</translation>
+    </message>
+    <message id="tank_type_raw_water">
+      <location filename="../../src/enums.cpp" line="528"/>
+      <source>Raw water</source>
+      <translation>Rou water</translation>
+    </message>
     <message id="listItem_no_access">
       <location filename="../../components/listitems/core/ListItem.qml" line="102"/>
       <source>Setting locked for access level</source>
@@ -5328,6 +4858,7 @@ Wil jy voortgaan?</translation>
     <message id="welcome_brief_title">
       <location filename="../../pages/welcome/WelcomeView.qml" line="81"/>
       <source>Brief</source>
+      <extracomment>The 'Brief' page</extracomment>
       <translation>Kort</translation>
     </message>
     <message id="welcome_overview_title">
@@ -5344,23 +4875,6 @@ Wil jy voortgaan?</translation>
       <location filename="../../pages/NotificationsPage.qml" line="13"/>
       <source>Notifications</source>
       <translation>Kennisgewings</translation>
-    </message>
-    <message id="notifications_page_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="43"/>
-      <source>Active Notifications</source>
-      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_page_inactive_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="47"/>
-      <source>Inactive Notifications</source>
-      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_no_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="106"/>
-      <source>No active notifications</source>
-      <translation type="unfinished"/>
     </message>
     <message id="utils_formatTimestamp_now">
       <location filename="../../components/Utils.js" line="258"/>
@@ -5465,11 +4979,6 @@ Wil jy voortgaan?</translation>
       <source>Self-consumption above limit</source>
       <translation>Selfverbruik bo limiet</translation>
     </message>
-    <message id="cgwacs_battery_schedule_pv">
-      <location filename="../../components/listitems/ListChargeSchedule.qml" line="171"/>
-      <source>PV</source>
-      <translation type="unfinished">PV</translation>
-    </message>
     <message id="settings_multirs_pv">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="185"/>
       <source>PV</source>
@@ -5480,8 +4989,8 @@ Wil jy voortgaan?</translation>
       <source>PV &amp; Battery</source>
       <translation>PV &amp; Battery</translation>
     </message>
-    <message id="settings_firmware_checking">
-      <location filename="../../components/listitems/ListFirmwareCheckButton.qml" line="16"/>
+    <message id="pagesettingssupportstate_firmware_checking">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
       <source>Checking...</source>
       <translation>Nagaan...</translation>
     </message>
@@ -5489,12 +4998,6 @@ Wil jy voortgaan?</translation>
       <location filename="../../components/listitems/ListAlarmState.qml" line="11"/>
       <source>Alarm state</source>
       <translation>Alarm toestand</translation>
-    </message>
-    <message id="devicelist_battery_alarm_state">
-      <location filename="../../components/listitems/ListAlarmState.qml" line="19"/>
-      <source>Alarm</source>
-      <extracomment>Alarm state is active</extracomment>
-      <translation type="unfinished">Alarm</translation>
     </message>
     <message id="clear_history_button_clear_history">
       <location filename="../../components/listitems/ListClearHistoryButton.qml" line="15"/>
@@ -5646,11 +5149,6 @@ Wil jy voortgaan?</translation>
       <source>Max Voltage</source>
       <translation>Maksimum spanning</translation>
     </message>
-    <message id="charger_history_box_max_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="64"/>
-      <source>Max Voltage</source>
-      <translation type="unfinished">Maksimum spanning</translation>
-    </message>
     <message id="charger_history_box_max_current">
       <location filename="../../components/SolarDetailBox.qml" line="70"/>
       <source>Max Current</source>
@@ -5661,24 +5159,6 @@ Wil jy voortgaan?</translation>
       <source>Charge time</source>
       <extracomment>Statistics for battery charging time</extracomment>
       <translation>Laai tyd</translation>
-    </message>
-    <message id="charger_history_box_bulk">
-      <location filename="../../components/SolarDetailBox.qml" line="136"/>
-      <source>Bulk</source>
-      <extracomment>Battery: time spent in 'Bulk' mode</extracomment>
-      <translation type="unfinished">Grootmaat</translation>
-    </message>
-    <message id="charger_history_box_float">
-      <location filename="../../components/SolarDetailBox.qml" line="148"/>
-      <source>Float</source>
-      <extracomment>Battery: time spent in 'Float' mode</extracomment>
-      <translation type="unfinished">Vlot</translation>
-    </message>
-    <message id="charger_history_hr">
-      <location filename="../../components/SolarDetailBox.qml" line="174"/>
-      <source>hr</source>
-      <extracomment>Abbreviation of "hour"</extracomment>
-      <translation type="unfinished">hr</translation>
     </message>
     <message id="solarchargers_state_bulk">
       <location filename="../../src/enums.cpp" line="337"/>
@@ -5750,11 +5230,6 @@ Wil jy voortgaan?</translation>
       <source>Connecting</source>
       <translation>Verbind</translation>
     </message>
-    <message id="splash_view_connecting">
-      <location filename="../../components/SplashView.qml" line="288"/>
-      <source>Connecting</source>
-      <translation type="unfinished">Verbind</translation>
-    </message>
     <message id="splash_view_connected">
       <location filename="../../components/SplashView.qml" line="290"/>
       <source>Connected, awaiting broker messages</source>
@@ -5810,6 +5285,11 @@ Wil jy voortgaan?</translation>
       <source>MQTT protocol level 5 error</source>
       <translation type="unfinished">MQTT protokol vlak 5 fout</translation>
     </message>
+    <message id="common_words_silence_alarm">
+      <location filename="../../components/CommonWords.qml" line="476"/>
+      <source>Silence alarm</source>
+      <translation>Stil alarm</translation>
+    </message>
     <message id="vebus_device_page_total_power">
       <location filename="../../components/ThreePhaseQuantityTable.qml" line="47"/>
       <source>Total Power</source>
@@ -5860,20 +5340,10 @@ Wil jy voortgaan?</translation>
       <source>Retrieving IP address</source>
       <translation>Haal tans IP-adres op</translation>
     </message>
-    <message id="utils_connman_connected">
-      <location filename="../../components/Utils.js" line="292"/>
-      <source>Connected</source>
-      <translation type="unfinished">Gekoppel</translation>
-    </message>
     <message id="utils_connman_disconnect">
       <location filename="../../components/Utils.js" line="295"/>
       <source>Disconnect</source>
       <translation>Ontkoppel</translation>
-    </message>
-    <message id="utils_connman_disconnected">
-      <location filename="../../components/Utils.js" line="299"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Ontkoppel</translation>
     </message>
     <message id="overview_widget_acloads_title">
       <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
@@ -5911,11 +5381,6 @@ Wil jy voortgaan?</translation>
       <source>Shore current limit</source>
       <translation>Strandstroomlimiet</translation>
     </message>
-    <message id="acInputs_statusCode_stopping">
-      <location filename="../../data/AcInputs.qml" line="170"/>
-      <source>Stopping</source>
-      <translation type="unfinished">Stop</translation>
-    </message>
     <message id="page_generator_stopping">
       <location filename="../../data/Generators.qml" line="44"/>
       <source>Stopping</source>
@@ -5931,7 +5396,7 @@ Wil jy voortgaan?</translation>
       <location filename="../../data/common/TankDescription.qml" line="24"/>
       <location filename="../../src/device.cpp" line="133"/>
       <source>%1 tank (%2)</source>
-      <extracomment>Tank description. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
       <translation>%1 tenk (%2)</translation>
     </message>
     <message id="dcMeter_ac_charger">
@@ -5980,11 +5445,6 @@ Wil jy voortgaan?</translation>
       <location filename="../../data/Ess.qml" line="20"/>
       <source>Keep batteries charged</source>
       <translation>Hou batterye gelaai</translation>
-    </message>
-    <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="50"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Ontkoppel</translation>
     </message>
     <message id="evchargers_status_charged">
       <location filename="../../data/EvChargers.qml" line="58"/>
@@ -6045,16 +5505,6 @@ Wil jy voortgaan?</translation>
       <location filename="../../data/EvChargers.qml" line="97"/>
       <source>Start charging</source>
       <translation>Begin laai</translation>
-    </message>
-    <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="113"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Onbekend</translation>
-    </message>
-    <message id="evchargers_mode_scheduled">
-      <location filename="../../data/EvChargers.qml" line="126"/>
-      <source>Scheduled</source>
-      <translation type="unfinished">Geskeduleer</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
       <location filename="../../data/System.qml" line="195"/>
@@ -6179,11 +5629,6 @@ Wil jy voortgaan?</translation>
       <source>Power supply mode</source>
       <translation>Kragtoevoermodus</translation>
     </message>
-    <message id="inverters_state_sustain">
-      <location filename="../../data/System.qml" line="158"/>
-      <source>Sustain</source>
-      <translation type="unfinished">Onderhou</translation>
-    </message>
     <message id="inverters_state_wakeup">
       <location filename="../../data/System.qml" line="162"/>
       <source>Wake up</source>
@@ -6218,16 +5663,6 @@ Wil jy voortgaan?</translation>
       <location filename="../../data/System.qml" line="180"/>
       <source>Test</source>
       <translation>Toets</translation>
-    </message>
-    <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="183"/>
-      <source>External control</source>
-      <translation type="unfinished">Eksterne beheer</translation>
-    </message>
-    <message id="inverters_state_dynamic_ess">
-      <location filename="../../data/System.qml" line="198"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">Dinamiese WSD</translation>
     </message>
     <message id="settings_rs_ess_dess">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="97"/>
@@ -6306,16 +5741,13 @@ Wil jy voortgaan?</translation>
     <message id="ess_recommended">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="73"/>
       <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
       <translation>Vir litiumbatterye word onder 10% laai nie aanbeveel nie. Vir ander batterytipes, gaan die datablad na vir die minimum vlak wat deur die vervaardiger aanbeveel word.</translation>
-    </message>
-    <message id="controlcard_generator_label_autostart">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="63"/>
-      <source>Autostart</source>
-      <translation type="unfinished">Outomatiese begin</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
       <location filename="../../pages/controlcards/GeneratorCard.qml" line="70"/>
       <source>Start and stop the generator based on the configured autostart conditions.</source>
+      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
       <translation>Begin en stop die kragopwekker gebaseer op die gekonfigureerde outostart toestande.</translation>
     </message>
     <message id="generator_dialog_disabled">
@@ -6338,11 +5770,13 @@ Wil jy voortgaan?</translation>
       <location filename="../../pages/controlcards/InverterChargerCard.qml" line="26"/>
       <source>Inverter / Charger (%1)</source>
       <extracomment>%1 = the inverter/charger name</extracomment>
+      <oldsource>Inverter / Charger</oldsource>
       <translation>Omskakelaar/laaier (%1)</translation>
     </message>
     <message id="settings_page_debug_quit_application">
       <location filename="../../pages/settings/debug/PageDebug.qml" line="36"/>
       <source>Quit application</source>
+      <oldsource>Quit Application</oldsource>
       <translation>Verlaat toepassing</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
@@ -6353,12 +5787,8 @@ Wil jy voortgaan?</translation>
     <message id="settings_page_relay_generator_run_time">
       <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
       <source>Current run time</source>
+      <oldsource>Run time</oldsource>
       <translation>Huidige looptyd</translation>
-    </message>
-    <message id="settings_page_genset_generator_run_time">
-      <location filename="../../components/PageGensetModel.qml" line="102"/>
-      <source>Current run time</source>
-      <translation type="unfinished">Huidige looptyd</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
       <location filename="../../components/PageGensetModel.qml" line="110"/>
@@ -6385,19 +5815,10 @@ Wil jy voortgaan?</translation>
       <source>Remote start mode</source>
       <translation>Afstandbeginmodus</translation>
     </message>
-    <message id="ac-in-genset_speed">
-      <location filename="../../components/PageGensetModel.qml" line="245"/>
-      <source>Speed</source>
-      <translation type="unfinished">Spoed</translation>
-    </message>
-    <message id="ac-in-genset_load">
-      <location filename="../../components/PageGensetModel.qml" line="252"/>
-      <source>Load</source>
-      <translation type="unfinished">Laai</translation>
-    </message>
     <message id="ac-in-genset_oil_pressure">
       <location filename="../../components/PageGensetModel.qml" line="260"/>
       <source>Oil pressure</source>
+      <oldsource>Oil Pressure</oldsource>
       <translation>Oliedruk</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
@@ -6493,11 +5914,13 @@ Wil jy voortgaan?</translation>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
       <source>High starter battery voltage alarms</source>
+      <oldsource>High starter batttery voltage alarms</oldsource>
       <translation>Hoë aansitter battery spanning alarms</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
       <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
       <translation>Let daarop dat die verandering van die Time-to-go-ontladingsvloerinstelling ook die Lae toestand-van-lading-instelling in die afloskieslys verander.</translation>
     </message>
     <message id="lynxionsystem_cells_per_battery">
@@ -6574,6 +5997,7 @@ Wil jy voortgaan?</translation>
       <location filename="../../pages/settings/devicelist/delegates/DeviceListDelegate_solarcharger.qml" line="34"/>
       <source>Error: #%1</source>
       <extracomment>%1 = error number</extracomment>
+      <oldsource>Error: %1</oldsource>
       <translation>Fout: #%1</translation>
     </message>
     <message id="devicelistpage_genset">
@@ -6630,17 +6054,14 @@ Wil jy voortgaan?</translation>
     <message id="settings_page_relay_generator_auto_start_enabled">
       <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
       <source>Autostart functionality</source>
+      <oldsource>Auto start functionality</oldsource>
       <translation>Autostart-funksie</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="97"/>
       <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
       <translation>Maak seker dat die kragopwekker nie aan AC-invoer %1 gekoppel is wanneer hierdie opsie gebruik word nie</translation>
-    </message>
-    <message id="page_generator_conditions_inverter_high_temperature">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="139"/>
-      <source>Inverter high temperature</source>
-      <translation type="unfinished">Omskakelaar hoë temperatuur</translation>
     </message>
     <message id="page_generator_conditions_tank_level">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="159"/>
@@ -6670,30 +6091,34 @@ Wil jy voortgaan?</translation>
     <message id="settings_generator_function_not_enabled">
       <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
       <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
+      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
       <translation>Kragopwekker begin/stop-funksie is nie geaktiveer nie, gaan na aflosinstellings en stel funksie op "Genset start/stop"</translation>
     </message>
     <message id="settings_batteries_intro">
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="45"/>
       <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
       <translation>Gebruik hierdie kieslys om die batterydata te definieer wat gewys word wanneer die Battery-ikoon op die Oorsig-bladsy geklik word. Dieselfde keuse is ook sigbaar op die VRM-portaal.</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
       <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
       <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
       <translation>Deurlopende skandering kan inmeng met Wi-Fi-werking.</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
       <source>CAN-bus BMS LV (500 kbit/s)</source>
+      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
       <translation>CAN-bus BMS LV (500 kbit/s)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
       <source>CAN-bus BMS HV (500 kbit/s)</source>
       <translation>CAN-bus BMS HV (500 kbit/s)</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
       <source>Up, but no services (500 kbit/s)</source>
       <translation>Op, maar geen dienste (500 kbit/s)</translation>
     </message>
@@ -6706,41 +6131,6 @@ Wil jy voortgaan?</translation>
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="127"/>
       <source>Brief page</source>
       <translation>Kort bladsy</translation>
-    </message>
-    <message id="settings_displayoff_1min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="46"/>
-      <source>1 min</source>
-      <translation type="unfinished">1 min</translation>
-    </message>
-    <message id="settings_displayoff_10min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="48"/>
-      <source>10 min</source>
-      <translation type="unfinished">10 min</translation>
-    </message>
-    <message id="settings_displayoff_30min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="50"/>
-      <source>30 min</source>
-      <translation type="unfinished">30 min</translation>
-    </message>
-    <message id="settings_displayoff_never">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="52"/>
-      <source>Never</source>
-      <translation type="unfinished">Nooit nie</translation>
-    </message>
-    <message id="settings_remote_console_appearance_auto">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="112"/>
-      <source>Auto</source>
-      <translation type="unfinished">Outo</translation>
-    </message>
-    <message id="settings_brief_view_start_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="119"/>
-      <source>Start page</source>
-      <translation type="unfinished">Begin bladsy</translation>
-    </message>
-    <message id="settings_display_boat_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="135"/>
-      <source>Boat page</source>
-      <translation type="unfinished">Bootbladsy</translation>
     </message>
     <message id="settings_display_minmax">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="148"/>
@@ -6795,21 +6185,6 @@ Wil jy voortgaan?</translation>
       <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
       <translation>%1 is op %2 gestel</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_unsupported_device">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="50"/>
-      <source>Unsupported GX device</source>
-      <translation type="unfinished">Ongesteunde GX-toestel</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_clean">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="55"/>
-      <source>Clean</source>
-      <translation type="unfinished">Skoon</translation>
-    </message>
-    <message id="pagesettingsgeneral_firmware">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="112"/>
-      <source>Firmware</source>
-      <translation type="unfinished">Firmware</translation>
-    </message>
     <message id="pagesettingsgeneral_access_and_security">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
       <source>Access &amp; Security</source>
@@ -6843,6 +6218,7 @@ Wil jy voortgaan?</translation>
     <message id="settings_language_please_wait">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="209"/>
       <source>Please wait while the language is changed.</source>
+      <oldsource>Please wait while the language is changed</oldsource>
       <translation>Wag asseblief terwyl die taal verander word.</translation>
     </message>
     <message id="settings_briefview_totals">
@@ -6859,11 +6235,6 @@ Wil jy voortgaan?</translation>
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="71"/>
       <source>Tank is not connected.</source>
       <translation>Tenk is nie gekoppel nie.</translation>
-    </message>
-    <message id="settings_briefview_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="83"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">Aktiewe batterymonitor</translation>
     </message>
     <message id="settings_briefview_individual_batteries">
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="86"/>
@@ -6914,6 +6285,7 @@ Wil jy voortgaan?</translation>
     <message id="settings_dvcc_charge_current_limits">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="30"/>
       <source>Charge current limits</source>
+      <oldsource>Charge Current limits</oldsource>
       <translation>Laai Huidige limiete</translation>
     </message>
     <message id="settings_firmware_official_release">
@@ -6993,11 +6365,6 @@ Wil jy voortgaan?</translation>
       <source>No password and the network communication is not encrypted</source>
       <translation>Geen wagwoord nie en die netwerkkommunikasie is nie geïnkripteer nie</translation>
     </message>
-    <message id="settings_logout_now">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
-      <source>Log out now</source>
-      <translation type="unfinished">Meld nou uit</translation>
-    </message>
     <message id="settings_security_profile_password_incorrect_length">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="28"/>
       <source>Password needs to be at least 8 characters long</source>
@@ -7048,25 +6415,10 @@ Wil jy voortgaan?</translation>
       <source>Page will automatically reload in 5 seconds</source>
       <translation>Bladsy sal outomaties binne 5 sekondes herlaai</translation>
     </message>
-    <message id="settings_security_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="159"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">Wagwoord moet ten minste 8 karakters lank wees</translation>
-    </message>
     <message id="settings_root_password">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="269"/>
       <source>Root password</source>
       <translation>Wortel wagwoord</translation>
-    </message>
-    <message id="settings_root_enter_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="272"/>
-      <source>Enter password</source>
-      <translation type="unfinished">Sleutel wagwoord in</translation>
-    </message>
-    <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="277"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">Wagwoord moet ten minste 8 karakters lank wees</translation>
     </message>
     <message id="settings_root_password_changed_to">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="283"/>
@@ -7082,6 +6434,11 @@ Wil jy voortgaan?</translation>
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="321"/>
       <source>Logout</source>
       <translation>Teken uit</translation>
+    </message>
+    <message id="settings_logout_now">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
+      <source>Log out now</source>
+      <translation>Meld nou uit</translation>
     </message>
     <message id="settings_logout_dialog_title">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="335"/>
@@ -7141,11 +6498,13 @@ Wil jy voortgaan?</translation>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="141"/>
       <source>Alarm when generator is not in autostart mode</source>
+      <oldsource>Alarm when generator is not in auto start mode</oldsource>
       <translation>Alarm wanneer kragopwekker nie in outostart-modus is nie</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="147"/>
       <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
       <translation>'n Alarm sal geaktiveer word wanneer outobeginfunksie vir meer as 10 minute gedeaktiveer gelaat word</translation>
     </message>
     <message id="settings_units_amps_exceptions">
@@ -7161,6 +6520,11 @@ Wil jy voortgaan?</translation>
     <message id="settings_ess_use_this_option_for_peak_shaving">
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
       <source>Use this option for peak shaving.</source>
+      <oldsource>Use this option for peak shaving.
+
+The peak shaving threshold is set using the AC input current limit setting.
+
+See documentation for further information.</oldsource>
       <translation>Gebruik hierdie opsie vir  piek skeer</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
@@ -7204,17 +6568,17 @@ Wil jy voortgaan?</translation>
       <translation>Maksimum stelsel uitvoerstroom (per fase)</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="71"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="73"/>
       <source>Self-consumption from battery</source>
       <translation>Selfverbruik uit battery</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="76"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
       <source>All system loads</source>
       <translation>Alle stelsel laai</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="80"/>
       <source>Only critical loads</source>
       <translation>Slegs kritieke vragte</translation>
     </message>
@@ -7272,26 +6636,6 @@ Wil jy voortgaan?</translation>
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="194"/>
       <source>Server Applications</source>
       <translation>Bedienertoepassings</translation>
-    </message>
-    <message id="pagesettingsintegrations_venus_os_enable_large_features">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
-      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_large_victron_community">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="274"/>
-      <source>Victron Community</source>
-      <translation type="unfinished">Victron-gemeenskap</translation>
-    </message>
-    <message id="pagesettingsintegrations_ui_plugins">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
-      <source>UI Plugins</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
-      <source>Integrates with the device list</source>
-      <translation type="unfinished"/>
     </message>
     <message id="pagesettingssupportstate_modbus_tcp_server">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="453"/>
@@ -7394,25 +6738,10 @@ Wil jy voortgaan?</translation>
       <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
       <translation>Verandering van firmware-weergawe is nie moontlik sonder dat "Netwerksekuriteitsprofiel" in "Instellings / Algemeen" gekies is nie.</translation>
     </message>
-    <message id="pagesettingsconnectivity_ethernet">
-      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
-      <source>Ethernet</source>
-      <translation type="unfinished">Ethernet</translation>
-    </message>
     <message id="pagesettingsconnectivity_mobile_network">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="53"/>
       <source>Mobile Network</source>
       <translation>Mobiele netwerk</translation>
-    </message>
-    <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Boat</source>
-      <translation type="unfinished">Boot</translation>
-    </message>
-    <message id="settings_system_name_auto">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="32"/>
-      <source>Automatic</source>
-      <translation type="unfinished">Outomatiese</translation>
     </message>
     <message id="pagesettingssystem_ac_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
@@ -7443,11 +6772,6 @@ Wil jy voortgaan?</translation>
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="89"/>
       <source>Distributed Voltage and Current Control (DVCC)</source>
       <translation>Verspreide spanning en stroombeheer (DVCC)</translation>
-    </message>
-    <message id="settings_system_grid">
-      <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="18"/>
-      <source>Grid</source>
-      <translation type="unfinished">Rooster</translation>
     </message>
     <message id="settings_system_ac_position">
       <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="58"/>
@@ -7487,16 +6811,19 @@ Wil jy voortgaan?</translation>
     <message id="settings_system_has_dc_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="97"/>
       <source>Display DC Loads</source>
+      <oldsource>Has DC system</oldsource>
       <translation>Vertoon DC-ladings</translation>
     </message>
     <message id="settings_system_battery_measurements">
       <location filename="../../pages/settings/PageSettingsBatteries.qml" line="65"/>
       <source>Battery measurements</source>
+      <oldsource>Battery Measurements</oldsource>
       <translation>Battery metings</translation>
     </message>
     <message id="settings_system_system_status">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
       <source>System status</source>
+      <oldsource>System Status</oldsource>
       <translation>Stelsel Status</translation>
     </message>
     <message id="settings_tcpip_wired">
@@ -7507,11 +6834,13 @@ Wil jy voortgaan?</translation>
     <message id="settings_vecan_device_instance">
       <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
       <source>VE.Can Device Instance</source>
+      <oldsource>Device Instance</oldsource>
       <translation>VE.Can Device Instance</translation>
     </message>
     <message id="settings_vecan_device_number">
       <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="32"/>
       <source>VE.Can Instance# %1</source>
+      <oldsource>Device# %1</oldsource>
       <translation>VE.Can Instance# %1</translation>
     </message>
     <message id="settings_tz_antarctica">
@@ -7542,6 +6871,7 @@ Wil jy voortgaan?</translation>
     <message id="settings_vrm">
       <location filename="../../pages/SettingsPage.qml" line="59"/>
       <source>VRM</source>
+      <extracomment>Forced by %2 to dark</extracomment>
       <translation>VRM</translation>
     </message>
     <message id="settings_remote_monitoring_portal">
@@ -7549,20 +6879,10 @@ Wil jy voortgaan?</translation>
       <source>Remote monitoring portal</source>
       <translation>Afgeleë moniteringsportaal</translation>
     </message>
-    <message id="settings_advanced">
-      <location filename="../../pages/SettingsPage.qml" line="68"/>
-      <source>Advanced</source>
-      <translation type="unfinished">Gevorderd</translation>
-    </message>
-    <message id="settings_integrations">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
+    <message id="pagesettingssupportstate_integrations">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
       <source>Integrations</source>
       <translation>Integrasies</translation>
-    </message>
-    <message id="settings_relays_sensors_tanks">
-      <location filename="../../pages/SettingsPage.qml" line="75"/>
-      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
-      <translation type="unfinished">Relais, sensors, tenks, PV-omskakelaars, Modbus, MQTT …</translation>
     </message>
     <message id="settings_acdcsystem_ess_dvcc_battery">
       <location filename="../../pages/SettingsPage.qml" line="84"/>
@@ -7582,11 +6902,13 @@ Wil jy voortgaan?</translation>
     <message id="settings_system_setup">
       <location filename="../../pages/SettingsPage.qml" line="82"/>
       <source>System Setup</source>
+      <oldsource>System setup</oldsource>
       <translation>Stelsel opstelling</translation>
     </message>
     <message id="settings_vrm_device_instances">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
       <source>VRM device instances</source>
+      <oldsource>VRM Device Instances</oldsource>
       <translation>VRM-toestelgevalle</translation>
     </message>
     <message id="solarcharger_not_supported">
@@ -7604,28 +6926,10 @@ Wil jy voortgaan?</translation>
       <source>The firmware version in the MPPT Solar Charger must be v1.09 or later. Contact Victron Service for update instructions and files.</source>
       <translation>Die firmware weergawe in die MPPT Solar Charger moet v1.09 of later wees. Kontak Victron Service vir opdateringsinstruksies en lêers.</translation>
     </message>
-    <message id="solarcharger_pv">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="102"/>
-      <source>PV</source>
-      <extracomment>PV power for solar charger</extracomment>
-      <translation type="unfinished">PV</translation>
-    </message>
     <message id="solarcharger_total_power">
       <location filename="../../pages/solar/PageSolarCharger.qml" line="127"/>
       <source>Total PV power</source>
       <translation>Totale PV-krag</translation>
-    </message>
-    <message id="solarcharger_total_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="211"/>
-      <source>Total yield</source>
-      <extracomment>Solar charger total yield</extracomment>
-      <translation type="unfinished">Totale opbrengs</translation>
-    </message>
-    <message id="solarcharger_system_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="220"/>
-      <source>System yield</source>
-      <extracomment>Solar charger system yield</extracomment>
-      <translation type="unfinished">Stelsel opbrengs</translation>
     </message>
     <message id="settings_multirs_total_yield">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="63"/>
@@ -7661,16 +6965,19 @@ Wil jy voortgaan?</translation>
     <message id="vebus_device_update_firmware">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="133"/>
       <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
       <translation>Hierdie kenmerk vereis firmware weergawe 400 of hoër. Kontak jou installeerder om jou Multi/Quattro op te dateer.</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="139"/>
       <source>Charger not ready, equalization cannot be started</source>
+      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
       <translation>Laaier nie gereed nie, gelykstelling kan nie begin word nie</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="143"/>
       <source>Equalization cannot be triggered during bulk charge state</source>
+      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
       <translation>Gelykstelling kan nie tydens grootmaatladingtoestand geaktiveer word nie</translation>
     </message>
     <message id="vebus_device_restart_vebus_system_restart_confirmation_description">
@@ -7693,78 +7000,20 @@ Wil jy voortgaan?</translation>
       <source>Auto-started • %1</source>
       <translation>Outo-begin • %1</translation>
     </message>
-    <message id="common_words_battery">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery</source>
-      <translation type="unfinished">Battery</translation>
-    </message>
-    <message id="common_words_boat_page">
-      <location filename="../../components/CommonWords.qml" line="111"/>
-      <source>Boat</source>
-      <extracomment>The 'Boat' page</extracomment>
-      <translation type="unfinished">Boot</translation>
-    </message>
-    <message id="common_words_brief_page">
-      <location filename="../../components/CommonWords.qml" line="115"/>
-      <source>Brief</source>
-      <extracomment>The 'Brief' page</extracomment>
-      <translation type="unfinished">Kort</translation>
-    </message>
-    <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation type="unfinished">Gesluit</translation>
-    </message>
-    <message id="common_words_color">
-      <location filename="../../components/CommonWords.qml" line="136"/>
-      <source>Color</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_connected">
-      <location filename="../../components/CommonWords.qml" line="139"/>
-      <source>Connected</source>
-      <translation type="unfinished">Gekoppel</translation>
-    </message>
     <message id="common_words_daily_history">
       <location filename="../../components/CommonWords.qml" line="152"/>
       <source>Daily history</source>
       <translation>Daaglikse geskiedenis</translation>
-    </message>
-    <message id="common_words_disabled">
-      <location filename="../../components/CommonWords.qml" line="169"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Ontsluit</translation>
-    </message>
-    <message id="common_words_disconnected">
-      <location filename="../../components/CommonWords.qml" line="175"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Ontkoppel</translation>
-    </message>
-    <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="191"/>
-      <source>Error</source>
-      <translation type="unfinished">Fout</translation>
     </message>
     <message id="common_words_error_not_a_number">
       <location filename="../../components/CommonWords.qml" line="200"/>
       <source>'%1' is not a number.</source>
       <translation>'%1' is nie 'n nommer nie.</translation>
     </message>
-    <message id="common_words_generator">
-      <location filename="../../components/CommonWords.qml" line="217"/>
-      <source>Generator</source>
-      <translation type="unfinished">Opwekker</translation>
-    </message>
     <message id="common_words_input_current_limit">
       <location filename="../../components/CommonWords.qml" line="261"/>
       <source>Input current limit</source>
       <translation>Invoerstroomlimiet</translation>
-    </message>
-    <message id="common_words_inverter_charger">
-      <location filename="../../components/CommonWords.qml" line="264"/>
-      <source>Inverter / Charger</source>
-      <translation type="unfinished">Omsetter/laaier</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
       <location filename="../../components/CommonWords.qml" line="268"/>
@@ -7777,12 +7026,6 @@ Wil jy voortgaan?</translation>
       <source>Manual stop</source>
       <translation>Handmatige stop</translation>
     </message>
-    <message id="common_words_max">
-      <location filename="../../components/CommonWords.qml" line="315"/>
-      <source>Max</source>
-      <extracomment>Short for Maximum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_maximum_current">
       <location filename="../../components/CommonWords.qml" line="318"/>
       <source>Maximum current</source>
@@ -7793,62 +7036,10 @@ Wil jy voortgaan?</translation>
       <source>Maximum power</source>
       <translation>Maksimum krag</translation>
     </message>
-    <message id="common_words_min">
-      <location filename="../../components/CommonWords.qml" line="331"/>
-      <source>Min</source>
-      <extracomment>Short for Minimum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_minimum_current">
       <location filename="../../components/CommonWords.qml" line="334"/>
       <source>Minimum current</source>
       <translation>Minimum stroom</translation>
-    </message>
-    <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="433"/>
-      <source>No</source>
-      <translation type="unfinished">Nee/geen/nie</translation>
-    </message>
-    <message id="common_words_none_option">
-      <location filename="../../components/CommonWords.qml" line="364"/>
-      <source>None</source>
-      <translation type="unfinished">Geen</translation>
-    </message>
-    <message id="common_words_none_errors">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>None</source>
-      <extracomment>Indicates there are no errors</extracomment>
-      <translation type="unfinished">Geen</translation>
-    </message>
-    <message id="common_words_not_available">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Not available</source>
-      <translation type="unfinished">Nie beskikbaar nie</translation>
-    </message>
-    <message id="common_words_off">
-      <location filename="../../components/CommonWords.qml" line="377"/>
-      <source>Off</source>
-      <translation type="unfinished">Af</translation>
-    </message>
-    <message id="common_words_ok">
-      <location filename="../../components/CommonWords.qml" line="383"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="41"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="45"/>
-      <source>OK</source>
-      <translation type="unfinished">Reg</translation>
-    </message>
-    <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="386"/>
-      <source>On</source>
-      <translation type="unfinished">Aan</translation>
-    </message>
-    <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="393"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation type="unfinished">Oop</translation>
     </message>
     <message id="common_words_open_circuit">
       <location filename="../../components/CommonWords.qml" line="396"/>
@@ -7860,108 +7051,17 @@ Wil jy voortgaan?</translation>
       <source>Overall history</source>
       <translation>Algehele geskiedenis</translation>
     </message>
-    <message id="common_words_press">
-      <location filename="../../components/CommonWords.qml" line="419"/>
-      <source>Press</source>
-      <translation type="unfinished">Pers</translation>
-    </message>
-    <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation type="unfinished">Hardloop</translation>
-    </message>
-    <message id="common_words_settings">
-      <location filename="../../components/CommonWords.qml" line="467"/>
-      <source>Settings</source>
-      <translation type="unfinished">Instellings</translation>
-    </message>
-    <message id="common_words_silence_alarm">
-      <location filename="../../components/CommonWords.qml" line="476"/>
-      <source>Silence alarm</source>
-      <translation type="unfinished">Stil alarm</translation>
-    </message>
     <message id="common_words_soc">
       <location filename="../../components/CommonWords.qml" line="480"/>
       <source>SOC %1</source>
       <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
       <translation>SOC %1%</translation>
     </message>
-    <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation type="unfinished">Spoed</translation>
-    </message>
-    <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="487"/>
-      <source>Standby</source>
-      <translation type="unfinished">Staan by</translation>
-    </message>
-    <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="502"/>
-      <source>State</source>
-      <translation type="unfinished">Toestand</translation>
-    </message>
-    <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="512"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation type="unfinished">Opstart (%1)</translation>
-    </message>
-    <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>Stopped</source>
-      <translation type="unfinished">Gestop</translation>
-    </message>
-    <message id="common_words_total_power">
-      <location filename="../../components/CommonWords.qml" line="540"/>
-      <source>Total power</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="547"/>
-      <source>Type</source>
-      <translation type="unfinished">Tipe</translation>
-    </message>
-    <message id="common_words_unknown_status">
-      <location filename="../../components/CommonWords.qml" line="554"/>
-      <source>Unknown</source>
-      <extracomment>Status = "unknown"</extracomment>
-      <translation type="unfinished">Onbekend</translation>
-    </message>
-    <message id="common_words_value_must_be_greater_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="557"/>
-      <source>Value must be greater than start value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_value_must_be_greater_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="560"/>
-      <source>Value must be greater than stop value</source>
-      <translation type="unfinished">Waarde moet groter as stopwaarde wees</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="563"/>
-      <source>Value must be lower than start value</source>
-      <translation type="unfinished">Waarde moet laer as beginwaarde wees</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="566"/>
-      <source>Value must be lower than stop value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="581"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="431"/>
-      <source>Yes</source>
-      <translation type="unfinished">Ja</translation>
-    </message>
     <message id="common_words_yield_today">
       <location filename="../../components/CommonWords.qml" line="592"/>
       <source>Yield Today</source>
       <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+      <oldsource>Yield today</oldsource>
       <translation>Opbrengs vandag</translation>
     </message>
     <message id="common_words_format_error">
@@ -7988,10 +7088,11 @@ Wil jy voortgaan?</translation>
     <message id="settings_firmware_installed_rebooting">
       <location filename="../../components/FirmwareUpdate.qml" line="79"/>
       <source>Firmware installed, device rebooting</source>
+      <oldsource>Firmware installed, rebooting.</oldsource>
       <translation>Fermware geïnstalleer, toestel herlaai</translation>
     </message>
-    <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/RadioButtonListPage.qml" line="121"/>
+    <message id="modaldialog_confirm">
+      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
       <source>Confirm</source>
       <extracomment>Confirm password, and verify it if possible</extracomment>
       <translation>Bevestig</translation>
@@ -8009,11 +7110,13 @@ Wil jy voortgaan?</translation>
     <message id="cgwacs_battery_schedule_duration">
       <location filename="../../components/listitems/ListChargeSchedule.qml" line="144"/>
       <source>Duration</source>
+      <oldsource>Duration (hh:mm)</oldsource>
       <translation>Duur</translation>
     </message>
     <message id="settings_relay_deactivation_value">
       <location filename="../../components/TemperatureRelaySettings.qml" line="86"/>
       <source>Deactivation value</source>
+      <oldsource>Deativation value</oldsource>
       <translation>Deaktiveringswaarde</translation>
     </message>
     <message id="splash_view_device_disconnected">
@@ -8061,29 +7164,6 @@ Wil jy voortgaan?</translation>
       <source>Temperature warning</source>
       <translation>Waarskuwing oor temperatuur</translation>
     </message>
-    <message id="battery_mode_idle">
-      <location filename="../../src/enums.cpp" line="26"/>
-      <source>Idle</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Ledig</translation>
-    </message>
-    <message id="battery_mode_charging">
-      <location filename="../../src/enums.cpp" line="30"/>
-      <source>Charging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Laai</translation>
-    </message>
-    <message id="battery_mode_discharging">
-      <location filename="../../src/enums.cpp" line="34"/>
-      <source>Discharging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Ontlaai</translation>
-    </message>
-    <message id="dcMeter_bilge_pump">
-      <location filename="../../src/enums.cpp" line="115"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">Lenspomp</translation>
-    </message>
     <message id="switch_state_channel_fault">
       <location filename="../../src/enums.cpp" line="372"/>
       <source>Channel Fault</source>
@@ -8114,26 +7194,6 @@ Wil jy voortgaan?</translation>
       <source>Slave of %1</source>
       <translation>Slaaf van %1</translation>
     </message>
-    <message id="switchable_output_numeric_input">
-      <location filename="../../src/enums.cpp" line="418"/>
-      <source>Numeric input</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bilge_pump">
-      <location filename="../../src/enums.cpp" line="424"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">Lenspomp</translation>
-    </message>
-    <message id="switchable_output_not_running">
-      <location filename="../../src/enums.cpp" line="448"/>
-      <source>Not running</source>
-      <translation type="unfinished">Nie hardloop nie</translation>
-    </message>
-    <message id="switchable_output_off">
-      <location filename="../../src/enums.cpp" line="451"/>
-      <source>Off</source>
-      <translation type="unfinished">Af</translation>
-    </message>
     <message id="switchable_output_powered">
       <location filename="../../src/enums.cpp" line="455"/>
       <source>Powered</source>
@@ -8162,16 +7222,19 @@ Wil jy voortgaan?</translation>
     <message id="evchargers_status_welded_contacts_error">
       <location filename="../../data/EvChargers.qml" line="76"/>
       <source>Welded contacts test error (shorted)</source>
+      <oldsource>Welded contacts error</oldsource>
       <translation>Gelaste kontakte toetsfout (verkort)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
       <location filename="../../data/EvChargers.qml" line="100"/>
       <source>Switching to 3 phase</source>
+      <oldsource>Switching to 3-phase</oldsource>
       <translation>Skakel oor na 3 fase</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
       <location filename="../../data/EvChargers.qml" line="103"/>
       <source>Switching to 1 phase</source>
+      <oldsource>Switching to single phase</oldsource>
       <translation>Skakel oor na 1 fase</translation>
     </message>
     <message id="evchargers_status_stop_charging">
@@ -8324,17 +7387,6 @@ As die kragopwekker tans aan die gang is as gevolg van 'n outostart toestand, sa
       <source>Open link</source>
       <translation>Maak skakel oop</translation>
     </message>
-    <message id="listlink_show_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="43"/>
-      <source>Show QR code</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="listlink_scan_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="52"/>
-      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
-      <extracomment>%1 = url text</extracomment>
-      <translation type="unfinished">Skandeer die QR-kode met jou draagbare toestel.&lt;br /&gt;Of voeg die skakel in: %1</translation>
-    </message>
     <message id="settings_services_mqtt_access">
       <location filename="../../components/listitems/ListMqttAccessSwitch.qml" line="11"/>
       <source>MQTT Access</source>
@@ -8406,12 +7458,6 @@ As die kragopwekker tans aan die gang is as gevolg van 'n outostart toestand, sa
       <extracomment>The 'Brief' page, with the side panel opened</extracomment>
       <translation>Kort (sypaneel oop)</translation>
     </message>
-    <message id="startpage_option_overview">
-      <location filename="../../data/StartPageConfiguration.qml" line="37"/>
-      <source>Overview</source>
-      <extracomment>The 'Overview' page</extracomment>
-      <translation type="unfinished">Oorsig</translation>
-    </message>
     <message id="startpage_option_levels_tanks">
       <location filename="../../data/StartPageConfiguration.qml" line="43"/>
       <source>Levels (Tanks)</source>
@@ -8430,12 +7476,12 @@ As die kragopwekker tans aan die gang is as gevolg van 'n outostart toestand, sa
       <translation>Battery lys</translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
+      <location filename="../../pages/DialogLayer.qml" line="56"/>
       <source>GX device has been updated</source>
       <translation>GX-toestel is opgedateer</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
+      <location filename="../../pages/DialogLayer.qml" line="58"/>
       <source>Page will automatically reload in ten seconds to load the latest version.</source>
       <translation>Bladsy sal outomaties binne tien sekondes herlaai om die nuutste weergawe te laai.</translation>
     </message>
@@ -8605,8 +7651,8 @@ Let daarop dat hierdie spyskaart slegs Carlo Gavazzi-meters wys wat oor RS485 ge
       <source>Unit</source>
       <translation>Eenheid</translation>
     </message>
-    <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="61"/>
+    <message id="page_settings_fronius_unitid_invalid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
       <source>%1 is not a valid unit number. Use a number between 1-247.</source>
       <translation>%1 is nie 'n geldige eenheidnommer nie. Gebruik 'n nommer tussen 1-247.</translation>
     </message>
@@ -8721,11 +7767,6 @@ Let daarop dat hierdie spyskaart slegs Carlo Gavazzi-meters wys wat oor RS485 ge
       <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="66"/>
       <source>Controller Temperature</source>
       <translation>Kontroleerder temperatuur</translation>
-    </message>
-    <message id="devicelist_motordrive_motordirectioninverted">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
-      <source>Motor Direction Inverted</source>
-      <translation type="unfinished"/>
     </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
@@ -8917,11 +7958,6 @@ Met vaartbelynde navigasie en 'n vars voorkoms is alles waarvan jy hou nou selfs
     <message id="welcome_done">
       <location filename="../../pages/welcome/WelcomeView.qml" line="136"/>
       <source>Done</source>
-      <translation type="unfinished">Klaar</translation>
-    </message>
-    <message id="mk2vsc_state_done">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="20"/>
-      <source>Done</source>
       <translation>Klaar</translation>
     </message>
     <message id="welcome_next">
@@ -8979,6 +8015,7 @@ Die GX-toestel kan net een gekoppelde genset beheer en neem die een met die laag
     <message id="settings_tz_etc">
       <location filename="../../pages/settings/PageTzInfo.qml" line="280"/>
       <source>Other</source>
+      <oldsource>Etc</oldsource>
       <translation>Ander</translation>
     </message>
     <message id="ac-in-modeldefault_energy_reverse_x">
@@ -8996,6 +8033,11 @@ Die GX-toestel kan net een gekoppelde genset beheer en neem die een met die laag
       <location filename="../../src/enums.cpp" line="438"/>
       <source>Unsupported type: %1</source>
       <translation>Nie-ondersteunde tipe: %1</translation>
+    </message>
+    <message id="common_words_press">
+      <location filename="../../components/CommonWords.qml" line="419"/>
+      <source>Press</source>
+      <translation>Pers</translation>
     </message>
     <message id="output_aux_battery_service_changed_dcdc">
       <location filename="../../components/listitems/ListOutputBatteryRadioButtonGroup.qml" line="27"/>
@@ -9136,13 +8178,6 @@ Die GX-toestel kan net een gekoppelde genset beheer en neem die een met die laag
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="38"/>
       <source>Resetting VE.Bus products</source>
       <translation>Herstel van VE.Bus-produkte</translation>
-    </message>
-    <message id="Unknown">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Onbekend</translation>
     </message>
     <message id="mk2vsc_error_mk2_mk3_comm">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="47"/>
@@ -9448,11 +8483,6 @@ Die GX-toestel kan net een gekoppelde genset beheer en neem die een met die laag
       <source>Changing the GX Password</source>
       <translation>Verandering van die GX Wagwoord</translation>
     </message>
-    <message id="modaldialog_confirm">
-      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
-      <source>Confirm</source>
-      <translation type="unfinished">Bevestig</translation>
-    </message>
     <message id="settings_security_profile_change_password_description">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="83"/>
       <source>Please enter a new GX password:</source>
@@ -9545,21 +8575,6 @@ Die GX-toestel kan net een gekoppelde genset beheer en neem die een met die laag
       <source>Modifications installed</source>
       <translation>Wysigings geïnstalleer</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_modbus">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="28"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">Modbus TCP-bediener</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_signalk">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="32"/>
-      <source>Signal K</source>
-      <translation type="unfinished">Sein K</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_nodered">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="36"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">Node-ROOI</translation>
-    </message>
     <message id="pagesettingsgeneral_modificationchecks_running_integrations">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="43"/>
       <source>%1 running integrations</source>
@@ -9635,16 +8650,6 @@ Die GX-toestel kan net een gekoppelde genset beheer en neem die een met die laag
       <source>Installed and enabled, disables at next boot</source>
       <translation>Geïnstalleer en geaktiveer, deaktiveer by volgende herlaai</translation>
     </message>
-    <message id="pagesettingssupportstate_firmware_checking">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
-      <source>Checking...</source>
-      <translation type="unfinished">Nagaan...</translation>
-    </message>
-    <message id="pagesettingssupportstate_firmware_unknown">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="166"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Onbekend</translation>
-    </message>
     <message id="pagesettingssupportstate_support_status">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="228"/>
       <source>Support status</source>
@@ -9666,11 +8671,6 @@ Die GX-toestel kan net een gekoppelde genset beheer en neem die een met die laag
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="288"/>
       <source>Press 'OK' to disable custom startup scripts and reboot</source>
       <translation>Druk 'OK' om pasgemaakte opstartskripte te deaktiveer en herlaai</translation>
-    </message>
-    <message id="pagesettingssupportstate_re_enable_custom_startup_scripts">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="309"/>
-      <source>Re-enable custom startup scripts</source>
-      <translation type="unfinished">Heraktiveer pasgemaakte opstartskripte</translation>
     </message>
     <message id="pagesettingssupportstate_reenable_and_reboot_now">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="322"/>
@@ -9697,11 +8697,6 @@ Die GX-toestel kan net een gekoppelde genset beheer en neem die een met die laag
       <source>Disable also custom startup scripts?</source>
       <translation>Deaktiveer ook pasgemaakte opstartskripte?</translation>
     </message>
-    <message id="pagesettingssupportstate_integrations">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
-      <source>Integrations</source>
-      <translation type="unfinished">Integrasies</translation>
-    </message>
     <message id="pagesettingssupportstate_orange_items_description">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="494"/>
       <source>Items colored orange are supported and provided by Victron Energy, but using them incorrectly can affect system stability. In case of troubleshooting, disable those first.</source>
@@ -9713,7 +8708,7 @@ Die GX-toestel kan net een gekoppelde genset beheer en neem die een met die laag
       <translation>Koppel 'n versoenbare Bluetooth USB-dongel om Bluetooth-konneksie te aktiveer.</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="140"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="142"/>
       <source>BatteryLife state</source>
       <translation>BatteryLife toestand</translation>
     </message>
@@ -9721,23 +8716,6 @@ Die GX-toestel kan net een gekoppelde genset beheer en neem die een met die laag
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="33"/>
       <source>Device Integrations</source>
       <translation>Toestelintegrasies</translation>
-    </message>
-    <message id="pagesettingsintegrations_modbus_tcp_server">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="201"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">Modbus TCP-bediener</translation>
-    </message>
-    <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="226"/>
-      <location filename="../../pages/settings/PageSettingsSignalK.qml" line="18"/>
-      <source>Signal K</source>
-      <translation type="unfinished">Sein K</translation>
-    </message>
-    <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="241"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">Node-ROOI</translation>
     </message>
     <message id="settings_venusos_large_documentation">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="267"/>
@@ -9747,6 +8725,7 @@ Die GX-toestel kan net een gekoppelde genset beheer en neem die een met die laag
     <message id="settings_modbus_enable_modbus_tcp">
       <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
       <source>Enable Modbus TCP Server</source>
+      <oldsource>Enable Modbus/TCP</oldsource>
       <translation>Aktiveer Modbus TCP Bediener</translation>
     </message>
     <message id="pagesettingsconnectivity_bluetooth_for_victronconnect_app">
@@ -9840,11 +8819,13 @@ Die GX-toestel kan net een gekoppelde genset beheer en neem die een met die laag
     <message id="settings_gps_format_kmh">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="93"/>
       <source>Kilometres per hour</source>
+      <oldsource>Kilometers per hour</oldsource>
       <translation>Kilometers per uur</translation>
     </message>
     <message id="settings_gps_format_ms">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="95"/>
       <source>Metres per second</source>
+      <oldsource>Meters per second</oldsource>
       <translation>Meter per sekonde</translation>
     </message>
     <message id="components_volumeunit_cubic_metres">
@@ -9872,8 +8853,8 @@ Die GX-toestel kan net een gekoppelde genset beheer en neem die een met die laag
       <source>The Relay can now be found in the devices list</source>
       <translation>Die Relais kan nou in die toestellys gevind word</translation>
     </message>
-    <message id="common_words_gx_device_relays">
-      <location filename="../../components/CommonWords.qml" line="223"/>
+    <message id="gx_device_relays">
+      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
       <source>GX device relays</source>
       <translation>GX toestel relais</translation>
     </message>
@@ -9927,12 +8908,6 @@ Die GX-toestel kan net een gekoppelde genset beheer en neem die een met die laag
       <extracomment>Forced by app to %1</extracomment>
       <translation>outo</translation>
     </message>
-    <message id="settings_remote_console_forced_by_vrm">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="94"/>
-      <source>VRM</source>
-      <extracomment>Forced by %2 to dark</extracomment>
-      <translation type="unfinished">VRM</translation>
-    </message>
     <message id="settings_remote_console_forced_by_app">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="97"/>
       <source>app</source>
@@ -9982,6 +8957,7 @@ Die GX-toestel kan net een gekoppelde genset beheer en neem die een met die laag
     <message id="settings_large_access_signal_k">
       <location filename="../../pages/settings/PageSettingsSignalK.qml" line="24"/>
       <source>Access Signal K</source>
+      <oldsource>Access Signal K (local network)</oldsource>
       <translation>Toegang Sein K</translation>
     </message>
     <message id="pagesettingsintegrations_shelly_devices">
@@ -9992,6 +8968,7 @@ Die GX-toestel kan net een gekoppelde genset beheer en neem die een met die laag
     <message id="settings_large_access_node_red">
       <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
       <source>Access Node-RED</source>
+      <oldsource>Access Node-RED (local network)</oldsource>
       <translation>Toegang Node-RED</translation>
     </message>
     <message id="settings_wifi_access_point_password">
@@ -10059,57 +9036,6 @@ Die GX-toestel kan net een gekoppelde genset beheer en neem die een met die laag
       <source>Wind charger</source>
       <translation>Windlaaier</translation>
     </message>
-    <message id="digitalinputs_type_disabled">
-      <location filename="../../src/enums.cpp" line="192"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Ontsluit</translation>
-    </message>
-    <message id="digitalinputs_state_off">
-      <location filename="../../src/enums.cpp" line="242"/>
-      <source>Off</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Af</translation>
-    </message>
-    <message id="digitalinputs_state_on">
-      <location filename="../../src/enums.cpp" line="246"/>
-      <source>On</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Aan</translation>
-    </message>
-    <message id="digitalinputs_state_ok">
-      <location filename="../../src/enums.cpp" line="266"/>
-      <source>OK</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Reg</translation>
-    </message>
-    <message id="digitalinputs_state_alarm">
-      <location filename="../../src/enums.cpp" line="270"/>
-      <source>Alarm</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Alarm</translation>
-    </message>
-    <message id="digitalinputs_state_running">
-      <location filename="../../src/enums.cpp" line="274"/>
-      <source>Running</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Hardloop</translation>
-    </message>
-    <message id="pvinverter_statusCode_running">
-      <location filename="../../src/enums.cpp" line="300"/>
-      <source>Running</source>
-      <extracomment>PV inverter status code</extracomment>
-      <translation type="unfinished">Hardloop</translation>
-    </message>
-    <message id="solarchargers_state_external control">
-      <location filename="../../src/enums.cpp" line="352"/>
-      <source>External control</source>
-      <translation type="unfinished">Eksterne beheer</translation>
-    </message>
-    <message id="switch_state_over_temperature">
-      <location filename="../../src/enums.cpp" line="366"/>
-      <source>Over temperature</source>
-      <translation type="unfinished">Oor temperatuur</translation>
-    </message>
     <message id="switchable_output_temperature_setpoint">
       <location filename="../../src/enums.cpp" line="398"/>
       <source>Temperature setpoint</source>
@@ -10119,11 +9045,6 @@ Die GX-toestel kan net een gekoppelde genset beheer en neem die een met die laag
       <location filename="../../src/enums.cpp" line="401"/>
       <source>Stepped switch</source>
       <translation>Gegradueerde skakelaar</translation>
-    </message>
-    <message id="switchable_output_slave">
-      <location filename="../../src/enums.cpp" line="408"/>
-      <source>Slave</source>
-      <translation type="unfinished">Slaaf</translation>
     </message>
     <message id="switchable_output_dropdown">
       <location filename="../../src/enums.cpp" line="412"/>
@@ -10135,122 +9056,10 @@ Die GX-toestel kan net een gekoppelde genset beheer en neem die een met die laag
       <source>Basic slider</source>
       <translation>Basiese skuifbalk</translation>
     </message>
-    <message id="switchable_output_rgb_color_wheel">
-      <location filename="../../src/enums.cpp" line="427"/>
-      <source>RGB color wheel</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_cct_color_wheel">
-      <location filename="../../src/enums.cpp" line="431"/>
-      <source>CCT color wheel</source>
-      <extracomment>Correlated Color Temperature color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_rgbw_color_wheel">
-      <location filename="../../src/enums.cpp" line="435"/>
-      <source>RGB + W color wheel</source>
-      <extracomment>RGB + white color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bypassed">
-      <location filename="../../src/enums.cpp" line="484"/>
-      <source>Bypassed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="tank_type_fuel">
-      <location filename="../../src/enums.cpp" line="495"/>
-      <source>Fuel</source>
-      <translation type="unfinished">Brandstof</translation>
-    </message>
-    <message id="tank_type_fresh_water">
-      <location filename="../../src/enums.cpp" line="498"/>
-      <source>Fresh water</source>
-      <translation type="unfinished">Vars water</translation>
-    </message>
-    <message id="tank_type_waste_water">
-      <location filename="../../src/enums.cpp" line="501"/>
-      <source>Waste water</source>
-      <translation type="unfinished">Afvalwater</translation>
-    </message>
-    <message id="tank_type_live_well">
-      <location filename="../../src/enums.cpp" line="504"/>
-      <source>Live well</source>
-      <translation type="unfinished">Leef goed</translation>
-    </message>
-    <message id="tank_type_oil">
-      <location filename="../../src/enums.cpp" line="507"/>
-      <source>Oil</source>
-      <translation type="unfinished">Olie</translation>
-    </message>
-    <message id="tank_type_black_water">
-      <location filename="../../src/enums.cpp" line="510"/>
-      <source>Black water</source>
-      <translation type="unfinished">Swart water</translation>
-    </message>
-    <message id="tank_type_gasoline">
-      <location filename="../../src/enums.cpp" line="513"/>
-      <source>Gasoline</source>
-      <translation type="unfinished">Petrol</translation>
-    </message>
-    <message id="tank_type_diesel">
-      <location filename="../../src/enums.cpp" line="516"/>
-      <source>Diesel</source>
-      <translation type="unfinished">Diesel</translation>
-    </message>
-    <message id="tank_type_lpg">
-      <location filename="../../src/enums.cpp" line="519"/>
-      <source>LPG</source>
-      <translation type="unfinished">VPG</translation>
-    </message>
-    <message id="tank_type_lng">
-      <location filename="../../src/enums.cpp" line="522"/>
-      <source>LNG</source>
-      <translation type="unfinished">VNG</translation>
-    </message>
-    <message id="tank_type_hydraulic_oil">
-      <location filename="../../src/enums.cpp" line="525"/>
-      <source>Hydraulic oil</source>
-      <translation type="unfinished">Hidroliese olie</translation>
-    </message>
-    <message id="tank_type_raw_water">
-      <location filename="../../src/enums.cpp" line="528"/>
-      <source>Raw water</source>
-      <translation type="unfinished">Rou water</translation>
-    </message>
-    <message id="microgrid_mode_hybrid_droop">
-      <location filename="../../src/enums.cpp" line="539"/>
-      <source>Hybrid droop</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_following">
-      <location filename="../../src/enums.cpp" line="542"/>
-      <source>Grid-following</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_forming">
-      <location filename="../../src/enums.cpp" line="545"/>
-      <source>Grid-forming</source>
-      <translation type="unfinished"/>
-    </message>
     <message id="switchable_output_three_state_switch">
       <location filename="../../src/enums.cpp" line="421"/>
       <source>Three-state switch</source>
       <translation>Drie-staat skakelaar</translation>
-    </message>
-    <message id="switchable_output_fault">
-      <location filename="../../src/enums.cpp" line="464"/>
-      <source>Fault</source>
-      <translation type="unfinished">Fout</translation>
-    </message>
-    <message id="switchable_output_running">
-      <location filename="../../src/enums.cpp" line="468"/>
-      <source>Running</source>
-      <translation type="unfinished">Hardloop</translation>
-    </message>
-    <message id="switchable_output_trip_low_voltage">
-      <location filename="../../src/enums.cpp" line="481"/>
-      <source>Trip low voltage</source>
-      <translation type="unfinished">Ontsluit</translation>
     </message>
     <message id="settings_modbus_tcp_unit_id_note">
       <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="41"/>
@@ -10272,281 +9081,1152 @@ Die GX-toestel kan net een gekoppelde genset beheer en neem die een met die laag
       <source>Press to refresh</source>
       <translation>Druk om te verfris</translation>
     </message>
-    <message id="temperature_type_unknown">
-      <location filename="../../data/EnvironmentInputs.qml" line="65"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Onbekend</translation>
-    </message>
-    <message id="brief_solar_yield">
-      <location filename="../../pages/BriefSidePanel.qml" line="24"/>
-      <source>Solar yield</source>
-      <translation type="unfinished">Sonopbrengs</translation>
-    </message>
-    <message id="brief_dc_input">
-      <location filename="../../pages/BriefSidePanel.qml" line="214"/>
-      <source>DC input</source>
-      <translation type="unfinished">DC-invoer</translation>
-    </message>
-    <message id="brief_ac_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="257"/>
-      <source>AC Loads</source>
-      <translation type="unfinished">WS-ladings</translation>
-    </message>
-    <message id="brief_dc_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="284"/>
-      <source>DC Loads</source>
-      <translation type="unfinished">DG-ladings</translation>
-    </message>
-    <message id="nav_overview">
-      <location filename="../../pages/OverviewPage.qml" line="450"/>
-      <source>Overview</source>
-      <translation type="unfinished">Oorsig</translation>
-    </message>
-    <message id="settings_state">
-      <location filename="../../pages/settings/PageCanbusStatus.qml" line="116"/>
-      <source>State</source>
-      <translation type="unfinished">Toestand</translation>
-    </message>
-    <message id="inverter_pv">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="56"/>
-      <source>PV</source>
-      <translation type="unfinished">PV</translation>
-    </message>
-    <message id="inverter_total_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="76"/>
-      <source>Total yield</source>
-      <translation type="unfinished">Totale opbrengs</translation>
-    </message>
-    <message id="inverter_system_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="84"/>
-      <source>System yield</source>
-      <translation type="unfinished">Stelsel opbrengs</translation>
-    </message>
-    <message id="charger_total_pv_power">
-      <location filename="../../pages/solar/SolarDevicePage.qml" line="61"/>
-      <source>Total PV Power</source>
-      <translation type="unfinished">Totale PV-krag</translation>
-    </message>
-    <message id="vebus_device_alarm_only">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
-      <source>Alarm only</source>
-      <translation type="unfinished">Slegs alarm</translation>
-    </message>
-    <message id="vebus_device_alarms_and_warnings">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
-      <source>Alarms &amp; warnings</source>
-      <translation type="unfinished">Alarms en waarskuwings</translation>
-    </message>
-    <message id="vebus_device_alarm_group_warning">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
-      <source>Warning</source>
-      <translation type="unfinished">Waarskuwing</translation>
-    </message>
-    <message id="load_delegate_status">
-      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
-      <source>Status: %1</source>
-      <translation type="unfinished"/>
+    <message id="common_words_total_power">
+      <location filename="../../components/CommonWords.qml" line="540"/>
+      <source>Total power</source>
+      <translation>Totale drywing</translation>
     </message>
     <message id="venus_os_gui">
       <location filename="../../Main.qml" line="17"/>
       <source>Venus OS GUI</source>
       <extracomment>Application title</extracomment>
-      <translation type="unfinished"/>
       <extra-Context>only shown on desktop systems</extra-Context>
+      <translation>Venus OS GUI</translation>
+    </message>
+    <message id="load_delegate_status">
+      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
+      <source>Status: %1</source>
+      <translation>Status: %1</translation>
+    </message>
+    <message id="settings_relay_polarity_relay1">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
+      <source>Polarity (Relay 1)</source>
+      <translation>Polariteit (Relais 1)</translation>
+    </message>
+    <message id="settings_relay_polarity">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
+      <source>Polarity</source>
+      <translation>Polariteit</translation>
+    </message>
+    <message id="settings_relay_polarity_relay2">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
+      <source>Polarity (Relay 2)</source>
+      <translation>Polariteit (Relais 2)</translation>
+    </message>
+    <message id="page_settings_wifi_invalid_password">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
+      <source>Password length must be either 0 or between 10 and 63 characters long</source>
+      <translation>Wagwoordlengte moet óf 0 óf tussen 10 en 63 karakters lank wees</translation>
+    </message>
+    <message id="page_settings_wifi_password_updated">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
+      <source>Password updated</source>
+      <translation>Wagwoord opgedateer</translation>
+    </message>
+    <message id="common_words_max">
+      <location filename="../../components/CommonWords.qml" line="315"/>
+      <source>Max</source>
+      <extracomment>Short for Maximum</extracomment>
+      <translation>Maks</translation>
+    </message>
+    <message id="common_words_min">
+      <location filename="../../components/CommonWords.qml" line="331"/>
+      <source>Min</source>
+      <extracomment>Short for Minimum</extracomment>
+      <translation>Min</translation>
+    </message>
+    <message id="settings_ess_deprecated">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="321"/>
+      <source>Deprecated settings</source>
+      <translation>Verouderde instellings</translation>
+    </message>
+    <message id="settings_ess_max_charge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="328"/>
+      <source>Battery charge limit (% of CCL)</source>
+      <translation>Battery laai limiet (% van CCL)</translation>
+    </message>
+    <message id="settings_ess_max_discharge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="339"/>
+      <source>Battery discharge limit (% of DCL)</source>
+      <translation>Battery ontlaai limiet (% van DCL)</translation>
+    </message>
+    <message id="vebus_device_bms_message">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
+      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
+      <oldsource>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</oldsource>
+      <translation>'n VE.Bus BMS skakel die stelsel outomaties af wanneer nodig om die battery te beskerm. Om die stelsel vanaf die GX-toestel te beheer is dus nie moontlik nie.</translation>
+    </message>
+    <message id="switchable_output_numeric_input">
+      <location filename="../../src/enums.cpp" line="418"/>
+      <source>Numeric input</source>
+      <translation>Numeriese invoer</translation>
     </message>
     <message id="autotoggleswitch_disable_auto_mode_info">
       <location filename="../../components/controls/AutoToggleButton.qml" line="34"/>
       <source>Disable Auto mode first</source>
-      <translation type="unfinished"/>
+      <translation>Skakel eers Outo-modus af</translation>
+    </message>
+    <message id="pagesettingsintegrations_venus_os_enable_large_features">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
+      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
+      <translation>Aktiveer die Venus OS Large fermware om Node-RED of Signal-K te gebruik</translation>
+    </message>
+    <message id="settings_relays_sensors_tanks">
+      <location filename="../../pages/SettingsPage.qml" line="75"/>
+      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
+      <oldsource>Relays, Sensors, Tanks, PV Inverters, Modbus, MQTT…</oldsource>
+      <translation>Relais, Sensors, PV Omskakelaars, Modbus, Node-RED</translation>
+    </message>
+    <message id="vebus_device_page_microgrid_parameters">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
+      <source>Microgrid parameters</source>
+      <translation>Mikro-netwerk parameters</translation>
+    </message>
+    <message id="microgrid_mode_hybrid_droop">
+      <location filename="../../src/enums.cpp" line="539"/>
+      <source>Hybrid droop</source>
+      <translation>Hibridiese droop</translation>
+    </message>
+    <message id="microgrid_mode_grid_following">
+      <location filename="../../src/enums.cpp" line="542"/>
+      <source>Grid-following</source>
+      <translation>Netwerk-volgend</translation>
+    </message>
+    <message id="microgrid_mode_grid_forming">
+      <location filename="../../src/enums.cpp" line="545"/>
+      <source>Grid-forming</source>
+      <translation>Netwerk-vormend</translation>
+    </message>
+    <message id="switchable_output_trip_low_voltage">
+      <location filename="../../src/enums.cpp" line="481"/>
+      <source>Trip low voltage</source>
+      <oldsource>Disabled</oldsource>
+      <translation>Ontkoppel lae spanning</translation>
     </message>
     <message id="microgrid">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="15"/>
       <source>Microgrid</source>
-      <translation type="unfinished"/>
+      <translation>Mikro-netwerk</translation>
     </message>
     <message id="page_microgrid_active_mode">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="19"/>
       <source>Active mode</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_microgrid_from_p1_to_p2">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="34"/>
-      <source>%1 %2 to %3 %4</source>
-      <extracomment>Describes a range from one quantity to another, e.g. "30 W to 60 W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
-      <translation type="unfinished"/>
+      <translation>Aktiewe modus</translation>
     </message>
     <message id="page_microgrid_hybrid_droop_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="92"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
       <source>Hybrid droop parameters</source>
-      <translation type="unfinished"/>
+      <translation>Hibridiese droop parameters</translation>
     </message>
     <message id="page_microgrid_reference_active_power_p0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="105"/>
       <source>Reference active power (P&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Verwysings aktiewe krag (P&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_frequency_f0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="108"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="112"/>
       <source>Reference frequency (f&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Verwysings frekwensie (f&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_frequency_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="117"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="119"/>
       <source>Frequency droop slope (droop&lt;sub&gt;fP&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Frekwensie droop helling (droop&lt;sub&gt;fP&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_reactive_power">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="126"/>
       <source>Reference reactive power (Q&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Verwysings reaktiewe krag (Q&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_voltage">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="135"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="133"/>
       <source>Reference Voltage (U&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Verwysings spanning (U&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_voltage_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="144"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="140"/>
       <source>Voltage droop slope (droop&lt;sub&gt;UQ&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Spanning droop helling (droop&lt;sub&gt;UQ&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_minimum_and_maximum_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="146"/>
       <source>Minimum and maximum parameters</source>
-      <translation type="unfinished"/>
+      <translation>Minimum en maksimum parameters</translation>
     </message>
     <message id="page_microgrid_allowed_active_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="156"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
       <source>Allowed active power range</source>
-      <translation type="unfinished"/>
+      <translation>Toegelate aktiewe krag reeks</translation>
     </message>
     <message id="page_microgrid_allowed_reactive_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="164"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="159"/>
       <source>Allowed reactive power range</source>
-      <translation type="unfinished"/>
+      <translation>Toegelate reaktiewe krag reeks</translation>
     </message>
     <message id="page_microgrid_p_q_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="176"/>
       <source>P-Q direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>P-Q direkte dryf instellings</translation>
     </message>
     <message id="page_microgrid_active_power_setpoint_p">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="186"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
       <source>Active power setpoint (P)</source>
-      <translation type="unfinished"/>
+      <translation>Aktiewe krag stel punt (P)</translation>
     </message>
     <message id="page_microgrid_reactive_power_setpoint_q">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="194"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="188"/>
       <source>Reactive power setpoint (Q)</source>
-      <translation type="unfinished"/>
+      <translation>Reaktiewe krag stel punt (Q)</translation>
     </message>
     <message id="page_microgrid_allowed_frequency_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="202"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="195"/>
       <source>Allowed frequency range</source>
-      <translation type="unfinished"/>
+      <translation>Toegelate frekwensie reeks</translation>
     </message>
     <message id="page_microgrid_allowed_voltage_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="210"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="203"/>
       <source>Allowed voltage range</source>
-      <translation type="unfinished"/>
+      <translation>Toegelate spanning reeks</translation>
     </message>
     <message id="page_microgrid_v_f_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="227"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="220"/>
       <source>V-f direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>V-f direkte dryf instellings</translation>
     </message>
     <message id="page_microgrid_voltage_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="225"/>
       <source>Voltage setpoint (U)</source>
-      <translation type="unfinished"/>
+      <translation>Spanning stel punt (U)</translation>
     </message>
     <message id="page_microgrid_frequency_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="240"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
       <source>Frequency setpoint (f)</source>
-      <translation type="unfinished"/>
+      <translation>Frekwensie stel punt (f)</translation>
     </message>
-    <message id="temperature_slider_current">
-      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
-      <source>Current</source>
-      <extracomment>The current temperature measurement</extracomment>
-      <translation type="unfinished">Huidige</translation>
+    <message id="pagesettingsintegrations_canopenmotordrive">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
+      <source>CANopen motor drives</source>
+      <translation>CANopen motor drywe</translation>
+    </message>
+    <message id="pagesettingsintegrations_ui_plugins">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
+      <source>UI Plugins</source>
+      <translation>UI Inproppe</translation>
+    </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
+      <source>Motor Direction Inverted</source>
+      <translation>Motorrigting Omgekeer</translation>
     </message>
     <message id="page_settings_canopenmotordrive_scan_for_motor_drives">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="31"/>
       <source>Scan for motor drives</source>
-      <translation type="unfinished"/>
+      <translation>Soek vir motor drywe</translation>
     </message>
     <message id="page_settings_canopenmotordrive_discovered_motor_drive_ids">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="39"/>
       <source>Discovered motor drive IDs</source>
-      <translation type="unfinished"/>
+      <translation>Ontdekte motor dryf ID's</translation>
     </message>
-    <message id="switchableoutput_gx_device_relays">
-      <location filename="../../src/switchableoutput.cpp" line="388"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">GX toestel relais</translation>
+    <message id="temperature_pm25">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
+      <source>PM2.5</source>
+      <translation>PM2.5</translation>
     </message>
-    <message id="gx_device_relays">
-      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">GX toestel relais</translation>
+    <message id="temperature_co2">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+      <source>CO₂</source>
+      <translation>CO₂</translation>
     </message>
-    <message id="color_preset">
-      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
-      <source>Preset</source>
-      <translation type="unfinished"/>
+    <message id="temperature_voc">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
+      <source>VOC index</source>
+      <translation>VOC indeks</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_location">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
-      <source>Add Modbus port and unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_nox">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
+      <source>NOx index</source>
+      <translation>NOx indeks</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_unitid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
-      <source>Unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_luminosity">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
+      <source>Luminosity</source>
+      <translation>Omseil</translation>
     </message>
-    <message id="page_settings_fronius_unitid_invalid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation type="unfinished">%1 is nie 'n geldige eenheidnommer nie. Gebruik 'n nommer tussen 1-247.</translation>
-    </message>
-    <message id="page_settings_fronius_add_modbus_location_button">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
-      <source>Add</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_locations_note">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
-      <source>The default modbus port is 502 and the default unit ID is 126.
-Here you can add additional ports and unit IDs to scan for PV inverters.</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_location_number">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
-      <source>Port/Unit ID %1</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location_description">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
-      <source>Port: %1 (Unit %2)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
-      <source>Remove Modbus port and unit ID?</source>
-      <translation type="unfinished"/>
+    <message id="switchable_output_bypassed">
+      <location filename="../../src/enums.cpp" line="484"/>
+      <source>Bypassed</source>
+      <translation>Omseil</translation>
     </message>
     <message id="switchableoutput_list_delegate_auto_status">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="84"/>
       <source>Auto (%1)</source>
       <extracomment>%1 = 'On' or 'Off'</extracomment>
-      <translation type="unfinished"/>
+      <translation>Outomaties (%1)</translation>
     </message>
     <message id="switchableoutput_list_delegate_state_forced">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="100"/>
       <source>Forced</source>
-      <translation type="unfinished"/>
+      <translation>Geforseer</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_settings">
+      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
+      <source>Modbus port and unit ID settings</source>
+      <translation>Modbus-poort en eenheid-ID-instellings</translation>
+    </message>
+    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
+      <source>Integrates with the device list</source>
+      <translation>Integreer met die toestellys</translation>
+    </message>
+    <message id="common_words_color">
+      <location filename="../../components/CommonWords.qml" line="136"/>
+      <source>Color</source>
+      <translation>Kleur</translation>
+    </message>
+    <message id="common_words_value_must_be_greater_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="557"/>
+      <source>Value must be greater than start value</source>
+      <translation>Waarde moet groter wees as beginwaarde</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="566"/>
+      <source>Value must be lower than stop value</source>
+      <translation>Waarde moet laer wees as stopwaarde</translation>
+    </message>
+    <message id="notifications_page_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="43"/>
+      <source>Active Notifications</source>
+      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
+      <translation>Aktiewe Kennisgewings</translation>
+    </message>
+    <message id="notifications_page_inactive_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="47"/>
+      <source>Inactive Notifications</source>
+      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
+      <translation>Onaktiewe Kennisgewings</translation>
+    </message>
+    <message id="notifications_no_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="106"/>
+      <source>No active notifications</source>
+      <translation>Geen aktiewe kennisgewings nie</translation>
+    </message>
+    <message id="switchable_output_rgb_color_wheel">
+      <location filename="../../src/enums.cpp" line="427"/>
+      <source>RGB color wheel</source>
+      <translation>RGB-kleurwiel</translation>
+    </message>
+    <message id="switchable_output_cct_color_wheel">
+      <location filename="../../src/enums.cpp" line="431"/>
+      <source>CCT color wheel</source>
+      <extracomment>Correlated Color Temperature color wheel</extracomment>
+      <translation>CCT-kleurwiel</translation>
+    </message>
+    <message id="switchable_output_rgbw_color_wheel">
+      <location filename="../../src/enums.cpp" line="435"/>
+      <source>RGB + W color wheel</source>
+      <extracomment>RGB + white color wheel</extracomment>
+      <translation>RGB + W-kleurwiel</translation>
+    </message>
+    <message id="listlink_show_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="43"/>
+      <source>Show QR code</source>
+      <translation>Wys QR-kode</translation>
+    </message>
+    <message id="listlink_scan_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="52"/>
+      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
+      <extracomment>%1 = url text</extracomment>
+      <oldsource>Scan the QR code with your portable device.&lt;br /&gt;Or insert the link: %1</oldsource>
+      <translation>Maak die QR-kode oop om dit met jou draagbare toestel te skandeer.&lt;br /&gt;Of voeg die skakel in: %1</translation>
+    </message>
+    <message id="color_preset">
+      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
+      <source>Preset</source>
+      <translation>Voorafinstelling</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
+      <source>Add Modbus port and unit ID</source>
+      <translation>Voeg Modbus-poort en eenheid-ID by</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_unitid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
+      <source>Unit ID</source>
+      <translation>Eenheid-ID</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location_button">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
+      <source>Add</source>
+      <translation>Voeg by</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_locations_note">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
+      <source>The default modbus port is 502 and the default unit ID is 126.
+Here you can add additional ports and unit IDs to scan for PV inverters.</source>
+      <translation>Die verstek Modbus-poort is 502 en die verstek eenheid-ID is 126.
+Hier kan jy bykomende poorte en eenheid-ID's byvoeg om vir PV-omsetters te skandeer.</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_location_number">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
+      <source>Port/Unit ID %1</source>
+      <translation>Poort/Eenheid-ID %1</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location_description">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
+      <source>Port: %1 (Unit %2)</source>
+      <translation>Poort: %1 (Eenheid %2)</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
+      <source>Remove Modbus port and unit ID?</source>
+      <translation>Verwyder Modbus-poort en eenheid-ID?</translation>
+    </message>
+    <message id="devicelist_tankshape_edit_point">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="182"/>
+      <source>Edit point %1</source>
+      <extracomment>%1 = which point is being edited, a number like "1" or "2"</extracomment>
+      <translation></translation>
+    </message>
+    <message id="settings_canbus_vecan">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
+      <source>VE.Can (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_250">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <source>VE.Can &amp; CANopen E-drive (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_500">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
+      <source>CANopen E-drive (500 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="page_microgrid_from_p1_to_p2">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="39"/>
+      <source>%1%2 to %3%4</source>
+      <extracomment>Describes a range from one quantity to another, e.g. "30W to 60W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
+      <translation></translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAfricaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
+      <source>Morocco Standard Time</source>
+      <translation>Marokko Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
+      <source>W. Central Africa Standard Time</source>
+      <translation>W. Sentraal-Afrika Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
+      <source>South Africa Standard Time</source>
+      <translation>Suid-Afrika Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
+      <source>Namibia Standard Time</source>
+      <translation>Namibië Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
+      <source>Egypt Standard Time</source>
+      <translation>Egipte Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
+      <source>E. Africa Standard Time</source>
+      <translation>O. Afrika Standaardtyd</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAmericaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
+      <source>Argentina Standard Time</source>
+      <translation>Argentinië Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
+      <source>E. South America Standard Time</source>
+      <translation>O. Suid-Amerika Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
+      <source>Greenland Standard Time</source>
+      <translation>Groenland Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
+      <source>Montevideo Standard Time</source>
+      <translation>Montevideo Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
+      <source>Newfoundland Standard Time</source>
+      <translation>Newfoundland Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
+      <source>SA Eastern Standard Time</source>
+      <translation>SA Oostelike Standardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
+      <source>Atlantic Standard Time</source>
+      <translation>Atlantiese Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
+      <source>Central Brazilian Standard Time</source>
+      <translation>Sentraal Brasiliaanse standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>Stille Oseaan SA Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
+      <source>Paraguay Standard Time</source>
+      <translation>Paraguay Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
+      <source>SA Western Standard Time</source>
+      <translation>SA Westelike Standardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
+      <source>Venezuela Standard Time</source>
+      <translation>Venezuela Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
+      <source>Eastern Standard Time</source>
+      <translation>Oostelike Standardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
+      <source>SA Pacific Standard Time</source>
+      <translation>SA Stille Oseaan Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
+      <source>US Eastern Standard Time</source>
+      <translation>Amerikaanse Oostelie Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
+      <source>Canada Central Standard Time</source>
+      <translation>Kanada Sentraal Standaardttyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
+      <source>Central America Standard Time</source>
+      <translation>Sentraal-Amerika Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
+      <source>Central Standard Time (Mexico)</source>
+      <translation>Sentrale Standaardtyd (Mexiko)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
+      <source>Central Standard Time</source>
+      <translation>Sentrale Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
+      <source>Mountain Standard Time (Mexico)</source>
+      <translation>Berg Standaardtyd (Mexiko)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
+      <source>Mountain Standard Time</source>
+      <translation>Berg Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
+      <source>US Mountain Standard Time</source>
+      <translation>Amerikaanse bergestandaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
+      <source>Pacific Standard Time (Mexico)</source>
+      <translation>Stille Oseaan Standardtyd (Mexiko)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
+      <source>Pacific Standard Time</source>
+      <translation>Stille Oseaan Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
+      <source>Alaskan Standard Time</source>
+      <translation>Alaska Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
+      <source>Hawaii-Aleutian</source>
+      <translation>Hawaii-Aleuties</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
+      <source>Atlantic Daylight Time</source>
+      <translation>Atlantiese dagligtyd</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAntarcticaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+      <source>New Zealand Standard Time</source>
+      <translation>Nieu-Seeland Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>Sentraal-Stille Oseaan Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+      <source>West Pacific Standard Time</source>
+      <translation>Westelike Stille Oseaan Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+      <source>W. Australia Standard Time</source>
+      <translation>W. Australië Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+      <source>SE Asia Standard Time</source>
+      <translation>SO Asië Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+      <source>Central Asia Standard Time</source>
+      <translation>Sentraal-Asië Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+      <source>West Asia Standard Time</source>
+      <translation>Wes-Asië standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+      <source>E. Africa Standard Time</source>
+      <translation>O. Afrika Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>Stille Oseaan SA Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+      <source>SA Western Standard Time</source>
+      <translation>SA Western Standard Time</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzArcticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
+      <source>W. Europe Standard Time</source>
+      <translation>W. Europa Standaard Tyd</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAsiaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
+      <source>Kamchatka Standard Time</source>
+      <translation>Kamchatka Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
+      <source>Magadan Standard Time</source>
+      <translation>Magadan Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
+      <source>Vladivostok Standard Time</source>
+      <translation>Vladivostok Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
+      <source>Yakutsk Standard Time</source>
+      <translation>Yakutsk Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
+      <source>Tokyo Standard Time</source>
+      <translation>Tokio Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
+      <source>Korea Standard Time</source>
+      <translation>Korea Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
+      <source>Singapore Standard Time</source>
+      <translation>Singapoer Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
+      <source>Ulaanbaatar Standard Time</source>
+      <translation>Ulaanbaatar Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
+      <source>Taipei Standard Time</source>
+      <translation>Taipei Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
+      <source>North Asia East Standard Time</source>
+      <translation>Noord-Asië Oos Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
+      <source>China Standard Time</source>
+      <translation>China Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
+      <source>SE Asia Standard Time</source>
+      <translation>SO Asië Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
+      <source>North Asia Standard Time</source>
+      <translation>Noord-Asië Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
+      <source>Myanmar Standard Time</source>
+      <translation>Myanmar Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
+      <source>N. Central Asia Standard Time</source>
+      <translation>N. Sentraal-Asië Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
+      <source>Central Asia Standard Time</source>
+      <translation>Sentraal-Asië Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
+      <source>Bangladesh Standard Time</source>
+      <translation>Bangladesj Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
+      <source>Nepal Standard Time</source>
+      <translation>Nepal Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
+      <source>Sri Lanka Standard Time</source>
+      <translation>Sri Lanka Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
+      <source>India Standard Time</source>
+      <translation>Indië Standaard Tyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
+      <source>West Asia Standard Time</source>
+      <translation>Wes-Asië standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
+      <source>Pakistan Standard Time</source>
+      <translation>Pakistan Standaard Tyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
+      <source>Ekaterinburg Standard Time</source>
+      <translation>Ekaterinburg Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
+      <source>Georgian Standard Time</source>
+      <translation>Georgiese Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
+      <source>Caucasus Standard Time</source>
+      <translation>Kaukasus Standaard Tyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
+      <source>Azerbaijan Standard Time</source>
+      <translation>Azerbeidjan Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
+      <source>Arabian Standard Time</source>
+      <translation>Arabiese Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
+      <source>Afghanistan Standard Time</source>
+      <translation>Afghanistan Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
+      <source>Iran Standard Time</source>
+      <translation>Iran Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
+      <source>Arabic Standard Time</source>
+      <translation>Arabiese Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
+      <source>Arab Standard Time</source>
+      <translation>Arabiese Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
+      <source>Syria Standard Time</source>
+      <translation>Sirië Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
+      <source>Middle East Standard Time</source>
+      <translation>Midde-Ooste Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
+      <source>Jordan Standard Time</source>
+      <translation>Jordan Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
+      <source>Israel Standard Time</source>
+      <translation>Israel Standaardtyd</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAtlanticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+      <source>Greenwich Standard Time</source>
+      <translation>Greenwich Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+      <source>Azores Standard Time</source>
+      <translation>Asore Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+      <source>Cape Verde Standard Time</source>
+      <translation>Kaap Verdiese Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
+      <source>Mid-Atlantic Standard Time</source>
+      <translation>Mid-Atlantiese Standaardtyd</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAustraliaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+      <source>Tasmania Standard Time</source>
+      <translation>Tasmanië Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+      <source>E. Australia Standard Time</source>
+      <translation>O. Australië Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+      <source>AUS Eastern Standard Time</source>
+      <translation>Oostelike Eastern Standardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+      <source>Cen. Australia Standard Time</source>
+      <translation>Cen. Australië Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+      <source>AUS Central Standard Time</source>
+      <translation>AUS Sentrale Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+      <source>W. Australia Standard Time</source>
+      <translation>W. Australië Standaardtyd</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEtcData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
+      <source>GMT +12</source>
+      <translation>GMT +12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
+      <source>GMT -02</source>
+      <translation>GMT -02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
+      <source>GMT -11</source>
+      <translation>GMT -11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
+      <source>GMT -13</source>
+      <translation>GMT -13</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
+      <source>GMT -12</source>
+      <translation>GMT -12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
+      <source>GMT -10</source>
+      <translation>GMT -10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
+      <source>GMT -09</source>
+      <translation>GMT -09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
+      <source>GMT -08</source>
+      <translation>GMT -08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
+      <source>GMT -07</source>
+      <translation>GMT -07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
+      <source>GMT -06</source>
+      <translation>GMT -06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
+      <source>GMT -05</source>
+      <translation>GMT -05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
+      <source>GMT -04</source>
+      <translation>GMT -04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
+      <source>GMT -03</source>
+      <translation>GMT -03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
+      <source>GMT -01</source>
+      <translation>GMT -01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
+      <source>GMT</source>
+      <translation>GMT</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
+      <source>GMT +01</source>
+      <translation>GMT +01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
+      <source>GMT +02</source>
+      <translation>GMT +02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
+      <source>GMT +03</source>
+      <translation>GMT +03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
+      <source>GMT +04</source>
+      <translation>GMT +04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
+      <source>GMT +05</source>
+      <translation>GMT +05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
+      <source>GMT +06</source>
+      <translation>GMT +06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
+      <source>GMT +07</source>
+      <translation>GMT +07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
+      <source>GMT +08</source>
+      <translation>GMT +08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
+      <source>GMT +09</source>
+      <translation>GMT +09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
+      <source>GMT +10</source>
+      <translation>GMT +10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
+      <source>GMT +11</source>
+      <translation>GMT +11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
+      <source>UTC</source>
+      <translation>UTC</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEuropeData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
+      <source>GMT Standard Time</source>
+      <translation>GMT Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
+      <source>Central Europe Standard Time</source>
+      <translation>Sentraal-Europa Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
+      <source>Central European Standard Time</source>
+      <translation>Sentraal-Europese Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
+      <source>Romance Standard Time</source>
+      <translation>Romanse Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
+      <source>W. Europe Standard Time</source>
+      <translation>W. Europa Standaard Tyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
+      <source>E. Europe Standard Time</source>
+      <translation>E. Europa Standaard Tyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
+      <source>FLE Standard Time</source>
+      <translation>FLE Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
+      <source>GTB Standard Time</source>
+      <translation>GTB Standaard Tyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
+      <source>Belarus Standard Time</source>
+      <translation>Wit-Rusland Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
+      <source>Russian Standard Time</source>
+      <translation>Russiese Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
+      <source>Turkey Standard Time</source>
+      <translation>Turkye Standaardtyd</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzIndianData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
+      <source>Mauritius Standard Time</source>
+      <translation>Mauritius Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
+      <source>Christmas Island Standard Time</source>
+      <translation>Kersfees-eiland Standaardtyd</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzPacificData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
+      <source>Tonga Standard Time</source>
+      <translation>Tonga Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
+      <source>Fiji Standard Time</source>
+      <translation>Fidji Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
+      <source>New Zealand Standard Time</source>
+      <translation>Nieu-Seeland Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>Sentraal-Stille Oseaan Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
+      <source>West Pacific Standard Time</source>
+      <translation>West Stille Oseaan Standardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
+      <source>Samoa Standard Time</source>
+      <translation>Samoa Standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
+      <source>Hawaiian Standard Time</source>
+      <translation>Hawaiiaanse standaardtyd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
+      <source>Easter Island Standard Time</source>
+      <translation>Paaseiland Standaardtyd</translation>
     </message>
   </context>
   <context>
@@ -12175,838 +11855,6 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
     </message>
   </context>
   <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>Marokko Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>W. Sentraal-Afrika Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>Suid-Afrika Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>Namibië Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>Egipte Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>O. Afrika Standaardtyd</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>Argentinië Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>O. Suid-Amerika Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>Groenland Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>Montevideo Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>Newfoundland Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>SA Oostelike Standardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Atlantic Standard Time</source>
-      <translation>Atlantiese Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>Sentraal Brasiliaanse standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Stille Oseaan SA Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>Paraguay Standard Time</source>
-      <translation>Paraguay Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>SA Western Standard Time</source>
-      <translation>SA Westelike Standardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Venezuela Standard Time</source>
-      <translation>Venezuela Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>Eastern Standard Time</source>
-      <translation>Oostelike Standardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>SA Stille Oseaan Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>US Eastern Standard Time</source>
-      <translation>Amerikaanse Oostelie Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Canada Central Standard Time</source>
-      <translation>Kanada Sentraal Standaardttyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central America Standard Time</source>
-      <translation>Sentraal-Amerika Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>Sentrale Standaardtyd (Mexiko)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Central Standard Time</source>
-      <translation>Sentrale Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>Berg Standaardtyd (Mexiko)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>Mountain Standard Time</source>
-      <translation>Berg Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>US Mountain Standard Time</source>
-      <translation>Amerikaanse bergestandaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>Stille Oseaan Standardtyd (Mexiko)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Pacific Standard Time</source>
-      <translation>Stille Oseaan Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Alaskan Standard Time</source>
-      <translation>Alaska Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>Hawaii-Aleuties</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Daylight Time</source>
-      <translation>Atlantiese dagligtyd</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Nieu-Seeland Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Sentraal-Stille Oseaan Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Westelike Stille Oseaan Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>W. Australië Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>SO Asië Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Sentraal-Asië Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>Wes-Asië standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>O. Afrika Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Stille Oseaan SA Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>SA Western Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>W. Europa Standaard Tyd</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>Kamchatka Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>Magadan Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>Vladivostok Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>Yakutsk Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>Tokio Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>Korea Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>Singapoer Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>Ulaanbaatar Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>Taipei Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>Noord-Asië Oos Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>China Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>SO Asië Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>Noord-Asië Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>Myanmar Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>N. Sentraal-Asië Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Sentraal-Asië Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>Bangladesj Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>Nepal Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>Sri Lanka Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>Indië Standaard Tyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>Wes-Asië standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>Pakistan Standaard Tyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>Ekaterinburg Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>Georgiese Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>Kaukasus Standaard Tyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>Azerbeidjan Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>Arabiese Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>Afghanistan Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>Iran Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>Arabiese Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>Arabiese Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>Sirië Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>Midde-Ooste Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>Jordan Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>Israel Standaardtyd</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>Greenwich Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>Asore Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>Kaap Verdiese Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>Mid-Atlantiese Standaardtyd</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>Tasmanië Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>O. Australië Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>Oostelike Eastern Standardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>Cen. Australië Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>AUS Sentrale Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>W. Australië Standaardtyd</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
-      <source>GMT +12</source>
-      <translation>GMT +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
-      <source>GMT -02</source>
-      <translation>GMT -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT -13</source>
-      <translation>GMT -13</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT -12</source>
-      <translation>GMT -12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -10</source>
-      <translation>GMT -10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -09</source>
-      <translation>GMT -09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>GMT -08</source>
-      <translation>GMT -08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
-      <source>GMT -07</source>
-      <translation>GMT -07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
-      <source>GMT -06</source>
-      <translation>GMT -06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
-      <source>GMT -05</source>
-      <translation>GMT -05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
-      <source>GMT -04</source>
-      <translation>GMT -04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
-      <source>GMT -03</source>
-      <translation>GMT -03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
-      <source>GMT -01</source>
-      <translation>GMT -01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
-      <source>GMT</source>
-      <translation>GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
-      <source>GMT +01</source>
-      <translation>GMT +01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
-      <source>GMT +02</source>
-      <translation>GMT +02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
-      <source>GMT +03</source>
-      <translation>GMT +03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
-      <source>GMT +04</source>
-      <translation>GMT +04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
-      <source>GMT +05</source>
-      <translation>GMT +05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
-      <source>GMT +06</source>
-      <translation>GMT +06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
-      <source>GMT +07</source>
-      <translation>GMT +07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
-      <source>GMT +08</source>
-      <translation>GMT +08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
-      <source>GMT +09</source>
-      <translation>GMT +09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
-      <source>GMT +10</source>
-      <translation>GMT +10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
-      <source>GMT +11</source>
-      <translation>GMT +11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
-      <source>UTC</source>
-      <translation>UTC</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>GMT Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>Sentraal-Europa Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>Sentraal-Europese Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>Romanse Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>W. Europa Standaard Tyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>E. Europa Standaard Tyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>FLE Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>GTB Standaard Tyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>Wit-Rusland Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>Russiese Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>Turkye Standaardtyd</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>Mauritius Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>Kersfees-eiland Standaardtyd</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>Tonga Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>Fidji Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Nieu-Seeland Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Sentraal-Stille Oseaan Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>West Stille Oseaan Standardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>Samoa Standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>Hawaiiaanse standaardtyd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>Paaseiland Standaardtyd</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation type="unfinished">Interne fout</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation type="unfinished"/>
-    </message>
-  </context>
-  <context>
     <name>Wakespeed</name>
     <message>
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
@@ -13183,6 +12031,119 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
       <source>DC/DC misconfiguration</source>
       <translation>DC/DC verkeerde konfigurasie</translation>
+    </message>
+  </context>
+  <context>
+    <name>VebusError</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+      <source>Device switched off</source>
+      <translation>Toestel afgeskakel</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+      <source>Mixed old/new MK2</source>
+      <translation>Gemengde ou/nuwe MK2</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+      <source>Expected devices error</source>
+      <translation>Verwagte toestelfout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+      <source>No other device detected</source>
+      <translation>Geen ander toestel bespeur nie</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+      <source>Overvoltage on AC-out</source>
+      <translation>Oorspanning op AC-uit</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+      <source>DDC program error</source>
+      <translation>DDC-programfout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+      <source>VE.Bus BMS without assistant</source>
+      <translation>VE.Bus BMS sonder assistent</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+      <source>Ground relay test failed</source>
+      <translation>Grondrelais toets het gefaal</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+      <source>System time sync error</source>
+      <translation>Stelseltyd sinchronisasie fout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+      <source>Grid relay test fault</source>
+      <translation>Netrelais toets fout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+      <source>Config mismatch with 2nd mcu</source>
+      <translation>Konfigurasie stem nie ooreen met 2de mcu nie</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+      <source>Device transmit error</source>
+      <translation>Toestel se transmissie fout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+      <source>Awaiting configuration or dongle missing</source>
+      <translation>Wag vir konfigurasie of dongle ontbreek</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+      <source>Phase master missing</source>
+      <translation>Fase hoof ontbreek</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+      <source>Overvoltage has occurred</source>
+      <translation>Oorspanning het voorgekom</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+      <source>Slave does not have AC input!</source>
+      <translation>Slaaf het nie AC-inset nie!</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+      <source>Device can't be slave</source>
+      <translation>Toestel kan nie 'n slaaf wees nie</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+      <source>System protection initiated</source>
+      <translation>Stelselbeskerming geïnisieer</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+      <source>Firmware incompatibiltiy</source>
+      <translation>Firmware onverenigbaarheid</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+      <source>Internal error</source>
+      <translation>Interne fout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+      <source>Failing relay test prevents connection</source>
+      <translation>Falende relais toets verhoed verbinding</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+      <source>VE.Bus error</source>
+      <translation>VE.Bus fout</translation>
     </message>
   </context>
 </TS>

--- a/i18n/venus-gui-v2_ar.ts
+++ b/i18n/venus-gui-v2_ar.ts
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="ar">
   <context>
-    <name/>
+    <name></name>
     <message id="switchable_output_disabled">
       <location filename="../../src/enums.cpp" line="478"/>
       <source>Disabled</source>
@@ -22,6 +22,7 @@
     <message id="solarchargers_state_off">
       <location filename="../../src/enums.cpp" line="331"/>
       <source>Off</source>
+      <extracomment>Digital input state</extracomment>
       <translation>مطفأ</translation>
     </message>
     <message id="common_words_auto">
@@ -52,18 +53,25 @@
     <message id="settings_startpage_none">
       <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
       <source>None</source>
+      <extracomment>Indicates no phase</extracomment>
       <translation>لا أحد</translation>
     </message>
     <message id="common_words_position_ac">
       <location filename="../../components/CommonWords.qml" line="416"/>
       <source>Position</source>
-      <extracomment>AC input or output position</extracomment>
+      <extracomment>EVCS AC input/output position</extracomment>
       <translation>الموقع</translation>
     </message>
     <message id="settings_minmax_speed">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="193"/>
       <source>Speed</source>
+      <extracomment>A speed measurement value</extracomment>
       <translation>السرعة</translation>
+    </message>
+    <message id="common_words_state">
+      <location filename="../../components/CommonWords.qml" line="502"/>
+      <source>State</source>
+      <translation>الحالة</translation>
     </message>
     <message id="settings_firmware_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="67"/>
@@ -101,8 +109,8 @@
       <source>Solar yield</source>
       <translation>إنتاج الطاقة الشمسية</translation>
     </message>
-    <message id="ess_state_external_control">
-      <location filename="../../data/Ess.qml" line="41"/>
+    <message id="inverters_state_externalccontrol">
+      <location filename="../../data/System.qml" line="183"/>
       <source>External control</source>
       <translation>التحكم الخارجي</translation>
     </message>
@@ -140,6 +148,11 @@
       <location filename="../../components/CommonWords.qml" line="203"/>
       <source>ESS</source>
       <translation>ESS</translation>
+    </message>
+    <message id="pagesettingsconnectivity_ethernet">
+      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
+      <source>Ethernet</source>
+      <translation>إيثرنت</translation>
     </message>
     <message id="pagesettingsconnectivity_wifi">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="28"/>
@@ -262,11 +275,6 @@
       <source>Name</source>
       <translation>اسم</translation>
     </message>
-    <message id="settings_deviceinfo_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="38"/>
-      <source>Name</source>
-      <translation type="unfinished">اسم</translation>
-    </message>
     <message id="settings_deviceinfo_product_id">
       <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
       <source>Product ID</source>
@@ -327,15 +335,20 @@
       <source>Daily run time</source>
       <translation>وقت التشغيل اليومي</translation>
     </message>
+    <message id="common_words_value_must_be_greater_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="560"/>
+      <source>Value must be greater than stop value</source>
+      <translation>القيمة يجب أن تكون أعلى من قيمة التوقف</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="563"/>
+      <source>Value must be lower than start value</source>
+      <translation>القيمة يجب أن تكون أقل من قيمة التشغيل</translation>
+    </message>
     <message id="settings_minmax_acout_max_power">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="124"/>
       <source>AC output</source>
       <translation>خرج التيار المتردد</translation>
-    </message>
-    <message id="ac_output">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="15"/>
-      <source>AC output</source>
-      <translation type="unfinished">خرج التيار المتردد</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
       <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="25"/>
@@ -382,16 +395,6 @@
       <source>Unavailable monitor, set another</source>
       <translation>الشاشة غير متاحة، عيّن غيرها</translation>
     </message>
-    <message id="page_generator_conditions_battery_monitor">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="42"/>
-      <source>Battery monitor</source>
-      <translation type="unfinished">شاشة البطارية</translation>
-    </message>
-    <message id="page_generator_conditions_unavailable_monitor_set_another">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="44"/>
-      <source>Unavailable monitor, set another</source>
-      <translation type="unfinished">الشاشة غير متاحة، عيّن غيرها</translation>
-    </message>
     <message id="page_generator_conditions_on_loss_of_communication">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="68"/>
       <source>On loss of communication</source>
@@ -416,11 +419,6 @@
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="105"/>
       <source>Battery SOC</source>
       <translation>بطارية SOC</translation>
-    </message>
-    <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="173"/>
-      <source>Periodic run</source>
-      <translation type="unfinished">تشغيل دوري</translation>
     </message>
     <message id="settings_inverter_high_temperature">
       <location filename="../../data/Generators.qml" line="83"/>
@@ -505,7 +503,7 @@
     <message id="settings_gps_speed_kmh">
       <location filename="../../pages/settings/PageGps.qml" line="83"/>
       <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometres per hour</extracomment>
+      <extracomment>GPS speed data, in kilometers per hour</extracomment>
       <translation>%1 كم/ ساعة</translation>
     </message>
     <message id="settings_gps_speed_mph">
@@ -523,7 +521,7 @@
     <message id="settings_gps_speed_ms">
       <location filename="../../pages/settings/PageGps.qml" line="95"/>
       <source>%1 m/s</source>
-      <extracomment>GPS speed data, in metres per second</extracomment>
+      <extracomment>GPS speed data, in meters per second</extracomment>
       <translation>%1 متر/ ثانية</translation>
     </message>
     <message id="settings_gps_course">
@@ -580,21 +578,6 @@
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="64"/>
       <source>%1 (Output %2)</source>
       <translation>%1 (مخرجات %2)</translation>
-    </message>
-    <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">شاشة البطارية مفعلة</translation>
-    </message>
-    <message id="settings_batteries_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="101"/>
-      <source>Name</source>
-      <translation type="unfinished">اسم</translation>
-    </message>
-    <message id="settings_batteries_enter_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="103"/>
-      <source>Enter name</source>
-      <translation type="unfinished">إدخال الاسم</translation>
     </message>
     <message id="settings_briefview_center_active_battery_monitor">
       <location filename="../../components/listitems/ListBriefCenterDetails.qml" line="27"/>
@@ -656,45 +639,25 @@
       <source>CAN-bus profile</source>
       <translation>ضابط مجال الشبكة-بيانات المسار التجميعي</translation>
     </message>
-    <message id="settings_disabled">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="31"/>
-      <source>Disabled</source>
-      <translation type="unfinished">معطل</translation>
-    </message>
-    <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can و Lynx Ion BMS (250 كيلوبت/ثانية)</translation>
-    </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
       <location filename="../../pages/settings/CanbusProfile.qml" line="42"/>
       <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
       <translation>VE.Can و CAN-مسار تجميعي BMS (250 كيلوبت/ثانية)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
       <source>Oceanvolt (250 kbit/s)</source>
       <translation>Oceanvolt (250 كيلوبت/ثانية)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
       <source>RV-C (250 kbit/s)</source>
       <translation>بروتوكول الاتصالات RV-C (250 كيلو بت/ الثانية)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
       <source>Up, but no services (250 kbit/s)</source>
       <translation>أعلى، لكن دون خدمات (250 كيلو بت/ ثانية)</translation>
-    </message>
-    <message id="settings_canopen_motordrive_250">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
-      <source>CANopen Motor drive (250 kbit/s)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_canopen_motordrive_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
-      <source>CANopen Motor drive (500 kbit/s)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_devices">
       <location filename="../../components/CommonWords.qml" line="166"/>
@@ -731,11 +694,6 @@
       <source>Check Unique id numbers</source>
       <translation>تحقق من هوية الأرقام الفريدة</translation>
     </message>
-    <message id="settings_canbus_unique_id_press_to_check">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Press to check</source>
-      <translation type="unfinished">اضغط للتحقق</translation>
-    </message>
     <message id="settings_canbus_unique_id_conflict">
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="125"/>
       <source>There is another device connected with this unique number, please select a new number.</source>
@@ -745,11 +703,6 @@
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="133"/>
       <source>OK: No other device is connected with this unique number.</source>
       <translation>جيد. ليس هناك أي جهاز متصل مع نفس هذا الرقم الفريد.</translation>
-    </message>
-    <message id="pagesettingsintegrations_canopenmotordrive">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
-      <source>CANopen motor drives</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_network_status">
       <location filename="../../components/CommonWords.qml" line="349"/>
@@ -884,11 +837,6 @@
       <source>Unavailable sensor, set another</source>
       <translation>مستشعر غير متوفر، اختر واحدا آخر</translation>
     </message>
-    <message id="settings_system_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="81"/>
-      <source>Unavailable sensor, set another</source>
-      <translation type="unfinished">مستشعر غير متوفر، اختر واحدا آخر</translation>
-    </message>
     <message id="settings_dvcc_used_sensor">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="120"/>
       <source>Used sensor</source>
@@ -945,12 +893,6 @@
       <source>Auto selected</source>
       <translation>التحديد التلقائي</translation>
     </message>
-    <message id="settings_dvcc_auto_selected_none">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="208"/>
-      <source>None</source>
-      <extracomment>Indicates no option is selected</extracomment>
-      <translation type="unfinished">لا أحد</translation>
-    </message>
     <message id="settings_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
       <source>Build date/time</source>
@@ -986,12 +928,6 @@
       <source>Installing %1</source>
       <extracomment>%1 = firmware version</extracomment>
       <translation>تثبيت %1</translation>
-    </message>
-    <message id="settings_firmware_offline_press_to_install">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">اضغط للتحديث إلى %1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="90"/>
@@ -1062,12 +998,6 @@
       <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
       <translation>تثبيت %1 %2%</translation>
     </message>
-    <message id="settings_firmware_online_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="86"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">جارٍ التثبيت %1...</translation>
-    </message>
     <message id="settings_firmware_update_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="109"/>
       <source>Update build date/time</source>
@@ -1097,11 +1027,6 @@
       <location filename="../../pages/settings/PageSettingsFronius.qml" line="56"/>
       <source>TCP port</source>
       <translation>منفذ بروتوكول التحكم في الإرسال</translation>
-    </message>
-    <message id="page_settings_fronius_modbus_settings">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
-      <source>Modbus port and unit ID settings</source>
-      <translation type="unfinished"/>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
       <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
@@ -1153,16 +1078,6 @@
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="64"/>
       <source>AC-Out MP</source>
       <translation>AC-Out MP</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="52"/>
-      <source>AC-In1 L%1</source>
-      <translation type="unfinished">AC-In1 L%1/&gt;</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="56"/>
-      <source>AC-In1 --</source>
-      <translation type="unfinished">AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="70"/>
@@ -1330,12 +1245,6 @@
       <source>Reset service timer</source>
       <translation>إعادة ضبط مؤقت الصيانة</translation>
     </message>
-    <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
-      <source>Volume</source>
-      <extracomment>Title for a list of units of volume (e.g. cubic metres, litres, gallons)</extracomment>
-      <translation type="unfinished">الحجم</translation>
-    </message>
     <message id="settings_gps_format">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="69"/>
       <source>Format</source>
@@ -1438,42 +1347,6 @@ If that doesn't work, check sim-card in a phone to make sure that there is credi
       <source>Wrong PIN</source>
       <translation>دبوس الخطأ</translation>
     </message>
-    <message id="page_settings_gsm_ok">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>OK</source>
-      <translation type="unfinished">صحيح</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="128"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">خطأ غير معروف</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_state">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="153"/>
-      <source>Unknown</source>
-      <translation type="unfinished">مجهول</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_value">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="182"/>
-      <source>Unknown</source>
-      <translation type="unfinished">مجهول</translation>
-    </message>
-    <message id="page_settings_gsm_offline">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="173"/>
-      <source>Offline</source>
-      <translation type="unfinished">خارج الخط</translation>
-    </message>
-    <message id="page_settings_gsm_connecting">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="176"/>
-      <source>Connecting</source>
-      <translation type="unfinished">جاري الاتصال</translation>
-    </message>
-    <message id="page_settings_gsm_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="179"/>
-      <source>Connected</source>
-      <translation type="unfinished">متصل</translation>
-    </message>
     <message id="page_settings_gsm_pin">
       <location filename="../../pages/settings/PageSettingsGsm.qml" line="191"/>
       <source>PIN</source>
@@ -1530,32 +1403,32 @@ If that doesn't work, check sim-card in a phone to make sure that there is credi
       <translation>قياس الشبكة</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
       <source>External meter</source>
       <translation>عداد خارجي</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="67"/>
       <source>Inverter/Charger</source>
       <translation>معاكس/شاحن</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
       <source>Multiphase regulation</source>
       <translation>ضبط الطور المتعدد</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="91"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
       <source>Total of all phases</source>
       <translation>العدد الكلي للأطوار</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="95"/>
       <source>Individual phase</source>
       <translation>طور وحيد</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="99"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="101"/>
       <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
@@ -1564,68 +1437,13 @@ CAUTION: Use only if required by the utility provider.</source>
 تنبيه: الاستخدام فقط حسب الاقتضاء بواسطة مقدم خدمات المرافق.</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="104"/>
       <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
       <translation>يتم تنظيم إجمالي جميع الأطوار بشكل ذكي للوصول إلى نقطة ضبط الشبكة (تحسن كفاءة النظام).
 
 يتم الاستخدام ما لم يحظر بواسطة مقدم خدمات المرافق.</translation>
-    </message>
-    <message id="settings_ess_min_soc">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation type="unfinished">الحد الأدنى لـ SoC (إلا إذا فشلت الشبكة)</translation>
-    </message>
-    <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="129"/>
-      <source>Active SOC limit</source>
-      <translation type="unfinished">الحد النشط لـ SoC</translation>
-    </message>
-    <message id="settings_ess_battery_life_sustain">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
-      <source>Sustain</source>
-      <translation type="unfinished">ركيزة</translation>
-    </message>
-    <message id="settings_ess_battery_life_recharge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="157"/>
-      <source>Recharge</source>
-      <translation type="unfinished">الشحن</translation>
-    </message>
-    <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <source>Scheduled charge levels</source>
-      <translation type="unfinished">مستويات الشحن المجدولة</translation>
-    </message>
-    <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="257"/>
-      <source>Active (%1)</source>
-      <translation type="unfinished">نشط (%1)</translation>
-    </message>
-    <message id="settings_ess_inactive">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="259"/>
-      <source>Inactive</source>
-      <translation type="unfinished">غير نشط</translation>
-    </message>
-    <message id="settings_ess_dynamic">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="293"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">نظام تخزين الطاقة الديناميكي (ESS)</translation>
-    </message>
-    <message id="settings_ess_deprecated">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="319"/>
-      <source>Deprecated settings</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_charge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="326"/>
-      <source>Battery charge limit (% of CCL)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_discharge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="337"/>
-      <source>Battery discharge limit (% of DCL)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_rs_ess_min_soc">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="40"/>
@@ -1637,13 +1455,8 @@ Use unless prohibited by the utility provider.</source>
       <source>Active SOC limit</source>
       <translation>الحد النشط لـ SoC</translation>
     </message>
-    <message id="scheduled_charge_inactive">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
-      <source>Inactive</source>
-      <translation type="unfinished">غير نشط</translation>
-    </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="245"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="247"/>
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
       <source>Peak shaving</source>
       <translation>تخفيف الأحمال</translation>
@@ -1659,12 +1472,12 @@ Use unless prohibited by the utility provider.</source>
       <translation>دائمًا</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="151"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
       <source>Discharge disabled</source>
       <translation>تفريغ الشحن معطل</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
       <source>Slow charge</source>
       <translation>شحن بطيء</translation>
     </message>
@@ -1679,32 +1492,32 @@ Use unless prohibited by the utility provider.</source>
       <translation>الشحن</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="165"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="167"/>
       <source>Limit charge power</source>
       <translation>تحديد قدرة الشحن</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="183"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="185"/>
       <source>Maximum charge power</source>
       <translation>أقصى حد لقدرة الشحن</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="196"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="198"/>
       <source>Limit inverter power</source>
       <translation>تحديد قدرة العاكس</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="214"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="216"/>
       <source>Maximum inverter power</source>
       <translation>الحد الأقصى لقدرة العاكس</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="225"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="227"/>
       <source>Grid setpoint</source>
       <translation>نقطة ضبط الشبكة</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="236"/>
       <source>Grid feed-in</source>
       <translation>تغذية داخلية للشبكة</translation>
     </message>
@@ -1743,8 +1556,8 @@ Use unless prohibited by the utility provider.</source>
       <source>Door alarm</source>
       <translation>إنذار الباب</translation>
     </message>
-    <message id="digitalinputs_type_bilgepump">
-      <location filename="../../src/enums.cpp" line="201"/>
+    <message id="switchable_output_bilge_pump">
+      <location filename="../../src/enums.cpp" line="424"/>
       <source>Bilge pump</source>
       <translation>مضخة الماء الآسن</translation>
     </message>
@@ -1796,11 +1609,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Deferred by %1s</source>
       <extracomment>%1 = number of seconds</extracomment>
       <translation>مؤجل بمقدار %1ثانية</translation>
-    </message>
-    <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="75"/>
-      <source>Are you sure?</source>
-      <translation type="unfinished">هل أنت متأكد؟</translation>
     </message>
     <message id="settings_vrm_portal_id">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="87"/>
@@ -1939,11 +1747,6 @@ Use unless prohibited by the utility provider.</source>
       <source>External storage</source>
       <translation>التخزين الخارجي</translation>
     </message>
-    <message id="settings_vrm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="308"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">خطأ غير معروف</translation>
-    </message>
     <message id="settings_vrm_no_error">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="311"/>
       <source>No Error</source>
@@ -2029,37 +1832,10 @@ Use unless prohibited by the utility provider.</source>
       <source>Function</source>
       <translation>وظيفة</translation>
     </message>
-    <message id="settings_relay_disabled">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="54"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="98"/>
-      <source>Disabled</source>
-      <translation type="unfinished">معطل</translation>
-    </message>
     <message id="settings_relay_alarm_relay">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="56"/>
       <source>Alarm relay</source>
       <translation>إنذار المرحل</translation>
-    </message>
-    <message id="settings_relay_tank_pump">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="62"/>
-      <source>Tank pump</source>
-      <translation type="unfinished">مضخة الخزان</translation>
-    </message>
-    <message id="settings_relay_manual">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="64"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="100"/>
-      <source>Manual</source>
-      <translation type="unfinished">يدوي</translation>
-    </message>
-    <message id="settings_relay_polarity_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
-      <source>Polarity (Relay 1)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_relay_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
-      <source>Polarity</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_normally_open">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="83"/>
@@ -2075,11 +1851,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="93"/>
       <source>Function (Relay 2)</source>
       <translation>الوظيفة (مرحل 2)</translation>
-    </message>
-    <message id="settings_relay_polarity_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
-      <source>Polarity (Relay 2)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_temp_control_rules">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="119"/>
@@ -2111,12 +1882,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
       <source>Press to boot</source>
       <translation>اضغط للتشغيل</translation>
-    </message>
-    <message id="settings_firmware_backup_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
-      <translation type="unfinished">البرنامج الثابت %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
@@ -2152,6 +1917,7 @@ Use unless prohibited by the utility provider.</source>
     <message id="nav_boat">
       <location filename="../../pages/boat/BoatPage.qml" line="14"/>
       <source>Boat</source>
+      <extracomment>The 'Boat' page</extracomment>
       <translation>قارب</translation>
     </message>
     <message id="settings_system_name">
@@ -2219,11 +1985,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Solar charger current control</source>
       <translation>منظم تيار الشاحن الضوئي</translation>
     </message>
-    <message id="settings_system_status_bms_params">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
-      <source>BMS control</source>
-      <translation type="unfinished">التحكم بنظام إدارة البطارية</translation>
-    </message>
     <message id="common_words_bms_control">
       <location filename="../../components/CommonWords.qml" line="101"/>
       <source>BMS control</source>
@@ -2238,11 +1999,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
       <source>Pump state</source>
       <translation>حالة المضخة</translation>
-    </message>
-    <message id="settings_pump_auto">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="56"/>
-      <source>Auto</source>
-      <translation type="unfinished">آلي</translation>
     </message>
     <message id="settings_tank_sensor">
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
@@ -2271,11 +2027,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="35"/>
       <source>Unplugged</source>
       <translation>مفصول</translation>
-    </message>
-    <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="16"/>
-      <source>Name</source>
-      <translation type="unfinished">اسم</translation>
     </message>
     <message id="settings_tcpip_hidden">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="21"/>
@@ -2317,16 +2068,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="99"/>
       <source>IP configuration</source>
       <translation>هيئة بروبوكول الإنترنت</translation>
-    </message>
-    <message id="settings_tcpip_manual">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="105"/>
-      <source>Manual</source>
-      <translation type="unfinished">يدوي</translation>
-    </message>
-    <message id="settings_tcpip_off">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="107"/>
-      <source>Off</source>
-      <translation type="unfinished">مطفأ</translation>
     </message>
     <message id="settings_tcpip_fixed">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="109"/>
@@ -2382,21 +2123,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="30"/>
       <source>Create access point</source>
       <translation>إنشاء نقطة توصيل</translation>
-    </message>
-    <message id="settings_wifi_access_point_enter_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="68"/>
-      <source>Enter password</source>
-      <translation type="unfinished">إدخال كلمة المرور</translation>
-    </message>
-    <message id="page_settings_wifi_invalid_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
-      <source>Password length must be either 0 or between 10 and 63 characters long</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_wifi_password_updated">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
-      <source>Password updated</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_wifi_networks">
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="86"/>
@@ -2539,20 +2265,10 @@ Use unless prohibited by the utility provider.</source>
       <extracomment>Network status: Standalone</extracomment>
       <translation>مستقل</translation>
     </message>
-    <message id="charger_standalone">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="45"/>
-      <source>Standalone</source>
-      <translation type="unfinished">مستقل</translation>
-    </message>
     <message id="charger_charge">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="48"/>
       <source>Charge</source>
       <translation>تحميل</translation>
-    </message>
-    <message id="charger_external_control">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="51"/>
-      <source>External control</source>
-      <translation type="unfinished">التحكم الخارجي</translation>
     </message>
     <message id="charger_charge_hub_1">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="54"/>
@@ -2584,16 +2300,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Master setting</source>
       <translation>إعداد الرئيسي</translation>
     </message>
-    <message id="charger_slave">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="85"/>
-      <source>Slave</source>
-      <translation type="unfinished">تابع</translation>
-    </message>
-    <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation type="unfinished">الجهد الكهربائي للشحن</translation>
-    </message>
     <message id="systemsettings_networkstatus_slave">
       <location filename="../../data/SystemSettings.qml" line="148"/>
       <source>Slave</source>
@@ -2615,14 +2321,15 @@ Use unless prohibited by the utility provider.</source>
       <source>Group &amp; Charge master</source>
       <translation>رئيس الشحن والمجموعة</translation>
     </message>
-    <message id="genset_charge_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="365"/>
+    <message id="charger_charge_voltage">
+      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
       <source>Charge voltage</source>
       <translation>الجهد الكهربائي للشحن</translation>
     </message>
     <message id="common_words_reset">
       <location filename="../../components/CommonWords.qml" line="448"/>
       <source>Reset</source>
+      <extracomment>Reset the BMS control</extracomment>
       <translation>إعادة ضبط</translation>
     </message>
     <message id="solarcharger_load">
@@ -2651,14 +2358,14 @@ Use unless prohibited by the utility provider.</source>
       <extracomment>Voltage alarm is at "Warning" level</extracomment>
       <translation>تحذير</translation>
     </message>
-    <message id="listitems_alarm_level_alarm">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="25"/>
+    <message id="digitalinputs_state_alarm">
+      <location filename="../../src/enums.cpp" line="270"/>
       <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
+      <extracomment>Relay function is 'alarm'</extracomment>
       <translation>إنذار</translation>
     </message>
-    <message id="devicelist_tankshape_volume">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="190"/>
+    <message id="components_volumeunit_volume">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
       <source>Volume</source>
       <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
       <translation>الحجم</translation>
@@ -2808,26 +2515,10 @@ Use unless prohibited by the utility provider.</source>
       <source>Relay function</source>
       <translation>عمل المرحل</translation>
     </message>
-    <message id="batterysettingrelay_alarm">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation type="unfinished">إنذار</translation>
-    </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
       <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
       <source>Charger or generator start/stop</source>
       <translation>بدء/وقف الشاحن أو المولد</translation>
-    </message>
-    <message id="batterysettingrelay_manual_control">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
-      <source>Manual control</source>
-      <translation type="unfinished">تحكم يدوي</translation>
-    </message>
-    <message id="batterysettingrelay_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">انصهار متضخم</translation>
     </message>
     <message id="common_words_manual_control">
       <location filename="../../components/CommonWords.qml" line="302"/>
@@ -2853,12 +2544,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
       <source>Status LEDs</source>
       <translation>حالة الثنائيات الباعثة للضوء</translation>
-    </message>
-    <message id="batterydiagnostics_none">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
-      <source>None</source>
-      <extracomment>Indicates no alarm is set</extracomment>
-      <translation type="unfinished">لا أحد</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
@@ -2888,7 +2573,7 @@ Use unless prohibited by the utility provider.</source>
     <message id="common_words_switch">
       <location filename="../../components/CommonWords.qml" line="525"/>
       <source>Switch</source>
-      <extracomment>Change the mode value</extracomment>
+      <extracomment>Change the battery mode</extracomment>
       <translation>مبدل</translation>
     </message>
     <message id="devicelist_battery_initializing">
@@ -2956,21 +2641,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Top section voltage</source>
       <translation>الفرع الأعلى للتيار</translation>
     </message>
-    <message id="battery_bank_error_communication">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="96"/>
-      <source>Communication error</source>
-      <translation type="unfinished">خطأ في الاتصال</translation>
-    </message>
-    <message id="battery_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="182"/>
-      <source>State of health</source>
-      <translation type="unfinished">حالة الصلاحية</translation>
-    </message>
-    <message id="battery_bus_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="212"/>
-      <source>Bus voltage</source>
-      <translation type="unfinished">الجهد الكهربائي للمسار التجميعي</translation>
-    </message>
     <message id="battery_bottom_section_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="228"/>
       <source>Bottom section voltage</source>
@@ -3016,16 +2686,6 @@ Use unless prohibited by the utility provider.</source>
       <source>IO</source>
       <translation>داخل/خارج</translation>
     </message>
-    <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="391"/>
-      <source>System</source>
-      <translation type="unfinished">النظام</translation>
-    </message>
-    <message id="battery_press_to_redetect">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="433"/>
-      <source>Press to redetect</source>
-      <translation type="unfinished">اضغط لإعادة الكشف</translation>
-    </message>
     <message id="pagesettingsgeneral_system">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="107"/>
       <source>System</source>
@@ -3066,16 +2726,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Low SOC</source>
       <translation>SoC منخفض</translation>
     </message>
-    <message id="batteryalarms_high_battery_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
-      <source>High battery voltage</source>
-      <translation type="unfinished">جهد البطارية مرتفع</translation>
-    </message>
-    <message id="batteryalarms_low_soc">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low SOC</source>
-      <translation type="unfinished">SoC منخفض</translation>
-    </message>
     <message id="batteryalarms_low_starter_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="73"/>
       <source>Low starter voltage</source>
@@ -3095,11 +2745,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
       <source>Mid-point voltage</source>
       <translation>تيار نقطة الوسط</translation>
-    </message>
-    <message id="batteryalarms_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">انصهار متضخم</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
@@ -3293,11 +2938,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Restore factory defaults</source>
       <translation>استعادة القيمة الافتراضية للمصنع</translation>
     </message>
-    <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation type="unfinished">اضغط للعودة إلى الضبط الأصلي</translation>
-    </message>
     <message id="vebus_backup_press_to_restore">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="362"/>
       <source>Press to restore</source>
@@ -3337,11 +2977,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="18"/>
       <source>Capacity</source>
       <translation>استيعاب</translation>
-    </message>
-    <message id="batterysettingsbattery_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
-      <source>Capacity</source>
-      <translation type="unfinished">استيعاب</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
@@ -3418,11 +3053,6 @@ Use unless prohibited by the utility provider.</source>
       <source>No power on busbar</source>
       <translation>لا توجد طاقة على قضيب التجميع</translation>
     </message>
-    <message id="lynxdistributor_connection_lost">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
-      <source>Connection lost</source>
-      <translation type="unfinished">اتصال مفقود</translation>
-    </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
       <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
       <source>%n fuse(s) blown</source>
@@ -3462,26 +3092,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Shutdowns due error</source>
       <translation>إغلاق بسبب الأخطاء</translation>
     </message>
-    <message id="lynxiondiagnostics_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
-      <source>Last error</source>
-      <translation type="unfinished">آخر خطأ</translation>
-    </message>
-    <message id="lynxiondiagnostics_2nd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
-      <source>2nd last error</source>
-      <translation type="unfinished">ثاني آخر خطأ</translation>
-    </message>
-    <message id="lynxiondiagnostics_3rd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
-      <source>3rd last error</source>
-      <translation type="unfinished">ثالث آخر خطأ</translation>
-    </message>
-    <message id="lynxiondiagnostics_4th_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
-      <source>4th last error</source>
-      <translation type="unfinished">رابع آخر خطأ</translation>
-    </message>
     <message id="lynxionio_system_switch">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
       <source>System Switch</source>
@@ -3501,11 +3111,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../components/CommonWords.qml" line="54"/>
       <source>Batteries</source>
       <translation>بطاريات</translation>
-    </message>
-    <message id="lynxionsystem_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
-      <source>Capacity</source>
-      <translation type="unfinished">استيعاب</translation>
     </message>
     <message id="lynxionsystem_parallel">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="30"/>
@@ -3527,20 +3132,10 @@ Use unless prohibited by the utility provider.</source>
       <source>Min/max cell temperature</source>
       <translation>الحد الأدنى/الحد الأعلى لحرارة الخلية</translation>
     </message>
-    <message id="lynxionsystem_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="92"/>
-      <source>Balancing</source>
-      <translation type="unfinished">يقوم بالموازنة</translation>
-    </message>
     <message id="lynxionsystem_balancer_balancing">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
       <source>Balancing</source>
       <translation>يقوم بالموازنة</translation>
-    </message>
-    <message id="lynxionsystem_balancer_unknown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="117"/>
-      <source>Unknown</source>
-      <translation type="unfinished">مجهول</translation>
     </message>
     <message id="dc_output">
       <location filename="../../components/listitems/ListDcOutputQuantityGroup.qml" line="16"/>
@@ -3648,11 +3243,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Remaining</source>
       <translation>المتبقي</translation>
     </message>
-    <message id="devicelist_tanksensor_sensor_battery">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="51"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">بطارية المستشعر</translation>
-    </message>
     <message id="temperature_sensor_battery">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="112"/>
       <source>Sensor battery</source>
@@ -3681,7 +3271,7 @@ Use unless prohibited by the utility provider.</source>
     <message id="devicelist_tanksetup_custom">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="53"/>
       <source>Custom</source>
-      <translation type="unfinished">تخصيص</translation>
+      <translation>تخصيص</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="59"/>
@@ -3714,34 +3304,34 @@ Use unless prohibited by the utility provider.</source>
       <translation>قيمة جهاز الاستشعار</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="75"/>
       <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
       <translation>لم يتم تحديد شكل مخصص يمكنك تحديد نقطة واحدة حتى عشر نقاط. يرجى العلم أن 0% و100% مشمولة.</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="91"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="89"/>
       <source>Point %1</source>
       <extracomment>%1 = the point number</extracomment>
       <translation>النقطة %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="133"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="179"/>
       <source>Add point</source>
       <translation>إضافة درجة</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="156"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="205"/>
       <source>Sensor level</source>
       <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
       <translation>مستوى المستشعر</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="256"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="311"/>
       <source>Duplicate sensor level values are not allowed.</source>
       <translation>لا يسمح بقيم مستوى الحساس المكررة.</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="262"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="317"/>
       <source>Volume values must be increasing.</source>
       <translation>يجب زيادة قيم الحجم.</translation>
     </message>
@@ -3781,11 +3371,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Switch position</source>
       <translation>موضع المفتاح</translation>
     </message>
-    <message id="ac-in-setup_single_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="142"/>
-      <source>Single phase</source>
-      <translation type="unfinished">طور مفرد</translation>
-    </message>
     <message id="ac-in-setup_two_phase">
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="144"/>
       <source>2-phase</source>
@@ -3795,11 +3380,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="146"/>
       <source>3-phase</source>
       <translation>3-طور</translation>
-    </message>
-    <message id="ac-in-setup_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="161"/>
-      <source>Devices</source>
-      <translation type="unfinished">أجهزة</translation>
     </message>
     <message id="ac-in-genset_ac">
       <location filename="../../components/PageGensetModel.qml" line="194"/>
@@ -3893,12 +3473,6 @@ Use unless prohibited by the utility provider.</source>
       <extracomment>%1 = CT device number</extracomment>
       <translation>محول التيار %1</translation>
     </message>
-    <message id="smappeect_phase_none">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation type="unfinished">لا أحد</translation>
-    </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
       <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
       <source>Flashing LED indicates this CT</source>
@@ -3912,11 +3486,13 @@ Use unless prohibited by the utility provider.</source>
     <message id="common_words_setting_disabled_when_dmc_connected">
       <location filename="../../components/CommonWords.qml" line="355"/>
       <source>This setting is disabled when a Digital Multi Control is connected.</source>
+      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>تم تعطيل هذا الإعداد عند توصيل التحكم الرقمي المتعدد.</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
       <location filename="../../components/CommonWords.qml" line="358"/>
       <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>تم تعطيل هذا الإعداد عند توصيل VE.Bus BMS.</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
@@ -3934,16 +3510,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="21"/>
       <source>Inverted</source>
       <translation>محول</translation>
-    </message>
-    <message id="digitalinput_enable_alarm">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="48"/>
-      <source>Enable alarm</source>
-      <translation type="unfinished">تفعيل الإنذار</translation>
-    </message>
-    <message id="digitalinput_inverted">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="54"/>
-      <source>Inverted</source>
-      <translation type="unfinished">محول</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
       <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="60"/>
@@ -3980,16 +3546,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Wind speed</source>
       <translation>سرعة الرياح</translation>
     </message>
-    <message id="page_meteo_battery_voltage">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="99"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">بطارية المستشعر</translation>
-    </message>
-    <message id="meteo_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="120"/>
-      <source>Low</source>
-      <translation type="unfinished">منخفض</translation>
-    </message>
     <message id="page_meteo_settings_auto_detect">
       <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
       <source>Auto-detect</source>
@@ -4020,16 +3576,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Reset counter</source>
       <translation>عداد ضبط النظام</translation>
     </message>
-    <message id="temperature_short_circuited">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="32"/>
-      <source>Short circuited</source>
-      <translation type="unfinished">حدثت دائرة قصر</translation>
-    </message>
-    <message id="temperature_reverse_polarity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="35"/>
-      <source>Reverse polarity</source>
-      <translation type="unfinished">قطبية معاكسة</translation>
-    </message>
     <message id="temperature_sensor_battery_low">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
       <source>Sensor battery low</source>
@@ -4044,36 +3590,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="62"/>
       <source>Pressure</source>
       <translation>الضغط</translation>
-    </message>
-    <message id="temperature_pm25">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
-      <source>PM2.5</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_co2">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>CO₂</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_voc">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
-      <source>VOC index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_nox">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
-      <source>NOx index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_luminosity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
-      <source>Luminosity</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="133"/>
-      <source>Low</source>
-      <translation type="unfinished">منخفض</translation>
     </message>
     <message id="temperature_offset">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
@@ -4127,25 +3643,10 @@ NOTE: The update might temporarily stop the system.</source>
       <source>Updating the MK3, values will reappear after the update is complete</source>
       <translation>تحديث MK3، ستظهر القيم مرة أخرى بعد استكمال التحديث</translation>
     </message>
-    <message id="vebus_device_charging_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="78"/>
-      <source>Charging the battery to 100%</source>
-      <translation type="unfinished">شحن البطارية إلى 100%</translation>
-    </message>
     <message id="vebus_device_charging_the_battery_to_100">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="93"/>
       <source>Charging the battery to 100%</source>
       <translation>شحن البطارية إلى 100%</translation>
-    </message>
-    <message id="vebus_device_page_microgrid_parameters">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
-      <source>Microgrid parameters</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="vebus_device_page_advanced">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
-      <source>Advanced</source>
-      <translation type="unfinished">متقدم</translation>
     </message>
     <message id="vebus_device_in_progress">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="80"/>
@@ -4201,15 +3702,15 @@ Do you want to continue?</source>
       <source>DC Current</source>
       <translation>التيار المستمر الحالي</translation>
     </message>
+    <message id="vebus_device_page_advanced">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
+      <source>Advanced</source>
+      <translation>متقدم</translation>
+    </message>
     <message id="common_words_alarm_setup">
       <location filename="../../components/CommonWords.qml" line="65"/>
       <source>Alarm setup</source>
       <translation>إعادة ضبط الإنذار</translation>
-    </message>
-    <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
-      <translation type="unfinished">المسار التجميعي VE لنظام إدارة البطارية تقوم بإيقاف النظام آليا عندما تحتاج إلى حماية البطارية. ومن ثم فالتحكم بالنظام عبر إعدادات الألوان غير متاح.</translation>
     </message>
     <message id="vebus_device_bms_not_found">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="240"/>
@@ -4250,7 +3751,7 @@ Do you want to continue?</source>
     <message id="vebus_device_starting">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="117"/>
       <source>Starting...</source>
-      <translation type="unfinished">البدء...</translation>
+      <translation>البدء...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="120"/>
@@ -4316,16 +3817,6 @@ Do you want to continue?</source>
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="260"/>
       <source>ESS Relay test</source>
       <translation>اختبار مرحل ESS</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_completed">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="266"/>
-      <source>Completed</source>
-      <translation type="unfinished">مكتمل</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_pending">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="268"/>
-      <source>Pending</source>
-      <translation type="unfinished">قيد الانتظار</translation>
     </message>
     <message id="cycle_history_completed">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
@@ -4512,6 +4003,7 @@ Do you want to continue?</source>
     <message id="rssystemalarms_overload">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
       <source>Overload</source>
+      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
       <translation>حمل زائد</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
@@ -4524,11 +4016,6 @@ Do you want to continue?</source>
       <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
       <source>Voltage Sensor</source>
       <translation>حساس التيار</translation>
-    </message>
-    <message id="vebus_device_phase_rotation">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
-      <source>Phase rotation</source>
-      <translation type="unfinished">تناوب المرحلة</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
@@ -4560,12 +4047,6 @@ Do you want to continue?</source>
       <source>VE.Bus BMS version</source>
       <translation>نسخة المسار التجميعي VE لنظام إدارة البطارية</translation>
     </message>
-    <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="15"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="52"/>
-      <source>Minimum SOC</source>
-      <translation type="unfinished">أدنى حالة للشحن</translation>
-    </message>
     <message id="ess_unless_grid_fails">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="32"/>
       <source>Unless grid fails</source>
@@ -4585,7 +4066,7 @@ Do you want to continue?</source>
     <message id="common_words_ac_input_role">
       <location filename="../../components/CommonWords.qml" line="24"/>
       <source>Role</source>
-      <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
       <translation>الدور</translation>
     </message>
     <message id="common_words_ac_load">
@@ -4624,18 +4105,6 @@ Do you want to continue?</source>
       <source>Active</source>
       <extracomment>Status is 'active'</extracomment>
       <translation>نشط</translation>
-    </message>
-    <message id="common_words_alarm">
-      <location filename="../../components/CommonWords.qml" line="51"/>
-      <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
-      <translation type="unfinished">إنذار</translation>
-    </message>
-    <message id="common_words_alarm_setting_overload">
-      <location filename="../../components/CommonWords.qml" line="58"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation type="unfinished">حمل زائد</translation>
     </message>
     <message id="common_words_alarm_status">
       <location filename="../../components/CommonWords.qml" line="68"/>
@@ -4682,8 +4151,8 @@ Do you want to continue?</source>
       <source>Charge current</source>
       <translation>تيار الشحن</translation>
     </message>
-    <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="125"/>
+    <message id="battery_mode_charging">
+      <location filename="../../src/enums.cpp" line="30"/>
       <source>Charging</source>
       <extracomment>"Charging" state</extracomment>
       <translation>يقوم بالشحن</translation>
@@ -4697,7 +4166,7 @@ Do you want to continue?</source>
     <message id="digitalinputs_state_closed">
       <location filename="../../src/enums.cpp" line="262"/>
       <source>Closed</source>
-      <extracomment>Digital input state</extracomment>
+      <extracomment>Status is 'closed'</extracomment>
       <translation>مغلق</translation>
     </message>
     <message id="evchargers_status_connected">
@@ -4705,8 +4174,8 @@ Do you want to continue?</source>
       <source>Connected</source>
       <translation>متصل</translation>
     </message>
-    <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="143"/>
+    <message id="temperature_slider_current">
+      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
       <source>Current</source>
       <extracomment>Electric current, as measured in Amps</extracomment>
       <translation>التيار</translation>
@@ -4733,9 +4202,10 @@ Do you want to continue?</source>
       <extracomment>Title for device information</extracomment>
       <translation>الجهاز</translation>
     </message>
-    <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="172"/>
+    <message id="battery_mode_discharging">
+      <location filename="../../src/enums.cpp" line="34"/>
       <source>Discharging</source>
+      <extracomment>Battery mode</extracomment>
       <translation>يقوم بتفريغ الشحن</translation>
     </message>
     <message id="wifimodel_disconnected">
@@ -4821,13 +4291,14 @@ Do you want to continue?</source>
       <source>%1 Hour(s)</source>
       <translation>%1 ساعة/ ساعات</translation>
     </message>
-    <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="251"/>
+    <message id="battery_mode_idle">
+      <location filename="../../src/enums.cpp" line="26"/>
       <source>Idle</source>
+      <extracomment>Battery mode</extracomment>
       <translation>ساكن</translation>
     </message>
-    <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="258"/>
+    <message id="scheduled_charge_inactive">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
       <source>Inactive</source>
       <extracomment>Status is 'inactive'</extracomment>
       <translation>غير نشط</translation>
@@ -4929,8 +4400,8 @@ Do you want to continue?</source>
       <source>Offline</source>
       <translation>خارج الخط</translation>
     </message>
-    <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="17"/>
+    <message id="digitalinputs_state_ok">
+      <location filename="../../src/enums.cpp" line="266"/>
       <source>OK</source>
       <extracomment>Voltage alarm is at "OK" level</extracomment>
       <translation>صحيح</translation>
@@ -4938,6 +4409,7 @@ Do you want to continue?</source>
     <message id="switchable_output_on">
       <location filename="../../src/enums.cpp" line="471"/>
       <source>On</source>
+      <extracomment>Digital input state</extracomment>
       <translation>مشغل</translation>
     </message>
     <message id="common_words_online">
@@ -4948,7 +4420,7 @@ Do you want to continue?</source>
     <message id="digitalinputs_state_open">
       <location filename="../../src/enums.cpp" line="258"/>
       <source>Open</source>
-      <extracomment>Digital input open</extracomment>
+      <extracomment>Status is 'open'</extracomment>
       <translation>مفتوح</translation>
     </message>
     <message id="common_words_password">
@@ -5008,9 +4480,10 @@ Do you want to continue?</source>
       <source>Remove</source>
       <translation>إزالة</translation>
     </message>
-    <message id="switch_state_running">
-      <location filename="../../src/enums.cpp" line="363"/>
+    <message id="switchable_output_running">
+      <location filename="../../src/enums.cpp" line="468"/>
       <source>Running</source>
+      <extracomment>Status = "running"</extracomment>
       <translation>مشغل</translation>
     </message>
     <message id="common_words_scanning">
@@ -5077,7 +4550,7 @@ Do you want to continue?</source>
     <message id="pvinverter_statusCode_startup">
       <location filename="../../src/enums.cpp" line="296"/>
       <source>Startup (%1)</source>
-      <extracomment>PV inverter status code. %1 = the startup status number</extracomment>
+      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
       <translation>بدء التشغيل (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
@@ -5132,8 +4605,10 @@ Do you want to continue?</source>
       <source>Unique Identity Number</source>
       <translation>رقم التعريف الفريد</translation>
     </message>
-    <message id="settings_radio_button_group_unknown">
-      <location filename="../../components/listitems/core/ListRadioButtonGroup.qml" line="44"/>
+    <message id="Unknown">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
       <source>Unknown</source>
       <translation>مجهول</translation>
     </message>
@@ -5288,11 +4763,6 @@ Do you want to continue?</source>
       <source>Error while checking for firmware updates</source>
       <translation>خطأ في أثناء التحقق من تحديثات البرنامج الثابت</translation>
     </message>
-    <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation type="unfinished">خطأ في أثناء التحقق من تحديثات البرنامج الثابت</translation>
-    </message>
     <message id="settings_firmware_downloading_and_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="63"/>
       <source>Downloading and installing firmware %1...</source>
@@ -5319,6 +4789,66 @@ Do you want to continue?</source>
       <source>No firmware found</source>
       <translation>لم يتم إيجاد برنامج مبيت</translation>
     </message>
+    <message id="tank_type_fuel">
+      <location filename="../../src/enums.cpp" line="495"/>
+      <source>Fuel</source>
+      <translation>وقود</translation>
+    </message>
+    <message id="tank_type_fresh_water">
+      <location filename="../../src/enums.cpp" line="498"/>
+      <source>Fresh water</source>
+      <translation>ماء نقي</translation>
+    </message>
+    <message id="tank_type_waste_water">
+      <location filename="../../src/enums.cpp" line="501"/>
+      <source>Waste water</source>
+      <translation>ماء فاسد</translation>
+    </message>
+    <message id="tank_type_live_well">
+      <location filename="../../src/enums.cpp" line="504"/>
+      <source>Live well</source>
+      <translation>حيوية جيدة</translation>
+    </message>
+    <message id="tank_type_oil">
+      <location filename="../../src/enums.cpp" line="507"/>
+      <source>Oil</source>
+      <translation>زيت</translation>
+    </message>
+    <message id="tank_type_black_water">
+      <location filename="../../src/enums.cpp" line="510"/>
+      <source>Black water</source>
+      <translation>مياه سوداء</translation>
+    </message>
+    <message id="tank_type_gasoline">
+      <location filename="../../src/enums.cpp" line="513"/>
+      <source>Gasoline</source>
+      <translation>البنزين</translation>
+    </message>
+    <message id="tank_type_diesel">
+      <location filename="../../src/enums.cpp" line="516"/>
+      <source>Diesel</source>
+      <translation>الديزل</translation>
+    </message>
+    <message id="tank_type_lpg">
+      <location filename="../../src/enums.cpp" line="519"/>
+      <source>LPG</source>
+      <translation>الغاز النفطي المسال</translation>
+    </message>
+    <message id="tank_type_lng">
+      <location filename="../../src/enums.cpp" line="522"/>
+      <source>LNG</source>
+      <translation>الغاز الطبيعي المسال</translation>
+    </message>
+    <message id="tank_type_hydraulic_oil">
+      <location filename="../../src/enums.cpp" line="525"/>
+      <source>Hydraulic oil</source>
+      <translation>زيت هيدروليكي</translation>
+    </message>
+    <message id="tank_type_raw_water">
+      <location filename="../../src/enums.cpp" line="528"/>
+      <source>Raw water</source>
+      <translation>ماء غير معالج</translation>
+    </message>
     <message id="listItem_no_access">
       <location filename="../../components/listitems/core/ListItem.qml" line="102"/>
       <source>Setting locked for access level</source>
@@ -5332,6 +4862,7 @@ Do you want to continue?</source>
     <message id="welcome_brief_title">
       <location filename="../../pages/welcome/WelcomeView.qml" line="81"/>
       <source>Brief</source>
+      <extracomment>The 'Brief' page</extracomment>
       <translation>مختصر</translation>
     </message>
     <message id="welcome_overview_title">
@@ -5348,23 +4879,6 @@ Do you want to continue?</source>
       <location filename="../../pages/NotificationsPage.qml" line="13"/>
       <source>Notifications</source>
       <translation>الإعلامات</translation>
-    </message>
-    <message id="notifications_page_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="43"/>
-      <source>Active Notifications</source>
-      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_page_inactive_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="47"/>
-      <source>Inactive Notifications</source>
-      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_no_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="106"/>
-      <source>No active notifications</source>
-      <translation type="unfinished"/>
     </message>
     <message id="utils_formatTimestamp_now">
       <location filename="../../components/Utils.js" line="258"/>
@@ -5469,11 +4983,6 @@ Do you want to continue?</source>
       <source>Self-consumption above limit</source>
       <translation>الاستهلاك الذاتي زائد عن الحد</translation>
     </message>
-    <message id="cgwacs_battery_schedule_pv">
-      <location filename="../../components/listitems/ListChargeSchedule.qml" line="171"/>
-      <source>PV</source>
-      <translation type="unfinished">جهاز ضوئي</translation>
-    </message>
     <message id="settings_multirs_pv">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="185"/>
       <source>PV</source>
@@ -5484,8 +4993,8 @@ Do you want to continue?</source>
       <source>PV &amp; Battery</source>
       <translation>الخلايا الكهروضوئية والبطارية</translation>
     </message>
-    <message id="settings_firmware_checking">
-      <location filename="../../components/listitems/ListFirmwareCheckButton.qml" line="16"/>
+    <message id="pagesettingssupportstate_firmware_checking">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
       <source>Checking...</source>
       <translation>تدقيق...</translation>
     </message>
@@ -5493,12 +5002,6 @@ Do you want to continue?</source>
       <location filename="../../components/listitems/ListAlarmState.qml" line="11"/>
       <source>Alarm state</source>
       <translation>حالة المنبه</translation>
-    </message>
-    <message id="devicelist_battery_alarm_state">
-      <location filename="../../components/listitems/ListAlarmState.qml" line="19"/>
-      <source>Alarm</source>
-      <extracomment>Alarm state is active</extracomment>
-      <translation type="unfinished">إنذار</translation>
     </message>
     <message id="clear_history_button_clear_history">
       <location filename="../../components/listitems/ListClearHistoryButton.qml" line="15"/>
@@ -5650,11 +5153,6 @@ Do you want to continue?</source>
       <source>Max Voltage</source>
       <translation>أقصى جهد كهربي</translation>
     </message>
-    <message id="charger_history_box_max_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="64"/>
-      <source>Max Voltage</source>
-      <translation type="unfinished">أقصى جهد كهربي</translation>
-    </message>
     <message id="charger_history_box_max_current">
       <location filename="../../components/SolarDetailBox.qml" line="70"/>
       <source>Max Current</source>
@@ -5665,24 +5163,6 @@ Do you want to continue?</source>
       <source>Charge time</source>
       <extracomment>Statistics for battery charging time</extracomment>
       <translation>زمن الشحن</translation>
-    </message>
-    <message id="charger_history_box_bulk">
-      <location filename="../../components/SolarDetailBox.qml" line="136"/>
-      <source>Bulk</source>
-      <extracomment>Battery: time spent in 'Bulk' mode</extracomment>
-      <translation type="unfinished">كتلة</translation>
-    </message>
-    <message id="charger_history_box_float">
-      <location filename="../../components/SolarDetailBox.qml" line="148"/>
-      <source>Float</source>
-      <extracomment>Battery: time spent in 'Float' mode</extracomment>
-      <translation type="unfinished">بالتعويم</translation>
-    </message>
-    <message id="charger_history_hr">
-      <location filename="../../components/SolarDetailBox.qml" line="174"/>
-      <source>hr</source>
-      <extracomment>Abbreviation of "hour"</extracomment>
-      <translation type="unfinished">ساعة</translation>
     </message>
     <message id="solarchargers_state_bulk">
       <location filename="../../src/enums.cpp" line="337"/>
@@ -5754,11 +5234,6 @@ Do you want to continue?</source>
       <source>Connecting</source>
       <translation>جاري الاتصال</translation>
     </message>
-    <message id="splash_view_connecting">
-      <location filename="../../components/SplashView.qml" line="288"/>
-      <source>Connecting</source>
-      <translation type="unfinished">جاري الاتصال</translation>
-    </message>
     <message id="splash_view_connected">
       <location filename="../../components/SplashView.qml" line="290"/>
       <source>Connected, awaiting broker messages</source>
@@ -5814,6 +5289,11 @@ Do you want to continue?</source>
       <source>MQTT protocol level 5 error</source>
       <translation>خطأ المستوى الخامس من بروتوكول MQTT</translation>
     </message>
+    <message id="common_words_silence_alarm">
+      <location filename="../../components/CommonWords.qml" line="476"/>
+      <source>Silence alarm</source>
+      <translation>إنذار صامت</translation>
+    </message>
     <message id="vebus_device_page_total_power">
       <location filename="../../components/ThreePhaseQuantityTable.qml" line="47"/>
       <source>Total Power</source>
@@ -5864,20 +5344,10 @@ Do you want to continue?</source>
       <source>Retrieving IP address</source>
       <translation>استرجاع عنوان بروتوكول الإنترنت</translation>
     </message>
-    <message id="utils_connman_connected">
-      <location filename="../../components/Utils.js" line="292"/>
-      <source>Connected</source>
-      <translation type="unfinished">متصل</translation>
-    </message>
     <message id="utils_connman_disconnect">
       <location filename="../../components/Utils.js" line="295"/>
       <source>Disconnect</source>
       <translation>فصل</translation>
-    </message>
-    <message id="utils_connman_disconnected">
-      <location filename="../../components/Utils.js" line="299"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">منفصل</translation>
     </message>
     <message id="overview_widget_acloads_title">
       <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
@@ -5915,11 +5385,6 @@ Do you want to continue?</source>
       <source>Shore current limit</source>
       <translation>حد تيار الشاطئ</translation>
     </message>
-    <message id="acInputs_statusCode_stopping">
-      <location filename="../../data/AcInputs.qml" line="170"/>
-      <source>Stopping</source>
-      <translation type="unfinished">توقف</translation>
-    </message>
     <message id="page_generator_stopping">
       <location filename="../../data/Generators.qml" line="44"/>
       <source>Stopping</source>
@@ -5935,7 +5400,7 @@ Do you want to continue?</source>
       <location filename="../../data/common/TankDescription.qml" line="24"/>
       <location filename="../../src/device.cpp" line="133"/>
       <source>%1 tank (%2)</source>
-      <extracomment>Tank description. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
       <translation>%1 خزان (%2)</translation>
     </message>
     <message id="dcMeter_ac_charger">
@@ -5984,11 +5449,6 @@ Do you want to continue?</source>
       <location filename="../../data/Ess.qml" line="20"/>
       <source>Keep batteries charged</source>
       <translation>حافظ على أن تكون البطاريات مشحونة</translation>
-    </message>
-    <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="50"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">منفصل</translation>
     </message>
     <message id="evchargers_status_charged">
       <location filename="../../data/EvChargers.qml" line="58"/>
@@ -6049,16 +5509,6 @@ Do you want to continue?</source>
       <location filename="../../data/EvChargers.qml" line="97"/>
       <source>Start charging</source>
       <translation>ابدأ الشحن</translation>
-    </message>
-    <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="113"/>
-      <source>Unknown</source>
-      <translation type="unfinished">مجهول</translation>
-    </message>
-    <message id="evchargers_mode_scheduled">
-      <location filename="../../data/EvChargers.qml" line="126"/>
-      <source>Scheduled</source>
-      <translation type="unfinished">مجدول</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
       <location filename="../../data/System.qml" line="195"/>
@@ -6183,11 +5633,6 @@ Do you want to continue?</source>
       <source>Power supply mode</source>
       <translation>وضع إمدادات الطاقة</translation>
     </message>
-    <message id="inverters_state_sustain">
-      <location filename="../../data/System.qml" line="158"/>
-      <source>Sustain</source>
-      <translation type="unfinished">ركيزة</translation>
-    </message>
     <message id="inverters_state_wakeup">
       <location filename="../../data/System.qml" line="162"/>
       <source>Wake up</source>
@@ -6222,16 +5667,6 @@ Do you want to continue?</source>
       <location filename="../../data/System.qml" line="180"/>
       <source>Test</source>
       <translation>معاينة</translation>
-    </message>
-    <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="183"/>
-      <source>External control</source>
-      <translation type="unfinished">التحكم الخارجي</translation>
-    </message>
-    <message id="inverters_state_dynamic_ess">
-      <location filename="../../data/System.qml" line="198"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">نظام تخزين الطاقة الديناميكي (ESS)</translation>
     </message>
     <message id="settings_rs_ess_dess">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="97"/>
@@ -6310,16 +5745,13 @@ Do you want to continue?</source>
     <message id="ess_recommended">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="73"/>
       <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
       <translation>بالنسبة لبطاريات الليثيوم، لا يوصى بشحن أقل من 10%. بالنسبة لأنواع البطاريات الأخرى، تحقق من ورقة البيانات لمعرفة الحد الأدنى الموصى به من قبل الشركة المصنعة.</translation>
-    </message>
-    <message id="controlcard_generator_label_autostart">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="63"/>
-      <source>Autostart</source>
-      <translation type="unfinished">التشغيل الآلي</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
       <location filename="../../pages/controlcards/GeneratorCard.qml" line="70"/>
       <source>Start and stop the generator based on the configured autostart conditions.</source>
+      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
       <translation>شغل وأوقف المولد حسب أوضاع التشغيل الآلي المحددة.</translation>
     </message>
     <message id="generator_dialog_disabled">
@@ -6342,11 +5774,13 @@ Do you want to continue?</source>
       <location filename="../../pages/controlcards/InverterChargerCard.qml" line="26"/>
       <source>Inverter / Charger (%1)</source>
       <extracomment>%1 = the inverter/charger name</extracomment>
+      <oldsource>Inverter / Charger</oldsource>
       <translation>محول التردد/ الشاحن (%1)</translation>
     </message>
     <message id="settings_page_debug_quit_application">
       <location filename="../../pages/settings/debug/PageDebug.qml" line="36"/>
       <source>Quit application</source>
+      <oldsource>Quit Application</oldsource>
       <translation>إلغاء التطبيق</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
@@ -6357,12 +5791,8 @@ Do you want to continue?</source>
     <message id="settings_page_relay_generator_run_time">
       <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
       <source>Current run time</source>
+      <oldsource>Run time</oldsource>
       <translation>وقت التشغيل الحالي</translation>
-    </message>
-    <message id="settings_page_genset_generator_run_time">
-      <location filename="../../components/PageGensetModel.qml" line="102"/>
-      <source>Current run time</source>
-      <translation type="unfinished">وقت التشغيل الحالي</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
       <location filename="../../components/PageGensetModel.qml" line="110"/>
@@ -6389,19 +5819,10 @@ Do you want to continue?</source>
       <source>Remote start mode</source>
       <translation>وضع البدء عن بعد</translation>
     </message>
-    <message id="ac-in-genset_speed">
-      <location filename="../../components/PageGensetModel.qml" line="245"/>
-      <source>Speed</source>
-      <translation type="unfinished">السرعة</translation>
-    </message>
-    <message id="ac-in-genset_load">
-      <location filename="../../components/PageGensetModel.qml" line="252"/>
-      <source>Load</source>
-      <translation type="unfinished">تحميل</translation>
-    </message>
     <message id="ac-in-genset_oil_pressure">
       <location filename="../../components/PageGensetModel.qml" line="260"/>
       <source>Oil pressure</source>
+      <oldsource>Oil Pressure</oldsource>
       <translation>ضغط الزيت</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
@@ -6497,11 +5918,13 @@ Do you want to continue?</source>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
       <source>High starter battery voltage alarms</source>
+      <oldsource>High starter batttery voltage alarms</oldsource>
       <translation>إنذارات ارتفاع جهد بطارية بدء التشغيل</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
       <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
       <translation>لاحظ أن تغيير إعداد أرضية التفريغ Time-to-go يؤدي أيضًا إلى تغيير إعداد حالة الشحن المنخفضة في قائمة الترحيل.</translation>
     </message>
     <message id="lynxionsystem_cells_per_battery">
@@ -6578,6 +6001,7 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/devicelist/delegates/DeviceListDelegate_solarcharger.qml" line="34"/>
       <source>Error: #%1</source>
       <extracomment>%1 = error number</extracomment>
+      <oldsource>Error: %1</oldsource>
       <translation>خطأ: #%1</translation>
     </message>
     <message id="devicelistpage_genset">
@@ -6634,17 +6058,14 @@ Do you want to continue?</source>
     <message id="settings_page_relay_generator_auto_start_enabled">
       <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
       <source>Autostart functionality</source>
+      <oldsource>Auto start functionality</oldsource>
       <translation>وظيفة التشغيل التلقائي</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="97"/>
       <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
       <translation>تأكد من عدم توصيل المولد بمدخل التيار المتردد %1 عند استخدام هذا الخيار</translation>
-    </message>
-    <message id="page_generator_conditions_inverter_high_temperature">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="139"/>
-      <source>Inverter high temperature</source>
-      <translation type="unfinished">درجة حرارة عالية في المعاكس</translation>
     </message>
     <message id="page_generator_conditions_tank_level">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="159"/>
@@ -6674,30 +6095,34 @@ Do you want to continue?</source>
     <message id="settings_generator_function_not_enabled">
       <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
       <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
+      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
       <translation>وظيفة التشغيل/التوقيف للمولد غير مفعلة، اذهب إلى إعدادات المرحل واختر وظيفة "تشغيل/توقيف المولد"</translation>
     </message>
     <message id="settings_batteries_intro">
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="45"/>
       <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
       <translation>استخدم هذه القائمة لتحديد بيانات البطارية التي تظهر عند النقر على أيقونة «البطارية» في صفحة «النظرة العامة». يظهر نفس الخيار على منصة VRM.</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
       <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
       <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
       <translation>قد يتداخل المسح المستمر مع تشغيل الواي فاي.</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
       <source>CAN-bus BMS LV (500 kbit/s)</source>
+      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
       <translation>نظام إدارة البطاريات (BMS) باستخدام ناقل CAN منخفض الجهد (500 كيلوبت/ثانية)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
       <source>CAN-bus BMS HV (500 kbit/s)</source>
       <translation>نظام إدارة البطاريات (BMS) باستخدام ناقل CAN عالي الجهد (500 كيلوبت/ثانية)</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
       <source>Up, but no services (500 kbit/s)</source>
       <translation>أعلى، لكن دون خدمات (500 كيلو بت/ ثانية)</translation>
     </message>
@@ -6710,41 +6135,6 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="127"/>
       <source>Brief page</source>
       <translation>صفحة المختصر</translation>
-    </message>
-    <message id="settings_displayoff_1min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="46"/>
-      <source>1 min</source>
-      <translation type="unfinished">دقيقة</translation>
-    </message>
-    <message id="settings_displayoff_10min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="48"/>
-      <source>10 min</source>
-      <translation type="unfinished">عشرة دقائق</translation>
-    </message>
-    <message id="settings_displayoff_30min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="50"/>
-      <source>30 min</source>
-      <translation type="unfinished">ثلاثون دقيقة</translation>
-    </message>
-    <message id="settings_displayoff_never">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="52"/>
-      <source>Never</source>
-      <translation type="unfinished">أبدا</translation>
-    </message>
-    <message id="settings_remote_console_appearance_auto">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="112"/>
-      <source>Auto</source>
-      <translation type="unfinished">آلي</translation>
-    </message>
-    <message id="settings_brief_view_start_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="119"/>
-      <source>Start page</source>
-      <translation type="unfinished">صفحة البدء</translation>
-    </message>
-    <message id="settings_display_boat_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="135"/>
-      <source>Boat page</source>
-      <translation type="unfinished">صفحة البوت</translation>
     </message>
     <message id="settings_display_minmax">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="148"/>
@@ -6799,21 +6189,6 @@ Do you want to continue?</source>
       <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
       <translation>تم ضبط %1 إلى %2.</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_unsupported_device">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="50"/>
-      <source>Unsupported GX device</source>
-      <translation type="unfinished">جهاز GX غير مدعوم</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_clean">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="55"/>
-      <source>Clean</source>
-      <translation type="unfinished">تنظيف</translation>
-    </message>
-    <message id="pagesettingsgeneral_firmware">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="112"/>
-      <source>Firmware</source>
-      <translation type="unfinished">البرامج الثابتة</translation>
-    </message>
     <message id="pagesettingsgeneral_access_and_security">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
       <source>Access &amp; Security</source>
@@ -6847,6 +6222,7 @@ Do you want to continue?</source>
     <message id="settings_language_please_wait">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="209"/>
       <source>Please wait while the language is changed.</source>
+      <oldsource>Please wait while the language is changed</oldsource>
       <translation>يرجى الانتظار بينما يتم تغيير اللغة.</translation>
     </message>
     <message id="settings_briefview_totals">
@@ -6863,11 +6239,6 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="71"/>
       <source>Tank is not connected.</source>
       <translation>الخزان غير متصل.</translation>
-    </message>
-    <message id="settings_briefview_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="83"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">شاشة البطارية مفعلة</translation>
     </message>
     <message id="settings_briefview_individual_batteries">
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="86"/>
@@ -6918,6 +6289,7 @@ Do you want to continue?</source>
     <message id="settings_dvcc_charge_current_limits">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="30"/>
       <source>Charge current limits</source>
+      <oldsource>Charge Current limits</oldsource>
       <translation>حدود تيار الشحن</translation>
     </message>
     <message id="settings_firmware_official_release">
@@ -6997,11 +6369,6 @@ Do you want to continue?</source>
       <source>No password and the network communication is not encrypted</source>
       <translation>لا توجد كلمة مرور والاتصال الشبكي غير مشفر</translation>
     </message>
-    <message id="settings_logout_now">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
-      <source>Log out now</source>
-      <translation type="unfinished">تسجيل خروج الآن</translation>
-    </message>
     <message id="settings_security_profile_password_incorrect_length">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="28"/>
       <source>Password needs to be at least 8 characters long</source>
@@ -7047,25 +6414,10 @@ Do you want to continue?</source>
       <source>Page will automatically reload in 5 seconds</source>
       <translation>سيعاد تحميل الصفحة تلقائيا خلال 5 ثوانٍ.</translation>
     </message>
-    <message id="settings_security_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="159"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">يجب أن تحتوي كلمة المرور على الأقل على 8 رموز</translation>
-    </message>
     <message id="settings_root_password">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="269"/>
       <source>Root password</source>
       <translation>كلمة المرور الرئيسية</translation>
-    </message>
-    <message id="settings_root_enter_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="272"/>
-      <source>Enter password</source>
-      <translation type="unfinished">إدخال كلمة المرور</translation>
-    </message>
-    <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="277"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">يجب أن تحتوي كلمة المرور على الأقل على 8 رموز</translation>
     </message>
     <message id="settings_root_password_changed_to">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="283"/>
@@ -7081,6 +6433,11 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="321"/>
       <source>Logout</source>
       <translation>تسجيل الخروج</translation>
+    </message>
+    <message id="settings_logout_now">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
+      <source>Log out now</source>
+      <translation>تسجيل خروج الآن</translation>
     </message>
     <message id="settings_logout_dialog_title">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="335"/>
@@ -7140,11 +6497,13 @@ Do you want to continue?</source>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="141"/>
       <source>Alarm when generator is not in autostart mode</source>
+      <oldsource>Alarm when generator is not in auto start mode</oldsource>
       <translation>إنذار عندما لا يكون المولد في وضع التشغيل التلقائي</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="147"/>
       <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
       <translation>سيتم إطلاق إنذار عند ترك وظيفة التشغيل التلقائي معطلة لأكثر من 10 دقائق</translation>
     </message>
     <message id="settings_units_amps_exceptions">
@@ -7160,6 +6519,11 @@ Do you want to continue?</source>
     <message id="settings_ess_use_this_option_for_peak_shaving">
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
       <source>Use this option for peak shaving.</source>
+      <oldsource>Use this option for peak shaving.
+
+The peak shaving threshold is set using the AC input current limit setting.
+
+See documentation for further information.</oldsource>
       <translation>استخدم هذا الخيار لتقليل استهلاك الطاقة خلال أوقات الذروة.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
@@ -7203,17 +6567,17 @@ Do you want to continue?</source>
       <translation>أقصى تيار صادر بالنظام (لكل طور(</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="71"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="73"/>
       <source>Self-consumption from battery</source>
       <translation>الاستهلاك الذاتي من البطارية</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="76"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
       <source>All system loads</source>
       <translation>جميع أحمال النظام</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="80"/>
       <source>Only critical loads</source>
       <translation>الأحمال الحرجة فقط</translation>
     </message>
@@ -7271,26 +6635,6 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="194"/>
       <source>Server Applications</source>
       <translation>تطبيقات الخادم</translation>
-    </message>
-    <message id="pagesettingsintegrations_venus_os_enable_large_features">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
-      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_large_victron_community">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="274"/>
-      <source>Victron Community</source>
-      <translation type="unfinished">مجتمع Victron</translation>
-    </message>
-    <message id="pagesettingsintegrations_ui_plugins">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
-      <source>UI Plugins</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
-      <source>Integrates with the device list</source>
-      <translation type="unfinished"/>
     </message>
     <message id="pagesettingssupportstate_modbus_tcp_server">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="453"/>
@@ -7393,25 +6737,10 @@ Do you want to continue?</source>
       <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
       <translation>لا يمكن تبديل نسخة البرنامج الثابت دون تحديد "ملف تعريف أمن الشبكة" في "الإعدادات / عام".</translation>
     </message>
-    <message id="pagesettingsconnectivity_ethernet">
-      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
-      <source>Ethernet</source>
-      <translation type="unfinished">إيثرنت</translation>
-    </message>
     <message id="pagesettingsconnectivity_mobile_network">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="53"/>
       <source>Mobile Network</source>
       <translation>شبكة الجوال</translation>
-    </message>
-    <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Boat</source>
-      <translation type="unfinished">قارب</translation>
-    </message>
-    <message id="settings_system_name_auto">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="32"/>
-      <source>Automatic</source>
-      <translation type="unfinished">آلي</translation>
     </message>
     <message id="pagesettingssystem_ac_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
@@ -7442,11 +6771,6 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="89"/>
       <source>Distributed Voltage and Current Control (DVCC)</source>
       <translation>نظام التحكم للجهد الكهربائي الموزع</translation>
-    </message>
-    <message id="settings_system_grid">
-      <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="18"/>
-      <source>Grid</source>
-      <translation type="unfinished">الشبكة</translation>
     </message>
     <message id="settings_system_ac_position">
       <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="58"/>
@@ -7486,16 +6810,19 @@ Do you want to continue?</source>
     <message id="settings_system_has_dc_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="97"/>
       <source>Display DC Loads</source>
+      <oldsource>Has DC system</oldsource>
       <translation>عرض أحمال التيار المتردد</translation>
     </message>
     <message id="settings_system_battery_measurements">
       <location filename="../../pages/settings/PageSettingsBatteries.qml" line="65"/>
       <source>Battery measurements</source>
+      <oldsource>Battery Measurements</oldsource>
       <translation>قياسات البطارية</translation>
     </message>
     <message id="settings_system_system_status">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
       <source>System status</source>
+      <oldsource>System Status</oldsource>
       <translation>حالة النظام</translation>
     </message>
     <message id="settings_tcpip_wired">
@@ -7506,11 +6833,13 @@ Do you want to continue?</source>
     <message id="settings_vecan_device_instance">
       <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
       <source>VE.Can Device Instance</source>
+      <oldsource>Device Instance</oldsource>
       <translation>نسخة الجهاز VE.Can</translation>
     </message>
     <message id="settings_vecan_device_number">
       <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="32"/>
       <source>VE.Can Instance# %1</source>
+      <oldsource>Device# %1</oldsource>
       <translation>#نسخة الجهاز VE.Can%1</translation>
     </message>
     <message id="settings_tz_antarctica">
@@ -7541,6 +6870,7 @@ Do you want to continue?</source>
     <message id="settings_vrm">
       <location filename="../../pages/SettingsPage.qml" line="59"/>
       <source>VRM</source>
+      <extracomment>Forced by %2 to dark</extracomment>
       <translation>VRM</translation>
     </message>
     <message id="settings_remote_monitoring_portal">
@@ -7548,20 +6878,10 @@ Do you want to continue?</source>
       <source>Remote monitoring portal</source>
       <translation>بوابة المراقبة عن بعد</translation>
     </message>
-    <message id="settings_advanced">
-      <location filename="../../pages/SettingsPage.qml" line="68"/>
-      <source>Advanced</source>
-      <translation type="unfinished">متقدم</translation>
-    </message>
-    <message id="settings_integrations">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
+    <message id="pagesettingssupportstate_integrations">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
       <source>Integrations</source>
       <translation>التكاملات</translation>
-    </message>
-    <message id="settings_relays_sensors_tanks">
-      <location filename="../../pages/SettingsPage.qml" line="75"/>
-      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
-      <translation type="unfinished">الموصلات، الحساسات، الخزانات، العواكس الكهروضوئية، Modbus، MQTT...</translation>
     </message>
     <message id="settings_acdcsystem_ess_dvcc_battery">
       <location filename="../../pages/SettingsPage.qml" line="84"/>
@@ -7581,11 +6901,13 @@ Do you want to continue?</source>
     <message id="settings_system_setup">
       <location filename="../../pages/SettingsPage.qml" line="82"/>
       <source>System Setup</source>
+      <oldsource>System setup</oldsource>
       <translation>إعادة ضبط النظام</translation>
     </message>
     <message id="settings_vrm_device_instances">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
       <source>VRM device instances</source>
+      <oldsource>VRM Device Instances</oldsource>
       <translation>حالات جهاز VRM</translation>
     </message>
     <message id="solarcharger_not_supported">
@@ -7603,28 +6925,10 @@ Do you want to continue?</source>
       <source>The firmware version in the MPPT Solar Charger must be v1.09 or later. Contact Victron Service for update instructions and files.</source>
       <translation>يجب أن تكون نسخة البرنامج الثابت للشاحن الشمسي MPPT نسخة v1.09 أو بعد ذلك. تواصل مع Victron Service للتعليمات والملفات المحدثة.</translation>
     </message>
-    <message id="solarcharger_pv">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="102"/>
-      <source>PV</source>
-      <extracomment>PV power for solar charger</extracomment>
-      <translation type="unfinished">جهاز ضوئي</translation>
-    </message>
     <message id="solarcharger_total_power">
       <location filename="../../pages/solar/PageSolarCharger.qml" line="127"/>
       <source>Total PV power</source>
       <translation>إجمالي الطاقة الكهروضوئية</translation>
-    </message>
-    <message id="solarcharger_total_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="211"/>
-      <source>Total yield</source>
-      <extracomment>Solar charger total yield</extracomment>
-      <translation type="unfinished">الإنتاجية الكلية</translation>
-    </message>
-    <message id="solarcharger_system_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="220"/>
-      <source>System yield</source>
-      <extracomment>Solar charger system yield</extracomment>
-      <translation type="unfinished">إنتاجية النظام</translation>
     </message>
     <message id="settings_multirs_total_yield">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="63"/>
@@ -7660,16 +6964,19 @@ Do you want to continue?</source>
     <message id="vebus_device_update_firmware">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="133"/>
       <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
       <translation>تتطلب هذه الميزة الإصدار 400 من البرنامج الثابت أو إصدارًا أعلى.  اتصل بمسئول التثبيت لتحديث Multi/Quattro.</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="139"/>
       <source>Charger not ready, equalization cannot be started</source>
+      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
       <translation>الشاحن غير جاهز، ولا يمكن بدء عملية التعادل</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="143"/>
       <source>Equalization cannot be triggered during bulk charge state</source>
+      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
       <translation>لا يمكن تفعيل التعادل في أثناء حالة الشحن المجمع</translation>
     </message>
     <message id="vebus_device_restart_vebus_system_restart_confirmation_description">
@@ -7692,78 +6999,20 @@ Do you want to continue?</source>
       <source>Auto-started • %1</source>
       <translation>بدأ التشغيل تلقائيا• %1</translation>
     </message>
-    <message id="common_words_battery">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery</source>
-      <translation type="unfinished">بطارية</translation>
-    </message>
-    <message id="common_words_boat_page">
-      <location filename="../../components/CommonWords.qml" line="111"/>
-      <source>Boat</source>
-      <extracomment>The 'Boat' page</extracomment>
-      <translation type="unfinished">قارب</translation>
-    </message>
-    <message id="common_words_brief_page">
-      <location filename="../../components/CommonWords.qml" line="115"/>
-      <source>Brief</source>
-      <extracomment>The 'Brief' page</extracomment>
-      <translation type="unfinished">مختصر</translation>
-    </message>
-    <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation type="unfinished">مغلق</translation>
-    </message>
-    <message id="common_words_color">
-      <location filename="../../components/CommonWords.qml" line="136"/>
-      <source>Color</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_connected">
-      <location filename="../../components/CommonWords.qml" line="139"/>
-      <source>Connected</source>
-      <translation type="unfinished">متصل</translation>
-    </message>
     <message id="common_words_daily_history">
       <location filename="../../components/CommonWords.qml" line="152"/>
       <source>Daily history</source>
       <translation>السجل اليومي</translation>
-    </message>
-    <message id="common_words_disabled">
-      <location filename="../../components/CommonWords.qml" line="169"/>
-      <source>Disabled</source>
-      <translation type="unfinished">معطل</translation>
-    </message>
-    <message id="common_words_disconnected">
-      <location filename="../../components/CommonWords.qml" line="175"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">منفصل</translation>
-    </message>
-    <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="191"/>
-      <source>Error</source>
-      <translation type="unfinished">خطأ</translation>
     </message>
     <message id="common_words_error_not_a_number">
       <location filename="../../components/CommonWords.qml" line="200"/>
       <source>'%1' is not a number.</source>
       <translation>«%1» ليس رقماً.</translation>
     </message>
-    <message id="common_words_generator">
-      <location filename="../../components/CommonWords.qml" line="217"/>
-      <source>Generator</source>
-      <translation type="unfinished">مولد</translation>
-    </message>
     <message id="common_words_input_current_limit">
       <location filename="../../components/CommonWords.qml" line="261"/>
       <source>Input current limit</source>
       <translation>حد تيار الدخل</translation>
-    </message>
-    <message id="common_words_inverter_charger">
-      <location filename="../../components/CommonWords.qml" line="264"/>
-      <source>Inverter / Charger</source>
-      <translation type="unfinished">محول التردد/ الشاحن</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
       <location filename="../../components/CommonWords.qml" line="268"/>
@@ -7776,12 +7025,6 @@ Do you want to continue?</source>
       <source>Manual stop</source>
       <translation>الإيقاف اليدوي</translation>
     </message>
-    <message id="common_words_max">
-      <location filename="../../components/CommonWords.qml" line="315"/>
-      <source>Max</source>
-      <extracomment>Short for Maximum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_maximum_current">
       <location filename="../../components/CommonWords.qml" line="318"/>
       <source>Maximum current</source>
@@ -7792,62 +7035,10 @@ Do you want to continue?</source>
       <source>Maximum power</source>
       <translation>الطاقة القصوى</translation>
     </message>
-    <message id="common_words_min">
-      <location filename="../../components/CommonWords.qml" line="331"/>
-      <source>Min</source>
-      <extracomment>Short for Minimum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_minimum_current">
       <location filename="../../components/CommonWords.qml" line="334"/>
       <source>Minimum current</source>
       <translation>الحد الأدنى للتيار</translation>
-    </message>
-    <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="433"/>
-      <source>No</source>
-      <translation type="unfinished">لا</translation>
-    </message>
-    <message id="common_words_none_option">
-      <location filename="../../components/CommonWords.qml" line="364"/>
-      <source>None</source>
-      <translation type="unfinished">لا أحد</translation>
-    </message>
-    <message id="common_words_none_errors">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>None</source>
-      <extracomment>Indicates there are no errors</extracomment>
-      <translation type="unfinished">لا أحد</translation>
-    </message>
-    <message id="common_words_not_available">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Not available</source>
-      <translation type="unfinished">غير متوفر</translation>
-    </message>
-    <message id="common_words_off">
-      <location filename="../../components/CommonWords.qml" line="377"/>
-      <source>Off</source>
-      <translation type="unfinished">مطفأ</translation>
-    </message>
-    <message id="common_words_ok">
-      <location filename="../../components/CommonWords.qml" line="383"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="41"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="45"/>
-      <source>OK</source>
-      <translation type="unfinished">صحيح</translation>
-    </message>
-    <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="386"/>
-      <source>On</source>
-      <translation type="unfinished">مشغل</translation>
-    </message>
-    <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="393"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation type="unfinished">مفتوح</translation>
     </message>
     <message id="common_words_open_circuit">
       <location filename="../../components/CommonWords.qml" line="396"/>
@@ -7859,108 +7050,17 @@ Do you want to continue?</source>
       <source>Overall history</source>
       <translation>السجل الإجمالي</translation>
     </message>
-    <message id="common_words_press">
-      <location filename="../../components/CommonWords.qml" line="419"/>
-      <source>Press</source>
-      <translation type="unfinished">اضغط</translation>
-    </message>
-    <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation type="unfinished">مشغل</translation>
-    </message>
-    <message id="common_words_settings">
-      <location filename="../../components/CommonWords.qml" line="467"/>
-      <source>Settings</source>
-      <translation type="unfinished">الإعدادات</translation>
-    </message>
-    <message id="common_words_silence_alarm">
-      <location filename="../../components/CommonWords.qml" line="476"/>
-      <source>Silence alarm</source>
-      <translation type="unfinished">إنذار صامت</translation>
-    </message>
     <message id="common_words_soc">
       <location filename="../../components/CommonWords.qml" line="480"/>
       <source>SOC %1</source>
       <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
       <translation>حالة الشحن %1%</translation>
     </message>
-    <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation type="unfinished">السرعة</translation>
-    </message>
-    <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="487"/>
-      <source>Standby</source>
-      <translation type="unfinished">انتظار</translation>
-    </message>
-    <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="502"/>
-      <source>State</source>
-      <translation type="unfinished">الحالة</translation>
-    </message>
-    <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="512"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation type="unfinished">بدء التشغيل (%1)</translation>
-    </message>
-    <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>Stopped</source>
-      <translation type="unfinished">متوقف</translation>
-    </message>
-    <message id="common_words_total_power">
-      <location filename="../../components/CommonWords.qml" line="540"/>
-      <source>Total power</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="547"/>
-      <source>Type</source>
-      <translation type="unfinished">النوع</translation>
-    </message>
-    <message id="common_words_unknown_status">
-      <location filename="../../components/CommonWords.qml" line="554"/>
-      <source>Unknown</source>
-      <extracomment>Status = "unknown"</extracomment>
-      <translation type="unfinished">مجهول</translation>
-    </message>
-    <message id="common_words_value_must_be_greater_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="557"/>
-      <source>Value must be greater than start value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_value_must_be_greater_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="560"/>
-      <source>Value must be greater than stop value</source>
-      <translation type="unfinished">القيمة يجب أن تكون أعلى من قيمة التوقف</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="563"/>
-      <source>Value must be lower than start value</source>
-      <translation type="unfinished">القيمة يجب أن تكون أقل من قيمة التشغيل</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="566"/>
-      <source>Value must be lower than stop value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="581"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="431"/>
-      <source>Yes</source>
-      <translation type="unfinished">نعم</translation>
-    </message>
     <message id="common_words_yield_today">
       <location filename="../../components/CommonWords.qml" line="592"/>
       <source>Yield Today</source>
       <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+      <oldsource>Yield today</oldsource>
       <translation>الناتج اليوم</translation>
     </message>
     <message id="common_words_format_error">
@@ -7987,10 +7087,11 @@ Do you want to continue?</source>
     <message id="settings_firmware_installed_rebooting">
       <location filename="../../components/FirmwareUpdate.qml" line="79"/>
       <source>Firmware installed, device rebooting</source>
+      <oldsource>Firmware installed, rebooting.</oldsource>
       <translation>تم تثبيت البرامج الثابتة وإعادة تشغيل الجهاز</translation>
     </message>
-    <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/RadioButtonListPage.qml" line="121"/>
+    <message id="modaldialog_confirm">
+      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
       <source>Confirm</source>
       <extracomment>Confirm password, and verify it if possible</extracomment>
       <translation>تأكيد</translation>
@@ -8008,11 +7109,13 @@ Do you want to continue?</source>
     <message id="cgwacs_battery_schedule_duration">
       <location filename="../../components/listitems/ListChargeSchedule.qml" line="144"/>
       <source>Duration</source>
+      <oldsource>Duration (hh:mm)</oldsource>
       <translation>المدة</translation>
     </message>
     <message id="settings_relay_deactivation_value">
       <location filename="../../components/TemperatureRelaySettings.qml" line="86"/>
       <source>Deactivation value</source>
+      <oldsource>Deativation value</oldsource>
       <translation>قيمة إلغاء التفعيل</translation>
     </message>
     <message id="splash_view_device_disconnected">
@@ -8060,29 +7163,6 @@ Do you want to continue?</source>
       <source>Temperature warning</source>
       <translation>تحذير الحرارة</translation>
     </message>
-    <message id="battery_mode_idle">
-      <location filename="../../src/enums.cpp" line="26"/>
-      <source>Idle</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">ساكن</translation>
-    </message>
-    <message id="battery_mode_charging">
-      <location filename="../../src/enums.cpp" line="30"/>
-      <source>Charging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">يقوم بالشحن</translation>
-    </message>
-    <message id="battery_mode_discharging">
-      <location filename="../../src/enums.cpp" line="34"/>
-      <source>Discharging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">يقوم بتفريغ الشحن</translation>
-    </message>
-    <message id="dcMeter_bilge_pump">
-      <location filename="../../src/enums.cpp" line="115"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">مضخة الماء الآسن</translation>
-    </message>
     <message id="switch_state_channel_fault">
       <location filename="../../src/enums.cpp" line="372"/>
       <source>Channel Fault</source>
@@ -8113,26 +7193,6 @@ Do you want to continue?</source>
       <source>Slave of %1</source>
       <translation>تابع لـ%1</translation>
     </message>
-    <message id="switchable_output_numeric_input">
-      <location filename="../../src/enums.cpp" line="418"/>
-      <source>Numeric input</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bilge_pump">
-      <location filename="../../src/enums.cpp" line="424"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">مضخة الماء الآسن</translation>
-    </message>
-    <message id="switchable_output_not_running">
-      <location filename="../../src/enums.cpp" line="448"/>
-      <source>Not running</source>
-      <translation type="unfinished">لا يعمل</translation>
-    </message>
-    <message id="switchable_output_off">
-      <location filename="../../src/enums.cpp" line="451"/>
-      <source>Off</source>
-      <translation type="unfinished">مطفأ</translation>
-    </message>
     <message id="switchable_output_powered">
       <location filename="../../src/enums.cpp" line="455"/>
       <source>Powered</source>
@@ -8161,16 +7221,19 @@ Do you want to continue?</source>
     <message id="evchargers_status_welded_contacts_error">
       <location filename="../../data/EvChargers.qml" line="76"/>
       <source>Welded contacts test error (shorted)</source>
+      <oldsource>Welded contacts error</oldsource>
       <translation>خطأ اختبار التلامسات الملحومة (تماس قصير)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
       <location filename="../../data/EvChargers.qml" line="100"/>
       <source>Switching to 3 phase</source>
+      <oldsource>Switching to 3-phase</oldsource>
       <translation>التحويل إلى ثلاثي الطور</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
       <location filename="../../data/EvChargers.qml" line="103"/>
       <source>Switching to 1 phase</source>
+      <oldsource>Switching to single phase</oldsource>
       <translation>التحويل إلى أحادي الطور</translation>
     </message>
     <message id="evchargers_status_stop_charging">
@@ -8322,17 +7385,6 @@ If the generator is currently running due to a autostart condition, disabling au
       <source>Open link</source>
       <translation>فتح الرابط</translation>
     </message>
-    <message id="listlink_show_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="43"/>
-      <source>Show QR code</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="listlink_scan_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="52"/>
-      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
-      <extracomment>%1 = url text</extracomment>
-      <translation type="unfinished">قم بمسح رمز الاستجابة السريعة باستخدام جهازك المحمول، &lt;br /&gt; أو أدخل الرابط:%1</translation>
-    </message>
     <message id="settings_services_mqtt_access">
       <location filename="../../components/listitems/ListMqttAccessSwitch.qml" line="11"/>
       <source>MQTT Access</source>
@@ -8404,12 +7456,6 @@ If the generator is currently running due to a autostart condition, disabling au
       <extracomment>The 'Brief' page, with the side panel opened</extracomment>
       <translation>مختصر (اللوحة الجانبية مفتوحة)</translation>
     </message>
-    <message id="startpage_option_overview">
-      <location filename="../../data/StartPageConfiguration.qml" line="37"/>
-      <source>Overview</source>
-      <extracomment>The 'Overview' page</extracomment>
-      <translation type="unfinished">نظرة عامة</translation>
-    </message>
     <message id="startpage_option_levels_tanks">
       <location filename="../../data/StartPageConfiguration.qml" line="43"/>
       <source>Levels (Tanks)</source>
@@ -8428,12 +7474,12 @@ If the generator is currently running due to a autostart condition, disabling au
       <translation>قائمة البطارية</translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
+      <location filename="../../pages/DialogLayer.qml" line="56"/>
       <source>GX device has been updated</source>
       <translation>تم تحديث جهاز GX</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
+      <location filename="../../pages/DialogLayer.qml" line="58"/>
       <source>Page will automatically reload in ten seconds to load the latest version.</source>
       <translation>سيتم إعادة تحميل الصفحة تلقائيًا خلال عشر ثوانٍ لتحميل أحدث إصدار.</translation>
     </message>
@@ -8607,8 +7653,8 @@ Note that this menu only shows Carlo Gavazzi meters connected over RS485. For an
       <source>Unit</source>
       <translation>وحدة</translation>
     </message>
-    <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="61"/>
+    <message id="page_settings_fronius_unitid_invalid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
       <source>%1 is not a valid unit number. Use a number between 1-247.</source>
       <translation>إن «%1» رقم وحدة غير صالح. استخدم رقماً بين 1-247.</translation>
     </message>
@@ -8723,11 +7769,6 @@ Note that this menu only shows Carlo Gavazzi meters connected over RS485. For an
       <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="66"/>
       <source>Controller Temperature</source>
       <translation>درجة الحرارة المتحكم</translation>
-    </message>
-    <message id="devicelist_motordrive_motordirectioninverted">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
-      <source>Motor Direction Inverted</source>
-      <translation type="unfinished"/>
     </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
@@ -8917,11 +7958,6 @@ With streamlined navigation and a fresh look, everything you love is now even ea
     <message id="welcome_done">
       <location filename="../../pages/welcome/WelcomeView.qml" line="136"/>
       <source>Done</source>
-      <translation type="unfinished">تم</translation>
-    </message>
-    <message id="mk2vsc_state_done">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="20"/>
-      <source>Done</source>
       <translation>تم</translation>
     </message>
     <message id="welcome_next">
@@ -8978,6 +8014,7 @@ The GX device can only control one connected genset and takes the one with the l
     <message id="settings_tz_etc">
       <location filename="../../pages/settings/PageTzInfo.qml" line="280"/>
       <source>Other</source>
+      <oldsource>Etc</oldsource>
       <translation>أخرى</translation>
     </message>
     <message id="ac-in-modeldefault_energy_reverse_x">
@@ -8995,6 +8032,11 @@ The GX device can only control one connected genset and takes the one with the l
       <location filename="../../src/enums.cpp" line="438"/>
       <source>Unsupported type: %1</source>
       <translation>غنوع غير مدعوم:%1</translation>
+    </message>
+    <message id="common_words_press">
+      <location filename="../../components/CommonWords.qml" line="419"/>
+      <source>Press</source>
+      <translation>اضغط</translation>
     </message>
     <message id="output_aux_battery_service_changed_dcdc">
       <location filename="../../components/listitems/ListOutputBatteryRadioButtonGroup.qml" line="27"/>
@@ -9135,13 +8177,6 @@ The GX device can only control one connected genset and takes the one with the l
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="38"/>
       <source>Resetting VE.Bus products</source>
       <translation>إعادة ضبط أجهزة VE.Bus</translation>
-    </message>
-    <message id="Unknown">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
-      <source>Unknown</source>
-      <translation type="unfinished">مجهول</translation>
     </message>
     <message id="mk2vsc_error_mk2_mk3_comm">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="47"/>
@@ -9447,11 +8482,6 @@ The GX device can only control one connected genset and takes the one with the l
       <source>Changing the GX Password</source>
       <translation>تغيير كلمة مرور GX</translation>
     </message>
-    <message id="modaldialog_confirm">
-      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
-      <source>Confirm</source>
-      <translation type="unfinished">تأكيد</translation>
-    </message>
     <message id="settings_security_profile_change_password_description">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="83"/>
       <source>Please enter a new GX password:</source>
@@ -9544,21 +8574,6 @@ The GX device can only control one connected genset and takes the one with the l
       <source>Modifications installed</source>
       <translation>التعديلات المثبتة</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_modbus">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="28"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">خادم Modbus TCP</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_signalk">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="32"/>
-      <source>Signal K</source>
-      <translation type="unfinished">الإشارة K</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_nodered">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="36"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">أداة التطوير Node-RED</translation>
-    </message>
     <message id="pagesettingsgeneral_modificationchecks_running_integrations">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="43"/>
       <source>%1 running integrations</source>
@@ -9634,16 +8649,6 @@ The GX device can only control one connected genset and takes the one with the l
       <source>Installed and enabled, disables at next boot</source>
       <translation>مثبت وممكن، يتم تعطيله عند إعادة التشغيل التالية</translation>
     </message>
-    <message id="pagesettingssupportstate_firmware_checking">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
-      <source>Checking...</source>
-      <translation type="unfinished">تدقيق...</translation>
-    </message>
-    <message id="pagesettingssupportstate_firmware_unknown">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="166"/>
-      <source>Unknown</source>
-      <translation type="unfinished">مجهول</translation>
-    </message>
     <message id="pagesettingssupportstate_support_status">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="228"/>
       <source>Support status</source>
@@ -9665,11 +8670,6 @@ The GX device can only control one connected genset and takes the one with the l
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="288"/>
       <source>Press 'OK' to disable custom startup scripts and reboot</source>
       <translation>اضغط على 'موافق' لتعطيل البرامج النصية المخصصة لبدء التشغيل وإعادة التشغيل</translation>
-    </message>
-    <message id="pagesettingssupportstate_re_enable_custom_startup_scripts">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="309"/>
-      <source>Re-enable custom startup scripts</source>
-      <translation type="unfinished">إعادة تمكين البرامج النصية المخصصة لبدء التشغيل</translation>
     </message>
     <message id="pagesettingssupportstate_reenable_and_reboot_now">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="322"/>
@@ -9696,11 +8696,6 @@ The GX device can only control one connected genset and takes the one with the l
       <source>Disable also custom startup scripts?</source>
       <translation>هل تريد تعطيل البرامج النصية المخصصة لبدء التشغيل أيضًا؟</translation>
     </message>
-    <message id="pagesettingssupportstate_integrations">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
-      <source>Integrations</source>
-      <translation type="unfinished">التكاملات</translation>
-    </message>
     <message id="pagesettingssupportstate_orange_items_description">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="494"/>
       <source>Items colored orange are supported and provided by Victron Energy, but using them incorrectly can affect system stability. In case of troubleshooting, disable those first.</source>
@@ -9712,7 +8707,7 @@ The GX device can only control one connected genset and takes the one with the l
       <translation>قم بتوصيل دونجل USB Bluetooth متوافق لتمكين اتصال Bluetooth.</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="140"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="142"/>
       <source>BatteryLife state</source>
       <translation>حالة BatteryLife</translation>
     </message>
@@ -9720,23 +8715,6 @@ The GX device can only control one connected genset and takes the one with the l
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="33"/>
       <source>Device Integrations</source>
       <translation>تكاملات الأجهزة</translation>
-    </message>
-    <message id="pagesettingsintegrations_modbus_tcp_server">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="201"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">خادم Modbus TCP</translation>
-    </message>
-    <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="226"/>
-      <location filename="../../pages/settings/PageSettingsSignalK.qml" line="18"/>
-      <source>Signal K</source>
-      <translation type="unfinished">الإشارة K</translation>
-    </message>
-    <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="241"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">أداة التطوير Node-RED</translation>
     </message>
     <message id="settings_venusos_large_documentation">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="267"/>
@@ -9746,6 +8724,7 @@ The GX device can only control one connected genset and takes the one with the l
     <message id="settings_modbus_enable_modbus_tcp">
       <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
       <source>Enable Modbus TCP Server</source>
+      <oldsource>Enable Modbus/TCP</oldsource>
       <translation>تمكين خادم Modbus TCP</translation>
     </message>
     <message id="pagesettingsconnectivity_bluetooth_for_victronconnect_app">
@@ -9839,11 +8818,13 @@ The GX device can only control one connected genset and takes the one with the l
     <message id="settings_gps_format_kmh">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="93"/>
       <source>Kilometres per hour</source>
+      <oldsource>Kilometers per hour</oldsource>
       <translation>كيلومترات في الساعة</translation>
     </message>
     <message id="settings_gps_format_ms">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="95"/>
       <source>Metres per second</source>
+      <oldsource>Meters per second</oldsource>
       <translation>أمتار في الثانية</translation>
     </message>
     <message id="components_volumeunit_cubic_metres">
@@ -9871,8 +8852,8 @@ The GX device can only control one connected genset and takes the one with the l
       <source>The Relay can now be found in the devices list</source>
       <translation>يمكن الآن العثور على المرحل في قائمة الأجهزة</translation>
     </message>
-    <message id="common_words_gx_device_relays">
-      <location filename="../../components/CommonWords.qml" line="223"/>
+    <message id="gx_device_relays">
+      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
       <source>GX device relays</source>
       <translation>مرحلات جهاز GX</translation>
     </message>
@@ -9926,12 +8907,6 @@ The GX device can only control one connected genset and takes the one with the l
       <extracomment>Forced by app to %1</extracomment>
       <translation>تلقائي</translation>
     </message>
-    <message id="settings_remote_console_forced_by_vrm">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="94"/>
-      <source>VRM</source>
-      <extracomment>Forced by %2 to dark</extracomment>
-      <translation type="unfinished">VRM</translation>
-    </message>
     <message id="settings_remote_console_forced_by_app">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="97"/>
       <source>app</source>
@@ -9981,6 +8956,7 @@ The GX device can only control one connected genset and takes the one with the l
     <message id="settings_large_access_signal_k">
       <location filename="../../pages/settings/PageSettingsSignalK.qml" line="24"/>
       <source>Access Signal K</source>
+      <oldsource>Access Signal K (local network)</oldsource>
       <translation>الوصول إلى Signal K</translation>
     </message>
     <message id="pagesettingsintegrations_shelly_devices">
@@ -9991,6 +8967,7 @@ The GX device can only control one connected genset and takes the one with the l
     <message id="settings_large_access_node_red">
       <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
       <source>Access Node-RED</source>
+      <oldsource>Access Node-RED (local network)</oldsource>
       <translation>الوصول إلى Node-RED</translation>
     </message>
     <message id="settings_wifi_access_point_password">
@@ -10058,57 +9035,6 @@ The GX device can only control one connected genset and takes the one with the l
       <source>Wind charger</source>
       <translation>شاحن رياح</translation>
     </message>
-    <message id="digitalinputs_type_disabled">
-      <location filename="../../src/enums.cpp" line="192"/>
-      <source>Disabled</source>
-      <translation type="unfinished">معطل</translation>
-    </message>
-    <message id="digitalinputs_state_off">
-      <location filename="../../src/enums.cpp" line="242"/>
-      <source>Off</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">مطفأ</translation>
-    </message>
-    <message id="digitalinputs_state_on">
-      <location filename="../../src/enums.cpp" line="246"/>
-      <source>On</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">مشغل</translation>
-    </message>
-    <message id="digitalinputs_state_ok">
-      <location filename="../../src/enums.cpp" line="266"/>
-      <source>OK</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">صحيح</translation>
-    </message>
-    <message id="digitalinputs_state_alarm">
-      <location filename="../../src/enums.cpp" line="270"/>
-      <source>Alarm</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">إنذار</translation>
-    </message>
-    <message id="digitalinputs_state_running">
-      <location filename="../../src/enums.cpp" line="274"/>
-      <source>Running</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">مشغل</translation>
-    </message>
-    <message id="pvinverter_statusCode_running">
-      <location filename="../../src/enums.cpp" line="300"/>
-      <source>Running</source>
-      <extracomment>PV inverter status code</extracomment>
-      <translation type="unfinished">مشغل</translation>
-    </message>
-    <message id="solarchargers_state_external control">
-      <location filename="../../src/enums.cpp" line="352"/>
-      <source>External control</source>
-      <translation type="unfinished">التحكم الخارجي</translation>
-    </message>
-    <message id="switch_state_over_temperature">
-      <location filename="../../src/enums.cpp" line="366"/>
-      <source>Over temperature</source>
-      <translation type="unfinished">درجة حرارة زائدة</translation>
-    </message>
     <message id="switchable_output_temperature_setpoint">
       <location filename="../../src/enums.cpp" line="398"/>
       <source>Temperature setpoint</source>
@@ -10118,11 +9044,6 @@ The GX device can only control one connected genset and takes the one with the l
       <location filename="../../src/enums.cpp" line="401"/>
       <source>Stepped switch</source>
       <translation>مفتاح متدرج</translation>
-    </message>
-    <message id="switchable_output_slave">
-      <location filename="../../src/enums.cpp" line="408"/>
-      <source>Slave</source>
-      <translation type="unfinished">تابع</translation>
     </message>
     <message id="switchable_output_dropdown">
       <location filename="../../src/enums.cpp" line="412"/>
@@ -10134,122 +9055,10 @@ The GX device can only control one connected genset and takes the one with the l
       <source>Basic slider</source>
       <translation>شريط تمرير أساسي</translation>
     </message>
-    <message id="switchable_output_rgb_color_wheel">
-      <location filename="../../src/enums.cpp" line="427"/>
-      <source>RGB color wheel</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_cct_color_wheel">
-      <location filename="../../src/enums.cpp" line="431"/>
-      <source>CCT color wheel</source>
-      <extracomment>Correlated Color Temperature color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_rgbw_color_wheel">
-      <location filename="../../src/enums.cpp" line="435"/>
-      <source>RGB + W color wheel</source>
-      <extracomment>RGB + white color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bypassed">
-      <location filename="../../src/enums.cpp" line="484"/>
-      <source>Bypassed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="tank_type_fuel">
-      <location filename="../../src/enums.cpp" line="495"/>
-      <source>Fuel</source>
-      <translation type="unfinished">وقود</translation>
-    </message>
-    <message id="tank_type_fresh_water">
-      <location filename="../../src/enums.cpp" line="498"/>
-      <source>Fresh water</source>
-      <translation type="unfinished">ماء نقي</translation>
-    </message>
-    <message id="tank_type_waste_water">
-      <location filename="../../src/enums.cpp" line="501"/>
-      <source>Waste water</source>
-      <translation type="unfinished">ماء فاسد</translation>
-    </message>
-    <message id="tank_type_live_well">
-      <location filename="../../src/enums.cpp" line="504"/>
-      <source>Live well</source>
-      <translation type="unfinished">حيوية جيدة</translation>
-    </message>
-    <message id="tank_type_oil">
-      <location filename="../../src/enums.cpp" line="507"/>
-      <source>Oil</source>
-      <translation type="unfinished">زيت</translation>
-    </message>
-    <message id="tank_type_black_water">
-      <location filename="../../src/enums.cpp" line="510"/>
-      <source>Black water</source>
-      <translation type="unfinished">مياه سوداء</translation>
-    </message>
-    <message id="tank_type_gasoline">
-      <location filename="../../src/enums.cpp" line="513"/>
-      <source>Gasoline</source>
-      <translation type="unfinished">البنزين</translation>
-    </message>
-    <message id="tank_type_diesel">
-      <location filename="../../src/enums.cpp" line="516"/>
-      <source>Diesel</source>
-      <translation type="unfinished">الديزل</translation>
-    </message>
-    <message id="tank_type_lpg">
-      <location filename="../../src/enums.cpp" line="519"/>
-      <source>LPG</source>
-      <translation type="unfinished">الغاز النفطي المسال</translation>
-    </message>
-    <message id="tank_type_lng">
-      <location filename="../../src/enums.cpp" line="522"/>
-      <source>LNG</source>
-      <translation type="unfinished">الغاز الطبيعي المسال</translation>
-    </message>
-    <message id="tank_type_hydraulic_oil">
-      <location filename="../../src/enums.cpp" line="525"/>
-      <source>Hydraulic oil</source>
-      <translation type="unfinished">زيت هيدروليكي</translation>
-    </message>
-    <message id="tank_type_raw_water">
-      <location filename="../../src/enums.cpp" line="528"/>
-      <source>Raw water</source>
-      <translation type="unfinished">ماء غير معالج</translation>
-    </message>
-    <message id="microgrid_mode_hybrid_droop">
-      <location filename="../../src/enums.cpp" line="539"/>
-      <source>Hybrid droop</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_following">
-      <location filename="../../src/enums.cpp" line="542"/>
-      <source>Grid-following</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_forming">
-      <location filename="../../src/enums.cpp" line="545"/>
-      <source>Grid-forming</source>
-      <translation type="unfinished"/>
-    </message>
     <message id="switchable_output_three_state_switch">
       <location filename="../../src/enums.cpp" line="421"/>
       <source>Three-state switch</source>
       <translation>مفتاح ثلاثي الأوضاع</translation>
-    </message>
-    <message id="switchable_output_fault">
-      <location filename="../../src/enums.cpp" line="464"/>
-      <source>Fault</source>
-      <translation type="unfinished">خلل</translation>
-    </message>
-    <message id="switchable_output_running">
-      <location filename="../../src/enums.cpp" line="468"/>
-      <source>Running</source>
-      <translation type="unfinished">مشغل</translation>
-    </message>
-    <message id="switchable_output_trip_low_voltage">
-      <location filename="../../src/enums.cpp" line="481"/>
-      <source>Trip low voltage</source>
-      <translation type="unfinished">معطل</translation>
     </message>
     <message id="settings_modbus_tcp_unit_id_note">
       <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="41"/>
@@ -10271,281 +9080,1152 @@ The GX device can only control one connected genset and takes the one with the l
       <source>Press to refresh</source>
       <translation>اضغط للتحديث</translation>
     </message>
-    <message id="temperature_type_unknown">
-      <location filename="../../data/EnvironmentInputs.qml" line="65"/>
-      <source>Unknown</source>
-      <translation type="unfinished">مجهول</translation>
-    </message>
-    <message id="brief_solar_yield">
-      <location filename="../../pages/BriefSidePanel.qml" line="24"/>
-      <source>Solar yield</source>
-      <translation type="unfinished">إنتاج الطاقة الشمسية</translation>
-    </message>
-    <message id="brief_dc_input">
-      <location filename="../../pages/BriefSidePanel.qml" line="214"/>
-      <source>DC input</source>
-      <translation type="unfinished">دخل التيار المستمر</translation>
-    </message>
-    <message id="brief_ac_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="257"/>
-      <source>AC Loads</source>
-      <translation type="unfinished">تحميلات التيار المتردد</translation>
-    </message>
-    <message id="brief_dc_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="284"/>
-      <source>DC Loads</source>
-      <translation type="unfinished">أحمال التيار المستمر</translation>
-    </message>
-    <message id="nav_overview">
-      <location filename="../../pages/OverviewPage.qml" line="450"/>
-      <source>Overview</source>
-      <translation type="unfinished">نظرة عامة</translation>
-    </message>
-    <message id="settings_state">
-      <location filename="../../pages/settings/PageCanbusStatus.qml" line="116"/>
-      <source>State</source>
-      <translation type="unfinished">الحالة</translation>
-    </message>
-    <message id="inverter_pv">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="56"/>
-      <source>PV</source>
-      <translation type="unfinished">جهاز ضوئي</translation>
-    </message>
-    <message id="inverter_total_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="76"/>
-      <source>Total yield</source>
-      <translation type="unfinished">الإنتاجية الكلية</translation>
-    </message>
-    <message id="inverter_system_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="84"/>
-      <source>System yield</source>
-      <translation type="unfinished">إنتاجية النظام</translation>
-    </message>
-    <message id="charger_total_pv_power">
-      <location filename="../../pages/solar/SolarDevicePage.qml" line="61"/>
-      <source>Total PV Power</source>
-      <translation type="unfinished">إجمالي الطاقة الكهروضوئية</translation>
-    </message>
-    <message id="vebus_device_alarm_only">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
-      <source>Alarm only</source>
-      <translation type="unfinished">منبه فقط</translation>
-    </message>
-    <message id="vebus_device_alarms_and_warnings">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
-      <source>Alarms &amp; warnings</source>
-      <translation type="unfinished">إنذارات وتنبيهات</translation>
-    </message>
-    <message id="vebus_device_alarm_group_warning">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
-      <source>Warning</source>
-      <translation type="unfinished">تحذير</translation>
-    </message>
-    <message id="load_delegate_status">
-      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
-      <source>Status: %1</source>
-      <translation type="unfinished"/>
+    <message id="common_words_total_power">
+      <location filename="../../components/CommonWords.qml" line="540"/>
+      <source>Total power</source>
+      <translation>إجمالي الطاقة</translation>
     </message>
     <message id="venus_os_gui">
       <location filename="../../Main.qml" line="17"/>
       <source>Venus OS GUI</source>
       <extracomment>Application title</extracomment>
-      <translation type="unfinished"/>
       <extra-Context>only shown on desktop systems</extra-Context>
+      <translation>واجهة المستخدم الرسومية لنظام التشغيل Venus</translation>
+    </message>
+    <message id="load_delegate_status">
+      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
+      <source>Status: %1</source>
+      <translation>الحالة: %1</translation>
+    </message>
+    <message id="settings_relay_polarity_relay1">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
+      <source>Polarity (Relay 1)</source>
+      <translation>القطبية (المرحل 1)</translation>
+    </message>
+    <message id="settings_relay_polarity">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
+      <source>Polarity</source>
+      <translation>القطبية</translation>
+    </message>
+    <message id="settings_relay_polarity_relay2">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
+      <source>Polarity (Relay 2)</source>
+      <translation>القطبية (المرحل 2)</translation>
+    </message>
+    <message id="page_settings_wifi_invalid_password">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
+      <source>Password length must be either 0 or between 10 and 63 characters long</source>
+      <translation>يجب أن يكون طول كلمة المرور إما 0 أو بين 10 و 63 حرفًا</translation>
+    </message>
+    <message id="page_settings_wifi_password_updated">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
+      <source>Password updated</source>
+      <translation>تم تحديث كلمة المرور</translation>
+    </message>
+    <message id="common_words_max">
+      <location filename="../../components/CommonWords.qml" line="315"/>
+      <source>Max</source>
+      <extracomment>Short for Maximum</extracomment>
+      <translation>الحد الأقصى</translation>
+    </message>
+    <message id="common_words_min">
+      <location filename="../../components/CommonWords.qml" line="331"/>
+      <source>Min</source>
+      <extracomment>Short for Minimum</extracomment>
+      <translation>الحد الأدنى</translation>
+    </message>
+    <message id="settings_ess_deprecated">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="321"/>
+      <source>Deprecated settings</source>
+      <translation>إعدادات مهجورة</translation>
+    </message>
+    <message id="settings_ess_max_charge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="328"/>
+      <source>Battery charge limit (% of CCL)</source>
+      <translation>الحد الأقصى لشحن البطارية (% من CCL)</translation>
+    </message>
+    <message id="settings_ess_max_discharge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="339"/>
+      <source>Battery discharge limit (% of DCL)</source>
+      <translation>الحد الأقصى لتفريغ البطارية (% من DCL)</translation>
+    </message>
+    <message id="vebus_device_bms_message">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
+      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
+      <oldsource>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</oldsource>
+      <translation>يقوم نظام إدارة البطارية VE.Bus بإيقاف تشغيل النظام تلقائيًا عند الحاجة لحماية البطارية. لذلك، لا يمكن التحكم في النظام من جهاز GX.</translation>
+    </message>
+    <message id="switchable_output_numeric_input">
+      <location filename="../../src/enums.cpp" line="418"/>
+      <source>Numeric input</source>
+      <translation>إدخال رقمي</translation>
     </message>
     <message id="autotoggleswitch_disable_auto_mode_info">
       <location filename="../../components/controls/AutoToggleButton.qml" line="34"/>
       <source>Disable Auto mode first</source>
-      <translation type="unfinished"/>
+      <translation>قم بتعطيل الوضع التلقائي أولاً</translation>
+    </message>
+    <message id="pagesettingsintegrations_venus_os_enable_large_features">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
+      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
+      <translation>تمكين برنامج Venus OS Large الثابت لاستخدام Node-RED أو Signal-K</translation>
+    </message>
+    <message id="settings_relays_sensors_tanks">
+      <location filename="../../pages/SettingsPage.qml" line="75"/>
+      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
+      <oldsource>Relays, Sensors, Tanks, PV Inverters, Modbus, MQTT…</oldsource>
+      <translation>المرحلات، وأجهزة الاستشعار، ومحولات الطاقة الشمسية الكهروضوئية، و Modbus، و Node-RED</translation>
+    </message>
+    <message id="vebus_device_page_microgrid_parameters">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
+      <source>Microgrid parameters</source>
+      <translation>معلمات الشبكة الدقيقة</translation>
+    </message>
+    <message id="microgrid_mode_hybrid_droop">
+      <location filename="../../src/enums.cpp" line="539"/>
+      <source>Hybrid droop</source>
+      <translation>ترهل هجين</translation>
+    </message>
+    <message id="microgrid_mode_grid_following">
+      <location filename="../../src/enums.cpp" line="542"/>
+      <source>Grid-following</source>
+      <translation>تتبع الشبكة</translation>
+    </message>
+    <message id="microgrid_mode_grid_forming">
+      <location filename="../../src/enums.cpp" line="545"/>
+      <source>Grid-forming</source>
+      <translation>تكوين الشبكة</translation>
+    </message>
+    <message id="switchable_output_trip_low_voltage">
+      <location filename="../../src/enums.cpp" line="481"/>
+      <source>Trip low voltage</source>
+      <oldsource>Disabled</oldsource>
+      <translation>فصل الجهد المنخفض</translation>
     </message>
     <message id="microgrid">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="15"/>
       <source>Microgrid</source>
-      <translation type="unfinished"/>
+      <translation>شبكة دقيقة</translation>
     </message>
     <message id="page_microgrid_active_mode">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="19"/>
       <source>Active mode</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_microgrid_from_p1_to_p2">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="34"/>
-      <source>%1 %2 to %3 %4</source>
-      <extracomment>Describes a range from one quantity to another, e.g. "30 W to 60 W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
-      <translation type="unfinished"/>
+      <translation>الوضع النشط</translation>
     </message>
     <message id="page_microgrid_hybrid_droop_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="92"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
       <source>Hybrid droop parameters</source>
-      <translation type="unfinished"/>
+      <translation>معلمات الترهل الهجين</translation>
     </message>
     <message id="page_microgrid_reference_active_power_p0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="105"/>
       <source>Reference active power (P&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>طاقة فعالة مرجعية (P&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_frequency_f0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="108"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="112"/>
       <source>Reference frequency (f&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>تردد مرجعي (f&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_frequency_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="117"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="119"/>
       <source>Frequency droop slope (droop&lt;sub&gt;fP&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>ميل انحدار التردد (droop&lt;sub&gt;fP&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_reactive_power">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="126"/>
       <source>Reference reactive power (Q&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>طاقة رد فعل مرجعية (Q&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_voltage">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="135"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="133"/>
       <source>Reference Voltage (U&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>جهد مرجعي (U&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_voltage_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="144"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="140"/>
       <source>Voltage droop slope (droop&lt;sub&gt;UQ&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>ميل انحدار الجهد (droop&lt;sub&gt;UQ&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_minimum_and_maximum_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="146"/>
       <source>Minimum and maximum parameters</source>
-      <translation type="unfinished"/>
+      <translation>المعلمات الدنيا والقصوى</translation>
     </message>
     <message id="page_microgrid_allowed_active_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="156"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
       <source>Allowed active power range</source>
-      <translation type="unfinished"/>
+      <translation>نطاق الطاقة الفعالة المسموح به</translation>
     </message>
     <message id="page_microgrid_allowed_reactive_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="164"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="159"/>
       <source>Allowed reactive power range</source>
-      <translation type="unfinished"/>
+      <translation>نطاق طاقة رد الفعل المسموح به</translation>
     </message>
     <message id="page_microgrid_p_q_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="176"/>
       <source>P-Q direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>إعدادات القيادة المباشرة P-Q</translation>
     </message>
     <message id="page_microgrid_active_power_setpoint_p">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="186"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
       <source>Active power setpoint (P)</source>
-      <translation type="unfinished"/>
+      <translation>نقطة ضبط الطاقة الفعالة (P)</translation>
     </message>
     <message id="page_microgrid_reactive_power_setpoint_q">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="194"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="188"/>
       <source>Reactive power setpoint (Q)</source>
-      <translation type="unfinished"/>
+      <translation>نقطة ضبط طاقة رد الفعل (Q)</translation>
     </message>
     <message id="page_microgrid_allowed_frequency_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="202"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="195"/>
       <source>Allowed frequency range</source>
-      <translation type="unfinished"/>
+      <translation>نطاق التردد المسموح به</translation>
     </message>
     <message id="page_microgrid_allowed_voltage_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="210"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="203"/>
       <source>Allowed voltage range</source>
-      <translation type="unfinished"/>
+      <translation>نطاق الجهد المسموح به</translation>
     </message>
     <message id="page_microgrid_v_f_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="227"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="220"/>
       <source>V-f direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>إعدادات القيادة المباشرة V-f</translation>
     </message>
     <message id="page_microgrid_voltage_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="225"/>
       <source>Voltage setpoint (U)</source>
-      <translation type="unfinished"/>
+      <translation>نقطة ضبط الجهد (U)</translation>
     </message>
     <message id="page_microgrid_frequency_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="240"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
       <source>Frequency setpoint (f)</source>
-      <translation type="unfinished"/>
+      <translation>نقطة ضبط التردد (f)</translation>
     </message>
-    <message id="temperature_slider_current">
-      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
-      <source>Current</source>
-      <extracomment>The current temperature measurement</extracomment>
-      <translation type="unfinished">التيار</translation>
+    <message id="pagesettingsintegrations_canopenmotordrive">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
+      <source>CANopen motor drives</source>
+      <translation>محركات CANopen</translation>
+    </message>
+    <message id="pagesettingsintegrations_ui_plugins">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
+      <source>UI Plugins</source>
+      <translation>ملحقات واجهة المستخدم الرسومية</translation>
+    </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
+      <source>Motor Direction Inverted</source>
+      <translation>اتجاه المحرك معكوس</translation>
     </message>
     <message id="page_settings_canopenmotordrive_scan_for_motor_drives">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="31"/>
       <source>Scan for motor drives</source>
-      <translation type="unfinished"/>
+      <translation>البحث عن محركات</translation>
     </message>
     <message id="page_settings_canopenmotordrive_discovered_motor_drive_ids">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="39"/>
       <source>Discovered motor drive IDs</source>
-      <translation type="unfinished"/>
+      <translation>معرفات محركات مكتشفة</translation>
     </message>
-    <message id="switchableoutput_gx_device_relays">
-      <location filename="../../src/switchableoutput.cpp" line="388"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">مرحلات جهاز GX</translation>
+    <message id="temperature_pm25">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
+      <source>PM2.5</source>
+      <translation>PM2.5</translation>
     </message>
-    <message id="gx_device_relays">
-      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">مرحلات جهاز GX</translation>
+    <message id="temperature_co2">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+      <source>CO₂</source>
+      <translation>CO₂</translation>
     </message>
-    <message id="color_preset">
-      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
-      <source>Preset</source>
-      <translation type="unfinished"/>
+    <message id="temperature_voc">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
+      <source>VOC index</source>
+      <translation>مؤشر المركبات العضوية المتطايرة</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_location">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
-      <source>Add Modbus port and unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_nox">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
+      <source>NOx index</source>
+      <translation>مؤشر NOx</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_unitid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
-      <source>Unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_luminosity">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
+      <source>Luminosity</source>
+      <translation>السطوع</translation>
     </message>
-    <message id="page_settings_fronius_unitid_invalid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation type="unfinished">إن «%1» رقم وحدة غير صالح. استخدم رقماً بين 1-247.</translation>
-    </message>
-    <message id="page_settings_fronius_add_modbus_location_button">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
-      <source>Add</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_locations_note">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
-      <source>The default modbus port is 502 and the default unit ID is 126.
-Here you can add additional ports and unit IDs to scan for PV inverters.</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_location_number">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
-      <source>Port/Unit ID %1</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location_description">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
-      <source>Port: %1 (Unit %2)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
-      <source>Remove Modbus port and unit ID?</source>
-      <translation type="unfinished"/>
+    <message id="switchable_output_bypassed">
+      <location filename="../../src/enums.cpp" line="484"/>
+      <source>Bypassed</source>
+      <translation>تم تجاوز</translation>
     </message>
     <message id="switchableoutput_list_delegate_auto_status">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="84"/>
       <source>Auto (%1)</source>
       <extracomment>%1 = 'On' or 'Off'</extracomment>
-      <translation type="unfinished"/>
+      <translation>تلقائي (%1)</translation>
     </message>
     <message id="switchableoutput_list_delegate_state_forced">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="100"/>
       <source>Forced</source>
-      <translation type="unfinished"/>
+      <translation>إجباري</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_settings">
+      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
+      <source>Modbus port and unit ID settings</source>
+      <translation>إعدادات منفذ Modbus ومعرّف الوحدة</translation>
+    </message>
+    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
+      <source>Integrates with the device list</source>
+      <translation>يتكامل مع قائمة الأجهزة</translation>
+    </message>
+    <message id="common_words_color">
+      <location filename="../../components/CommonWords.qml" line="136"/>
+      <source>Color</source>
+      <translation>اللون</translation>
+    </message>
+    <message id="common_words_value_must_be_greater_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="557"/>
+      <source>Value must be greater than start value</source>
+      <translation>يجب أن تكون القيمة أكبر من قيمة البداية</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="566"/>
+      <source>Value must be lower than stop value</source>
+      <translation>يجب أن تكون القيمة أقل من قيمة الإيقاف</translation>
+    </message>
+    <message id="notifications_page_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="43"/>
+      <source>Active Notifications</source>
+      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
+      <translation>الإشعارات النشطة</translation>
+    </message>
+    <message id="notifications_page_inactive_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="47"/>
+      <source>Inactive Notifications</source>
+      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
+      <translation>الإشعارات غير النشطة</translation>
+    </message>
+    <message id="notifications_no_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="106"/>
+      <source>No active notifications</source>
+      <translation>لا توجد إشعارات نشطة</translation>
+    </message>
+    <message id="switchable_output_rgb_color_wheel">
+      <location filename="../../src/enums.cpp" line="427"/>
+      <source>RGB color wheel</source>
+      <translation>عجلة ألوان RGB</translation>
+    </message>
+    <message id="switchable_output_cct_color_wheel">
+      <location filename="../../src/enums.cpp" line="431"/>
+      <source>CCT color wheel</source>
+      <extracomment>Correlated Color Temperature color wheel</extracomment>
+      <translation>عجلة ألوان CCT</translation>
+    </message>
+    <message id="switchable_output_rgbw_color_wheel">
+      <location filename="../../src/enums.cpp" line="435"/>
+      <source>RGB + W color wheel</source>
+      <extracomment>RGB + white color wheel</extracomment>
+      <translation>عجلة ألوان RGB + W</translation>
+    </message>
+    <message id="listlink_show_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="43"/>
+      <source>Show QR code</source>
+      <translation>إظهار رمز QR</translation>
+    </message>
+    <message id="listlink_scan_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="52"/>
+      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
+      <extracomment>%1 = url text</extracomment>
+      <oldsource>Scan the QR code with your portable device.&lt;br /&gt;Or insert the link: %1</oldsource>
+      <translation>افتح رمز QR لمسحه ضوئيًا بجهازك المحمول. &lt;br /&gt;أو أدخل الرابط: %1</translation>
+    </message>
+    <message id="color_preset">
+      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
+      <source>Preset</source>
+      <translation>إعداد مسبق</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
+      <source>Add Modbus port and unit ID</source>
+      <translation>إضافة منفذ Modbus ومعرّف الوحدة</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_unitid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
+      <source>Unit ID</source>
+      <translation>معرّف الوحدة</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location_button">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
+      <source>Add</source>
+      <translation>إضافة</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_locations_note">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
+      <source>The default modbus port is 502 and the default unit ID is 126.
+Here you can add additional ports and unit IDs to scan for PV inverters.</source>
+      <translation>منفذ Modbus الافتراضي هو 502 ومعرّف الوحدة الافتراضي هو 126.
+يمكنك هنا إضافة منافذ إضافية ومعرفات وحدات للبحث عن محولات الطاقة الشمسية الكهروضوئية.</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_location_number">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
+      <source>Port/Unit ID %1</source>
+      <translation>المنفذ/معرّف الوحدة %1</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location_description">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
+      <source>Port: %1 (Unit %2)</source>
+      <translation>المنفذ: %1 (الوحدة %2)</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
+      <source>Remove Modbus port and unit ID?</source>
+      <translation>إزالة منفذ Modbus ومعرّف الوحدة؟</translation>
+    </message>
+    <message id="devicelist_tankshape_edit_point">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="182"/>
+      <source>Edit point %1</source>
+      <extracomment>%1 = which point is being edited, a number like "1" or "2"</extracomment>
+      <translation></translation>
+    </message>
+    <message id="settings_canbus_vecan">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
+      <source>VE.Can (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_250">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <source>VE.Can &amp; CANopen E-drive (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_500">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
+      <source>CANopen E-drive (500 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="page_microgrid_from_p1_to_p2">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="39"/>
+      <source>%1%2 to %3%4</source>
+      <extracomment>Describes a range from one quantity to another, e.g. "30W to 60W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
+      <translation></translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAfricaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
+      <source>Morocco Standard Time</source>
+      <translation>التوقيت المعياري للمغرب</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
+      <source>W. Central Africa Standard Time</source>
+      <translation>التوقيت المعياري لغرب وسط أفريقيا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
+      <source>South Africa Standard Time</source>
+      <translation>التوقيت المعياري لجنوب أفريقيا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
+      <source>Namibia Standard Time</source>
+      <translation>التوقيت المعياري لناميبيا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
+      <source>Egypt Standard Time</source>
+      <translation>التوقيت المعياري لمصر</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
+      <source>E. Africa Standard Time</source>
+      <translation>التوقيت المعياري لشرق أفريقيا</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAmericaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
+      <source>Argentina Standard Time</source>
+      <translation>التوقيت المعياري للأرجنتين</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
+      <source>E. South America Standard Time</source>
+      <translation>التوقيت المعياري لشرق جنوب أمريكا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
+      <source>Greenland Standard Time</source>
+      <translation>التوقيت المعياري لجرينلاند</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
+      <source>Montevideo Standard Time</source>
+      <translation>التوقيت المعياري لمونتفيدو</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
+      <source>Newfoundland Standard Time</source>
+      <translation>التوقيت المعياري لنيوفاوندلاند</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
+      <source>SA Eastern Standard Time</source>
+      <translation>التوقيت المعياري المنطقة الشرقية لجنوب أمريكا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
+      <source>Atlantic Standard Time</source>
+      <translation>التوقيت المعياري للأطلسي</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
+      <source>Central Brazilian Standard Time</source>
+      <translation>التوقيت المعياري لوسط البرازيل</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>التوقيت المعياري لمنطقة المحيط الهادئ لجنوب أمريكا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
+      <source>Paraguay Standard Time</source>
+      <translation>التوقيت المعياري لباراغواي</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
+      <source>SA Western Standard Time</source>
+      <translation>التوقيت المعياري لغرب جنوب أمريكا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
+      <source>Venezuela Standard Time</source>
+      <translation>التوقيت المعياري لفنزويلا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
+      <source>Eastern Standard Time</source>
+      <translation>التوقيت المعياري للشرق</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
+      <source>SA Pacific Standard Time</source>
+      <translation>التوقيت المعياري لمنطقة المحيط الهادئ لجنوب أمريكا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
+      <source>US Eastern Standard Time</source>
+      <translation>التوقيت المعياري لشرق الولايات المتحدة</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
+      <source>Canada Central Standard Time</source>
+      <translation>التوقيت المعياري لوسط الكندا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
+      <source>Central America Standard Time</source>
+      <translation>التوقيت المعياري لوسط أمريكا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
+      <source>Central Standard Time (Mexico)</source>
+      <translation>التوقيت المعياري للوسط (المكسيك)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
+      <source>Central Standard Time</source>
+      <translation>التوقيت المعياري للوسط</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
+      <source>Mountain Standard Time (Mexico)</source>
+      <translation>التوقيت المعياري للجبل (المكسيك)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
+      <source>Mountain Standard Time</source>
+      <translation>التوقيت المعياري للجبل</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
+      <source>US Mountain Standard Time</source>
+      <translation>التوقيت المعياري لجبل الولايات المتحدة</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
+      <source>Pacific Standard Time (Mexico)</source>
+      <translation>التوقيت المعياري للهادئ (المكسيك)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
+      <source>Pacific Standard Time</source>
+      <translation>التوقيت المعياري للهادئ</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
+      <source>Alaskan Standard Time</source>
+      <translation>التوقيت المعياري لألاسكا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
+      <source>Hawaii-Aleutian</source>
+      <translation>التوقيت المعياري لهاواي-إليوتينس</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
+      <source>Atlantic Daylight Time</source>
+      <translation>التوقيت الصيفي للأطلسي</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAntarcticaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+      <source>New Zealand Standard Time</source>
+      <translation>التوقيت المعياري لنيوزيلندا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>التوقيت المعياري لوسط الهادئ</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+      <source>West Pacific Standard Time</source>
+      <translation>التوقيت المعياري لغرب الهادئ</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+      <source>W. Australia Standard Time</source>
+      <translation>التوقيت المعياري لغرب أستراليا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+      <source>SE Asia Standard Time</source>
+      <translation>التوقيت المعياري لجنوب شرق آسيا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+      <source>Central Asia Standard Time</source>
+      <translation>التوقيت المعياري لوسط آسيا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+      <source>West Asia Standard Time</source>
+      <translation>التوقيت المعياري لغرب آسيا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+      <source>E. Africa Standard Time</source>
+      <translation>التوقيت المعياري لشرق أفريقيا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>التوقيت المعياري لمنطقة المحيط الهادئ لجنوب أمريكا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+      <source>SA Western Standard Time</source>
+      <translation>التوقيت المعياري لغرب جنوب أمريكا</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzArcticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
+      <source>W. Europe Standard Time</source>
+      <translation>التوقيت المعياري لغرب أوروبا</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAsiaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
+      <source>Kamchatka Standard Time</source>
+      <translation>التوقيت المعياري لكامشاتكا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
+      <source>Magadan Standard Time</source>
+      <translation>التوقيت المعياري لماجادان</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
+      <source>Vladivostok Standard Time</source>
+      <translation>التوقيت المعياري لفلاديفوستوك</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
+      <source>Yakutsk Standard Time</source>
+      <translation>التوقيت المعياري لياكتسك</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
+      <source>Tokyo Standard Time</source>
+      <translation>التوقيت المعياري لطوكيو</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
+      <source>Korea Standard Time</source>
+      <translation>التوقيت المعياري لكوريا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
+      <source>Singapore Standard Time</source>
+      <translation>التوقيت المعياري لسنغافورة</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
+      <source>Ulaanbaatar Standard Time</source>
+      <translation>التوقيت المعياري لأولان باتور</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
+      <source>Taipei Standard Time</source>
+      <translation>التوقيت المعياري لتايبيه</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
+      <source>North Asia East Standard Time</source>
+      <translation>التوقيت المعياري لشمال شرق آسيا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
+      <source>China Standard Time</source>
+      <translation>التوقيت المعياري للصين</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
+      <source>SE Asia Standard Time</source>
+      <translation>التوقيت المعياري لجنوب شرق آسيا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
+      <source>North Asia Standard Time</source>
+      <translation>التوقيت المعياري لشمال آسيا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
+      <source>Myanmar Standard Time</source>
+      <translation>التوقيت المعياري لبورما</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
+      <source>N. Central Asia Standard Time</source>
+      <translation>التوقيت المعياري لشمال وسط آسيا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
+      <source>Central Asia Standard Time</source>
+      <translation>التوقيت المعياري لوسط آسيا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
+      <source>Bangladesh Standard Time</source>
+      <translation>التوقيت المعياري لبنغلاديش</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
+      <source>Nepal Standard Time</source>
+      <translation>التوقيت المعياري للنيبال</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
+      <source>Sri Lanka Standard Time</source>
+      <translation>التوقيت المعياري لسريلانكا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
+      <source>India Standard Time</source>
+      <translation>التوقيت المعياري للهند</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
+      <source>West Asia Standard Time</source>
+      <translation>التوقيت المعياري لغرب آسيا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
+      <source>Pakistan Standard Time</source>
+      <translation>التوقيت المعياري لباكستان</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
+      <source>Ekaterinburg Standard Time</source>
+      <translation>التوقيت المعياري ليكترينبورغ</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
+      <source>Georgian Standard Time</source>
+      <translation>التوقيت المعياري لجورجيا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
+      <source>Caucasus Standard Time</source>
+      <translation>التوقيت المعياري للقوقاز</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
+      <source>Azerbaijan Standard Time</source>
+      <translation>التوقيت المعياري لأذربجان</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
+      <source>Arabian Standard Time</source>
+      <translation>التوقيت المعياري العربي</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
+      <source>Afghanistan Standard Time</source>
+      <translation>التوقيت المعياري أفغانستان</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
+      <source>Iran Standard Time</source>
+      <translation>التوقيت المعياري لإيران</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
+      <source>Arabic Standard Time</source>
+      <translation>التوقيت المعياري العربي</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
+      <source>Arab Standard Time</source>
+      <translation>التوقيت المعياري العربي</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
+      <source>Syria Standard Time</source>
+      <translation>التوقيت المعياري لسوريا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
+      <source>Middle East Standard Time</source>
+      <translation>التوقيت المعياري للشرق الأوسط</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
+      <source>Jordan Standard Time</source>
+      <translation>التوقيت المعياري للأردن</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
+      <source>Israel Standard Time</source>
+      <translation>التوقيت المعياري لإسرائيل</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAtlanticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+      <source>Greenwich Standard Time</source>
+      <translation>التوقيت المعياري لغرينتش</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+      <source>Azores Standard Time</source>
+      <translation>التوقيت المعياري للأزور</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+      <source>Cape Verde Standard Time</source>
+      <translation>التوقيت المعياري للرأس الأخضر</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
+      <source>Mid-Atlantic Standard Time</source>
+      <translation>التوقيت المعياري لوسط الأطلسي</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAustraliaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+      <source>Tasmania Standard Time</source>
+      <translation>التوقيت المعياري لتاسمانيا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+      <source>E. Australia Standard Time</source>
+      <translation>التوقيت المعياري لشرق أستراليا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+      <source>AUS Eastern Standard Time</source>
+      <translation>التوقيت المعياري لشرق أستراليا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+      <source>Cen. Australia Standard Time</source>
+      <translation>التوقيت المعياري لوسط أستراليا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+      <source>AUS Central Standard Time</source>
+      <translation>التوقيت المعياري لوسط أستراليا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+      <source>W. Australia Standard Time</source>
+      <translation>التوقيت المعياري لغرب أستراليا</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEtcData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
+      <source>GMT +12</source>
+      <translation>توقيت غرنتش +12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
+      <source>GMT -02</source>
+      <translation>توقيت غرينتش -02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
+      <source>GMT -11</source>
+      <translation>GMT -11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
+      <source>GMT -13</source>
+      <translation>توقيت غرينتش -13</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
+      <source>GMT -12</source>
+      <translation>توقيت غرينتش -12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
+      <source>GMT -10</source>
+      <translation>توقيت غرينتش -10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
+      <source>GMT -09</source>
+      <translation>توقيت غرينتش -09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
+      <source>GMT -08</source>
+      <translation>توقيت غرينتش -08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
+      <source>GMT -07</source>
+      <translation>توقيت غرينتش -07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
+      <source>GMT -06</source>
+      <translation>توقيت غرينتش -06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
+      <source>GMT -05</source>
+      <translation>توقيت غرينتش -05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
+      <source>GMT -04</source>
+      <translation>توقيت غرينتش -04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
+      <source>GMT -03</source>
+      <translation>توقيت غرينتش -03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
+      <source>GMT -01</source>
+      <translation>توقيت غرينتش -01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
+      <source>GMT</source>
+      <translation>GMT</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
+      <source>GMT +01</source>
+      <translation>توقيت غرينتش +01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
+      <source>GMT +02</source>
+      <translation>توقيت غرينتش +02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
+      <source>GMT +03</source>
+      <translation>توقيت غرينتش +03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
+      <source>GMT +04</source>
+      <translation>توقيت غرينتش +04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
+      <source>GMT +05</source>
+      <translation>توقيت غرينتش +05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
+      <source>GMT +06</source>
+      <translation>توقيت غرينتش +06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
+      <source>GMT +07</source>
+      <translation>توقيت غرينتش +07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
+      <source>GMT +08</source>
+      <translation>توقيت غرينتش +08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
+      <source>GMT +09</source>
+      <translation>توقيت غرينتش +09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
+      <source>GMT +10</source>
+      <translation>توقيت غرينتش +10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
+      <source>GMT +11</source>
+      <translation>توقيت غرينتش +11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
+      <source>UTC</source>
+      <translation>التوقيت العالمي المنسق</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEuropeData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
+      <source>GMT Standard Time</source>
+      <translation>التوقيت المعياري لغرينتش</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
+      <source>Central Europe Standard Time</source>
+      <translation>التوقيت المعياري لوسط أوروبا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
+      <source>Central European Standard Time</source>
+      <translation>التوقيت المعياري لوسط أوروبا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
+      <source>Romance Standard Time</source>
+      <translation>التوقيت المعياري لوسط أوروبا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
+      <source>W. Europe Standard Time</source>
+      <translation>التوقيت المعياري لغرب أوروبا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
+      <source>E. Europe Standard Time</source>
+      <translation>التوقيت المعياري لشرق أوروبا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
+      <source>FLE Standard Time</source>
+      <translation>التوقيت المعياري لفنلندا ليتوانيا إستونيا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
+      <source>GTB Standard Time</source>
+      <translation>التوقيت المعياري لليونان تركيا بلغاريا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
+      <source>Belarus Standard Time</source>
+      <translation>التوقيت المعياري لبلاروسيا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
+      <source>Russian Standard Time</source>
+      <translation>التوقيت المعياري لروسيا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
+      <source>Turkey Standard Time</source>
+      <translation>التوقيت المعياري لتركيا</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzIndianData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
+      <source>Mauritius Standard Time</source>
+      <translation>التوقيت المعياري لموريشيوس</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
+      <source>Christmas Island Standard Time</source>
+      <translation>الوقت المعياري لجزيرة كريسماس</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzPacificData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
+      <source>Tonga Standard Time</source>
+      <translation>التوقيت المعياري لتونغا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
+      <source>Fiji Standard Time</source>
+      <translation>التوقيت المعياري لفيجي</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
+      <source>New Zealand Standard Time</source>
+      <translation>التوقيت المعياري لنيوزيلندا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>التوقيت المعياري لوسط الهادئ</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
+      <source>West Pacific Standard Time</source>
+      <translation>التوقيت المعياري لغرب الهادئ</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
+      <source>Samoa Standard Time</source>
+      <translation>التوقيت المعياري لساموا</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
+      <source>Hawaiian Standard Time</source>
+      <translation>التوقيت المعياري لهاواي</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
+      <source>Easter Island Standard Time</source>
+      <translation>الوقت المعياري لجزيرة الفصح</translation>
     </message>
   </context>
   <context>
@@ -12174,838 +11854,6 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
     </message>
   </context>
   <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>التوقيت المعياري للمغرب</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>التوقيت المعياري لغرب وسط أفريقيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>التوقيت المعياري لجنوب أفريقيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>التوقيت المعياري لناميبيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>التوقيت المعياري لمصر</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>التوقيت المعياري لشرق أفريقيا</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>التوقيت المعياري للأرجنتين</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>التوقيت المعياري لشرق جنوب أمريكا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>التوقيت المعياري لجرينلاند</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>التوقيت المعياري لمونتفيدو</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>التوقيت المعياري لنيوفاوندلاند</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>التوقيت المعياري المنطقة الشرقية لجنوب أمريكا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Atlantic Standard Time</source>
-      <translation>التوقيت المعياري للأطلسي</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>التوقيت المعياري لوسط البرازيل</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>التوقيت المعياري لمنطقة المحيط الهادئ لجنوب أمريكا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>Paraguay Standard Time</source>
-      <translation>التوقيت المعياري لباراغواي</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>SA Western Standard Time</source>
-      <translation>التوقيت المعياري لغرب جنوب أمريكا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Venezuela Standard Time</source>
-      <translation>التوقيت المعياري لفنزويلا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>Eastern Standard Time</source>
-      <translation>التوقيت المعياري للشرق</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>التوقيت المعياري لمنطقة المحيط الهادئ لجنوب أمريكا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>US Eastern Standard Time</source>
-      <translation>التوقيت المعياري لشرق الولايات المتحدة</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Canada Central Standard Time</source>
-      <translation>التوقيت المعياري لوسط الكندا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central America Standard Time</source>
-      <translation>التوقيت المعياري لوسط أمريكا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>التوقيت المعياري للوسط (المكسيك)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Central Standard Time</source>
-      <translation>التوقيت المعياري للوسط</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>التوقيت المعياري للجبل (المكسيك)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>Mountain Standard Time</source>
-      <translation>التوقيت المعياري للجبل</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>US Mountain Standard Time</source>
-      <translation>التوقيت المعياري لجبل الولايات المتحدة</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>التوقيت المعياري للهادئ (المكسيك)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Pacific Standard Time</source>
-      <translation>التوقيت المعياري للهادئ</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Alaskan Standard Time</source>
-      <translation>التوقيت المعياري لألاسكا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>التوقيت المعياري لهاواي-إليوتينس</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Daylight Time</source>
-      <translation>التوقيت الصيفي للأطلسي</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>التوقيت المعياري لنيوزيلندا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>التوقيت المعياري لوسط الهادئ</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>التوقيت المعياري لغرب الهادئ</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>التوقيت المعياري لغرب أستراليا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>التوقيت المعياري لجنوب شرق آسيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>التوقيت المعياري لوسط آسيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>التوقيت المعياري لغرب آسيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>التوقيت المعياري لشرق أفريقيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>التوقيت المعياري لمنطقة المحيط الهادئ لجنوب أمريكا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>التوقيت المعياري لغرب جنوب أمريكا</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>التوقيت المعياري لغرب أوروبا</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>التوقيت المعياري لكامشاتكا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>التوقيت المعياري لماجادان</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>التوقيت المعياري لفلاديفوستوك</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>التوقيت المعياري لياكتسك</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>التوقيت المعياري لطوكيو</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>التوقيت المعياري لكوريا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>التوقيت المعياري لسنغافورة</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>التوقيت المعياري لأولان باتور</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>التوقيت المعياري لتايبيه</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>التوقيت المعياري لشمال شرق آسيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>التوقيت المعياري للصين</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>التوقيت المعياري لجنوب شرق آسيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>التوقيت المعياري لشمال آسيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>التوقيت المعياري لبورما</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>التوقيت المعياري لشمال وسط آسيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>التوقيت المعياري لوسط آسيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>التوقيت المعياري لبنغلاديش</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>التوقيت المعياري للنيبال</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>التوقيت المعياري لسريلانكا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>التوقيت المعياري للهند</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>التوقيت المعياري لغرب آسيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>التوقيت المعياري لباكستان</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>التوقيت المعياري ليكترينبورغ</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>التوقيت المعياري لجورجيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>التوقيت المعياري للقوقاز</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>التوقيت المعياري لأذربجان</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>التوقيت المعياري العربي</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>التوقيت المعياري أفغانستان</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>التوقيت المعياري لإيران</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>التوقيت المعياري العربي</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>التوقيت المعياري العربي</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>التوقيت المعياري لسوريا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>التوقيت المعياري للشرق الأوسط</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>التوقيت المعياري للأردن</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>التوقيت المعياري لإسرائيل</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>التوقيت المعياري لغرينتش</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>التوقيت المعياري للأزور</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>التوقيت المعياري للرأس الأخضر</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>التوقيت المعياري لوسط الأطلسي</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>التوقيت المعياري لتاسمانيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>التوقيت المعياري لشرق أستراليا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>التوقيت المعياري لشرق أستراليا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>التوقيت المعياري لوسط أستراليا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>التوقيت المعياري لوسط أستراليا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>التوقيت المعياري لغرب أستراليا</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
-      <source>GMT +12</source>
-      <translation>توقيت غرنتش +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
-      <source>GMT -02</source>
-      <translation>توقيت غرينتش -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT -13</source>
-      <translation>توقيت غرينتش -13</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT -12</source>
-      <translation>توقيت غرينتش -12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -10</source>
-      <translation>توقيت غرينتش -10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -09</source>
-      <translation>توقيت غرينتش -09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>GMT -08</source>
-      <translation>توقيت غرينتش -08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
-      <source>GMT -07</source>
-      <translation>توقيت غرينتش -07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
-      <source>GMT -06</source>
-      <translation>توقيت غرينتش -06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
-      <source>GMT -05</source>
-      <translation>توقيت غرينتش -05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
-      <source>GMT -04</source>
-      <translation>توقيت غرينتش -04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
-      <source>GMT -03</source>
-      <translation>توقيت غرينتش -03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
-      <source>GMT -01</source>
-      <translation>توقيت غرينتش -01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
-      <source>GMT</source>
-      <translation>GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
-      <source>GMT +01</source>
-      <translation>توقيت غرينتش +01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
-      <source>GMT +02</source>
-      <translation>توقيت غرينتش +02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
-      <source>GMT +03</source>
-      <translation>توقيت غرينتش +03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
-      <source>GMT +04</source>
-      <translation>توقيت غرينتش +04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
-      <source>GMT +05</source>
-      <translation>توقيت غرينتش +05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
-      <source>GMT +06</source>
-      <translation>توقيت غرينتش +06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
-      <source>GMT +07</source>
-      <translation>توقيت غرينتش +07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
-      <source>GMT +08</source>
-      <translation>توقيت غرينتش +08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
-      <source>GMT +09</source>
-      <translation>توقيت غرينتش +09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
-      <source>GMT +10</source>
-      <translation>توقيت غرينتش +10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
-      <source>GMT +11</source>
-      <translation>توقيت غرينتش +11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
-      <source>UTC</source>
-      <translation>التوقيت العالمي المنسق</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>التوقيت المعياري لغرينتش</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>التوقيت المعياري لوسط أوروبا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>التوقيت المعياري لوسط أوروبا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>التوقيت المعياري لوسط أوروبا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>التوقيت المعياري لغرب أوروبا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>التوقيت المعياري لشرق أوروبا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>التوقيت المعياري لفنلندا ليتوانيا إستونيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>التوقيت المعياري لليونان تركيا بلغاريا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>التوقيت المعياري لبلاروسيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>التوقيت المعياري لروسيا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>التوقيت المعياري لتركيا</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>التوقيت المعياري لموريشيوس</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>الوقت المعياري لجزيرة كريسماس</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>التوقيت المعياري لتونغا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>التوقيت المعياري لفيجي</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>التوقيت المعياري لنيوزيلندا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>التوقيت المعياري لوسط الهادئ</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>التوقيت المعياري لغرب الهادئ</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>التوقيت المعياري لساموا</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>التوقيت المعياري لهاواي</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>الوقت المعياري لجزيرة الفصح</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation type="unfinished">خطأ داخلي</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation type="unfinished"/>
-    </message>
-  </context>
-  <context>
     <name>Wakespeed</name>
     <message>
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
@@ -13182,6 +12030,119 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
       <source>DC/DC misconfiguration</source>
       <translation>خطأ إعداد الجهد المستمر</translation>
+    </message>
+  </context>
+  <context>
+    <name>VebusError</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+      <source>Device switched off</source>
+      <translation>تم إيقاف تشغيل الجهاز</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+      <source>Mixed old/new MK2</source>
+      <translation>MK2 قديم/جديد مختلط</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+      <source>Expected devices error</source>
+      <translation>خطأ الأجهزة المتوقعة</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+      <source>No other device detected</source>
+      <translation>لم يتم الكشف عن أي جهاز آخر</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+      <source>Overvoltage on AC-out</source>
+      <translation>ارتفاع الجهد على خرج التيار المتردد</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+      <source>DDC program error</source>
+      <translation>خطأ في برنامج DDC</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+      <source>VE.Bus BMS without assistant</source>
+      <translation>VE.Bus BMS بدون مساعد</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+      <source>Ground relay test failed</source>
+      <translation>فشل اختبار مرحل التأريض</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+      <source>System time sync error</source>
+      <translation>خطأ في مزامنة وقت النظام</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+      <source>Grid relay test fault</source>
+      <translation>خطأ في اختبار مرحل الشبكة</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+      <source>Config mismatch with 2nd mcu</source>
+      <translation>عدم تطابق التكوين مع وحدة التحكم الدقيقة الثانية</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+      <source>Device transmit error</source>
+      <translation>خطأ في إرسال الجهاز</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+      <source>Awaiting configuration or dongle missing</source>
+      <translation>في انتظار التكوين أو فقدان وحدة الربط</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+      <source>Phase master missing</source>
+      <translation>فقدان المرحلة الرئيسية</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+      <source>Overvoltage has occurred</source>
+      <translation>حدث ارتفاع في الجهد</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+      <source>Slave does not have AC input!</source>
+      <translation>التابع ليس لديه مدخل تيار متردد!</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+      <source>Device can't be slave</source>
+      <translation>لا يمكن أن يكون الجهاز تابعًا</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+      <source>System protection initiated</source>
+      <translation>بدء حماية النظام</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+      <source>Firmware incompatibiltiy</source>
+      <translation>عدم توافق البرنامج الثابت</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+      <source>Internal error</source>
+      <translation>خطأ داخلي</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+      <source>Failing relay test prevents connection</source>
+      <translation>فشل اختبار المرحل يمنع الاتصال</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+      <source>VE.Bus error</source>
+      <translation>خطأ VE.Bus</translation>
     </message>
   </context>
 </TS>

--- a/i18n/venus-gui-v2_cs.ts
+++ b/i18n/venus-gui-v2_cs.ts
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="cs">
   <context>
-    <name/>
+    <name></name>
     <message id="switchable_output_disabled">
       <location filename="../../src/enums.cpp" line="478"/>
       <source>Disabled</source>
@@ -22,6 +22,7 @@
     <message id="solarchargers_state_off">
       <location filename="../../src/enums.cpp" line="331"/>
       <source>Off</source>
+      <extracomment>Digital input state</extracomment>
       <translation>Vypnuto</translation>
     </message>
     <message id="common_words_auto">
@@ -52,18 +53,25 @@
     <message id="settings_startpage_none">
       <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
       <source>None</source>
+      <extracomment>Indicates no phase</extracomment>
       <translation>Žádný</translation>
     </message>
     <message id="common_words_position_ac">
       <location filename="../../components/CommonWords.qml" line="416"/>
       <source>Position</source>
-      <extracomment>AC input or output position</extracomment>
+      <extracomment>EVCS AC input/output position</extracomment>
       <translation>Pozice</translation>
     </message>
     <message id="settings_minmax_speed">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="193"/>
       <source>Speed</source>
+      <extracomment>A speed measurement value</extracomment>
       <translation>Rychlost</translation>
+    </message>
+    <message id="common_words_state">
+      <location filename="../../components/CommonWords.qml" line="502"/>
+      <source>State</source>
+      <translation>Stav</translation>
     </message>
     <message id="settings_firmware_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="67"/>
@@ -101,8 +109,8 @@
       <source>Solar yield</source>
       <translation>Solární výnos</translation>
     </message>
-    <message id="ess_state_external_control">
-      <location filename="../../data/Ess.qml" line="41"/>
+    <message id="inverters_state_externalccontrol">
+      <location filename="../../data/System.qml" line="183"/>
       <source>External control</source>
       <translation>Externí ovládání</translation>
     </message>
@@ -140,6 +148,11 @@
       <location filename="../../components/CommonWords.qml" line="203"/>
       <source>ESS</source>
       <translation>ESS</translation>
+    </message>
+    <message id="pagesettingsconnectivity_ethernet">
+      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
+      <source>Ethernet</source>
+      <translation>Ethernet</translation>
     </message>
     <message id="pagesettingsconnectivity_wifi">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="28"/>
@@ -262,11 +275,6 @@
       <source>Name</source>
       <translation>Název</translation>
     </message>
-    <message id="settings_deviceinfo_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="38"/>
-      <source>Name</source>
-      <translation type="unfinished">Název</translation>
-    </message>
     <message id="settings_deviceinfo_product_id">
       <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
       <source>Product ID</source>
@@ -327,15 +335,20 @@
       <source>Daily run time</source>
       <translation>Doba chodu za den</translation>
     </message>
+    <message id="common_words_value_must_be_greater_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="560"/>
+      <source>Value must be greater than stop value</source>
+      <translation>Hodnota musí být vyšší než hodnota zastavení</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="563"/>
+      <source>Value must be lower than start value</source>
+      <translation>Hodnota musí být nižší než spouštěcí hodnota</translation>
+    </message>
     <message id="settings_minmax_acout_max_power">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="124"/>
       <source>AC output</source>
       <translation>AC výstup</translation>
-    </message>
-    <message id="ac_output">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="15"/>
-      <source>AC output</source>
-      <translation type="unfinished">AC výstup</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
       <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="25"/>
@@ -382,16 +395,6 @@
       <source>Unavailable monitor, set another</source>
       <translation>Nedostupný monitor, nastavte jiný</translation>
     </message>
-    <message id="page_generator_conditions_battery_monitor">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="42"/>
-      <source>Battery monitor</source>
-      <translation type="unfinished">Monitor baterie</translation>
-    </message>
-    <message id="page_generator_conditions_unavailable_monitor_set_another">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="44"/>
-      <source>Unavailable monitor, set another</source>
-      <translation type="unfinished">Nedostupný monitor, nastavte jiný</translation>
-    </message>
     <message id="page_generator_conditions_on_loss_of_communication">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="68"/>
       <source>On loss of communication</source>
@@ -416,11 +419,6 @@
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="105"/>
       <source>Battery SOC</source>
       <translation>SOC baterie</translation>
-    </message>
-    <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="173"/>
-      <source>Periodic run</source>
-      <translation type="unfinished">Pravidelný chod</translation>
     </message>
     <message id="settings_inverter_high_temperature">
       <location filename="../../data/Generators.qml" line="83"/>
@@ -505,7 +503,7 @@
     <message id="settings_gps_speed_kmh">
       <location filename="../../pages/settings/PageGps.qml" line="83"/>
       <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometres per hour</extracomment>
+      <extracomment>GPS speed data, in kilometers per hour</extracomment>
       <translation>%1 km/h</translation>
     </message>
     <message id="settings_gps_speed_mph">
@@ -523,7 +521,7 @@
     <message id="settings_gps_speed_ms">
       <location filename="../../pages/settings/PageGps.qml" line="95"/>
       <source>%1 m/s</source>
-      <extracomment>GPS speed data, in metres per second</extracomment>
+      <extracomment>GPS speed data, in meters per second</extracomment>
       <translation>%1 m/s</translation>
     </message>
     <message id="settings_gps_course">
@@ -580,21 +578,6 @@
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="64"/>
       <source>%1 (Output %2)</source>
       <translation>%1 (Výstup %2)</translation>
-    </message>
-    <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">Aktivní monitor baterie</translation>
-    </message>
-    <message id="settings_batteries_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="101"/>
-      <source>Name</source>
-      <translation type="unfinished">Název</translation>
-    </message>
-    <message id="settings_batteries_enter_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="103"/>
-      <source>Enter name</source>
-      <translation type="unfinished">Zadejte jméno</translation>
     </message>
     <message id="settings_briefview_center_active_battery_monitor">
       <location filename="../../components/listitems/ListBriefCenterDetails.qml" line="27"/>
@@ -656,45 +639,25 @@
       <source>CAN-bus profile</source>
       <translation>CAN-bus profil</translation>
     </message>
-    <message id="settings_disabled">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="31"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Deaktivováno</translation>
-    </message>
-    <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</translation>
-    </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
       <location filename="../../pages/settings/CanbusProfile.qml" line="42"/>
       <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
       <translation>VE.Can &amp; CAN-bus BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
       <source>Oceanvolt (250 kbit/s)</source>
       <translation>Oceanvolt (250 kbit/s)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
       <source>RV-C (250 kbit/s)</source>
       <translation>RV-C (250 kbit/s)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
       <source>Up, but no services (250 kbit/s)</source>
       <translation>Nahoře, ale bez služeb (250 kbit/s)</translation>
-    </message>
-    <message id="settings_canopen_motordrive_250">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
-      <source>CANopen Motor drive (250 kbit/s)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_canopen_motordrive_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
-      <source>CANopen Motor drive (500 kbit/s)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_devices">
       <location filename="../../components/CommonWords.qml" line="166"/>
@@ -731,11 +694,6 @@
       <source>Check Unique id numbers</source>
       <translation>Zkontrolovat unikátní identifikační čísla</translation>
     </message>
-    <message id="settings_canbus_unique_id_press_to_check">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Press to check</source>
-      <translation type="unfinished">Stisknout pro kontrolu</translation>
-    </message>
     <message id="settings_canbus_unique_id_conflict">
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="125"/>
       <source>There is another device connected with this unique number, please select a new number.</source>
@@ -745,11 +703,6 @@
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="133"/>
       <source>OK: No other device is connected with this unique number.</source>
       <translation>OK: Žádné jiné zařízení není spojeno s tímto unikátním číslem.</translation>
-    </message>
-    <message id="pagesettingsintegrations_canopenmotordrive">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
-      <source>CANopen motor drives</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_network_status">
       <location filename="../../components/CommonWords.qml" line="349"/>
@@ -884,11 +837,6 @@
       <source>Unavailable sensor, set another</source>
       <translation>Nedostupný snímač, nastavte jiný</translation>
     </message>
-    <message id="settings_system_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="81"/>
-      <source>Unavailable sensor, set another</source>
-      <translation type="unfinished">Nedostupný snímač, nastavte jiný</translation>
-    </message>
     <message id="settings_dvcc_used_sensor">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="120"/>
       <source>Used sensor</source>
@@ -945,12 +893,6 @@
       <source>Auto selected</source>
       <translation>Automatická volba</translation>
     </message>
-    <message id="settings_dvcc_auto_selected_none">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="208"/>
-      <source>None</source>
-      <extracomment>Indicates no option is selected</extracomment>
-      <translation type="unfinished">Žádný</translation>
-    </message>
     <message id="settings_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
       <source>Build date/time</source>
@@ -986,12 +928,6 @@
       <source>Installing %1</source>
       <extracomment>%1 = firmware version</extracomment>
       <translation>Instalace %1</translation>
-    </message>
-    <message id="settings_firmware_offline_press_to_install">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">Stiskněte pro aktualizaci %1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="90"/>
@@ -1062,12 +998,6 @@
       <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
       <translation>Instaluji %1 %2%</translation>
     </message>
-    <message id="settings_firmware_online_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="86"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">Instaluji %1...</translation>
-    </message>
     <message id="settings_firmware_update_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="109"/>
       <source>Update build date/time</source>
@@ -1097,11 +1027,6 @@
       <location filename="../../pages/settings/PageSettingsFronius.qml" line="56"/>
       <source>TCP port</source>
       <translation>TCP port</translation>
-    </message>
-    <message id="page_settings_fronius_modbus_settings">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
-      <source>Modbus port and unit ID settings</source>
-      <translation type="unfinished"/>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
       <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
@@ -1153,16 +1078,6 @@
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="64"/>
       <source>AC-Out MP</source>
       <translation>AC-Out MP</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="52"/>
-      <source>AC-In1 L%1</source>
-      <translation type="unfinished">AC-In1 L%1</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="56"/>
-      <source>AC-In1 --</source>
-      <translation type="unfinished">AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="70"/>
@@ -1330,12 +1245,6 @@
       <source>Reset service timer</source>
       <translation>Resetování servisního časovače</translation>
     </message>
-    <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
-      <source>Volume</source>
-      <extracomment>Title for a list of units of volume (e.g. cubic metres, litres, gallons)</extracomment>
-      <translation type="unfinished">Objem</translation>
-    </message>
     <message id="settings_gps_format">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="69"/>
       <source>Format</source>
@@ -1438,42 +1347,6 @@ Pokud to nefunguje, zkontrolujte kartu SIM v telefonu a ujistěte se, že na ní
       <source>Wrong PIN</source>
       <translation>Špatný kód PIN</translation>
     </message>
-    <message id="page_settings_gsm_ok">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>OK</source>
-      <translation type="unfinished">Ok</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="128"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">Neznámá chyba</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_state">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="153"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Neznámý</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_value">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="182"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Neznámý</translation>
-    </message>
-    <message id="page_settings_gsm_offline">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="173"/>
-      <source>Offline</source>
-      <translation type="unfinished">Offline</translation>
-    </message>
-    <message id="page_settings_gsm_connecting">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="176"/>
-      <source>Connecting</source>
-      <translation type="unfinished">Připojení</translation>
-    </message>
-    <message id="page_settings_gsm_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="179"/>
-      <source>Connected</source>
-      <translation type="unfinished">Připojeno</translation>
-    </message>
     <message id="page_settings_gsm_pin">
       <location filename="../../pages/settings/PageSettingsGsm.qml" line="191"/>
       <source>PIN</source>
@@ -1530,32 +1403,32 @@ Pokud to nefunguje, zkontrolujte kartu SIM v telefonu a ujistěte se, že na ní
       <translation>Síťová měření</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
       <source>External meter</source>
       <translation>Externí měření</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="67"/>
       <source>Inverter/Charger</source>
       <translation>Měnič/nabíječ</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
       <source>Multiphase regulation</source>
       <translation>Způsob měření fází</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="91"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
       <source>Total of all phases</source>
       <translation>Součtové měření všech fází</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="95"/>
       <source>Individual phase</source>
       <translation>Individuální měření fází</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="99"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="101"/>
       <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
@@ -1564,68 +1437,13 @@ CAUTION: Use only if required by the utility provider.</source>
 UPOZORNĚNÍ: Používejte pouze v případě, že to vyžaduje dodavatel elektrické energie.</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="104"/>
       <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
       <translation>Součet všech fází je inteligentně regulován tak, aby bylo dosaženo žádané hodnoty sítě (účinnost systému je optimalizována).
 
 Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</translation>
-    </message>
-    <message id="settings_ess_min_soc">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation type="unfinished">Minimální úroveň vybíjení baterie (síť přítomna)</translation>
-    </message>
-    <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="129"/>
-      <source>Active SOC limit</source>
-      <translation type="unfinished">Aktuální úroveň vybíjení baterie (síť přítomna)</translation>
-    </message>
-    <message id="settings_ess_battery_life_sustain">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
-      <source>Sustain</source>
-      <translation type="unfinished">Udržování</translation>
-    </message>
-    <message id="settings_ess_battery_life_recharge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="157"/>
-      <source>Recharge</source>
-      <translation type="unfinished">Nabíjení</translation>
-    </message>
-    <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <source>Scheduled charge levels</source>
-      <translation type="unfinished">Naplánované úrovně nabití</translation>
-    </message>
-    <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="257"/>
-      <source>Active (%1)</source>
-      <translation type="unfinished">Aktivní (%1)</translation>
-    </message>
-    <message id="settings_ess_inactive">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="259"/>
-      <source>Inactive</source>
-      <translation type="unfinished">Neaktivní</translation>
-    </message>
-    <message id="settings_ess_dynamic">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="293"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">Dynamické ESS</translation>
-    </message>
-    <message id="settings_ess_deprecated">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="319"/>
-      <source>Deprecated settings</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_charge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="326"/>
-      <source>Battery charge limit (% of CCL)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_discharge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="337"/>
-      <source>Battery discharge limit (% of DCL)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_rs_ess_min_soc">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="40"/>
@@ -1637,13 +1455,8 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <source>Active SOC limit</source>
       <translation>Aktuální úroveň vybíjení baterie (síť přítomna)</translation>
     </message>
-    <message id="scheduled_charge_inactive">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
-      <source>Inactive</source>
-      <translation type="unfinished">Neaktivní</translation>
-    </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="245"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="247"/>
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
       <source>Peak shaving</source>
       <translation>Peak shaving</translation>
@@ -1659,12 +1472,12 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <translation>Vždy</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="151"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
       <source>Discharge disabled</source>
       <translation>Vybití deaktivováno</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
       <source>Slow charge</source>
       <translation>Pomalé nabíjení</translation>
     </message>
@@ -1679,32 +1492,32 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <translation>Nabíjení</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="165"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="167"/>
       <source>Limit charge power</source>
       <translation>Limit nabíjecího výkonu</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="183"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="185"/>
       <source>Maximum charge power</source>
       <translation>Maximální nabíjecí výkon</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="196"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="198"/>
       <source>Limit inverter power</source>
       <translation>Omezení výkonu měniče</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="214"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="216"/>
       <source>Maximum inverter power</source>
       <translation>Maximální odběr z baterie</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="225"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="227"/>
       <source>Grid setpoint</source>
       <translation>Hodnota síťového odběru</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="236"/>
       <source>Grid feed-in</source>
       <translation>Dodávka solárních přebytků do sítě</translation>
     </message>
@@ -1743,8 +1556,8 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <source>Door alarm</source>
       <translation>Alarm dveří</translation>
     </message>
-    <message id="digitalinputs_type_bilgepump">
-      <location filename="../../src/enums.cpp" line="201"/>
+    <message id="switchable_output_bilge_pump">
+      <location filename="../../src/enums.cpp" line="424"/>
       <source>Bilge pump</source>
       <translation>Bilge pumpa</translation>
     </message>
@@ -1796,11 +1609,6 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <source>Deferred by %1s</source>
       <extracomment>%1 = number of seconds</extracomment>
       <translation>Odloženo o %1 sekund</translation>
-    </message>
-    <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="75"/>
-      <source>Are you sure?</source>
-      <translation type="unfinished">Jste si jistý?</translation>
     </message>
     <message id="settings_vrm_portal_id">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="87"/>
@@ -1939,11 +1747,6 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <source>External storage</source>
       <translation>Externí paměť</translation>
     </message>
-    <message id="settings_vrm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="308"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">Neznámá chyba</translation>
-    </message>
     <message id="settings_vrm_no_error">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="311"/>
       <source>No Error</source>
@@ -2029,37 +1832,10 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <source>Function</source>
       <translation>Funkce</translation>
     </message>
-    <message id="settings_relay_disabled">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="54"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="98"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Deaktivováno</translation>
-    </message>
     <message id="settings_relay_alarm_relay">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="56"/>
       <source>Alarm relay</source>
       <translation>Alarmové relé</translation>
-    </message>
-    <message id="settings_relay_tank_pump">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="62"/>
-      <source>Tank pump</source>
-      <translation type="unfinished">Čerpadlo nádrže</translation>
-    </message>
-    <message id="settings_relay_manual">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="64"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="100"/>
-      <source>Manual</source>
-      <translation type="unfinished">Manuální</translation>
-    </message>
-    <message id="settings_relay_polarity_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
-      <source>Polarity (Relay 1)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_relay_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
-      <source>Polarity</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_normally_open">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="83"/>
@@ -2075,11 +1851,6 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="93"/>
       <source>Function (Relay 2)</source>
       <translation>Funkce (relé 2)</translation>
-    </message>
-    <message id="settings_relay_polarity_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
-      <source>Polarity (Relay 2)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_temp_control_rules">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="119"/>
@@ -2111,12 +1882,6 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
       <source>Press to boot</source>
       <translation>Stiskněte pro načtení</translation>
-    </message>
-    <message id="settings_firmware_backup_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
-      <translation type="unfinished">Firmware %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
@@ -2152,6 +1917,7 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
     <message id="nav_boat">
       <location filename="../../pages/boat/BoatPage.qml" line="14"/>
       <source>Boat</source>
+      <extracomment>The 'Boat' page</extracomment>
       <translation>Loď</translation>
     </message>
     <message id="settings_system_name">
@@ -2219,11 +1985,6 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <source>Solar charger current control</source>
       <translation>Řízení proudu solárního regulátoru</translation>
     </message>
-    <message id="settings_system_status_bms_params">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
-      <source>BMS control</source>
-      <translation type="unfinished">BMS řízení</translation>
-    </message>
     <message id="common_words_bms_control">
       <location filename="../../components/CommonWords.qml" line="101"/>
       <source>BMS control</source>
@@ -2238,11 +1999,6 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
       <source>Pump state</source>
       <translation>Stav čerpadla</translation>
-    </message>
-    <message id="settings_pump_auto">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="56"/>
-      <source>Auto</source>
-      <translation type="unfinished">Auto</translation>
     </message>
     <message id="settings_tank_sensor">
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
@@ -2271,11 +2027,6 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="35"/>
       <source>Unplugged</source>
       <translation>Odpojeno</translation>
-    </message>
-    <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="16"/>
-      <source>Name</source>
-      <translation type="unfinished">Název</translation>
     </message>
     <message id="settings_tcpip_hidden">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="21"/>
@@ -2317,16 +2068,6 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="99"/>
       <source>IP configuration</source>
       <translation>IP konfigurace</translation>
-    </message>
-    <message id="settings_tcpip_manual">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="105"/>
-      <source>Manual</source>
-      <translation type="unfinished">Manuální</translation>
-    </message>
-    <message id="settings_tcpip_off">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="107"/>
-      <source>Off</source>
-      <translation type="unfinished">Vypnuto</translation>
     </message>
     <message id="settings_tcpip_fixed">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="109"/>
@@ -2382,21 +2123,6 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="30"/>
       <source>Create access point</source>
       <translation>Vytvořit přístupový bod</translation>
-    </message>
-    <message id="settings_wifi_access_point_enter_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="68"/>
-      <source>Enter password</source>
-      <translation type="unfinished">Zadejte heslo</translation>
-    </message>
-    <message id="page_settings_wifi_invalid_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
-      <source>Password length must be either 0 or between 10 and 63 characters long</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_wifi_password_updated">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
-      <source>Password updated</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_wifi_networks">
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="86"/>
@@ -2539,20 +2265,10 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <extracomment>Network status: Standalone</extracomment>
       <translation>Samostatný</translation>
     </message>
-    <message id="charger_standalone">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="45"/>
-      <source>Standalone</source>
-      <translation type="unfinished">Samostatný</translation>
-    </message>
     <message id="charger_charge">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="48"/>
       <source>Charge</source>
       <translation>Zátěž</translation>
-    </message>
-    <message id="charger_external_control">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="51"/>
-      <source>External control</source>
-      <translation type="unfinished">Externí ovládání</translation>
     </message>
     <message id="charger_charge_hub_1">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="54"/>
@@ -2584,16 +2300,6 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <source>Master setting</source>
       <translation>Nastavení masteru</translation>
     </message>
-    <message id="charger_slave">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="85"/>
-      <source>Slave</source>
-      <translation type="unfinished">Podřízený</translation>
-    </message>
-    <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation type="unfinished">Nabíjecí napětí</translation>
-    </message>
     <message id="systemsettings_networkstatus_slave">
       <location filename="../../data/SystemSettings.qml" line="148"/>
       <source>Slave</source>
@@ -2615,14 +2321,15 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <source>Group &amp; Charge master</source>
       <translation>Master skupiny a nabíjení</translation>
     </message>
-    <message id="genset_charge_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="365"/>
+    <message id="charger_charge_voltage">
+      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
       <source>Charge voltage</source>
       <translation>Nabíjecí napětí</translation>
     </message>
     <message id="common_words_reset">
       <location filename="../../components/CommonWords.qml" line="448"/>
       <source>Reset</source>
+      <extracomment>Reset the BMS control</extracomment>
       <translation>Reset</translation>
     </message>
     <message id="solarcharger_load">
@@ -2651,14 +2358,14 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <extracomment>Voltage alarm is at "Warning" level</extracomment>
       <translation>Upozornění</translation>
     </message>
-    <message id="listitems_alarm_level_alarm">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="25"/>
+    <message id="digitalinputs_state_alarm">
+      <location filename="../../src/enums.cpp" line="270"/>
       <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
+      <extracomment>Relay function is 'alarm'</extracomment>
       <translation>Alarm</translation>
     </message>
-    <message id="devicelist_tankshape_volume">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="190"/>
+    <message id="components_volumeunit_volume">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
       <source>Volume</source>
       <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
       <translation>Objem</translation>
@@ -2808,26 +2515,10 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <source>Relay function</source>
       <translation>Funkce relé</translation>
     </message>
-    <message id="batterysettingrelay_alarm">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation type="unfinished">Alarm</translation>
-    </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
       <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
       <source>Charger or generator start/stop</source>
       <translation>Spuštění/zastavení nabíječky nebo generátoru</translation>
-    </message>
-    <message id="batterysettingrelay_manual_control">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
-      <source>Manual control</source>
-      <translation type="unfinished">Ruční řízení</translation>
-    </message>
-    <message id="batterysettingrelay_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">Spálená pojistka</translation>
     </message>
     <message id="common_words_manual_control">
       <location filename="../../components/CommonWords.qml" line="302"/>
@@ -2853,12 +2544,6 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
       <source>Status LEDs</source>
       <translation>Stavové LED kontrolky</translation>
-    </message>
-    <message id="batterydiagnostics_none">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
-      <source>None</source>
-      <extracomment>Indicates no alarm is set</extracomment>
-      <translation type="unfinished">Žádný</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
@@ -2888,7 +2573,7 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
     <message id="common_words_switch">
       <location filename="../../components/CommonWords.qml" line="525"/>
       <source>Switch</source>
-      <extracomment>Change the mode value</extracomment>
+      <extracomment>Change the battery mode</extracomment>
       <translation>Spínač</translation>
     </message>
     <message id="devicelist_battery_initializing">
@@ -2956,21 +2641,6 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <source>Top section voltage</source>
       <translation>Napětí horní sekce</translation>
     </message>
-    <message id="battery_bank_error_communication">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="96"/>
-      <source>Communication error</source>
-      <translation type="unfinished">Chyba komunikace</translation>
-    </message>
-    <message id="battery_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="182"/>
-      <source>State of health</source>
-      <translation type="unfinished">Stav životnosti</translation>
-    </message>
-    <message id="battery_bus_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="212"/>
-      <source>Bus voltage</source>
-      <translation type="unfinished">Napětí sběrnice</translation>
-    </message>
     <message id="battery_bottom_section_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="228"/>
       <source>Bottom section voltage</source>
@@ -3016,16 +2686,6 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <source>IO</source>
       <translation>IO</translation>
     </message>
-    <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="391"/>
-      <source>System</source>
-      <translation type="unfinished">Systém</translation>
-    </message>
-    <message id="battery_press_to_redetect">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="433"/>
-      <source>Press to redetect</source>
-      <translation type="unfinished">Stisknout</translation>
-    </message>
     <message id="pagesettingsgeneral_system">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="107"/>
       <source>System</source>
@@ -3066,16 +2726,6 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <source>Low SOC</source>
       <translation>Nízký stav nabití baterie</translation>
     </message>
-    <message id="batteryalarms_high_battery_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
-      <source>High battery voltage</source>
-      <translation type="unfinished">Vysoké napětí baterie</translation>
-    </message>
-    <message id="batteryalarms_low_soc">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low SOC</source>
-      <translation type="unfinished">Nízký stav nabití baterie</translation>
-    </message>
     <message id="batteryalarms_low_starter_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="73"/>
       <source>Low starter voltage</source>
@@ -3095,11 +2745,6 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
       <source>Mid-point voltage</source>
       <translation>Střední napětí</translation>
-    </message>
-    <message id="batteryalarms_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">Spálená pojistka</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
@@ -3293,11 +2938,6 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <source>Restore factory defaults</source>
       <translation>Obnovit standardní tovární nastavení</translation>
     </message>
-    <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation type="unfinished">Stisknout pro obnovu</translation>
-    </message>
     <message id="vebus_backup_press_to_restore">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="362"/>
       <source>Press to restore</source>
@@ -3337,11 +2977,6 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="18"/>
       <source>Capacity</source>
       <translation>Kapacita</translation>
-    </message>
-    <message id="batterysettingsbattery_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
-      <source>Capacity</source>
-      <translation type="unfinished">Kapacita</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
@@ -3418,16 +3053,12 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <source>No power on busbar</source>
       <translation>Na sběrnicové liště není napájení</translation>
     </message>
-    <message id="lynxdistributor_connection_lost">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
-      <source>Connection lost</source>
-      <translation type="unfinished">Ztráta připojení</translation>
-    </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
       <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
       <source>%n fuse(s) blown</source>
       <extracomment>%n = number of fuses that have blown</extracomment>
       <translation>
+        <numerusform>%n pojistka(y) vyhořela(y)</numerusform>
         <numerusform>%n pojistka(y) vyhořela(y)</numerusform>
         <numerusform>%n pojistka(y) vyhořela(y)</numerusform>
         <numerusform>%n pojistka(y) vyhořela(y)</numerusform>
@@ -3459,26 +3090,6 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <source>Shutdowns due error</source>
       <translation>Zastavení provozu z důvodu chyby</translation>
     </message>
-    <message id="lynxiondiagnostics_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
-      <source>Last error</source>
-      <translation type="unfinished">Poslední chyba</translation>
-    </message>
-    <message id="lynxiondiagnostics_2nd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
-      <source>2nd last error</source>
-      <translation type="unfinished">Předposlední chyba</translation>
-    </message>
-    <message id="lynxiondiagnostics_3rd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
-      <source>3rd last error</source>
-      <translation type="unfinished">3. poslední chyba</translation>
-    </message>
-    <message id="lynxiondiagnostics_4th_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
-      <source>4th last error</source>
-      <translation type="unfinished">4. poslední chyba</translation>
-    </message>
     <message id="lynxionio_system_switch">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
       <source>System Switch</source>
@@ -3498,11 +3109,6 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <location filename="../../components/CommonWords.qml" line="54"/>
       <source>Batteries</source>
       <translation>Baterie</translation>
-    </message>
-    <message id="lynxionsystem_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
-      <source>Capacity</source>
-      <translation type="unfinished">Kapacita</translation>
     </message>
     <message id="lynxionsystem_parallel">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="30"/>
@@ -3524,20 +3130,10 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <source>Min/max cell temperature</source>
       <translation>Min/max teplota článku</translation>
     </message>
-    <message id="lynxionsystem_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="92"/>
-      <source>Balancing</source>
-      <translation type="unfinished">Vyrovnávání</translation>
-    </message>
     <message id="lynxionsystem_balancer_balancing">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
       <source>Balancing</source>
       <translation>Vyrovnávání</translation>
-    </message>
-    <message id="lynxionsystem_balancer_unknown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="117"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Neznámý</translation>
     </message>
     <message id="dc_output">
       <location filename="../../components/listitems/ListDcOutputQuantityGroup.qml" line="16"/>
@@ -3645,11 +3241,6 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <source>Remaining</source>
       <translation>Zbývající</translation>
     </message>
-    <message id="devicelist_tanksensor_sensor_battery">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="51"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">Bateriový senzor</translation>
-    </message>
     <message id="temperature_sensor_battery">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="112"/>
       <source>Sensor battery</source>
@@ -3678,7 +3269,7 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
     <message id="devicelist_tanksetup_custom">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="53"/>
       <source>Custom</source>
-      <translation type="unfinished">Vlastní</translation>
+      <translation>Vlastní</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="59"/>
@@ -3711,34 +3302,34 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <translation>Hodnota čidla</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="75"/>
       <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
       <translation>Není definován žádný vlastní tvar. Můžete definovat jeden s maximálně deseti body. Všimněte si, že 0 % a 100 % jsou implicitní.</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="91"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="89"/>
       <source>Point %1</source>
       <extracomment>%1 = the point number</extracomment>
       <translation>Bod %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="133"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="179"/>
       <source>Add point</source>
       <translation>Přidat bod</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="156"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="205"/>
       <source>Sensor level</source>
       <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
       <translation>Úroveň snímače</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="256"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="311"/>
       <source>Duplicate sensor level values are not allowed.</source>
       <translation>Duplicitní hodnoty úrovně snímače nejsou povoleny.</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="262"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="317"/>
       <source>Volume values must be increasing.</source>
       <translation>Hodnoty objemu se musí zvyšovat.</translation>
     </message>
@@ -3778,11 +3369,6 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <source>Switch position</source>
       <translation>Poloha spínače</translation>
     </message>
-    <message id="ac-in-setup_single_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="142"/>
-      <source>Single phase</source>
-      <translation type="unfinished">Jedna fáze</translation>
-    </message>
     <message id="ac-in-setup_two_phase">
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="144"/>
       <source>2-phase</source>
@@ -3792,11 +3378,6 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="146"/>
       <source>3-phase</source>
       <translation>3 fáze</translation>
-    </message>
-    <message id="ac-in-setup_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="161"/>
-      <source>Devices</source>
-      <translation type="unfinished">Zařízení</translation>
     </message>
     <message id="ac-in-genset_ac">
       <location filename="../../components/PageGensetModel.qml" line="194"/>
@@ -3890,12 +3471,6 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <extracomment>%1 = CT device number</extracomment>
       <translation>CT %1</translation>
     </message>
-    <message id="smappeect_phase_none">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation type="unfinished">Žádný</translation>
-    </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
       <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
       <source>Flashing LED indicates this CT</source>
@@ -3909,11 +3484,13 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
     <message id="common_words_setting_disabled_when_dmc_connected">
       <location filename="../../components/CommonWords.qml" line="355"/>
       <source>This setting is disabled when a Digital Multi Control is connected.</source>
+      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>Toto nastavení je vypnuto, pokud je připojen digitální multifunkční ovladač.</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
       <location filename="../../components/CommonWords.qml" line="358"/>
       <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>Toto nastavení je zakázáno, pokud je připojena sběrnicová jednotka BMS VE.Bus.</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
@@ -3931,16 +3508,6 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="21"/>
       <source>Inverted</source>
       <translation>Invertovaný</translation>
-    </message>
-    <message id="digitalinput_enable_alarm">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="48"/>
-      <source>Enable alarm</source>
-      <translation type="unfinished">Aktivace alarmu</translation>
-    </message>
-    <message id="digitalinput_inverted">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="54"/>
-      <source>Inverted</source>
-      <translation type="unfinished">Invertovaný</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
       <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="60"/>
@@ -3977,16 +3544,6 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <source>Wind speed</source>
       <translation>Rychlost větru</translation>
     </message>
-    <message id="page_meteo_battery_voltage">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="99"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">Bateriový senzor</translation>
-    </message>
-    <message id="meteo_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="120"/>
-      <source>Low</source>
-      <translation type="unfinished">Nízko</translation>
-    </message>
     <message id="page_meteo_settings_auto_detect">
       <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
       <source>Auto-detect</source>
@@ -4017,16 +3574,6 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <source>Reset counter</source>
       <translation>Reset počítání</translation>
     </message>
-    <message id="temperature_short_circuited">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="32"/>
-      <source>Short circuited</source>
-      <translation type="unfinished">Zkrat</translation>
-    </message>
-    <message id="temperature_reverse_polarity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="35"/>
-      <source>Reverse polarity</source>
-      <translation type="unfinished">Obrácená polarita</translation>
-    </message>
     <message id="temperature_sensor_battery_low">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
       <source>Sensor battery low</source>
@@ -4041,36 +3588,6 @@ Používejte, pokud to není zakázáno poskytovatelem elektrické energie.</tra
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="62"/>
       <source>Pressure</source>
       <translation>Tlak</translation>
-    </message>
-    <message id="temperature_pm25">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
-      <source>PM2.5</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_co2">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>CO₂</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_voc">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
-      <source>VOC index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_nox">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
-      <source>NOx index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_luminosity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
-      <source>Luminosity</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="133"/>
-      <source>Low</source>
-      <translation type="unfinished">Nízko</translation>
     </message>
     <message id="temperature_offset">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
@@ -4124,25 +3641,10 @@ POZNÁMKA: Aktualizace může dočasně zastavit systém.</translation>
       <source>Updating the MK3, values will reappear after the update is complete</source>
       <translation>Aktualizuji MK3, hodnoty se znovu objeví po dokončení aktualizace.</translation>
     </message>
-    <message id="vebus_device_charging_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="78"/>
-      <source>Charging the battery to 100%</source>
-      <translation type="unfinished">Nabíjení baterie na 100 %</translation>
-    </message>
     <message id="vebus_device_charging_the_battery_to_100">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="93"/>
       <source>Charging the battery to 100%</source>
       <translation>Nabíjení baterie na 100 %</translation>
-    </message>
-    <message id="vebus_device_page_microgrid_parameters">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
-      <source>Microgrid parameters</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="vebus_device_page_advanced">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
-      <source>Advanced</source>
-      <translation type="unfinished">Pokročilé</translation>
     </message>
     <message id="vebus_device_in_progress">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="80"/>
@@ -4198,15 +3700,15 @@ Chcete pokračovat?</translation>
       <source>DC Current</source>
       <translation>DC proud</translation>
     </message>
+    <message id="vebus_device_page_advanced">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
+      <source>Advanced</source>
+      <translation>Pokročilé</translation>
+    </message>
     <message id="common_words_alarm_setup">
       <location filename="../../components/CommonWords.qml" line="65"/>
       <source>Alarm setup</source>
       <translation>Nastavení alarmu</translation>
-    </message>
-    <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
-      <translation type="unfinished">VE.Bus BMS automaticky vypne systém, pokud je nutné ochránit baterii. Řízení systému z Color Control není proto možné.</translation>
     </message>
     <message id="vebus_device_bms_not_found">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="240"/>
@@ -4247,7 +3749,7 @@ Chcete pokračovat?</translation>
     <message id="vebus_device_starting">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="117"/>
       <source>Starting...</source>
-      <translation type="unfinished">Spouštím...</translation>
+      <translation>Spouštím...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="120"/>
@@ -4313,16 +3815,6 @@ Chcete pokračovat?</translation>
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="260"/>
       <source>ESS Relay test</source>
       <translation>Kontrola ESS relé</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_completed">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="266"/>
-      <source>Completed</source>
-      <translation type="unfinished">Hotovo</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_pending">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="268"/>
-      <source>Pending</source>
-      <translation type="unfinished">Čekající</translation>
     </message>
     <message id="cycle_history_completed">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
@@ -4509,6 +4001,7 @@ Chcete pokračovat?</translation>
     <message id="rssystemalarms_overload">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
       <source>Overload</source>
+      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
       <translation>Přetížení</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
@@ -4521,11 +4014,6 @@ Chcete pokračovat?</translation>
       <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
       <source>Voltage Sensor</source>
       <translation>Čidlo napětí</translation>
-    </message>
-    <message id="vebus_device_phase_rotation">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
-      <source>Phase rotation</source>
-      <translation type="unfinished">Otáčení fáze</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
@@ -4557,12 +4045,6 @@ Chcete pokračovat?</translation>
       <source>VE.Bus BMS version</source>
       <translation>Verze VE.Bus BMS</translation>
     </message>
-    <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="15"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="52"/>
-      <source>Minimum SOC</source>
-      <translation type="unfinished">Minimální SOC</translation>
-    </message>
     <message id="ess_unless_grid_fails">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="32"/>
       <source>Unless grid fails</source>
@@ -4582,7 +4064,7 @@ Chcete pokračovat?</translation>
     <message id="common_words_ac_input_role">
       <location filename="../../components/CommonWords.qml" line="24"/>
       <source>Role</source>
-      <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
       <translation>Role</translation>
     </message>
     <message id="common_words_ac_load">
@@ -4621,18 +4103,6 @@ Chcete pokračovat?</translation>
       <source>Active</source>
       <extracomment>Status is 'active'</extracomment>
       <translation>Aktivní</translation>
-    </message>
-    <message id="common_words_alarm">
-      <location filename="../../components/CommonWords.qml" line="51"/>
-      <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
-      <translation type="unfinished">Alarm</translation>
-    </message>
-    <message id="common_words_alarm_setting_overload">
-      <location filename="../../components/CommonWords.qml" line="58"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation type="unfinished">Přetížení</translation>
     </message>
     <message id="common_words_alarm_status">
       <location filename="../../components/CommonWords.qml" line="68"/>
@@ -4679,8 +4149,8 @@ Chcete pokračovat?</translation>
       <source>Charge current</source>
       <translation>Nabíjecí proud</translation>
     </message>
-    <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="125"/>
+    <message id="battery_mode_charging">
+      <location filename="../../src/enums.cpp" line="30"/>
       <source>Charging</source>
       <extracomment>"Charging" state</extracomment>
       <translation>Nabíjení</translation>
@@ -4694,7 +4164,7 @@ Chcete pokračovat?</translation>
     <message id="digitalinputs_state_closed">
       <location filename="../../src/enums.cpp" line="262"/>
       <source>Closed</source>
-      <extracomment>Digital input state</extracomment>
+      <extracomment>Status is 'closed'</extracomment>
       <translation>Sepnuto</translation>
     </message>
     <message id="evchargers_status_connected">
@@ -4702,8 +4172,8 @@ Chcete pokračovat?</translation>
       <source>Connected</source>
       <translation>Připojeno</translation>
     </message>
-    <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="143"/>
+    <message id="temperature_slider_current">
+      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
       <source>Current</source>
       <extracomment>Electric current, as measured in Amps</extracomment>
       <translation>Proud</translation>
@@ -4730,9 +4200,10 @@ Chcete pokračovat?</translation>
       <extracomment>Title for device information</extracomment>
       <translation>Zařízení</translation>
     </message>
-    <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="172"/>
+    <message id="battery_mode_discharging">
+      <location filename="../../src/enums.cpp" line="34"/>
       <source>Discharging</source>
+      <extracomment>Battery mode</extracomment>
       <translation>vybíjení</translation>
     </message>
     <message id="wifimodel_disconnected">
@@ -4818,13 +4289,14 @@ Chcete pokračovat?</translation>
       <source>%1 Hour(s)</source>
       <translation>%1 Hodina(y)</translation>
     </message>
-    <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="251"/>
+    <message id="battery_mode_idle">
+      <location filename="../../src/enums.cpp" line="26"/>
       <source>Idle</source>
+      <extracomment>Battery mode</extracomment>
       <translation>Nečinný</translation>
     </message>
-    <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="258"/>
+    <message id="scheduled_charge_inactive">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
       <source>Inactive</source>
       <extracomment>Status is 'inactive'</extracomment>
       <translation>Neaktivní</translation>
@@ -4926,8 +4398,8 @@ Chcete pokračovat?</translation>
       <source>Offline</source>
       <translation>Offline</translation>
     </message>
-    <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="17"/>
+    <message id="digitalinputs_state_ok">
+      <location filename="../../src/enums.cpp" line="266"/>
       <source>OK</source>
       <extracomment>Voltage alarm is at "OK" level</extracomment>
       <translation>Ok</translation>
@@ -4935,6 +4407,7 @@ Chcete pokračovat?</translation>
     <message id="switchable_output_on">
       <location filename="../../src/enums.cpp" line="471"/>
       <source>On</source>
+      <extracomment>Digital input state</extracomment>
       <translation>Zapnuto</translation>
     </message>
     <message id="common_words_online">
@@ -4945,7 +4418,7 @@ Chcete pokračovat?</translation>
     <message id="digitalinputs_state_open">
       <location filename="../../src/enums.cpp" line="258"/>
       <source>Open</source>
-      <extracomment>Digital input open</extracomment>
+      <extracomment>Status is 'open'</extracomment>
       <translation>Rozpojeno</translation>
     </message>
     <message id="common_words_password">
@@ -5005,9 +4478,10 @@ Chcete pokračovat?</translation>
       <source>Remove</source>
       <translation>Odstranit</translation>
     </message>
-    <message id="switch_state_running">
-      <location filename="../../src/enums.cpp" line="363"/>
+    <message id="switchable_output_running">
+      <location filename="../../src/enums.cpp" line="468"/>
       <source>Running</source>
+      <extracomment>Status = "running"</extracomment>
       <translation>Chod</translation>
     </message>
     <message id="common_words_scanning">
@@ -5074,7 +4548,7 @@ Chcete pokračovat?</translation>
     <message id="pvinverter_statusCode_startup">
       <location filename="../../src/enums.cpp" line="296"/>
       <source>Startup (%1)</source>
-      <extracomment>PV inverter status code. %1 = the startup status number</extracomment>
+      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
       <translation>Spuštění (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
@@ -5129,8 +4603,10 @@ Chcete pokračovat?</translation>
       <source>Unique Identity Number</source>
       <translation>Unikátní identifikační číslo</translation>
     </message>
-    <message id="settings_radio_button_group_unknown">
-      <location filename="../../components/listitems/core/ListRadioButtonGroup.qml" line="44"/>
+    <message id="Unknown">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
       <source>Unknown</source>
       <translation>Neznámý</translation>
     </message>
@@ -5285,11 +4761,6 @@ Chcete pokračovat?</translation>
       <source>Error while checking for firmware updates</source>
       <translation>Chyba při kontrole aktualizací firmwaru</translation>
     </message>
-    <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation type="unfinished">Chyba při kontrole aktualizací firmwaru</translation>
-    </message>
     <message id="settings_firmware_downloading_and_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="63"/>
       <source>Downloading and installing firmware %1...</source>
@@ -5316,6 +4787,66 @@ Chcete pokračovat?</translation>
       <source>No firmware found</source>
       <translation>Žádný firmaware nenalezen</translation>
     </message>
+    <message id="tank_type_fuel">
+      <location filename="../../src/enums.cpp" line="495"/>
+      <source>Fuel</source>
+      <translation>Palivo</translation>
+    </message>
+    <message id="tank_type_fresh_water">
+      <location filename="../../src/enums.cpp" line="498"/>
+      <source>Fresh water</source>
+      <translation>Čistá voda</translation>
+    </message>
+    <message id="tank_type_waste_water">
+      <location filename="../../src/enums.cpp" line="501"/>
+      <source>Waste water</source>
+      <translation>Odpadní voda</translation>
+    </message>
+    <message id="tank_type_live_well">
+      <location filename="../../src/enums.cpp" line="504"/>
+      <source>Live well</source>
+      <translation>Nádrž na vodu</translation>
+    </message>
+    <message id="tank_type_oil">
+      <location filename="../../src/enums.cpp" line="507"/>
+      <source>Oil</source>
+      <translation>Olej</translation>
+    </message>
+    <message id="tank_type_black_water">
+      <location filename="../../src/enums.cpp" line="510"/>
+      <source>Black water</source>
+      <translation>SPLAŠKY</translation>
+    </message>
+    <message id="tank_type_gasoline">
+      <location filename="../../src/enums.cpp" line="513"/>
+      <source>Gasoline</source>
+      <translation>Benzín</translation>
+    </message>
+    <message id="tank_type_diesel">
+      <location filename="../../src/enums.cpp" line="516"/>
+      <source>Diesel</source>
+      <translation>Nafta</translation>
+    </message>
+    <message id="tank_type_lpg">
+      <location filename="../../src/enums.cpp" line="519"/>
+      <source>LPG</source>
+      <translation>LPG</translation>
+    </message>
+    <message id="tank_type_lng">
+      <location filename="../../src/enums.cpp" line="522"/>
+      <source>LNG</source>
+      <translation>LNG</translation>
+    </message>
+    <message id="tank_type_hydraulic_oil">
+      <location filename="../../src/enums.cpp" line="525"/>
+      <source>Hydraulic oil</source>
+      <translation>Hydraulický olej</translation>
+    </message>
+    <message id="tank_type_raw_water">
+      <location filename="../../src/enums.cpp" line="528"/>
+      <source>Raw water</source>
+      <translation>Surová voda</translation>
+    </message>
     <message id="listItem_no_access">
       <location filename="../../components/listitems/core/ListItem.qml" line="102"/>
       <source>Setting locked for access level</source>
@@ -5329,6 +4860,7 @@ Chcete pokračovat?</translation>
     <message id="welcome_brief_title">
       <location filename="../../pages/welcome/WelcomeView.qml" line="81"/>
       <source>Brief</source>
+      <extracomment>The 'Brief' page</extracomment>
       <translation>Krátce</translation>
     </message>
     <message id="welcome_overview_title">
@@ -5345,23 +4877,6 @@ Chcete pokračovat?</translation>
       <location filename="../../pages/NotificationsPage.qml" line="13"/>
       <source>Notifications</source>
       <translation>Oznámení</translation>
-    </message>
-    <message id="notifications_page_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="43"/>
-      <source>Active Notifications</source>
-      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_page_inactive_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="47"/>
-      <source>Inactive Notifications</source>
-      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_no_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="106"/>
-      <source>No active notifications</source>
-      <translation type="unfinished"/>
     </message>
     <message id="utils_formatTimestamp_now">
       <location filename="../../components/Utils.js" line="258"/>
@@ -5466,11 +4981,6 @@ Chcete pokračovat?</translation>
       <source>Self-consumption above limit</source>
       <translation>Vlastní spotřeba překračuje stanovený limit</translation>
     </message>
-    <message id="cgwacs_battery_schedule_pv">
-      <location filename="../../components/listitems/ListChargeSchedule.qml" line="171"/>
-      <source>PV</source>
-      <translation type="unfinished">FV</translation>
-    </message>
     <message id="settings_multirs_pv">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="185"/>
       <source>PV</source>
@@ -5481,8 +4991,8 @@ Chcete pokračovat?</translation>
       <source>PV &amp; Battery</source>
       <translation>Fotovoltaické panely a baterie</translation>
     </message>
-    <message id="settings_firmware_checking">
-      <location filename="../../components/listitems/ListFirmwareCheckButton.qml" line="16"/>
+    <message id="pagesettingssupportstate_firmware_checking">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
       <source>Checking...</source>
       <translation>Kontrola...</translation>
     </message>
@@ -5490,12 +5000,6 @@ Chcete pokračovat?</translation>
       <location filename="../../components/listitems/ListAlarmState.qml" line="11"/>
       <source>Alarm state</source>
       <translation>Stav alarmu</translation>
-    </message>
-    <message id="devicelist_battery_alarm_state">
-      <location filename="../../components/listitems/ListAlarmState.qml" line="19"/>
-      <source>Alarm</source>
-      <extracomment>Alarm state is active</extracomment>
-      <translation type="unfinished">Alarm</translation>
     </message>
     <message id="clear_history_button_clear_history">
       <location filename="../../components/listitems/ListClearHistoryButton.qml" line="15"/>
@@ -5647,11 +5151,6 @@ Chcete pokračovat?</translation>
       <source>Max Voltage</source>
       <translation>Maximální napětí</translation>
     </message>
-    <message id="charger_history_box_max_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="64"/>
-      <source>Max Voltage</source>
-      <translation type="unfinished">Maximální napětí</translation>
-    </message>
     <message id="charger_history_box_max_current">
       <location filename="../../components/SolarDetailBox.qml" line="70"/>
       <source>Max Current</source>
@@ -5662,24 +5161,6 @@ Chcete pokračovat?</translation>
       <source>Charge time</source>
       <extracomment>Statistics for battery charging time</extracomment>
       <translation>Doba nabíjení</translation>
-    </message>
-    <message id="charger_history_box_bulk">
-      <location filename="../../components/SolarDetailBox.qml" line="136"/>
-      <source>Bulk</source>
-      <extracomment>Battery: time spent in 'Bulk' mode</extracomment>
-      <translation type="unfinished">Rychlé nabíjení (bulk)</translation>
-    </message>
-    <message id="charger_history_box_float">
-      <location filename="../../components/SolarDetailBox.qml" line="148"/>
-      <source>Float</source>
-      <extracomment>Battery: time spent in 'Float' mode</extracomment>
-      <translation type="unfinished">Udržování</translation>
-    </message>
-    <message id="charger_history_hr">
-      <location filename="../../components/SolarDetailBox.qml" line="174"/>
-      <source>hr</source>
-      <extracomment>Abbreviation of "hour"</extracomment>
-      <translation type="unfinished">hod</translation>
     </message>
     <message id="solarchargers_state_bulk">
       <location filename="../../src/enums.cpp" line="337"/>
@@ -5751,11 +5232,6 @@ Chcete pokračovat?</translation>
       <source>Connecting</source>
       <translation>Připojení</translation>
     </message>
-    <message id="splash_view_connecting">
-      <location filename="../../components/SplashView.qml" line="288"/>
-      <source>Connecting</source>
-      <translation type="unfinished">Připojení</translation>
-    </message>
     <message id="splash_view_connected">
       <location filename="../../components/SplashView.qml" line="290"/>
       <source>Connected, awaiting broker messages</source>
@@ -5811,6 +5287,11 @@ Chcete pokračovat?</translation>
       <source>MQTT protocol level 5 error</source>
       <translation>Chyba protokolu MQTT úrovně 5</translation>
     </message>
+    <message id="common_words_silence_alarm">
+      <location filename="../../components/CommonWords.qml" line="476"/>
+      <source>Silence alarm</source>
+      <translation>Vypnutí alarmu</translation>
+    </message>
     <message id="vebus_device_page_total_power">
       <location filename="../../components/ThreePhaseQuantityTable.qml" line="47"/>
       <source>Total Power</source>
@@ -5861,20 +5342,10 @@ Chcete pokračovat?</translation>
       <source>Retrieving IP address</source>
       <translation>Získávám IP adresu</translation>
     </message>
-    <message id="utils_connman_connected">
-      <location filename="../../components/Utils.js" line="292"/>
-      <source>Connected</source>
-      <translation type="unfinished">Připojeno</translation>
-    </message>
     <message id="utils_connman_disconnect">
       <location filename="../../components/Utils.js" line="295"/>
       <source>Disconnect</source>
       <translation>Odpojit</translation>
-    </message>
-    <message id="utils_connman_disconnected">
-      <location filename="../../components/Utils.js" line="299"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Odpojeno</translation>
     </message>
     <message id="overview_widget_acloads_title">
       <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
@@ -5912,11 +5383,6 @@ Chcete pokračovat?</translation>
       <source>Shore current limit</source>
       <translation>Břehový proudový limit</translation>
     </message>
-    <message id="acInputs_statusCode_stopping">
-      <location filename="../../data/AcInputs.qml" line="170"/>
-      <source>Stopping</source>
-      <translation type="unfinished">Zastavení</translation>
-    </message>
     <message id="page_generator_stopping">
       <location filename="../../data/Generators.qml" line="44"/>
       <source>Stopping</source>
@@ -5932,7 +5398,7 @@ Chcete pokračovat?</translation>
       <location filename="../../data/common/TankDescription.qml" line="24"/>
       <location filename="../../src/device.cpp" line="133"/>
       <source>%1 tank (%2)</source>
-      <extracomment>Tank description. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
       <translation>nádrž %1 (%2)</translation>
     </message>
     <message id="dcMeter_ac_charger">
@@ -5981,11 +5447,6 @@ Chcete pokračovat?</translation>
       <location filename="../../data/Ess.qml" line="20"/>
       <source>Keep batteries charged</source>
       <translation>Udržovat baterie v nabitém stavu</translation>
-    </message>
-    <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="50"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Odpojeno</translation>
     </message>
     <message id="evchargers_status_charged">
       <location filename="../../data/EvChargers.qml" line="58"/>
@@ -6046,16 +5507,6 @@ Chcete pokračovat?</translation>
       <location filename="../../data/EvChargers.qml" line="97"/>
       <source>Start charging</source>
       <translation>Zahájení nabíjení</translation>
-    </message>
-    <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="113"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Neznámý</translation>
-    </message>
-    <message id="evchargers_mode_scheduled">
-      <location filename="../../data/EvChargers.qml" line="126"/>
-      <source>Scheduled</source>
-      <translation type="unfinished">Naplánováno</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
       <location filename="../../data/System.qml" line="195"/>
@@ -6180,11 +5631,6 @@ Chcete pokračovat?</translation>
       <source>Power supply mode</source>
       <translation>Režim dodávky energie</translation>
     </message>
-    <message id="inverters_state_sustain">
-      <location filename="../../data/System.qml" line="158"/>
-      <source>Sustain</source>
-      <translation type="unfinished">Udržování</translation>
-    </message>
     <message id="inverters_state_wakeup">
       <location filename="../../data/System.qml" line="162"/>
       <source>Wake up</source>
@@ -6219,16 +5665,6 @@ Chcete pokračovat?</translation>
       <location filename="../../data/System.qml" line="180"/>
       <source>Test</source>
       <translation>Test</translation>
-    </message>
-    <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="183"/>
-      <source>External control</source>
-      <translation type="unfinished">Externí ovládání</translation>
-    </message>
-    <message id="inverters_state_dynamic_ess">
-      <location filename="../../data/System.qml" line="198"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">Dynamické ESS</translation>
     </message>
     <message id="settings_rs_ess_dess">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="97"/>
@@ -6307,16 +5743,13 @@ Chcete pokračovat?</translation>
     <message id="ess_recommended">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="73"/>
       <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
       <translation>U lithiových baterií se nedoporučuje nabíjení pod 10 %. U ostatních typů baterií zjistěte v datasheetu minimální úroveň doporučenou výrobcem.</translation>
-    </message>
-    <message id="controlcard_generator_label_autostart">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="63"/>
-      <source>Autostart</source>
-      <translation type="unfinished">Automatické spuštění</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
       <location filename="../../pages/controlcards/GeneratorCard.qml" line="70"/>
       <source>Start and stop the generator based on the configured autostart conditions.</source>
+      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
       <translation>Spouštění a zastavování generátoru na základě nakonfigurovaných podmínek automatického spouštění.</translation>
     </message>
     <message id="generator_dialog_disabled">
@@ -6339,11 +5772,13 @@ Chcete pokračovat?</translation>
       <location filename="../../pages/controlcards/InverterChargerCard.qml" line="26"/>
       <source>Inverter / Charger (%1)</source>
       <extracomment>%1 = the inverter/charger name</extracomment>
+      <oldsource>Inverter / Charger</oldsource>
       <translation>Střídač / nabíječka (%1)</translation>
     </message>
     <message id="settings_page_debug_quit_application">
       <location filename="../../pages/settings/debug/PageDebug.qml" line="36"/>
       <source>Quit application</source>
+      <oldsource>Quit Application</oldsource>
       <translation>Ukončení aplikace</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
@@ -6354,12 +5789,8 @@ Chcete pokračovat?</translation>
     <message id="settings_page_relay_generator_run_time">
       <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
       <source>Current run time</source>
+      <oldsource>Run time</oldsource>
       <translation>Aktuální doba běhu</translation>
-    </message>
-    <message id="settings_page_genset_generator_run_time">
-      <location filename="../../components/PageGensetModel.qml" line="102"/>
-      <source>Current run time</source>
-      <translation type="unfinished">Aktuální doba běhu</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
       <location filename="../../components/PageGensetModel.qml" line="110"/>
@@ -6386,19 +5817,10 @@ Chcete pokračovat?</translation>
       <source>Remote start mode</source>
       <translation>Režim dálkového spouštění</translation>
     </message>
-    <message id="ac-in-genset_speed">
-      <location filename="../../components/PageGensetModel.qml" line="245"/>
-      <source>Speed</source>
-      <translation type="unfinished">Rychlost</translation>
-    </message>
-    <message id="ac-in-genset_load">
-      <location filename="../../components/PageGensetModel.qml" line="252"/>
-      <source>Load</source>
-      <translation type="unfinished">Zátěž</translation>
-    </message>
     <message id="ac-in-genset_oil_pressure">
       <location filename="../../components/PageGensetModel.qml" line="260"/>
       <source>Oil pressure</source>
+      <oldsource>Oil Pressure</oldsource>
       <translation>Tlak oleje</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
@@ -6494,11 +5916,13 @@ Chcete pokračovat?</translation>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
       <source>High starter battery voltage alarms</source>
+      <oldsource>High starter batttery voltage alarms</oldsource>
       <translation>Alarmy vysokého napětí startovací baterie</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
       <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
       <translation>Všimněte si, že změnou nastavení dolní meze vybíjení Time-to-go se změní také nastavení Low state-of-charge (Nízký stav nabití) v nabídce relé.</translation>
     </message>
     <message id="lynxionsystem_cells_per_battery">
@@ -6575,6 +5999,7 @@ Chcete pokračovat?</translation>
       <location filename="../../pages/settings/devicelist/delegates/DeviceListDelegate_solarcharger.qml" line="34"/>
       <source>Error: #%1</source>
       <extracomment>%1 = error number</extracomment>
+      <oldsource>Error: %1</oldsource>
       <translation>Chyba: #%1</translation>
     </message>
     <message id="devicelistpage_genset">
@@ -6631,17 +6056,14 @@ Chcete pokračovat?</translation>
     <message id="settings_page_relay_generator_auto_start_enabled">
       <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
       <source>Autostart functionality</source>
+      <oldsource>Auto start functionality</oldsource>
       <translation>Funkce automatického spuštění</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="97"/>
       <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
       <translation>Při použití této možnosti se ujistěte, že generátor není připojen ke vstupu AC %1.</translation>
-    </message>
-    <message id="page_generator_conditions_inverter_high_temperature">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="139"/>
-      <source>Inverter high temperature</source>
-      <translation type="unfinished">Vysoká teplota měniče</translation>
     </message>
     <message id="page_generator_conditions_tank_level">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="159"/>
@@ -6671,30 +6093,34 @@ Chcete pokračovat?</translation>
     <message id="settings_generator_function_not_enabled">
       <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
       <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
+      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
       <translation>Funkce start/stop generátoru není povolena, přejděte do nastavení relé a nastavte funkci na "Genset start/stop".</translation>
     </message>
     <message id="settings_batteries_intro">
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="45"/>
       <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
       <translation>Pomocí této nabídky můžete definovat údaje o baterii, které se zobrazí po kliknutí na ikonu Baterie na stránce Přehled. Stejný výběr je viditelný také na portálu VRM.</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
       <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
       <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
       <translation>Nepřetržité skenování může rušit provoz Wi-Fi.</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
       <source>CAN-bus BMS LV (500 kbit/s)</source>
+      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
       <translation>CAN-bus BMS LV (500 kbit/s)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
       <source>CAN-bus BMS HV (500 kbit/s)</source>
       <translation>CAN-bus BMS HV (500 kbit/s)</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
       <source>Up, but no services (500 kbit/s)</source>
       <translation>Nahoře, ale bez služeb (500 kbit/s)</translation>
     </message>
@@ -6707,41 +6133,6 @@ Chcete pokračovat?</translation>
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="127"/>
       <source>Brief page</source>
       <translation>Stručná stránka</translation>
-    </message>
-    <message id="settings_displayoff_1min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="46"/>
-      <source>1 min</source>
-      <translation type="unfinished">1 minuta</translation>
-    </message>
-    <message id="settings_displayoff_10min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="48"/>
-      <source>10 min</source>
-      <translation type="unfinished">10 minut</translation>
-    </message>
-    <message id="settings_displayoff_30min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="50"/>
-      <source>30 min</source>
-      <translation type="unfinished">30 minut</translation>
-    </message>
-    <message id="settings_displayoff_never">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="52"/>
-      <source>Never</source>
-      <translation type="unfinished">Nikdy</translation>
-    </message>
-    <message id="settings_remote_console_appearance_auto">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="112"/>
-      <source>Auto</source>
-      <translation type="unfinished">Auto</translation>
-    </message>
-    <message id="settings_brief_view_start_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="119"/>
-      <source>Start page</source>
-      <translation type="unfinished">Úvodní stránka</translation>
-    </message>
-    <message id="settings_display_boat_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="135"/>
-      <source>Boat page</source>
-      <translation type="unfinished">Stránka lodi</translation>
     </message>
     <message id="settings_display_minmax">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="148"/>
@@ -6796,21 +6187,6 @@ Chcete pokračovat?</translation>
       <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
       <translation>%1 je nastaveno na %2</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_unsupported_device">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="50"/>
-      <source>Unsupported GX device</source>
-      <translation type="unfinished">Nepodporované zařízení GX</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_clean">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="55"/>
-      <source>Clean</source>
-      <translation type="unfinished">Čistý</translation>
-    </message>
-    <message id="pagesettingsgeneral_firmware">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="112"/>
-      <source>Firmware</source>
-      <translation type="unfinished">Firmware</translation>
-    </message>
     <message id="pagesettingsgeneral_access_and_security">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
       <source>Access &amp; Security</source>
@@ -6844,6 +6220,7 @@ Chcete pokračovat?</translation>
     <message id="settings_language_please_wait">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="209"/>
       <source>Please wait while the language is changed.</source>
+      <oldsource>Please wait while the language is changed</oldsource>
       <translation>Počkejte prosím na změnu jazyka.</translation>
     </message>
     <message id="settings_briefview_totals">
@@ -6860,11 +6237,6 @@ Chcete pokračovat?</translation>
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="71"/>
       <source>Tank is not connected.</source>
       <translation>Nádrž není připojena.</translation>
-    </message>
-    <message id="settings_briefview_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="83"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">Aktivní monitor baterie</translation>
     </message>
     <message id="settings_briefview_individual_batteries">
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="86"/>
@@ -6915,6 +6287,7 @@ Chcete pokračovat?</translation>
     <message id="settings_dvcc_charge_current_limits">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="30"/>
       <source>Charge current limits</source>
+      <oldsource>Charge Current limits</oldsource>
       <translation>Limity nabíjecího proudu</translation>
     </message>
     <message id="settings_firmware_official_release">
@@ -6994,11 +6367,6 @@ Chcete pokračovat?</translation>
       <source>No password and the network communication is not encrypted</source>
       <translation>Žádné heslo a síťová komunikace není šifrovaná.</translation>
     </message>
-    <message id="settings_logout_now">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
-      <source>Log out now</source>
-      <translation type="unfinished">Odhlásit se</translation>
-    </message>
     <message id="settings_security_profile_password_incorrect_length">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="28"/>
       <source>Password needs to be at least 8 characters long</source>
@@ -7049,25 +6417,10 @@ Chcete pokračovat?</translation>
       <source>Page will automatically reload in 5 seconds</source>
       <translation>Stránka se automaticky načte za 5 sekund</translation>
     </message>
-    <message id="settings_security_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="159"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">Heslo musí mít alespoň 8 znaků</translation>
-    </message>
     <message id="settings_root_password">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="269"/>
       <source>Root password</source>
       <translation>Kořenové heslo</translation>
-    </message>
-    <message id="settings_root_enter_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="272"/>
-      <source>Enter password</source>
-      <translation type="unfinished">Zadejte heslo</translation>
-    </message>
-    <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="277"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">Heslo musí mít alespoň 8 znaků</translation>
     </message>
     <message id="settings_root_password_changed_to">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="283"/>
@@ -7082,6 +6435,11 @@ Chcete pokračovat?</translation>
     <message id="settings_logout">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="321"/>
       <source>Logout</source>
+      <translation>Odhlásit se</translation>
+    </message>
+    <message id="settings_logout_now">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
+      <source>Log out now</source>
       <translation>Odhlásit se</translation>
     </message>
     <message id="settings_logout_dialog_title">
@@ -7142,11 +6500,13 @@ Chcete pokračovat?</translation>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="141"/>
       <source>Alarm when generator is not in autostart mode</source>
+      <oldsource>Alarm when generator is not in auto start mode</oldsource>
       <translation>Alarm, když generátor není v režimu automatického spuštění</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="147"/>
       <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
       <translation>Pokud je funkce autostart vypnutá déle než 10 minut, spustí se alarm.</translation>
     </message>
     <message id="settings_units_amps_exceptions">
@@ -7162,6 +6522,11 @@ Chcete pokračovat?</translation>
     <message id="settings_ess_use_this_option_for_peak_shaving">
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
       <source>Use this option for peak shaving.</source>
+      <oldsource>Use this option for peak shaving.
+
+The peak shaving threshold is set using the AC input current limit setting.
+
+See documentation for further information.</oldsource>
       <translation>Tuto možnost použijte pro špičkové holení.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
@@ -7205,17 +6570,17 @@ Chcete pokračovat?</translation>
       <translation>Maximální exportní proud systému (na fázi)</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="71"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="73"/>
       <source>Self-consumption from battery</source>
       <translation>Vlastní spotřeba z baterie</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="76"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
       <source>All system loads</source>
       <translation>Všechny systémové zátěže</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="80"/>
       <source>Only critical loads</source>
       <translation>Pouze kritická zatížení</translation>
     </message>
@@ -7273,26 +6638,6 @@ Chcete pokračovat?</translation>
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="194"/>
       <source>Server Applications</source>
       <translation>Serverové aplikace</translation>
-    </message>
-    <message id="pagesettingsintegrations_venus_os_enable_large_features">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
-      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_large_victron_community">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="274"/>
-      <source>Victron Community</source>
-      <translation type="unfinished">Komunita Victron</translation>
-    </message>
-    <message id="pagesettingsintegrations_ui_plugins">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
-      <source>UI Plugins</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
-      <source>Integrates with the device list</source>
-      <translation type="unfinished"/>
     </message>
     <message id="pagesettingssupportstate_modbus_tcp_server">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="453"/>
@@ -7395,25 +6740,10 @@ Chcete pokračovat?</translation>
       <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
       <translation>Přepnutí verze firmwaru není možné, pokud není vybrán "Network Security Profile" v "Settings / General".</translation>
     </message>
-    <message id="pagesettingsconnectivity_ethernet">
-      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
-      <source>Ethernet</source>
-      <translation type="unfinished">Ethernet</translation>
-    </message>
     <message id="pagesettingsconnectivity_mobile_network">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="53"/>
       <source>Mobile Network</source>
       <translation>Mobilní síť</translation>
-    </message>
-    <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Boat</source>
-      <translation type="unfinished">Loď</translation>
-    </message>
-    <message id="settings_system_name_auto">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="32"/>
-      <source>Automatic</source>
-      <translation type="unfinished">Automatický</translation>
     </message>
     <message id="pagesettingssystem_ac_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
@@ -7444,11 +6774,6 @@ Chcete pokračovat?</translation>
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="89"/>
       <source>Distributed Voltage and Current Control (DVCC)</source>
       <translation>Distribuované řízení napětí a proudu (DVCC)</translation>
-    </message>
-    <message id="settings_system_grid">
-      <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="18"/>
-      <source>Grid</source>
-      <translation type="unfinished">Síť</translation>
     </message>
     <message id="settings_system_ac_position">
       <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="58"/>
@@ -7488,16 +6813,19 @@ Chcete pokračovat?</translation>
     <message id="settings_system_has_dc_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="97"/>
       <source>Display DC Loads</source>
+      <oldsource>Has DC system</oldsource>
       <translation>Zobrazení stejnosměrného zatížení</translation>
     </message>
     <message id="settings_system_battery_measurements">
       <location filename="../../pages/settings/PageSettingsBatteries.qml" line="65"/>
       <source>Battery measurements</source>
+      <oldsource>Battery Measurements</oldsource>
       <translation>Měření na baterii</translation>
     </message>
     <message id="settings_system_system_status">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
       <source>System status</source>
+      <oldsource>System Status</oldsource>
       <translation>Stav systému</translation>
     </message>
     <message id="settings_tcpip_wired">
@@ -7508,11 +6836,13 @@ Chcete pokračovat?</translation>
     <message id="settings_vecan_device_instance">
       <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
       <source>VE.Can Device Instance</source>
+      <oldsource>Device Instance</oldsource>
       <translation>Instance zařízení VE.Can</translation>
     </message>
     <message id="settings_vecan_device_number">
       <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="32"/>
       <source>VE.Can Instance# %1</source>
+      <oldsource>Device# %1</oldsource>
       <translation>Instance VE.Can# %1</translation>
     </message>
     <message id="settings_tz_antarctica">
@@ -7543,6 +6873,7 @@ Chcete pokračovat?</translation>
     <message id="settings_vrm">
       <location filename="../../pages/SettingsPage.qml" line="59"/>
       <source>VRM</source>
+      <extracomment>Forced by %2 to dark</extracomment>
       <translation>VRM</translation>
     </message>
     <message id="settings_remote_monitoring_portal">
@@ -7550,20 +6881,10 @@ Chcete pokračovat?</translation>
       <source>Remote monitoring portal</source>
       <translation>Portál pro vzdálené monitorování</translation>
     </message>
-    <message id="settings_advanced">
-      <location filename="../../pages/SettingsPage.qml" line="68"/>
-      <source>Advanced</source>
-      <translation type="unfinished">Pokročilé</translation>
-    </message>
-    <message id="settings_integrations">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
+    <message id="pagesettingssupportstate_integrations">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
       <source>Integrations</source>
       <translation>Integrace</translation>
-    </message>
-    <message id="settings_relays_sensors_tanks">
-      <location filename="../../pages/SettingsPage.qml" line="75"/>
-      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
-      <translation type="unfinished">Relé, senzory, nádrže, fotovoltaické měniče, Modbus, MQTT...</translation>
     </message>
     <message id="settings_acdcsystem_ess_dvcc_battery">
       <location filename="../../pages/SettingsPage.qml" line="84"/>
@@ -7583,11 +6904,13 @@ Chcete pokračovat?</translation>
     <message id="settings_system_setup">
       <location filename="../../pages/SettingsPage.qml" line="82"/>
       <source>System Setup</source>
+      <oldsource>System setup</oldsource>
       <translation>Nastavení systému</translation>
     </message>
     <message id="settings_vrm_device_instances">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
       <source>VRM device instances</source>
+      <oldsource>VRM Device Instances</oldsource>
       <translation>Instance zařízení VRM</translation>
     </message>
     <message id="solarcharger_not_supported">
@@ -7605,28 +6928,10 @@ Chcete pokračovat?</translation>
       <source>The firmware version in the MPPT Solar Charger must be v1.09 or later. Contact Victron Service for update instructions and files.</source>
       <translation>Verze firmwaru solární nabíječky MPPT musí být v1.09 nebo novější. Pokyny k aktualizaci a soubory získáte od servisní služby Victron.</translation>
     </message>
-    <message id="solarcharger_pv">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="102"/>
-      <source>PV</source>
-      <extracomment>PV power for solar charger</extracomment>
-      <translation type="unfinished">FV</translation>
-    </message>
     <message id="solarcharger_total_power">
       <location filename="../../pages/solar/PageSolarCharger.qml" line="127"/>
       <source>Total PV power</source>
       <translation>Celkový FV výkon</translation>
-    </message>
-    <message id="solarcharger_total_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="211"/>
-      <source>Total yield</source>
-      <extracomment>Solar charger total yield</extracomment>
-      <translation type="unfinished">Celkový výnos</translation>
-    </message>
-    <message id="solarcharger_system_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="220"/>
-      <source>System yield</source>
-      <extracomment>Solar charger system yield</extracomment>
-      <translation type="unfinished">Systémový výnos</translation>
     </message>
     <message id="settings_multirs_total_yield">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="63"/>
@@ -7662,16 +6967,19 @@ Chcete pokračovat?</translation>
     <message id="vebus_device_update_firmware">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="133"/>
       <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
       <translation>Tato funkce vyžaduje firmware verze 400 nebo vyšší. Pro aktualizaci zařízení Multi/Quattro se obraťte na svého instalatéra.</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="139"/>
       <source>Charger not ready, equalization cannot be started</source>
+      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
       <translation>Nabíječka není připravena, vyrovnávání nelze spustit</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="143"/>
       <source>Equalization cannot be triggered during bulk charge state</source>
+      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
       <translation>Vyrovnání nelze spustit během stavu hromadného nabíjení</translation>
     </message>
     <message id="vebus_device_restart_vebus_system_restart_confirmation_description">
@@ -7694,78 +7002,20 @@ Chcete pokračovat?</translation>
       <source>Auto-started • %1</source>
       <translation>Automatické spuštění - %1</translation>
     </message>
-    <message id="common_words_battery">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery</source>
-      <translation type="unfinished">Baterie</translation>
-    </message>
-    <message id="common_words_boat_page">
-      <location filename="../../components/CommonWords.qml" line="111"/>
-      <source>Boat</source>
-      <extracomment>The 'Boat' page</extracomment>
-      <translation type="unfinished">Loď</translation>
-    </message>
-    <message id="common_words_brief_page">
-      <location filename="../../components/CommonWords.qml" line="115"/>
-      <source>Brief</source>
-      <extracomment>The 'Brief' page</extracomment>
-      <translation type="unfinished">Krátce</translation>
-    </message>
-    <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation type="unfinished">Sepnuto</translation>
-    </message>
-    <message id="common_words_color">
-      <location filename="../../components/CommonWords.qml" line="136"/>
-      <source>Color</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_connected">
-      <location filename="../../components/CommonWords.qml" line="139"/>
-      <source>Connected</source>
-      <translation type="unfinished">Připojeno</translation>
-    </message>
     <message id="common_words_daily_history">
       <location filename="../../components/CommonWords.qml" line="152"/>
       <source>Daily history</source>
       <translation>Denní historie</translation>
-    </message>
-    <message id="common_words_disabled">
-      <location filename="../../components/CommonWords.qml" line="169"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Deaktivováno</translation>
-    </message>
-    <message id="common_words_disconnected">
-      <location filename="../../components/CommonWords.qml" line="175"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Odpojeno</translation>
-    </message>
-    <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="191"/>
-      <source>Error</source>
-      <translation type="unfinished">Chyba</translation>
     </message>
     <message id="common_words_error_not_a_number">
       <location filename="../../components/CommonWords.qml" line="200"/>
       <source>'%1' is not a number.</source>
       <translation>'%1' není číslo.</translation>
     </message>
-    <message id="common_words_generator">
-      <location filename="../../components/CommonWords.qml" line="217"/>
-      <source>Generator</source>
-      <translation type="unfinished">Generátor</translation>
-    </message>
     <message id="common_words_input_current_limit">
       <location filename="../../components/CommonWords.qml" line="261"/>
       <source>Input current limit</source>
       <translation>Limit vstupního proudu</translation>
-    </message>
-    <message id="common_words_inverter_charger">
-      <location filename="../../components/CommonWords.qml" line="264"/>
-      <source>Inverter / Charger</source>
-      <translation type="unfinished">Měnič/nabíječ</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
       <location filename="../../components/CommonWords.qml" line="268"/>
@@ -7778,12 +7028,6 @@ Chcete pokračovat?</translation>
       <source>Manual stop</source>
       <translation>Ruční zastavení</translation>
     </message>
-    <message id="common_words_max">
-      <location filename="../../components/CommonWords.qml" line="315"/>
-      <source>Max</source>
-      <extracomment>Short for Maximum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_maximum_current">
       <location filename="../../components/CommonWords.qml" line="318"/>
       <source>Maximum current</source>
@@ -7794,62 +7038,10 @@ Chcete pokračovat?</translation>
       <source>Maximum power</source>
       <translation>Maximální výkon</translation>
     </message>
-    <message id="common_words_min">
-      <location filename="../../components/CommonWords.qml" line="331"/>
-      <source>Min</source>
-      <extracomment>Short for Minimum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_minimum_current">
       <location filename="../../components/CommonWords.qml" line="334"/>
       <source>Minimum current</source>
       <translation>Minimální proud</translation>
-    </message>
-    <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="433"/>
-      <source>No</source>
-      <translation type="unfinished">Ne</translation>
-    </message>
-    <message id="common_words_none_option">
-      <location filename="../../components/CommonWords.qml" line="364"/>
-      <source>None</source>
-      <translation type="unfinished">Žádný</translation>
-    </message>
-    <message id="common_words_none_errors">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>None</source>
-      <extracomment>Indicates there are no errors</extracomment>
-      <translation type="unfinished">Žádný</translation>
-    </message>
-    <message id="common_words_not_available">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Not available</source>
-      <translation type="unfinished">Není k dispozici</translation>
-    </message>
-    <message id="common_words_off">
-      <location filename="../../components/CommonWords.qml" line="377"/>
-      <source>Off</source>
-      <translation type="unfinished">Vypnuto</translation>
-    </message>
-    <message id="common_words_ok">
-      <location filename="../../components/CommonWords.qml" line="383"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="41"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="45"/>
-      <source>OK</source>
-      <translation type="unfinished">Ok</translation>
-    </message>
-    <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="386"/>
-      <source>On</source>
-      <translation type="unfinished">Zapnuto</translation>
-    </message>
-    <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="393"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation type="unfinished">Rozpojeno</translation>
     </message>
     <message id="common_words_open_circuit">
       <location filename="../../components/CommonWords.qml" line="396"/>
@@ -7861,108 +7053,17 @@ Chcete pokračovat?</translation>
       <source>Overall history</source>
       <translation>Celková historie</translation>
     </message>
-    <message id="common_words_press">
-      <location filename="../../components/CommonWords.qml" line="419"/>
-      <source>Press</source>
-      <translation type="unfinished">Tisk</translation>
-    </message>
-    <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation type="unfinished">Chod</translation>
-    </message>
-    <message id="common_words_settings">
-      <location filename="../../components/CommonWords.qml" line="467"/>
-      <source>Settings</source>
-      <translation type="unfinished">Nastavení</translation>
-    </message>
-    <message id="common_words_silence_alarm">
-      <location filename="../../components/CommonWords.qml" line="476"/>
-      <source>Silence alarm</source>
-      <translation type="unfinished">Vypnutí alarmu</translation>
-    </message>
     <message id="common_words_soc">
       <location filename="../../components/CommonWords.qml" line="480"/>
       <source>SOC %1</source>
       <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
       <translation>SOC %1%</translation>
     </message>
-    <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation type="unfinished">Rychlost</translation>
-    </message>
-    <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="487"/>
-      <source>Standby</source>
-      <translation type="unfinished">Standby</translation>
-    </message>
-    <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="502"/>
-      <source>State</source>
-      <translation type="unfinished">Stav</translation>
-    </message>
-    <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="512"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation type="unfinished">Spuštění (%1)</translation>
-    </message>
-    <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>Stopped</source>
-      <translation type="unfinished">Zastavený</translation>
-    </message>
-    <message id="common_words_total_power">
-      <location filename="../../components/CommonWords.qml" line="540"/>
-      <source>Total power</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="547"/>
-      <source>Type</source>
-      <translation type="unfinished">Typ</translation>
-    </message>
-    <message id="common_words_unknown_status">
-      <location filename="../../components/CommonWords.qml" line="554"/>
-      <source>Unknown</source>
-      <extracomment>Status = "unknown"</extracomment>
-      <translation type="unfinished">Neznámý</translation>
-    </message>
-    <message id="common_words_value_must_be_greater_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="557"/>
-      <source>Value must be greater than start value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_value_must_be_greater_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="560"/>
-      <source>Value must be greater than stop value</source>
-      <translation type="unfinished">Hodnota musí být vyšší než hodnota zastavení</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="563"/>
-      <source>Value must be lower than start value</source>
-      <translation type="unfinished">Hodnota musí být nižší než spouštěcí hodnota</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="566"/>
-      <source>Value must be lower than stop value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="581"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="431"/>
-      <source>Yes</source>
-      <translation type="unfinished">Ano</translation>
-    </message>
     <message id="common_words_yield_today">
       <location filename="../../components/CommonWords.qml" line="592"/>
       <source>Yield Today</source>
       <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+      <oldsource>Yield today</oldsource>
       <translation>Výnos dnes</translation>
     </message>
     <message id="common_words_format_error">
@@ -7989,10 +7090,11 @@ Chcete pokračovat?</translation>
     <message id="settings_firmware_installed_rebooting">
       <location filename="../../components/FirmwareUpdate.qml" line="79"/>
       <source>Firmware installed, device rebooting</source>
+      <oldsource>Firmware installed, rebooting.</oldsource>
       <translation>Firmware nainstalován, zařízení se restartuje</translation>
     </message>
-    <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/RadioButtonListPage.qml" line="121"/>
+    <message id="modaldialog_confirm">
+      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
       <source>Confirm</source>
       <extracomment>Confirm password, and verify it if possible</extracomment>
       <translation>Ano, odhlaste mě</translation>
@@ -8010,11 +7112,13 @@ Chcete pokračovat?</translation>
     <message id="cgwacs_battery_schedule_duration">
       <location filename="../../components/listitems/ListChargeSchedule.qml" line="144"/>
       <source>Duration</source>
+      <oldsource>Duration (hh:mm)</oldsource>
       <translation>Doba trvání &lt;wbr&gt;(hh:mm)</translation>
     </message>
     <message id="settings_relay_deactivation_value">
       <location filename="../../components/TemperatureRelaySettings.qml" line="86"/>
       <source>Deactivation value</source>
+      <oldsource>Deativation value</oldsource>
       <translation>Hodnota pro deaktivaci</translation>
     </message>
     <message id="splash_view_device_disconnected">
@@ -8062,29 +7166,6 @@ Chcete pokračovat?</translation>
       <source>Temperature warning</source>
       <translation>Upozornění na teplotu</translation>
     </message>
-    <message id="battery_mode_idle">
-      <location filename="../../src/enums.cpp" line="26"/>
-      <source>Idle</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Nečinný</translation>
-    </message>
-    <message id="battery_mode_charging">
-      <location filename="../../src/enums.cpp" line="30"/>
-      <source>Charging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Nabíjení</translation>
-    </message>
-    <message id="battery_mode_discharging">
-      <location filename="../../src/enums.cpp" line="34"/>
-      <source>Discharging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">vybíjení</translation>
-    </message>
-    <message id="dcMeter_bilge_pump">
-      <location filename="../../src/enums.cpp" line="115"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">Bilge pumpa</translation>
-    </message>
     <message id="switch_state_channel_fault">
       <location filename="../../src/enums.cpp" line="372"/>
       <source>Channel Fault</source>
@@ -8115,26 +7196,6 @@ Chcete pokračovat?</translation>
       <source>Slave of %1</source>
       <translation>Podřízený %1</translation>
     </message>
-    <message id="switchable_output_numeric_input">
-      <location filename="../../src/enums.cpp" line="418"/>
-      <source>Numeric input</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bilge_pump">
-      <location filename="../../src/enums.cpp" line="424"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">Bilge pumpa</translation>
-    </message>
-    <message id="switchable_output_not_running">
-      <location filename="../../src/enums.cpp" line="448"/>
-      <source>Not running</source>
-      <translation type="unfinished">Neprovádí se</translation>
-    </message>
-    <message id="switchable_output_off">
-      <location filename="../../src/enums.cpp" line="451"/>
-      <source>Off</source>
-      <translation type="unfinished">Vypnuto</translation>
-    </message>
     <message id="switchable_output_powered">
       <location filename="../../src/enums.cpp" line="455"/>
       <source>Powered</source>
@@ -8163,16 +7224,19 @@ Chcete pokračovat?</translation>
     <message id="evchargers_status_welded_contacts_error">
       <location filename="../../data/EvChargers.qml" line="76"/>
       <source>Welded contacts test error (shorted)</source>
+      <oldsource>Welded contacts error</oldsource>
       <translation>Chyba testu svařovaných kontaktů (zkrat)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
       <location filename="../../data/EvChargers.qml" line="100"/>
       <source>Switching to 3 phase</source>
+      <oldsource>Switching to 3-phase</oldsource>
       <translation>Přepnutí na 3 fáze</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
       <location filename="../../data/EvChargers.qml" line="103"/>
       <source>Switching to 1 phase</source>
+      <oldsource>Switching to single phase</oldsource>
       <translation>Přepnutí na 1 fázi</translation>
     </message>
     <message id="evchargers_status_stop_charging">
@@ -8325,17 +7389,6 @@ Pokud je generátor v současné době spuštěn na základě podmínky autostar
       <source>Open link</source>
       <translation>Otevřít odkaz</translation>
     </message>
-    <message id="listlink_show_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="43"/>
-      <source>Show QR code</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="listlink_scan_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="52"/>
-      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
-      <extracomment>%1 = url text</extracomment>
-      <translation type="unfinished">Naskenujte kód QR pomocí přenosného zařízení.&lt;br /&gt;Nebo vložte odkaz: %1</translation>
-    </message>
     <message id="settings_services_mqtt_access">
       <location filename="../../components/listitems/ListMqttAccessSwitch.qml" line="11"/>
       <source>MQTT Access</source>
@@ -8407,12 +7460,6 @@ Pokud je generátor v současné době spuštěn na základě podmínky autostar
       <extracomment>The 'Brief' page, with the side panel opened</extracomment>
       <translation>Stručný popis (otevřený boční panel)</translation>
     </message>
-    <message id="startpage_option_overview">
-      <location filename="../../data/StartPageConfiguration.qml" line="37"/>
-      <source>Overview</source>
-      <extracomment>The 'Overview' page</extracomment>
-      <translation type="unfinished">Přehled</translation>
-    </message>
     <message id="startpage_option_levels_tanks">
       <location filename="../../data/StartPageConfiguration.qml" line="43"/>
       <source>Levels (Tanks)</source>
@@ -8431,12 +7478,12 @@ Pokud je generátor v současné době spuštěn na základě podmínky autostar
       <translation>Seznam baterií</translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
+      <location filename="../../pages/DialogLayer.qml" line="56"/>
       <source>GX device has been updated</source>
       <translation>Zařízení GX bylo aktualizováno</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
+      <location filename="../../pages/DialogLayer.qml" line="58"/>
       <source>Page will automatically reload in ten seconds to load the latest version.</source>
       <translation>Stránka se automaticky načte za deset sekund, aby se načetla nejnovější verze.</translation>
     </message>
@@ -8530,6 +7577,7 @@ Všimněte si, že tato nabídka zobrazuje pouze měřiče Carlo Gavazzi připoj
         <numerusform>Po %n minutách</numerusform>
         <numerusform>Po %n minutách</numerusform>
         <numerusform>Po %n minutách</numerusform>
+        <numerusform>Po %n minutách</numerusform>
       </translation>
     </message>
     <message id="settings_startpage_description">
@@ -8607,8 +7655,8 @@ Všimněte si, že tato nabídka zobrazuje pouze měřiče Carlo Gavazzi připoj
       <source>Unit</source>
       <translation>Jednotka</translation>
     </message>
-    <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="61"/>
+    <message id="page_settings_fronius_unitid_invalid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
       <source>%1 is not a valid unit number. Use a number between 1-247.</source>
       <translation>%1 není platné číslo jednotky. Použijte číslo v rozmezí 1-247.</translation>
     </message>
@@ -8723,11 +7771,6 @@ Všimněte si, že tato nabídka zobrazuje pouze měřiče Carlo Gavazzi připoj
       <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="66"/>
       <source>Controller Temperature</source>
       <translation>Teplota ovladače</translation>
-    </message>
-    <message id="devicelist_motordrive_motordirectioninverted">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
-      <source>Motor Direction Inverted</source>
-      <translation type="unfinished"/>
     </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
@@ -8919,11 +7962,6 @@ Díky zjednodušené navigaci a novému vzhledu je nyní vše, co máte rádi, j
     <message id="welcome_done">
       <location filename="../../pages/welcome/WelcomeView.qml" line="136"/>
       <source>Done</source>
-      <translation type="unfinished">Hotovo</translation>
-    </message>
-    <message id="mk2vsc_state_done">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="20"/>
-      <source>Done</source>
       <translation>Hotovo</translation>
     </message>
     <message id="welcome_next">
@@ -8981,6 +8019,7 @@ Zařízení GX může ovládat pouze jednu připojenou generátorovou soustavu a
     <message id="settings_tz_etc">
       <location filename="../../pages/settings/PageTzInfo.qml" line="280"/>
       <source>Other</source>
+      <oldsource>Etc</oldsource>
       <translation>Jiné</translation>
     </message>
     <message id="ac-in-modeldefault_energy_reverse_x">
@@ -8998,6 +8037,11 @@ Zařízení GX může ovládat pouze jednu připojenou generátorovou soustavu a
       <location filename="../../src/enums.cpp" line="438"/>
       <source>Unsupported type: %1</source>
       <translation>Nepodporovaný typ: %1</translation>
+    </message>
+    <message id="common_words_press">
+      <location filename="../../components/CommonWords.qml" line="419"/>
+      <source>Press</source>
+      <translation>Tisk</translation>
     </message>
     <message id="output_aux_battery_service_changed_dcdc">
       <location filename="../../components/listitems/ListOutputBatteryRadioButtonGroup.qml" line="27"/>
@@ -9138,13 +8182,6 @@ Zařízení GX může ovládat pouze jednu připojenou generátorovou soustavu a
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="38"/>
       <source>Resetting VE.Bus products</source>
       <translation>Resetování produktů VE.Bus</translation>
-    </message>
-    <message id="Unknown">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Neznámý</translation>
     </message>
     <message id="mk2vsc_error_mk2_mk3_comm">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="47"/>
@@ -9450,11 +8487,6 @@ Zařízení GX může ovládat pouze jednu připojenou generátorovou soustavu a
       <source>Changing the GX Password</source>
       <translation>Změna hesla GX</translation>
     </message>
-    <message id="modaldialog_confirm">
-      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
-      <source>Confirm</source>
-      <translation type="unfinished">Ano, odhlaste mě</translation>
-    </message>
     <message id="settings_security_profile_change_password_description">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="83"/>
       <source>Please enter a new GX password:</source>
@@ -9547,21 +8579,6 @@ Zařízení GX může ovládat pouze jednu připojenou generátorovou soustavu a
       <source>Modifications installed</source>
       <translation>Nainstalované modifikace</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_modbus">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="28"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">Server Modbus TCP</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_signalk">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="32"/>
-      <source>Signal K</source>
-      <translation type="unfinished">Server Signál K</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_nodered">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="36"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">Server Node-RED</translation>
-    </message>
     <message id="pagesettingsgeneral_modificationchecks_running_integrations">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="43"/>
       <source>%1 running integrations</source>
@@ -9637,16 +8654,6 @@ Zařízení GX může ovládat pouze jednu připojenou generátorovou soustavu a
       <source>Installed and enabled, disables at next boot</source>
       <translation>Nainstalováno a aktivováno, deaktivuje se při příštím spuštění</translation>
     </message>
-    <message id="pagesettingssupportstate_firmware_checking">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
-      <source>Checking...</source>
-      <translation type="unfinished">Kontrola...</translation>
-    </message>
-    <message id="pagesettingssupportstate_firmware_unknown">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="166"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Neznámý</translation>
-    </message>
     <message id="pagesettingssupportstate_support_status">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="228"/>
       <source>Support status</source>
@@ -9668,11 +8675,6 @@ Zařízení GX může ovládat pouze jednu připojenou generátorovou soustavu a
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="288"/>
       <source>Press 'OK' to disable custom startup scripts and reboot</source>
       <translation>Stiskněte 'OK' pro zakázání vlastních spouštěcích skriptů a restartování</translation>
-    </message>
-    <message id="pagesettingssupportstate_re_enable_custom_startup_scripts">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="309"/>
-      <source>Re-enable custom startup scripts</source>
-      <translation type="unfinished">Znovu povolit vlastní spouštěcí skripty</translation>
     </message>
     <message id="pagesettingssupportstate_reenable_and_reboot_now">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="322"/>
@@ -9699,11 +8701,6 @@ Zařízení GX může ovládat pouze jednu připojenou generátorovou soustavu a
       <source>Disable also custom startup scripts?</source>
       <translation>Zakázat také vlastní spouštěcí skripty?</translation>
     </message>
-    <message id="pagesettingssupportstate_integrations">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
-      <source>Integrations</source>
-      <translation type="unfinished">Integrace</translation>
-    </message>
     <message id="pagesettingssupportstate_orange_items_description">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="494"/>
       <source>Items colored orange are supported and provided by Victron Energy, but using them incorrectly can affect system stability. In case of troubleshooting, disable those first.</source>
@@ -9715,7 +8712,7 @@ Zařízení GX může ovládat pouze jednu připojenou generátorovou soustavu a
       <translation>Pro aktivaci Bluetooth připojení připojte kompatibilní Bluetooth USB dongle.</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="140"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="142"/>
       <source>BatteryLife state</source>
       <translation>Stav BatteryLife</translation>
     </message>
@@ -9723,23 +8720,6 @@ Zařízení GX může ovládat pouze jednu připojenou generátorovou soustavu a
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="33"/>
       <source>Device Integrations</source>
       <translation>Integrace zařízení</translation>
-    </message>
-    <message id="pagesettingsintegrations_modbus_tcp_server">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="201"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">Server Modbus TCP</translation>
-    </message>
-    <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="226"/>
-      <location filename="../../pages/settings/PageSettingsSignalK.qml" line="18"/>
-      <source>Signal K</source>
-      <translation type="unfinished">Server Signál K</translation>
-    </message>
-    <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="241"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">Server Node-RED</translation>
     </message>
     <message id="settings_venusos_large_documentation">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="267"/>
@@ -9749,6 +8729,7 @@ Zařízení GX může ovládat pouze jednu připojenou generátorovou soustavu a
     <message id="settings_modbus_enable_modbus_tcp">
       <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
       <source>Enable Modbus TCP Server</source>
+      <oldsource>Enable Modbus/TCP</oldsource>
       <translation>Povolit Modbus TCP Server</translation>
     </message>
     <message id="pagesettingsconnectivity_bluetooth_for_victronconnect_app">
@@ -9842,11 +8823,13 @@ Zařízení GX může ovládat pouze jednu připojenou generátorovou soustavu a
     <message id="settings_gps_format_kmh">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="93"/>
       <source>Kilometres per hour</source>
+      <oldsource>Kilometers per hour</oldsource>
       <translation>Kilometry za hodinu</translation>
     </message>
     <message id="settings_gps_format_ms">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="95"/>
       <source>Metres per second</source>
+      <oldsource>Meters per second</oldsource>
       <translation>Metry za sekundu</translation>
     </message>
     <message id="components_volumeunit_cubic_metres">
@@ -9874,8 +8857,8 @@ Zařízení GX může ovládat pouze jednu připojenou generátorovou soustavu a
       <source>The Relay can now be found in the devices list</source>
       <translation>Relé nyní najdete v seznamu zařízení.</translation>
     </message>
-    <message id="common_words_gx_device_relays">
-      <location filename="../../components/CommonWords.qml" line="223"/>
+    <message id="gx_device_relays">
+      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
       <source>GX device relays</source>
       <translation>Relé zařízení GX</translation>
     </message>
@@ -9929,12 +8912,6 @@ Zařízení GX může ovládat pouze jednu připojenou generátorovou soustavu a
       <extracomment>Forced by app to %1</extracomment>
       <translation>automaticky</translation>
     </message>
-    <message id="settings_remote_console_forced_by_vrm">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="94"/>
-      <source>VRM</source>
-      <extracomment>Forced by %2 to dark</extracomment>
-      <translation type="unfinished">VRM</translation>
-    </message>
     <message id="settings_remote_console_forced_by_app">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="97"/>
       <source>app</source>
@@ -9984,6 +8961,7 @@ Zařízení GX může ovládat pouze jednu připojenou generátorovou soustavu a
     <message id="settings_large_access_signal_k">
       <location filename="../../pages/settings/PageSettingsSignalK.qml" line="24"/>
       <source>Access Signal K</source>
+      <oldsource>Access Signal K (local network)</oldsource>
       <translation>Přístup k Signal K</translation>
     </message>
     <message id="pagesettingsintegrations_shelly_devices">
@@ -9994,6 +8972,7 @@ Zařízení GX může ovládat pouze jednu připojenou generátorovou soustavu a
     <message id="settings_large_access_node_red">
       <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
       <source>Access Node-RED</source>
+      <oldsource>Access Node-RED (local network)</oldsource>
       <translation>Přístup k Node-RED</translation>
     </message>
     <message id="settings_wifi_access_point_password">
@@ -10061,57 +9040,6 @@ Zařízení GX může ovládat pouze jednu připojenou generátorovou soustavu a
       <source>Wind charger</source>
       <translation>Větrná nabíječka</translation>
     </message>
-    <message id="digitalinputs_type_disabled">
-      <location filename="../../src/enums.cpp" line="192"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Deaktivováno</translation>
-    </message>
-    <message id="digitalinputs_state_off">
-      <location filename="../../src/enums.cpp" line="242"/>
-      <source>Off</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Vypnuto</translation>
-    </message>
-    <message id="digitalinputs_state_on">
-      <location filename="../../src/enums.cpp" line="246"/>
-      <source>On</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Zapnuto</translation>
-    </message>
-    <message id="digitalinputs_state_ok">
-      <location filename="../../src/enums.cpp" line="266"/>
-      <source>OK</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Ok</translation>
-    </message>
-    <message id="digitalinputs_state_alarm">
-      <location filename="../../src/enums.cpp" line="270"/>
-      <source>Alarm</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Alarm</translation>
-    </message>
-    <message id="digitalinputs_state_running">
-      <location filename="../../src/enums.cpp" line="274"/>
-      <source>Running</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Chod</translation>
-    </message>
-    <message id="pvinverter_statusCode_running">
-      <location filename="../../src/enums.cpp" line="300"/>
-      <source>Running</source>
-      <extracomment>PV inverter status code</extracomment>
-      <translation type="unfinished">Chod</translation>
-    </message>
-    <message id="solarchargers_state_external control">
-      <location filename="../../src/enums.cpp" line="352"/>
-      <source>External control</source>
-      <translation type="unfinished">Externí ovládání</translation>
-    </message>
-    <message id="switch_state_over_temperature">
-      <location filename="../../src/enums.cpp" line="366"/>
-      <source>Over temperature</source>
-      <translation type="unfinished">Příliš vysoká teplota</translation>
-    </message>
     <message id="switchable_output_temperature_setpoint">
       <location filename="../../src/enums.cpp" line="398"/>
       <source>Temperature setpoint</source>
@@ -10121,11 +9049,6 @@ Zařízení GX může ovládat pouze jednu připojenou generátorovou soustavu a
       <location filename="../../src/enums.cpp" line="401"/>
       <source>Stepped switch</source>
       <translation>Krokový spínač</translation>
-    </message>
-    <message id="switchable_output_slave">
-      <location filename="../../src/enums.cpp" line="408"/>
-      <source>Slave</source>
-      <translation type="unfinished">Podřízený</translation>
     </message>
     <message id="switchable_output_dropdown">
       <location filename="../../src/enums.cpp" line="412"/>
@@ -10137,122 +9060,10 @@ Zařízení GX může ovládat pouze jednu připojenou generátorovou soustavu a
       <source>Basic slider</source>
       <translation>Základní posuvník</translation>
     </message>
-    <message id="switchable_output_rgb_color_wheel">
-      <location filename="../../src/enums.cpp" line="427"/>
-      <source>RGB color wheel</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_cct_color_wheel">
-      <location filename="../../src/enums.cpp" line="431"/>
-      <source>CCT color wheel</source>
-      <extracomment>Correlated Color Temperature color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_rgbw_color_wheel">
-      <location filename="../../src/enums.cpp" line="435"/>
-      <source>RGB + W color wheel</source>
-      <extracomment>RGB + white color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bypassed">
-      <location filename="../../src/enums.cpp" line="484"/>
-      <source>Bypassed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="tank_type_fuel">
-      <location filename="../../src/enums.cpp" line="495"/>
-      <source>Fuel</source>
-      <translation type="unfinished">Palivo</translation>
-    </message>
-    <message id="tank_type_fresh_water">
-      <location filename="../../src/enums.cpp" line="498"/>
-      <source>Fresh water</source>
-      <translation type="unfinished">Čistá voda</translation>
-    </message>
-    <message id="tank_type_waste_water">
-      <location filename="../../src/enums.cpp" line="501"/>
-      <source>Waste water</source>
-      <translation type="unfinished">Odpadní voda</translation>
-    </message>
-    <message id="tank_type_live_well">
-      <location filename="../../src/enums.cpp" line="504"/>
-      <source>Live well</source>
-      <translation type="unfinished">Nádrž na vodu</translation>
-    </message>
-    <message id="tank_type_oil">
-      <location filename="../../src/enums.cpp" line="507"/>
-      <source>Oil</source>
-      <translation type="unfinished">Olej</translation>
-    </message>
-    <message id="tank_type_black_water">
-      <location filename="../../src/enums.cpp" line="510"/>
-      <source>Black water</source>
-      <translation type="unfinished">SPLAŠKY</translation>
-    </message>
-    <message id="tank_type_gasoline">
-      <location filename="../../src/enums.cpp" line="513"/>
-      <source>Gasoline</source>
-      <translation type="unfinished">Benzín</translation>
-    </message>
-    <message id="tank_type_diesel">
-      <location filename="../../src/enums.cpp" line="516"/>
-      <source>Diesel</source>
-      <translation type="unfinished">Nafta</translation>
-    </message>
-    <message id="tank_type_lpg">
-      <location filename="../../src/enums.cpp" line="519"/>
-      <source>LPG</source>
-      <translation type="unfinished">LPG</translation>
-    </message>
-    <message id="tank_type_lng">
-      <location filename="../../src/enums.cpp" line="522"/>
-      <source>LNG</source>
-      <translation type="unfinished">LNG</translation>
-    </message>
-    <message id="tank_type_hydraulic_oil">
-      <location filename="../../src/enums.cpp" line="525"/>
-      <source>Hydraulic oil</source>
-      <translation type="unfinished">Hydraulický olej</translation>
-    </message>
-    <message id="tank_type_raw_water">
-      <location filename="../../src/enums.cpp" line="528"/>
-      <source>Raw water</source>
-      <translation type="unfinished">Surová voda</translation>
-    </message>
-    <message id="microgrid_mode_hybrid_droop">
-      <location filename="../../src/enums.cpp" line="539"/>
-      <source>Hybrid droop</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_following">
-      <location filename="../../src/enums.cpp" line="542"/>
-      <source>Grid-following</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_forming">
-      <location filename="../../src/enums.cpp" line="545"/>
-      <source>Grid-forming</source>
-      <translation type="unfinished"/>
-    </message>
     <message id="switchable_output_three_state_switch">
       <location filename="../../src/enums.cpp" line="421"/>
       <source>Three-state switch</source>
       <translation>Třípolohový přepínač</translation>
-    </message>
-    <message id="switchable_output_fault">
-      <location filename="../../src/enums.cpp" line="464"/>
-      <source>Fault</source>
-      <translation type="unfinished">Závada</translation>
-    </message>
-    <message id="switchable_output_running">
-      <location filename="../../src/enums.cpp" line="468"/>
-      <source>Running</source>
-      <translation type="unfinished">Chod</translation>
-    </message>
-    <message id="switchable_output_trip_low_voltage">
-      <location filename="../../src/enums.cpp" line="481"/>
-      <source>Trip low voltage</source>
-      <translation type="unfinished">Deaktivováno</translation>
     </message>
     <message id="settings_modbus_tcp_unit_id_note">
       <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="41"/>
@@ -10274,281 +9085,1152 @@ Zařízení GX může ovládat pouze jednu připojenou generátorovou soustavu a
       <source>Press to refresh</source>
       <translation>Stiskněte pro obnovení</translation>
     </message>
-    <message id="temperature_type_unknown">
-      <location filename="../../data/EnvironmentInputs.qml" line="65"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Neznámý</translation>
-    </message>
-    <message id="brief_solar_yield">
-      <location filename="../../pages/BriefSidePanel.qml" line="24"/>
-      <source>Solar yield</source>
-      <translation type="unfinished">Solární výnos</translation>
-    </message>
-    <message id="brief_dc_input">
-      <location filename="../../pages/BriefSidePanel.qml" line="214"/>
-      <source>DC input</source>
-      <translation type="unfinished">Stejnosměrný vstup</translation>
-    </message>
-    <message id="brief_ac_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="257"/>
-      <source>AC Loads</source>
-      <translation type="unfinished">AC zátěž</translation>
-    </message>
-    <message id="brief_dc_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="284"/>
-      <source>DC Loads</source>
-      <translation type="unfinished">DC zátěže</translation>
-    </message>
-    <message id="nav_overview">
-      <location filename="../../pages/OverviewPage.qml" line="450"/>
-      <source>Overview</source>
-      <translation type="unfinished">Přehled</translation>
-    </message>
-    <message id="settings_state">
-      <location filename="../../pages/settings/PageCanbusStatus.qml" line="116"/>
-      <source>State</source>
-      <translation type="unfinished">Stav</translation>
-    </message>
-    <message id="inverter_pv">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="56"/>
-      <source>PV</source>
-      <translation type="unfinished">FV</translation>
-    </message>
-    <message id="inverter_total_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="76"/>
-      <source>Total yield</source>
-      <translation type="unfinished">Celkový výnos</translation>
-    </message>
-    <message id="inverter_system_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="84"/>
-      <source>System yield</source>
-      <translation type="unfinished">Systémový výnos</translation>
-    </message>
-    <message id="charger_total_pv_power">
-      <location filename="../../pages/solar/SolarDevicePage.qml" line="61"/>
-      <source>Total PV Power</source>
-      <translation type="unfinished">Celkový FV výkon</translation>
-    </message>
-    <message id="vebus_device_alarm_only">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
-      <source>Alarm only</source>
-      <translation type="unfinished">Pouze alarm</translation>
-    </message>
-    <message id="vebus_device_alarms_and_warnings">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
-      <source>Alarms &amp; warnings</source>
-      <translation type="unfinished">Alarmy a upozornění</translation>
-    </message>
-    <message id="vebus_device_alarm_group_warning">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
-      <source>Warning</source>
-      <translation type="unfinished">Upozornění</translation>
-    </message>
-    <message id="load_delegate_status">
-      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
-      <source>Status: %1</source>
-      <translation type="unfinished"/>
+    <message id="common_words_total_power">
+      <location filename="../../components/CommonWords.qml" line="540"/>
+      <source>Total power</source>
+      <translation>Celkový výkon</translation>
     </message>
     <message id="venus_os_gui">
       <location filename="../../Main.qml" line="17"/>
       <source>Venus OS GUI</source>
       <extracomment>Application title</extracomment>
-      <translation type="unfinished"/>
       <extra-Context>only shown on desktop systems</extra-Context>
+      <translation>Venus OS GUI</translation>
+    </message>
+    <message id="load_delegate_status">
+      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
+      <source>Status: %1</source>
+      <translation>Stav: %1</translation>
+    </message>
+    <message id="settings_relay_polarity_relay1">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
+      <source>Polarity (Relay 1)</source>
+      <translation>Polarita (Relé 1)</translation>
+    </message>
+    <message id="settings_relay_polarity">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
+      <source>Polarity</source>
+      <translation>Polarita</translation>
+    </message>
+    <message id="settings_relay_polarity_relay2">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
+      <source>Polarity (Relay 2)</source>
+      <translation>Polarita (Relé 2)</translation>
+    </message>
+    <message id="page_settings_wifi_invalid_password">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
+      <source>Password length must be either 0 or between 10 and 63 characters long</source>
+      <translation>Délka hesla musí být 0 nebo mezi 10 a 63 znaky</translation>
+    </message>
+    <message id="page_settings_wifi_password_updated">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
+      <source>Password updated</source>
+      <translation>Heslo bylo aktualizováno</translation>
+    </message>
+    <message id="common_words_max">
+      <location filename="../../components/CommonWords.qml" line="315"/>
+      <source>Max</source>
+      <extracomment>Short for Maximum</extracomment>
+      <translation>Max.</translation>
+    </message>
+    <message id="common_words_min">
+      <location filename="../../components/CommonWords.qml" line="331"/>
+      <source>Min</source>
+      <extracomment>Short for Minimum</extracomment>
+      <translation>Min.</translation>
+    </message>
+    <message id="settings_ess_deprecated">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="321"/>
+      <source>Deprecated settings</source>
+      <translation>Zastaralá nastavení</translation>
+    </message>
+    <message id="settings_ess_max_charge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="328"/>
+      <source>Battery charge limit (% of CCL)</source>
+      <translation>Limit nabíjení baterie (% CCL)</translation>
+    </message>
+    <message id="settings_ess_max_discharge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="339"/>
+      <source>Battery discharge limit (% of DCL)</source>
+      <translation>Limit vybíjení baterie (% DCL)</translation>
+    </message>
+    <message id="vebus_device_bms_message">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
+      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
+      <oldsource>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</oldsource>
+      <translation>VE.Bus BMS automaticky vypne systém, když je to nutné k ochraně baterie. Ovládání systému ze zařízení GX proto není možné.</translation>
+    </message>
+    <message id="switchable_output_numeric_input">
+      <location filename="../../src/enums.cpp" line="418"/>
+      <source>Numeric input</source>
+      <translation>Číselný vstup</translation>
     </message>
     <message id="autotoggleswitch_disable_auto_mode_info">
       <location filename="../../components/controls/AutoToggleButton.qml" line="34"/>
       <source>Disable Auto mode first</source>
-      <translation type="unfinished"/>
+      <translation>Nejprve vypněte automatický režim</translation>
+    </message>
+    <message id="pagesettingsintegrations_venus_os_enable_large_features">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
+      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
+      <translation>Povolte použití firmwaru Venus OS Large pro Node-RED nebo Signal-K</translation>
+    </message>
+    <message id="settings_relays_sensors_tanks">
+      <location filename="../../pages/SettingsPage.qml" line="75"/>
+      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
+      <oldsource>Relays, Sensors, Tanks, PV Inverters, Modbus, MQTT…</oldsource>
+      <translation>Relé, Snímače, FV střídače, Modbus, Node-RED</translation>
+    </message>
+    <message id="vebus_device_page_microgrid_parameters">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
+      <source>Microgrid parameters</source>
+      <translation>Parametry mikrogridu</translation>
+    </message>
+    <message id="microgrid_mode_hybrid_droop">
+      <location filename="../../src/enums.cpp" line="539"/>
+      <source>Hybrid droop</source>
+      <translation>Hybridní kompenzace poklesu</translation>
+    </message>
+    <message id="microgrid_mode_grid_following">
+      <location filename="../../src/enums.cpp" line="542"/>
+      <source>Grid-following</source>
+      <translation>Sledování sítě</translation>
+    </message>
+    <message id="microgrid_mode_grid_forming">
+      <location filename="../../src/enums.cpp" line="545"/>
+      <source>Grid-forming</source>
+      <translation>Tvorba sítě</translation>
+    </message>
+    <message id="switchable_output_trip_low_voltage">
+      <location filename="../../src/enums.cpp" line="481"/>
+      <source>Trip low voltage</source>
+      <oldsource>Disabled</oldsource>
+      <translation>Odpojení při nízkém napětí</translation>
     </message>
     <message id="microgrid">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="15"/>
       <source>Microgrid</source>
-      <translation type="unfinished"/>
+      <translation>Mikrogrid</translation>
     </message>
     <message id="page_microgrid_active_mode">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="19"/>
       <source>Active mode</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_microgrid_from_p1_to_p2">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="34"/>
-      <source>%1 %2 to %3 %4</source>
-      <extracomment>Describes a range from one quantity to another, e.g. "30 W to 60 W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
-      <translation type="unfinished"/>
+      <translation>Aktivní režim</translation>
     </message>
     <message id="page_microgrid_hybrid_droop_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="92"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
       <source>Hybrid droop parameters</source>
-      <translation type="unfinished"/>
+      <translation>Parametry hybridní kompenzace poklesu</translation>
     </message>
     <message id="page_microgrid_reference_active_power_p0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="105"/>
       <source>Reference active power (P&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Referenční činný výkon (P&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_frequency_f0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="108"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="112"/>
       <source>Reference frequency (f&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Referenční frekvence (f&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_frequency_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="117"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="119"/>
       <source>Frequency droop slope (droop&lt;sub&gt;fP&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Sklon frekvenční kompenzace poklesu (droop&lt;sub&gt;fP&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_reactive_power">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="126"/>
       <source>Reference reactive power (Q&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Referenční jalový výkon (Q&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_voltage">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="135"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="133"/>
       <source>Reference Voltage (U&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Referenční napětí (U&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_voltage_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="144"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="140"/>
       <source>Voltage droop slope (droop&lt;sub&gt;UQ&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Sklon napěťové kompenzace poklesu (droop&lt;sub&gt;UQ&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_minimum_and_maximum_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="146"/>
       <source>Minimum and maximum parameters</source>
-      <translation type="unfinished"/>
+      <translation>Minimální a maximální parametry</translation>
     </message>
     <message id="page_microgrid_allowed_active_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="156"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
       <source>Allowed active power range</source>
-      <translation type="unfinished"/>
+      <translation>Povolený rozsah činného výkonu</translation>
     </message>
     <message id="page_microgrid_allowed_reactive_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="164"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="159"/>
       <source>Allowed reactive power range</source>
-      <translation type="unfinished"/>
+      <translation>Povolený rozsah jalového výkonu</translation>
     </message>
     <message id="page_microgrid_p_q_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="176"/>
       <source>P-Q direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>Nastavení P-Q přímého řízení</translation>
     </message>
     <message id="page_microgrid_active_power_setpoint_p">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="186"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
       <source>Active power setpoint (P)</source>
-      <translation type="unfinished"/>
+      <translation>Žádaná hodnota činného výkonu (P)</translation>
     </message>
     <message id="page_microgrid_reactive_power_setpoint_q">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="194"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="188"/>
       <source>Reactive power setpoint (Q)</source>
-      <translation type="unfinished"/>
+      <translation>Žádaná hodnota jalového výkonu (Q)</translation>
     </message>
     <message id="page_microgrid_allowed_frequency_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="202"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="195"/>
       <source>Allowed frequency range</source>
-      <translation type="unfinished"/>
+      <translation>Povolený rozsah frekvence</translation>
     </message>
     <message id="page_microgrid_allowed_voltage_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="210"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="203"/>
       <source>Allowed voltage range</source>
-      <translation type="unfinished"/>
+      <translation>Povolený rozsah napětí</translation>
     </message>
     <message id="page_microgrid_v_f_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="227"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="220"/>
       <source>V-f direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>Nastavení V-f přímého řízení</translation>
     </message>
     <message id="page_microgrid_voltage_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="225"/>
       <source>Voltage setpoint (U)</source>
-      <translation type="unfinished"/>
+      <translation>Žádaná hodnota napětí (U)</translation>
     </message>
     <message id="page_microgrid_frequency_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="240"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
       <source>Frequency setpoint (f)</source>
-      <translation type="unfinished"/>
+      <translation>Žádaná hodnota frekvence (f)</translation>
     </message>
-    <message id="temperature_slider_current">
-      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
-      <source>Current</source>
-      <extracomment>The current temperature measurement</extracomment>
-      <translation type="unfinished">Proud</translation>
+    <message id="pagesettingsintegrations_canopenmotordrive">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
+      <source>CANopen motor drives</source>
+      <translation>Pohony motorů CANopen</translation>
+    </message>
+    <message id="pagesettingsintegrations_ui_plugins">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
+      <source>UI Plugins</source>
+      <translation>Zásuvné moduly uživatelského rozhraní</translation>
+    </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
+      <source>Motor Direction Inverted</source>
+      <translation>Opačný směr otáčení motoru</translation>
     </message>
     <message id="page_settings_canopenmotordrive_scan_for_motor_drives">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="31"/>
       <source>Scan for motor drives</source>
-      <translation type="unfinished"/>
+      <translation>Vyhledat pohony motorů</translation>
     </message>
     <message id="page_settings_canopenmotordrive_discovered_motor_drive_ids">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="39"/>
       <source>Discovered motor drive IDs</source>
-      <translation type="unfinished"/>
+      <translation>Nalezená ID pohonů motorů</translation>
     </message>
-    <message id="switchableoutput_gx_device_relays">
-      <location filename="../../src/switchableoutput.cpp" line="388"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">Relé zařízení GX</translation>
+    <message id="temperature_pm25">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
+      <source>PM2.5</source>
+      <translation>PM2,5</translation>
     </message>
-    <message id="gx_device_relays">
-      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">Relé zařízení GX</translation>
+    <message id="temperature_co2">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+      <source>CO₂</source>
+      <translation>CO₂</translation>
     </message>
-    <message id="color_preset">
-      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
-      <source>Preset</source>
-      <translation type="unfinished"/>
+    <message id="temperature_voc">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
+      <source>VOC index</source>
+      <translation>Index VOC</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_location">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
-      <source>Add Modbus port and unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_nox">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
+      <source>NOx index</source>
+      <translation>Index NOx</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_unitid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
-      <source>Unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_luminosity">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
+      <source>Luminosity</source>
+      <translation>Svítivost</translation>
     </message>
-    <message id="page_settings_fronius_unitid_invalid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation type="unfinished">%1 není platné číslo jednotky. Použijte číslo v rozmezí 1-247.</translation>
-    </message>
-    <message id="page_settings_fronius_add_modbus_location_button">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
-      <source>Add</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_locations_note">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
-      <source>The default modbus port is 502 and the default unit ID is 126.
-Here you can add additional ports and unit IDs to scan for PV inverters.</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_location_number">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
-      <source>Port/Unit ID %1</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location_description">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
-      <source>Port: %1 (Unit %2)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
-      <source>Remove Modbus port and unit ID?</source>
-      <translation type="unfinished"/>
+    <message id="switchable_output_bypassed">
+      <location filename="../../src/enums.cpp" line="484"/>
+      <source>Bypassed</source>
+      <translation>Přemostěno</translation>
     </message>
     <message id="switchableoutput_list_delegate_auto_status">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="84"/>
       <source>Auto (%1)</source>
       <extracomment>%1 = 'On' or 'Off'</extracomment>
-      <translation type="unfinished"/>
+      <translation>Automaticky (%1)</translation>
     </message>
     <message id="switchableoutput_list_delegate_state_forced">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="100"/>
       <source>Forced</source>
-      <translation type="unfinished"/>
+      <translation>Vynuceno</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_settings">
+      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
+      <source>Modbus port and unit ID settings</source>
+      <translation>Nastavení portu Modbus a ID jednotky</translation>
+    </message>
+    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
+      <source>Integrates with the device list</source>
+      <translation>Integruje se se seznamem zařízení</translation>
+    </message>
+    <message id="common_words_color">
+      <location filename="../../components/CommonWords.qml" line="136"/>
+      <source>Color</source>
+      <translation>Barva</translation>
+    </message>
+    <message id="common_words_value_must_be_greater_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="557"/>
+      <source>Value must be greater than start value</source>
+      <translation>Hodnota musí být větší než počáteční hodnota</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="566"/>
+      <source>Value must be lower than stop value</source>
+      <translation>Hodnota musí být menší než koncová hodnota</translation>
+    </message>
+    <message id="notifications_page_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="43"/>
+      <source>Active Notifications</source>
+      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
+      <translation>Aktivní upozornění</translation>
+    </message>
+    <message id="notifications_page_inactive_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="47"/>
+      <source>Inactive Notifications</source>
+      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
+      <translation>Neaktivní upozornění</translation>
+    </message>
+    <message id="notifications_no_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="106"/>
+      <source>No active notifications</source>
+      <translation>Žádná aktivní upozornění</translation>
+    </message>
+    <message id="switchable_output_rgb_color_wheel">
+      <location filename="../../src/enums.cpp" line="427"/>
+      <source>RGB color wheel</source>
+      <translation>Barevné kolo RGB</translation>
+    </message>
+    <message id="switchable_output_cct_color_wheel">
+      <location filename="../../src/enums.cpp" line="431"/>
+      <source>CCT color wheel</source>
+      <extracomment>Correlated Color Temperature color wheel</extracomment>
+      <translation>Barevné kolo CCT</translation>
+    </message>
+    <message id="switchable_output_rgbw_color_wheel">
+      <location filename="../../src/enums.cpp" line="435"/>
+      <source>RGB + W color wheel</source>
+      <extracomment>RGB + white color wheel</extracomment>
+      <translation>Barevné kolo RGB + W</translation>
+    </message>
+    <message id="listlink_show_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="43"/>
+      <source>Show QR code</source>
+      <translation>Zobrazit QR kód</translation>
+    </message>
+    <message id="listlink_scan_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="52"/>
+      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
+      <extracomment>%1 = url text</extracomment>
+      <oldsource>Scan the QR code with your portable device.&lt;br /&gt;Or insert the link: %1</oldsource>
+      <translation>Otevřete QR kód a naskenujte jej pomocí svého přenosného zařízení.&lt;br /&gt;Nebo vložte odkaz: %1</translation>
+    </message>
+    <message id="color_preset">
+      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
+      <source>Preset</source>
+      <translation>Předvolba</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
+      <source>Add Modbus port and unit ID</source>
+      <translation>Přidat port Modbus a ID jednotky</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_unitid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
+      <source>Unit ID</source>
+      <translation>ID jednotky</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location_button">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
+      <source>Add</source>
+      <translation>Přidat</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_locations_note">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
+      <source>The default modbus port is 502 and the default unit ID is 126.
+Here you can add additional ports and unit IDs to scan for PV inverters.</source>
+      <translation>Výchozí port modbus je 502 a výchozí ID jednotky je 126.
+Zde můžete přidat další porty a ID jednotek pro vyhledávání FV střídačů.</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_location_number">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
+      <source>Port/Unit ID %1</source>
+      <translation>Port/ID jednotky %1</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location_description">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
+      <source>Port: %1 (Unit %2)</source>
+      <translation>Port: %1 (Jednotka %2)</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
+      <source>Remove Modbus port and unit ID?</source>
+      <translation>Odebrat port Modbus a ID jednotky?</translation>
+    </message>
+    <message id="devicelist_tankshape_edit_point">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="182"/>
+      <source>Edit point %1</source>
+      <extracomment>%1 = which point is being edited, a number like "1" or "2"</extracomment>
+      <translation></translation>
+    </message>
+    <message id="settings_canbus_vecan">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
+      <source>VE.Can (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_250">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <source>VE.Can &amp; CANopen E-drive (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_500">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
+      <source>CANopen E-drive (500 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="page_microgrid_from_p1_to_p2">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="39"/>
+      <source>%1%2 to %3%4</source>
+      <extracomment>Describes a range from one quantity to another, e.g. "30W to 60W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
+      <translation></translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAfricaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
+      <source>Morocco Standard Time</source>
+      <translation>Standardní čas v Maroku</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
+      <source>W. Central Africa Standard Time</source>
+      <translation>Standardní čas v západní střední Africe</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
+      <source>South Africa Standard Time</source>
+      <translation>Standardní čas v Jižní Africe</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
+      <source>Namibia Standard Time</source>
+      <translation>Standardní čas v Namibii</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
+      <source>Egypt Standard Time</source>
+      <translation>Standardní čas v Egyptě</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
+      <source>E. Africa Standard Time</source>
+      <translation>Standardní čas ve východní Africe</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAmericaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
+      <source>Argentina Standard Time</source>
+      <translation>Standardní čas v Argentině</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
+      <source>E. South America Standard Time</source>
+      <translation>Standardní čas na východě Jižní Ameriky</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
+      <source>Greenland Standard Time</source>
+      <translation>Standardní čas v Grónsku</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
+      <source>Montevideo Standard Time</source>
+      <translation>Standardní čas v Montevideu</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
+      <source>Newfoundland Standard Time</source>
+      <translation>Standardní čas na Newfoundlandu</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
+      <source>SA Eastern Standard Time</source>
+      <translation>Standardní čas ve východní části Jižní Ameriky</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
+      <source>Atlantic Standard Time</source>
+      <translation>Atlantický standardní čas</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
+      <source>Central Brazilian Standard Time</source>
+      <translation>Standardní čas v centrální Brazílii</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>Standardní čas v pacifické části Jižní Ameriky</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
+      <source>Paraguay Standard Time</source>
+      <translation>Standardní čas v Paraguay</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
+      <source>SA Western Standard Time</source>
+      <translation>Standardní čas v západní části Jižní Ameriky</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
+      <source>Venezuela Standard Time</source>
+      <translation>Standardní čas ve Venezuele</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
+      <source>Eastern Standard Time</source>
+      <translation>Východní standardní čas</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
+      <source>SA Pacific Standard Time</source>
+      <translation>Standardní čas v pacifické části Jižní Ameriky</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
+      <source>US Eastern Standard Time</source>
+      <translation>Standardní čas východního pobřeží Spojených států</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
+      <source>Canada Central Standard Time</source>
+      <translation>Standardní čas centrální části Kanady</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
+      <source>Central America Standard Time</source>
+      <translation>Standardní čas ve Střední Americe</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
+      <source>Central Standard Time (Mexico)</source>
+      <translation>Centrální standardní čas (Mexiko)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
+      <source>Central Standard Time</source>
+      <translation>Centrální standardní čas</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
+      <source>Mountain Standard Time (Mexico)</source>
+      <translation>Horský standardní čas (Mexiko)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
+      <source>Mountain Standard Time</source>
+      <translation>Horský standardní čas</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
+      <source>US Mountain Standard Time</source>
+      <translation>Horský standardní čas ve Spojených státech</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
+      <source>Pacific Standard Time (Mexico)</source>
+      <translation>Pacifický standardní čas (Mexiko)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
+      <source>Pacific Standard Time</source>
+      <translation>Pacifický standardní čas</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
+      <source>Alaskan Standard Time</source>
+      <translation>Standardní čas na Aljašce</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
+      <source>Hawaii-Aleutian</source>
+      <translation>Havaj-Aleutské ostrovy</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
+      <source>Atlantic Daylight Time</source>
+      <translation>Atlantický letní čas</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAntarcticaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+      <source>New Zealand Standard Time</source>
+      <translation>Standardní čas na Novém Zélandu</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>Standardní čas v centrálním Pacifiku</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+      <source>West Pacific Standard Time</source>
+      <translation>Standardní čas v západním Pacifiku</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+      <source>W. Australia Standard Time</source>
+      <translation>Standardní čas v Západní Austrálii</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+      <source>SE Asia Standard Time</source>
+      <translation>Standardní čas v Jihovýchodní Asii</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+      <source>Central Asia Standard Time</source>
+      <translation>Standardní čas v centrální Asii</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+      <source>West Asia Standard Time</source>
+      <translation>Standardní čas v západní Asii</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+      <source>E. Africa Standard Time</source>
+      <translation>Standardní čas ve východní Africe</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>Standardní čas v pacifické části Jižní Ameriky</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+      <source>SA Western Standard Time</source>
+      <translation>Standardní čas v západní části Jižní Ameriky</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzArcticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
+      <source>W. Europe Standard Time</source>
+      <translation>Standardní čas západní Evropy</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAsiaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
+      <source>Kamchatka Standard Time</source>
+      <translation>Standardní čas na Kamčatce</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
+      <source>Magadan Standard Time</source>
+      <translation>Standardní čas v Magadanu</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
+      <source>Vladivostok Standard Time</source>
+      <translation>Standardní čas ve Vladivostoku</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
+      <source>Yakutsk Standard Time</source>
+      <translation>Standardní čas v Jakutsku</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
+      <source>Tokyo Standard Time</source>
+      <translation>Standardní čas v Tokiu</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
+      <source>Korea Standard Time</source>
+      <translation>Standardní čas v Koreji</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
+      <source>Singapore Standard Time</source>
+      <translation>Standardní čas v Singapuru</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
+      <source>Ulaanbaatar Standard Time</source>
+      <translation>Standardní čas v Ulánbátaru</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
+      <source>Taipei Standard Time</source>
+      <translation>Standardní čas v Taipei</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
+      <source>North Asia East Standard Time</source>
+      <translation>Standardní čas v Severní Asii</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
+      <source>China Standard Time</source>
+      <translation>Standardní čas v Číně</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
+      <source>SE Asia Standard Time</source>
+      <translation>Standardní čas v Jihovýchodní Asii</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
+      <source>North Asia Standard Time</source>
+      <translation>Standardní čas v Severní Asii</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
+      <source>Myanmar Standard Time</source>
+      <translation>Standardní čas v Myanmaru</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
+      <source>N. Central Asia Standard Time</source>
+      <translation>Standardní čas v severní centrální Asii</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
+      <source>Central Asia Standard Time</source>
+      <translation>Standardní čas v centrální Asii</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
+      <source>Bangladesh Standard Time</source>
+      <translation>Standardní čas v Bangladéši</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
+      <source>Nepal Standard Time</source>
+      <translation>Standardní čas v Nepálu</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
+      <source>Sri Lanka Standard Time</source>
+      <translation>Standardní čas na Srí Lance</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
+      <source>India Standard Time</source>
+      <translation>Standardní čas v Indii</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
+      <source>West Asia Standard Time</source>
+      <translation>Standardní čas v západní Asii</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
+      <source>Pakistan Standard Time</source>
+      <translation>Standardní čas v Pákistánu</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
+      <source>Ekaterinburg Standard Time</source>
+      <translation>Standardní čas v Jekatěrinburgu</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
+      <source>Georgian Standard Time</source>
+      <translation>Standardní čas v Gruzii</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
+      <source>Caucasus Standard Time</source>
+      <translation>Standardní čas na Kavkaze</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
+      <source>Azerbaijan Standard Time</source>
+      <translation>Standardní čas v Ázerbájdžánu</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
+      <source>Arabian Standard Time</source>
+      <translation>Arabský standardní čas</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
+      <source>Afghanistan Standard Time</source>
+      <translation>Standardní čas v Afghánistánu</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
+      <source>Iran Standard Time</source>
+      <translation>Standardní čas v Íránu</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
+      <source>Arabic Standard Time</source>
+      <translation>Arabský standardní čas</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
+      <source>Arab Standard Time</source>
+      <translation>Arabský standardní čas</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
+      <source>Syria Standard Time</source>
+      <translation>Standardní čas v Sýrii</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
+      <source>Middle East Standard Time</source>
+      <translation>Standardní čas na středním východě</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
+      <source>Jordan Standard Time</source>
+      <translation>Standardní čas v Jordánsku</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
+      <source>Israel Standard Time</source>
+      <translation>Standardní čas v Izraeli</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAtlanticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+      <source>Greenwich Standard Time</source>
+      <translation>Standardní čas v Greenwich</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+      <source>Azores Standard Time</source>
+      <translation>Standardní čas na Azorách</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+      <source>Cape Verde Standard Time</source>
+      <translation>Standardní čas na Kapverdách</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
+      <source>Mid-Atlantic Standard Time</source>
+      <translation>Standardní čas ve středním Atlantiku</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAustraliaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+      <source>Tasmania Standard Time</source>
+      <translation>Standardní čas v Tasmánii</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+      <source>E. Australia Standard Time</source>
+      <translation>Standardní čas ve východní Austrálii</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+      <source>AUS Eastern Standard Time</source>
+      <translation>Standardní východoaustralský čas</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+      <source>Cen. Australia Standard Time</source>
+      <translation>Standardní čas v centrální Austrálii</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+      <source>AUS Central Standard Time</source>
+      <translation>Standardní čas v centrální Austrálii</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+      <source>W. Australia Standard Time</source>
+      <translation>Standardní čas v Západní Austrálii</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEtcData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
+      <source>GMT +12</source>
+      <translation>GMT +12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
+      <source>GMT -02</source>
+      <translation>GMT -02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
+      <source>GMT -11</source>
+      <translation>GMT -11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
+      <source>GMT -13</source>
+      <translation>GMT -13</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
+      <source>GMT -12</source>
+      <translation>GMT -12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
+      <source>GMT -10</source>
+      <translation>GMT -10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
+      <source>GMT -09</source>
+      <translation>GMT -09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
+      <source>GMT -08</source>
+      <translation>GMT -08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
+      <source>GMT -07</source>
+      <translation>GMT -07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
+      <source>GMT -06</source>
+      <translation>GMT -06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
+      <source>GMT -05</source>
+      <translation>GMT -05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
+      <source>GMT -04</source>
+      <translation>GMT -04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
+      <source>GMT -03</source>
+      <translation>GMT -03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
+      <source>GMT -01</source>
+      <translation>GMT -01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
+      <source>GMT</source>
+      <translation>GMT</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
+      <source>GMT +01</source>
+      <translation>GMT +01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
+      <source>GMT +02</source>
+      <translation>GMT +02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
+      <source>GMT +03</source>
+      <translation>GMT +03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
+      <source>GMT +04</source>
+      <translation>GMT +04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
+      <source>GMT +05</source>
+      <translation>GMT +05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
+      <source>GMT +06</source>
+      <translation>GMT +06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
+      <source>GMT +07</source>
+      <translation>GMT +07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
+      <source>GMT +08</source>
+      <translation>GMT +08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
+      <source>GMT +09</source>
+      <translation>GMT +09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
+      <source>GMT +10</source>
+      <translation>GMT +10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
+      <source>GMT +11</source>
+      <translation>GMT +11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
+      <source>UTC</source>
+      <translation>UTC</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEuropeData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
+      <source>GMT Standard Time</source>
+      <translation>GTM standardní čas</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
+      <source>Central Europe Standard Time</source>
+      <translation>Standardní čas střední Evropy</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
+      <source>Central European Standard Time</source>
+      <translation>Středoevrospký standardní čas</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
+      <source>Romance Standard Time</source>
+      <translation>Standardní čas v Rumunsku</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
+      <source>W. Europe Standard Time</source>
+      <translation>Standardní čas západní Evropy</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
+      <source>E. Europe Standard Time</source>
+      <translation>Standardní čas ve vých. Evropě</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
+      <source>FLE Standard Time</source>
+      <translation>Standardní čas FLE</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
+      <source>GTB Standard Time</source>
+      <translation>Standardní čas GTB</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
+      <source>Belarus Standard Time</source>
+      <translation>Standardní čas v Bělorusku</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
+      <source>Russian Standard Time</source>
+      <translation>Standardní čas v Rusku</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
+      <source>Turkey Standard Time</source>
+      <translation>Standardní čas v Turecku</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzIndianData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
+      <source>Mauritius Standard Time</source>
+      <translation>Standardní čas na Mauríciu</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
+      <source>Christmas Island Standard Time</source>
+      <translation>Standardní čas na Vánočním ostrově</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzPacificData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
+      <source>Tonga Standard Time</source>
+      <translation>Standardní čas na Tonze</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
+      <source>Fiji Standard Time</source>
+      <translation>Standardní čas na Fidži</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
+      <source>New Zealand Standard Time</source>
+      <translation>Standardní čas na Novém Zélandu</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>Standardní čas v centrálním Pacifiku</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
+      <source>West Pacific Standard Time</source>
+      <translation>Standardní čas v západním Pacifiku</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
+      <source>Samoa Standard Time</source>
+      <translation>Standardní čas na Samoi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
+      <source>Hawaiian Standard Time</source>
+      <translation>Standardní čas na Havaji</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
+      <source>Easter Island Standard Time</source>
+      <translation>Standardní čas na Velikonočním ostrově</translation>
     </message>
   </context>
   <context>
@@ -12177,838 +11859,6 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
     </message>
   </context>
   <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>Standardní čas v Maroku</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>Standardní čas v západní střední Africe</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>Standardní čas v Jižní Africe</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>Standardní čas v Namibii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>Standardní čas v Egyptě</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Standardní čas ve východní Africe</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>Standardní čas v Argentině</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>Standardní čas na východě Jižní Ameriky</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>Standardní čas v Grónsku</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>Standardní čas v Montevideu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>Standardní čas na Newfoundlandu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>Standardní čas ve východní části Jižní Ameriky</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Atlantic Standard Time</source>
-      <translation>Atlantický standardní čas</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>Standardní čas v centrální Brazílii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Standardní čas v pacifické části Jižní Ameriky</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>Paraguay Standard Time</source>
-      <translation>Standardní čas v Paraguay</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>SA Western Standard Time</source>
-      <translation>Standardní čas v západní části Jižní Ameriky</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Venezuela Standard Time</source>
-      <translation>Standardní čas ve Venezuele</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>Eastern Standard Time</source>
-      <translation>Východní standardní čas</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>Standardní čas v pacifické části Jižní Ameriky</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>US Eastern Standard Time</source>
-      <translation>Standardní čas východního pobřeží Spojených států</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Canada Central Standard Time</source>
-      <translation>Standardní čas centrální části Kanady</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central America Standard Time</source>
-      <translation>Standardní čas ve Střední Americe</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>Centrální standardní čas (Mexiko)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Central Standard Time</source>
-      <translation>Centrální standardní čas</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>Horský standardní čas (Mexiko)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>Mountain Standard Time</source>
-      <translation>Horský standardní čas</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>US Mountain Standard Time</source>
-      <translation>Horský standardní čas ve Spojených státech</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>Pacifický standardní čas (Mexiko)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Pacific Standard Time</source>
-      <translation>Pacifický standardní čas</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Alaskan Standard Time</source>
-      <translation>Standardní čas na Aljašce</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>Havaj-Aleutské ostrovy</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Daylight Time</source>
-      <translation>Atlantický letní čas</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Standardní čas na Novém Zélandu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Standardní čas v centrálním Pacifiku</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Standardní čas v západním Pacifiku</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Standardní čas v Západní Austrálii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Standardní čas v Jihovýchodní Asii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Standardní čas v centrální Asii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>Standardní čas v západní Asii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Standardní čas ve východní Africe</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Standardní čas v pacifické části Jižní Ameriky</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>Standardní čas v západní části Jižní Ameriky</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Standardní čas západní Evropy</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>Standardní čas na Kamčatce</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>Standardní čas v Magadanu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>Standardní čas ve Vladivostoku</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>Standardní čas v Jakutsku</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>Standardní čas v Tokiu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>Standardní čas v Koreji</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>Standardní čas v Singapuru</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>Standardní čas v Ulánbátaru</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>Standardní čas v Taipei</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>Standardní čas v Severní Asii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>Standardní čas v Číně</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Standardní čas v Jihovýchodní Asii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>Standardní čas v Severní Asii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>Standardní čas v Myanmaru</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>Standardní čas v severní centrální Asii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Standardní čas v centrální Asii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>Standardní čas v Bangladéši</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>Standardní čas v Nepálu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>Standardní čas na Srí Lance</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>Standardní čas v Indii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>Standardní čas v západní Asii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>Standardní čas v Pákistánu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>Standardní čas v Jekatěrinburgu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>Standardní čas v Gruzii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>Standardní čas na Kavkaze</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>Standardní čas v Ázerbájdžánu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>Arabský standardní čas</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>Standardní čas v Afghánistánu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>Standardní čas v Íránu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>Arabský standardní čas</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>Arabský standardní čas</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>Standardní čas v Sýrii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>Standardní čas na středním východě</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>Standardní čas v Jordánsku</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>Standardní čas v Izraeli</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>Standardní čas v Greenwich</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>Standardní čas na Azorách</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>Standardní čas na Kapverdách</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>Standardní čas ve středním Atlantiku</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>Standardní čas v Tasmánii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>Standardní čas ve východní Austrálii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>Standardní východoaustralský čas</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>Standardní čas v centrální Austrálii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>Standardní čas v centrální Austrálii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Standardní čas v Západní Austrálii</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
-      <source>GMT +12</source>
-      <translation>GMT +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
-      <source>GMT -02</source>
-      <translation>GMT -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT -13</source>
-      <translation>GMT -13</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT -12</source>
-      <translation>GMT -12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -10</source>
-      <translation>GMT -10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -09</source>
-      <translation>GMT -09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>GMT -08</source>
-      <translation>GMT -08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
-      <source>GMT -07</source>
-      <translation>GMT -07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
-      <source>GMT -06</source>
-      <translation>GMT -06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
-      <source>GMT -05</source>
-      <translation>GMT -05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
-      <source>GMT -04</source>
-      <translation>GMT -04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
-      <source>GMT -03</source>
-      <translation>GMT -03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
-      <source>GMT -01</source>
-      <translation>GMT -01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
-      <source>GMT</source>
-      <translation>GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
-      <source>GMT +01</source>
-      <translation>GMT +01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
-      <source>GMT +02</source>
-      <translation>GMT +02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
-      <source>GMT +03</source>
-      <translation>GMT +03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
-      <source>GMT +04</source>
-      <translation>GMT +04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
-      <source>GMT +05</source>
-      <translation>GMT +05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
-      <source>GMT +06</source>
-      <translation>GMT +06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
-      <source>GMT +07</source>
-      <translation>GMT +07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
-      <source>GMT +08</source>
-      <translation>GMT +08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
-      <source>GMT +09</source>
-      <translation>GMT +09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
-      <source>GMT +10</source>
-      <translation>GMT +10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
-      <source>GMT +11</source>
-      <translation>GMT +11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
-      <source>UTC</source>
-      <translation>UTC</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>GTM standardní čas</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>Standardní čas střední Evropy</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>Středoevrospký standardní čas</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>Standardní čas v Rumunsku</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Standardní čas západní Evropy</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>Standardní čas ve vých. Evropě</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>Standardní čas FLE</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>Standardní čas GTB</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>Standardní čas v Bělorusku</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>Standardní čas v Rusku</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>Standardní čas v Turecku</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>Standardní čas na Mauríciu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>Standardní čas na Vánočním ostrově</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>Standardní čas na Tonze</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>Standardní čas na Fidži</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Standardní čas na Novém Zélandu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Standardní čas v centrálním Pacifiku</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Standardní čas v západním Pacifiku</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>Standardní čas na Samoi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>Standardní čas na Havaji</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>Standardní čas na Velikonočním ostrově</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation type="unfinished">Interní chyba</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation type="unfinished"/>
-    </message>
-  </context>
-  <context>
     <name>Wakespeed</name>
     <message>
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
@@ -13185,6 +12035,119 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
       <source>DC/DC misconfiguration</source>
       <translation>Chybná konfigurace DC/DC</translation>
+    </message>
+  </context>
+  <context>
+    <name>VebusError</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+      <source>Device switched off</source>
+      <translation>Zařízení vypnuto</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+      <source>Mixed old/new MK2</source>
+      <translation>Kombinace starého/nového MK2</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+      <source>Expected devices error</source>
+      <translation>Chyba očekávaných zařízení</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+      <source>No other device detected</source>
+      <translation>Nebylo detekováno žádné další zařízení</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+      <source>Overvoltage on AC-out</source>
+      <translation>Přepětí na AC-out</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+      <source>DDC program error</source>
+      <translation>Chyba programu DDC</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+      <source>VE.Bus BMS without assistant</source>
+      <translation>VE.Bus BMS bez asistenta</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+      <source>Ground relay test failed</source>
+      <translation>Test zemního relé selhal</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+      <source>System time sync error</source>
+      <translation>Chyba synchronizace systémového času</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+      <source>Grid relay test fault</source>
+      <translation>Chyba testu relé sítě</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+      <source>Config mismatch with 2nd mcu</source>
+      <translation>Neshoda konfigurace s 2. MCU</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+      <source>Device transmit error</source>
+      <translation>Chyba přenosu zařízení</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+      <source>Awaiting configuration or dongle missing</source>
+      <translation>Čekání na konfiguraci nebo chybí dongle</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+      <source>Phase master missing</source>
+      <translation>Chybí hlavní fáze</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+      <source>Overvoltage has occurred</source>
+      <translation>Došlo k přepětí</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+      <source>Slave does not have AC input!</source>
+      <translation>Slave nemá AC vstup!</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+      <source>Device can't be slave</source>
+      <translation>Zařízení nemůže být slave</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+      <source>System protection initiated</source>
+      <translation>Byla zahájena ochrana systému</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+      <source>Firmware incompatibiltiy</source>
+      <translation>Nekompatibilita firmwaru</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+      <source>Internal error</source>
+      <translation>Interní chyba</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+      <source>Failing relay test prevents connection</source>
+      <translation>Selhání testu relé brání připojení</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+      <source>VE.Bus error</source>
+      <translation>VE.Bus chyba</translation>
     </message>
   </context>
 </TS>

--- a/i18n/venus-gui-v2_da.ts
+++ b/i18n/venus-gui-v2_da.ts
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="da">
   <context>
-    <name/>
+    <name></name>
     <message id="switchable_output_disabled">
       <location filename="../../src/enums.cpp" line="478"/>
       <source>Disabled</source>
@@ -22,6 +22,7 @@
     <message id="solarchargers_state_off">
       <location filename="../../src/enums.cpp" line="331"/>
       <source>Off</source>
+      <extracomment>Digital input state</extracomment>
       <translation>Fra</translation>
     </message>
     <message id="common_words_auto">
@@ -52,18 +53,25 @@
     <message id="settings_startpage_none">
       <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
       <source>None</source>
+      <extracomment>Indicates no phase</extracomment>
       <translation>Ingen</translation>
     </message>
     <message id="common_words_position_ac">
       <location filename="../../components/CommonWords.qml" line="416"/>
       <source>Position</source>
-      <extracomment>AC input or output position</extracomment>
+      <extracomment>EVCS AC input/output position</extracomment>
       <translation>Stilling</translation>
     </message>
     <message id="settings_minmax_speed">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="193"/>
       <source>Speed</source>
+      <extracomment>A speed measurement value</extracomment>
       <translation>Hastighed</translation>
+    </message>
+    <message id="common_words_state">
+      <location filename="../../components/CommonWords.qml" line="502"/>
+      <source>State</source>
+      <translation>Tilstand</translation>
     </message>
     <message id="settings_firmware_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="67"/>
@@ -101,8 +109,8 @@
       <source>Solar yield</source>
       <translation>Sol produktion</translation>
     </message>
-    <message id="ess_state_external_control">
-      <location filename="../../data/Ess.qml" line="41"/>
+    <message id="inverters_state_externalccontrol">
+      <location filename="../../data/System.qml" line="183"/>
       <source>External control</source>
       <translation>Ekstern styring</translation>
     </message>
@@ -140,6 +148,11 @@
       <location filename="../../components/CommonWords.qml" line="203"/>
       <source>ESS</source>
       <translation>ESS</translation>
+    </message>
+    <message id="pagesettingsconnectivity_ethernet">
+      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
+      <source>Ethernet</source>
+      <translation>Ethernet</translation>
     </message>
     <message id="pagesettingsconnectivity_wifi">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="28"/>
@@ -262,11 +275,6 @@
       <source>Name</source>
       <translation>Navn</translation>
     </message>
-    <message id="settings_deviceinfo_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="38"/>
-      <source>Name</source>
-      <translation type="unfinished">Navn</translation>
-    </message>
     <message id="settings_deviceinfo_product_id">
       <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
       <source>Product ID</source>
@@ -327,15 +335,20 @@
       <source>Daily run time</source>
       <translation>Daglig køre tid</translation>
     </message>
+    <message id="common_words_value_must_be_greater_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="560"/>
+      <source>Value must be greater than stop value</source>
+      <translation>Værdien skal være højere end stop værdien</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="563"/>
+      <source>Value must be lower than start value</source>
+      <translation>Værdien skal være lavere end start værdien</translation>
+    </message>
     <message id="settings_minmax_acout_max_power">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="124"/>
       <source>AC output</source>
       <translation>Vekselstrømsudgang</translation>
-    </message>
-    <message id="ac_output">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="15"/>
-      <source>AC output</source>
-      <translation type="unfinished">Vekselstrømsudgang</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
       <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="25"/>
@@ -382,16 +395,6 @@
       <source>Unavailable monitor, set another</source>
       <translation>Monitor utilgængelig, vælg en anden</translation>
     </message>
-    <message id="page_generator_conditions_battery_monitor">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="42"/>
-      <source>Battery monitor</source>
-      <translation type="unfinished">Batterimonitor</translation>
-    </message>
-    <message id="page_generator_conditions_unavailable_monitor_set_another">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="44"/>
-      <source>Unavailable monitor, set another</source>
-      <translation type="unfinished">Monitor utilgængelig, vælg en anden</translation>
-    </message>
     <message id="page_generator_conditions_on_loss_of_communication">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="68"/>
       <source>On loss of communication</source>
@@ -416,11 +419,6 @@
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="105"/>
       <source>Battery SOC</source>
       <translation>Batteri SoC</translation>
-    </message>
-    <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="173"/>
-      <source>Periodic run</source>
-      <translation type="unfinished">Periodisk kørsel</translation>
     </message>
     <message id="settings_inverter_high_temperature">
       <location filename="../../data/Generators.qml" line="83"/>
@@ -505,7 +503,7 @@
     <message id="settings_gps_speed_kmh">
       <location filename="../../pages/settings/PageGps.qml" line="83"/>
       <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometres per hour</extracomment>
+      <extracomment>GPS speed data, in kilometers per hour</extracomment>
       <translation>%1 km/t</translation>
     </message>
     <message id="settings_gps_speed_mph">
@@ -523,7 +521,7 @@
     <message id="settings_gps_speed_ms">
       <location filename="../../pages/settings/PageGps.qml" line="95"/>
       <source>%1 m/s</source>
-      <extracomment>GPS speed data, in metres per second</extracomment>
+      <extracomment>GPS speed data, in meters per second</extracomment>
       <translation>%1 m/s</translation>
     </message>
     <message id="settings_gps_course">
@@ -580,21 +578,6 @@
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="64"/>
       <source>%1 (Output %2)</source>
       <translation>%1 (Output %2)</translation>
-    </message>
-    <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">Aktiv batteri monitor</translation>
-    </message>
-    <message id="settings_batteries_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="101"/>
-      <source>Name</source>
-      <translation type="unfinished">Navn</translation>
-    </message>
-    <message id="settings_batteries_enter_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="103"/>
-      <source>Enter name</source>
-      <translation type="unfinished">Indtast navn</translation>
     </message>
     <message id="settings_briefview_center_active_battery_monitor">
       <location filename="../../components/listitems/ListBriefCenterDetails.qml" line="27"/>
@@ -656,45 +639,25 @@
       <source>CAN-bus profile</source>
       <translation>CAN-bus profil</translation>
     </message>
-    <message id="settings_disabled">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="31"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Deaktiveret</translation>
-    </message>
-    <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</translation>
-    </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
       <location filename="../../pages/settings/CanbusProfile.qml" line="42"/>
       <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
       <translation>VE.Can &amp; CAN-bus BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
       <source>Oceanvolt (250 kbit/s)</source>
       <translation>Oceanvolt (250 kbit/s)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
       <source>RV-C (250 kbit/s)</source>
       <translation>RV-C (250 kbit/s)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
       <source>Up, but no services (250 kbit/s)</source>
       <translation>Op, men ingen tjenester (250 kbit/s)</translation>
-    </message>
-    <message id="settings_canopen_motordrive_250">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
-      <source>CANopen Motor drive (250 kbit/s)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_canopen_motordrive_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
-      <source>CANopen Motor drive (500 kbit/s)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_devices">
       <location filename="../../components/CommonWords.qml" line="166"/>
@@ -731,11 +694,6 @@
       <source>Check Unique id numbers</source>
       <translation>Check unikke ID numre</translation>
     </message>
-    <message id="settings_canbus_unique_id_press_to_check">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Press to check</source>
-      <translation type="unfinished">Tryk for at tjekke</translation>
-    </message>
     <message id="settings_canbus_unique_id_conflict">
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="125"/>
       <source>There is another device connected with this unique number, please select a new number.</source>
@@ -745,11 +703,6 @@
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="133"/>
       <source>OK: No other device is connected with this unique number.</source>
       <translation>Ok: Ingen andre enheder er forbundet med dette nummer.</translation>
-    </message>
-    <message id="pagesettingsintegrations_canopenmotordrive">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
-      <source>CANopen motor drives</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_network_status">
       <location filename="../../components/CommonWords.qml" line="349"/>
@@ -884,11 +837,6 @@
       <source>Unavailable sensor, set another</source>
       <translation>Sensor utilgængelig, vælg en anden</translation>
     </message>
-    <message id="settings_system_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="81"/>
-      <source>Unavailable sensor, set another</source>
-      <translation type="unfinished">Sensor utilgængelig, vælg en anden</translation>
-    </message>
     <message id="settings_dvcc_used_sensor">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="120"/>
       <source>Used sensor</source>
@@ -945,12 +893,6 @@
       <source>Auto selected</source>
       <translation>Automatisk valgt</translation>
     </message>
-    <message id="settings_dvcc_auto_selected_none">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="208"/>
-      <source>None</source>
-      <extracomment>Indicates no option is selected</extracomment>
-      <translation type="unfinished">Ingen</translation>
-    </message>
     <message id="settings_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
       <source>Build date/time</source>
@@ -986,12 +928,6 @@
       <source>Installing %1</source>
       <extracomment>%1 = firmware version</extracomment>
       <translation>Installation af %1</translation>
-    </message>
-    <message id="settings_firmware_offline_press_to_install">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">Tryk for at opdatere til %1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="90"/>
@@ -1062,12 +998,6 @@
       <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
       <translation>Installerer %1 %2%</translation>
     </message>
-    <message id="settings_firmware_online_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="86"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">Installerer %1...</translation>
-    </message>
     <message id="settings_firmware_update_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="109"/>
       <source>Update build date/time</source>
@@ -1097,11 +1027,6 @@
       <location filename="../../pages/settings/PageSettingsFronius.qml" line="56"/>
       <source>TCP port</source>
       <translation>TCP Port</translation>
-    </message>
-    <message id="page_settings_fronius_modbus_settings">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
-      <source>Modbus port and unit ID settings</source>
-      <translation type="unfinished"/>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
       <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
@@ -1153,16 +1078,6 @@
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="64"/>
       <source>AC-Out MP</source>
       <translation>AC-Out MP</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="52"/>
-      <source>AC-In1 L%1</source>
-      <translation type="unfinished">AC-In1 L%1</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="56"/>
-      <source>AC-In1 --</source>
-      <translation type="unfinished">AC-In1...</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="70"/>
@@ -1330,12 +1245,6 @@
       <source>Reset service timer</source>
       <translation>Nulstil servicetimer</translation>
     </message>
-    <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
-      <source>Volume</source>
-      <extracomment>Title for a list of units of volume (e.g. cubic metres, litres, gallons)</extracomment>
-      <translation type="unfinished">Størrelse</translation>
-    </message>
     <message id="settings_gps_format">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="69"/>
       <source>Format</source>
@@ -1438,42 +1347,6 @@ Hvis det ikke virker, tjek Sim-kortet på en telefon for at være sikker på det
       <source>Wrong PIN</source>
       <translation>Forkert PIN</translation>
     </message>
-    <message id="page_settings_gsm_ok">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>OK</source>
-      <translation type="unfinished">OK</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="128"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">Ukendt fejl</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_state">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="153"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Ukendt</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_value">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="182"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Ukendt</translation>
-    </message>
-    <message id="page_settings_gsm_offline">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="173"/>
-      <source>Offline</source>
-      <translation type="unfinished">Offline</translation>
-    </message>
-    <message id="page_settings_gsm_connecting">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="176"/>
-      <source>Connecting</source>
-      <translation type="unfinished">Forbinder...</translation>
-    </message>
-    <message id="page_settings_gsm_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="179"/>
-      <source>Connected</source>
-      <translation type="unfinished">Forbundet</translation>
-    </message>
     <message id="page_settings_gsm_pin">
       <location filename="../../pages/settings/PageSettingsGsm.qml" line="191"/>
       <source>PIN</source>
@@ -1530,32 +1403,32 @@ Hvis det ikke virker, tjek Sim-kortet på en telefon for at være sikker på det
       <translation>Net måling</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
       <source>External meter</source>
       <translation>Ekstern måler</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="67"/>
       <source>Inverter/Charger</source>
       <translation>Inverter/oplader</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
       <source>Multiphase regulation</source>
       <translation>Multifase regulation</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="91"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
       <source>Total of all phases</source>
       <translation>Total af alle phaser</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="95"/>
       <source>Individual phase</source>
       <translation>Individuel fase</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="99"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="101"/>
       <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
@@ -1564,68 +1437,13 @@ CAUTION: Use only if required by the utility provider.</source>
 FORSIGTIG: Må kun bruges, hvis det kræves af forsyningsleverandøren.</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="104"/>
       <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
       <translation>Summen af alle faser reguleres intelligent for at opnå nettets setpunkt (systemets effektivitet optimeres).
 
 Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
-    </message>
-    <message id="settings_ess_min_soc">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation type="unfinished">Minimum SoC (med mindre nettet fejler)</translation>
-    </message>
-    <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="129"/>
-      <source>Active SOC limit</source>
-      <translation type="unfinished">Aktiv SoC grænse</translation>
-    </message>
-    <message id="settings_ess_battery_life_sustain">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
-      <source>Sustain</source>
-      <translation type="unfinished">Oprethold</translation>
-    </message>
-    <message id="settings_ess_battery_life_recharge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="157"/>
-      <source>Recharge</source>
-      <translation type="unfinished">Opladning</translation>
-    </message>
-    <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <source>Scheduled charge levels</source>
-      <translation type="unfinished">Skema lade niveauer</translation>
-    </message>
-    <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="257"/>
-      <source>Active (%1)</source>
-      <translation type="unfinished">Aktiv (%1)</translation>
-    </message>
-    <message id="settings_ess_inactive">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="259"/>
-      <source>Inactive</source>
-      <translation type="unfinished">Inaktiv</translation>
-    </message>
-    <message id="settings_ess_dynamic">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="293"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">Dynamisk ESS</translation>
-    </message>
-    <message id="settings_ess_deprecated">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="319"/>
-      <source>Deprecated settings</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_charge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="326"/>
-      <source>Battery charge limit (% of CCL)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_discharge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="337"/>
-      <source>Battery discharge limit (% of DCL)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_rs_ess_min_soc">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="40"/>
@@ -1637,13 +1455,8 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <source>Active SOC limit</source>
       <translation>Aktiv SoC grænse</translation>
     </message>
-    <message id="scheduled_charge_inactive">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
-      <source>Inactive</source>
-      <translation type="unfinished">Inaktiv</translation>
-    </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="245"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="247"/>
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
       <source>Peak shaving</source>
       <translation>Peak shaving</translation>
@@ -1659,12 +1472,12 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <translation>Altid</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="151"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
       <source>Discharge disabled</source>
       <translation>Afladning deaktiveret</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
       <source>Slow charge</source>
       <translation>Langsom ladning</translation>
     </message>
@@ -1679,32 +1492,32 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <translation>Opladning</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="165"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="167"/>
       <source>Limit charge power</source>
       <translation>Begræns opladnings power</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="183"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="185"/>
       <source>Maximum charge power</source>
       <translation>Maksimum opladnings power</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="196"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="198"/>
       <source>Limit inverter power</source>
       <translation>Begræns inverter power</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="214"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="216"/>
       <source>Maximum inverter power</source>
       <translation>Maksimum inverter power</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="225"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="227"/>
       <source>Grid setpoint</source>
       <translation>Net setpoint</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="236"/>
       <source>Grid feed-in</source>
       <translation>Net feed-in</translation>
     </message>
@@ -1743,8 +1556,8 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <source>Door alarm</source>
       <translation>Dør alarm</translation>
     </message>
-    <message id="digitalinputs_type_bilgepump">
-      <location filename="../../src/enums.cpp" line="201"/>
+    <message id="switchable_output_bilge_pump">
+      <location filename="../../src/enums.cpp" line="424"/>
       <source>Bilge pump</source>
       <translation>Sump pumpe</translation>
     </message>
@@ -1796,11 +1609,6 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <source>Deferred by %1s</source>
       <extracomment>%1 = number of seconds</extracomment>
       <translation>Udsat med %1s</translation>
-    </message>
-    <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="75"/>
-      <source>Are you sure?</source>
-      <translation type="unfinished">Er du sikker?</translation>
     </message>
     <message id="settings_vrm_portal_id">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="87"/>
@@ -1939,11 +1747,6 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <source>External storage</source>
       <translation>Ekstern hukommelse</translation>
     </message>
-    <message id="settings_vrm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="308"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">Ukendt fejl</translation>
-    </message>
     <message id="settings_vrm_no_error">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="311"/>
       <source>No Error</source>
@@ -2029,37 +1832,10 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <source>Function</source>
       <translation>Funktion</translation>
     </message>
-    <message id="settings_relay_disabled">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="54"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="98"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Deaktiveret</translation>
-    </message>
     <message id="settings_relay_alarm_relay">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="56"/>
       <source>Alarm relay</source>
       <translation>Alarm relæ</translation>
-    </message>
-    <message id="settings_relay_tank_pump">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="62"/>
-      <source>Tank pump</source>
-      <translation type="unfinished">Tank pumpe</translation>
-    </message>
-    <message id="settings_relay_manual">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="64"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="100"/>
-      <source>Manual</source>
-      <translation type="unfinished">Manual</translation>
-    </message>
-    <message id="settings_relay_polarity_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
-      <source>Polarity (Relay 1)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_relay_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
-      <source>Polarity</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_normally_open">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="83"/>
@@ -2075,11 +1851,6 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="93"/>
       <source>Function (Relay 2)</source>
       <translation>Funktion (Relæ 2)</translation>
-    </message>
-    <message id="settings_relay_polarity_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
-      <source>Polarity (Relay 2)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_temp_control_rules">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="119"/>
@@ -2111,12 +1882,6 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
       <source>Press to boot</source>
       <translation>Tryk for Reboot</translation>
-    </message>
-    <message id="settings_firmware_backup_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
-      <translation type="unfinished">Firmware %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
@@ -2152,6 +1917,7 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
     <message id="nav_boat">
       <location filename="../../pages/boat/BoatPage.qml" line="14"/>
       <source>Boat</source>
+      <extracomment>The 'Boat' page</extracomment>
       <translation>Båd</translation>
     </message>
     <message id="settings_system_name">
@@ -2219,11 +1985,6 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <source>Solar charger current control</source>
       <translation>Sol lader strøm styring</translation>
     </message>
-    <message id="settings_system_status_bms_params">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
-      <source>BMS control</source>
-      <translation type="unfinished">BMS styring</translation>
-    </message>
     <message id="common_words_bms_control">
       <location filename="../../components/CommonWords.qml" line="101"/>
       <source>BMS control</source>
@@ -2238,11 +1999,6 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
       <source>Pump state</source>
       <translation>Pumpe tilstand</translation>
-    </message>
-    <message id="settings_pump_auto">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="56"/>
-      <source>Auto</source>
-      <translation type="unfinished">Auto</translation>
     </message>
     <message id="settings_tank_sensor">
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
@@ -2271,11 +2027,6 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="35"/>
       <source>Unplugged</source>
       <translation>Utilsluttet</translation>
-    </message>
-    <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="16"/>
-      <source>Name</source>
-      <translation type="unfinished">Navn</translation>
     </message>
     <message id="settings_tcpip_hidden">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="21"/>
@@ -2317,16 +2068,6 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="99"/>
       <source>IP configuration</source>
       <translation>Ip Konfiguration</translation>
-    </message>
-    <message id="settings_tcpip_manual">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="105"/>
-      <source>Manual</source>
-      <translation type="unfinished">Manual</translation>
-    </message>
-    <message id="settings_tcpip_off">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="107"/>
-      <source>Off</source>
-      <translation type="unfinished">Fra</translation>
     </message>
     <message id="settings_tcpip_fixed">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="109"/>
@@ -2382,21 +2123,6 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="30"/>
       <source>Create access point</source>
       <translation>Opret access point</translation>
-    </message>
-    <message id="settings_wifi_access_point_enter_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="68"/>
-      <source>Enter password</source>
-      <translation type="unfinished">Indtast adgangskode</translation>
-    </message>
-    <message id="page_settings_wifi_invalid_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
-      <source>Password length must be either 0 or between 10 and 63 characters long</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_wifi_password_updated">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
-      <source>Password updated</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_wifi_networks">
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="86"/>
@@ -2539,20 +2265,10 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <extracomment>Network status: Standalone</extracomment>
       <translation>Standalone</translation>
     </message>
-    <message id="charger_standalone">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="45"/>
-      <source>Standalone</source>
-      <translation type="unfinished">Standalone</translation>
-    </message>
     <message id="charger_charge">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="48"/>
       <source>Charge</source>
       <translation>Oplad</translation>
-    </message>
-    <message id="charger_external_control">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="51"/>
-      <source>External control</source>
-      <translation type="unfinished">Ekstern styring</translation>
     </message>
     <message id="charger_charge_hub_1">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="54"/>
@@ -2584,16 +2300,6 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <source>Master setting</source>
       <translation>Master indstilling</translation>
     </message>
-    <message id="charger_slave">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="85"/>
-      <source>Slave</source>
-      <translation type="unfinished">Slave</translation>
-    </message>
-    <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation type="unfinished">Lade volt</translation>
-    </message>
     <message id="systemsettings_networkstatus_slave">
       <location filename="../../data/SystemSettings.qml" line="148"/>
       <source>Slave</source>
@@ -2615,14 +2321,15 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <source>Group &amp; Charge master</source>
       <translation>Gruppe &amp; lade master</translation>
     </message>
-    <message id="genset_charge_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="365"/>
+    <message id="charger_charge_voltage">
+      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
       <source>Charge voltage</source>
       <translation>Lade volt</translation>
     </message>
     <message id="common_words_reset">
       <location filename="../../components/CommonWords.qml" line="448"/>
       <source>Reset</source>
+      <extracomment>Reset the BMS control</extracomment>
       <translation>Nulstil</translation>
     </message>
     <message id="solarcharger_load">
@@ -2651,14 +2358,14 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <extracomment>Voltage alarm is at "Warning" level</extracomment>
       <translation>Advarsel</translation>
     </message>
-    <message id="listitems_alarm_level_alarm">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="25"/>
+    <message id="digitalinputs_state_alarm">
+      <location filename="../../src/enums.cpp" line="270"/>
       <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
+      <extracomment>Relay function is 'alarm'</extracomment>
       <translation>Alarm</translation>
     </message>
-    <message id="devicelist_tankshape_volume">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="190"/>
+    <message id="components_volumeunit_volume">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
       <source>Volume</source>
       <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
       <translation>Størrelse</translation>
@@ -2808,26 +2515,10 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <source>Relay function</source>
       <translation>Relæ funktion</translation>
     </message>
-    <message id="batterysettingrelay_alarm">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation type="unfinished">Alarm</translation>
-    </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
       <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
       <source>Charger or generator start/stop</source>
       <translation>Oplader eller generator start/stop</translation>
-    </message>
-    <message id="batterysettingrelay_manual_control">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
-      <source>Manual control</source>
-      <translation type="unfinished">Manuel styring</translation>
-    </message>
-    <message id="batterysettingrelay_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">Sikring sprunget</translation>
     </message>
     <message id="common_words_manual_control">
       <location filename="../../components/CommonWords.qml" line="302"/>
@@ -2853,12 +2544,6 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
       <source>Status LEDs</source>
       <translation>Status LEDs</translation>
-    </message>
-    <message id="batterydiagnostics_none">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
-      <source>None</source>
-      <extracomment>Indicates no alarm is set</extracomment>
-      <translation type="unfinished">Ingen</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
@@ -2888,7 +2573,7 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
     <message id="common_words_switch">
       <location filename="../../components/CommonWords.qml" line="525"/>
       <source>Switch</source>
-      <extracomment>Change the mode value</extracomment>
+      <extracomment>Change the battery mode</extracomment>
       <translation>Kontakt</translation>
     </message>
     <message id="devicelist_battery_initializing">
@@ -2956,21 +2641,6 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <source>Top section voltage</source>
       <translation>Top sektion volt</translation>
     </message>
-    <message id="battery_bank_error_communication">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="96"/>
-      <source>Communication error</source>
-      <translation type="unfinished">Kommunikationsfejl</translation>
-    </message>
-    <message id="battery_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="182"/>
-      <source>State of health</source>
-      <translation type="unfinished">State of Health</translation>
-    </message>
-    <message id="battery_bus_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="212"/>
-      <source>Bus voltage</source>
-      <translation type="unfinished">Bus Volt</translation>
-    </message>
     <message id="battery_bottom_section_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="228"/>
       <source>Bottom section voltage</source>
@@ -3016,16 +2686,6 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <source>IO</source>
       <translation>IO</translation>
     </message>
-    <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="391"/>
-      <source>System</source>
-      <translation type="unfinished">System</translation>
-    </message>
-    <message id="battery_press_to_redetect">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="433"/>
-      <source>Press to redetect</source>
-      <translation type="unfinished">Tryk for at genfinde</translation>
-    </message>
     <message id="pagesettingsgeneral_system">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="107"/>
       <source>System</source>
@@ -3066,16 +2726,6 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <source>Low SOC</source>
       <translation>Lav SoC</translation>
     </message>
-    <message id="batteryalarms_high_battery_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
-      <source>High battery voltage</source>
-      <translation type="unfinished">Høj batteri volt</translation>
-    </message>
-    <message id="batteryalarms_low_soc">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low SOC</source>
-      <translation type="unfinished">Lav SoC</translation>
-    </message>
     <message id="batteryalarms_low_starter_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="73"/>
       <source>Low starter voltage</source>
@@ -3095,11 +2745,6 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
       <source>Mid-point voltage</source>
       <translation>Mid-point volt</translation>
-    </message>
-    <message id="batteryalarms_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">Sikring sprunget</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
@@ -3293,11 +2938,6 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <source>Restore factory defaults</source>
       <translation>Gendan fabriks indstillinger</translation>
     </message>
-    <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation type="unfinished">Tryk for at gendanne</translation>
-    </message>
     <message id="vebus_backup_press_to_restore">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="362"/>
       <source>Press to restore</source>
@@ -3337,11 +2977,6 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="18"/>
       <source>Capacity</source>
       <translation>Kapacitet</translation>
-    </message>
-    <message id="batterysettingsbattery_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
-      <source>Capacity</source>
-      <translation type="unfinished">Kapacitet</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
@@ -3418,11 +3053,6 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <source>No power on busbar</source>
       <translation>Ingen strøm på busbar</translation>
     </message>
-    <message id="lynxdistributor_connection_lost">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
-      <source>Connection lost</source>
-      <translation type="unfinished">Forbindelse tabt</translation>
-    </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
       <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
       <source>%n fuse(s) blown</source>
@@ -3458,26 +3088,6 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <source>Shutdowns due error</source>
       <translation>Nedluknings fejl</translation>
     </message>
-    <message id="lynxiondiagnostics_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
-      <source>Last error</source>
-      <translation type="unfinished">Sidste fejl</translation>
-    </message>
-    <message id="lynxiondiagnostics_2nd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
-      <source>2nd last error</source>
-      <translation type="unfinished">Anden sidste fejl</translation>
-    </message>
-    <message id="lynxiondiagnostics_3rd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
-      <source>3rd last error</source>
-      <translation type="unfinished">Tredje sidste fejl</translation>
-    </message>
-    <message id="lynxiondiagnostics_4th_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
-      <source>4th last error</source>
-      <translation type="unfinished">Fjerde sidste fejl</translation>
-    </message>
     <message id="lynxionio_system_switch">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
       <source>System Switch</source>
@@ -3497,11 +3107,6 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <location filename="../../components/CommonWords.qml" line="54"/>
       <source>Batteries</source>
       <translation>Batterier</translation>
-    </message>
-    <message id="lynxionsystem_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
-      <source>Capacity</source>
-      <translation type="unfinished">Kapacitet</translation>
     </message>
     <message id="lynxionsystem_parallel">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="30"/>
@@ -3523,20 +3128,10 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <source>Min/max cell temperature</source>
       <translation>Min/max celle temperatur</translation>
     </message>
-    <message id="lynxionsystem_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="92"/>
-      <source>Balancing</source>
-      <translation type="unfinished">Balancering</translation>
-    </message>
     <message id="lynxionsystem_balancer_balancing">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
       <source>Balancing</source>
       <translation>Balancering</translation>
-    </message>
-    <message id="lynxionsystem_balancer_unknown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="117"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Ukendt</translation>
     </message>
     <message id="dc_output">
       <location filename="../../components/listitems/ListDcOutputQuantityGroup.qml" line="16"/>
@@ -3644,11 +3239,6 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <source>Remaining</source>
       <translation>Resterende</translation>
     </message>
-    <message id="devicelist_tanksensor_sensor_battery">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="51"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">Sensor battery</translation>
-    </message>
     <message id="temperature_sensor_battery">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="112"/>
       <source>Sensor battery</source>
@@ -3677,7 +3267,7 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
     <message id="devicelist_tanksetup_custom">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="53"/>
       <source>Custom</source>
-      <translation type="unfinished">Brugerdefineret</translation>
+      <translation>Brugerdefineret</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="59"/>
@@ -3710,34 +3300,34 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <translation>Sensor værdi</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="75"/>
       <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
       <translation>Ingen brugerdefineret form defineret. Du kan definere en med op til ti punkter. Bemærk, at 0% og 100% er underforstået.</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="91"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="89"/>
       <source>Point %1</source>
       <extracomment>%1 = the point number</extracomment>
       <translation>Punkt %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="133"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="179"/>
       <source>Add point</source>
       <translation>Tilføj punkt</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="156"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="205"/>
       <source>Sensor level</source>
       <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
       <translation>Sensor niveau</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="256"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="311"/>
       <source>Duplicate sensor level values are not allowed.</source>
       <translation>Duplikerede sensorniveauværdier er ikke tilladt.</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="262"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="317"/>
       <source>Volume values must be increasing.</source>
       <translation>Volumenværdierne skal være stigende.</translation>
     </message>
@@ -3777,11 +3367,6 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <source>Switch position</source>
       <translation>Kontakt position</translation>
     </message>
-    <message id="ac-in-setup_single_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="142"/>
-      <source>Single phase</source>
-      <translation type="unfinished">Enkelt fase</translation>
-    </message>
     <message id="ac-in-setup_two_phase">
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="144"/>
       <source>2-phase</source>
@@ -3791,11 +3376,6 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="146"/>
       <source>3-phase</source>
       <translation>3-Faset</translation>
-    </message>
-    <message id="ac-in-setup_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="161"/>
-      <source>Devices</source>
-      <translation type="unfinished">Enhed fundet</translation>
     </message>
     <message id="ac-in-genset_ac">
       <location filename="../../components/PageGensetModel.qml" line="194"/>
@@ -3889,12 +3469,6 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <extracomment>%1 = CT device number</extracomment>
       <translation>CT %1</translation>
     </message>
-    <message id="smappeect_phase_none">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation type="unfinished">Ingen</translation>
-    </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
       <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
       <source>Flashing LED indicates this CT</source>
@@ -3908,11 +3482,13 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
     <message id="common_words_setting_disabled_when_dmc_connected">
       <location filename="../../components/CommonWords.qml" line="355"/>
       <source>This setting is disabled when a Digital Multi Control is connected.</source>
+      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>Denne indstilling er deaktiveret, når der er tilsluttet en Digital Multi Control.</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
       <location filename="../../components/CommonWords.qml" line="358"/>
       <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>Denne indstilling er deaktiveret, når en VE.Bus BMS er tilsluttet.</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
@@ -3930,16 +3506,6 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="21"/>
       <source>Inverted</source>
       <translation>Omvendt</translation>
-    </message>
-    <message id="digitalinput_enable_alarm">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="48"/>
-      <source>Enable alarm</source>
-      <translation type="unfinished">Aktiver alarm</translation>
-    </message>
-    <message id="digitalinput_inverted">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="54"/>
-      <source>Inverted</source>
-      <translation type="unfinished">Omvendt</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
       <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="60"/>
@@ -3976,16 +3542,6 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <source>Wind speed</source>
       <translation>Vind hastighed</translation>
     </message>
-    <message id="page_meteo_battery_voltage">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="99"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">Sensor battery</translation>
-    </message>
-    <message id="meteo_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="120"/>
-      <source>Low</source>
-      <translation type="unfinished">Lav</translation>
-    </message>
     <message id="page_meteo_settings_auto_detect">
       <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
       <source>Auto-detect</source>
@@ -4016,16 +3572,6 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <source>Reset counter</source>
       <translation>Nulstil tæller</translation>
     </message>
-    <message id="temperature_short_circuited">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="32"/>
-      <source>Short circuited</source>
-      <translation type="unfinished">Kortslutning</translation>
-    </message>
-    <message id="temperature_reverse_polarity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="35"/>
-      <source>Reverse polarity</source>
-      <translation type="unfinished">Omvendt polaritet</translation>
-    </message>
     <message id="temperature_sensor_battery_low">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
       <source>Sensor battery low</source>
@@ -4040,36 +3586,6 @@ Brug, medmindre det er forbudt af forsyningsleverandøren.</translation>
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="62"/>
       <source>Pressure</source>
       <translation>Tryk</translation>
-    </message>
-    <message id="temperature_pm25">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
-      <source>PM2.5</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_co2">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>CO₂</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_voc">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
-      <source>VOC index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_nox">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
-      <source>NOx index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_luminosity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
-      <source>Luminosity</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="133"/>
-      <source>Low</source>
-      <translation type="unfinished">Lav</translation>
     </message>
     <message id="temperature_offset">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
@@ -4123,25 +3639,10 @@ BEMÆRK: Opdateringen kan stoppe systemet midlertidigt.</translation>
       <source>Updating the MK3, values will reappear after the update is complete</source>
       <translation>Ved opdatering af MK3, vil værdierne dukke op igen, efter at opdateringen er fuldført</translation>
     </message>
-    <message id="vebus_device_charging_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="78"/>
-      <source>Charging the battery to 100%</source>
-      <translation type="unfinished">Opladning af batteriet til 100%</translation>
-    </message>
     <message id="vebus_device_charging_the_battery_to_100">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="93"/>
       <source>Charging the battery to 100%</source>
       <translation>Opladning af batteriet til 100%</translation>
-    </message>
-    <message id="vebus_device_page_microgrid_parameters">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
-      <source>Microgrid parameters</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="vebus_device_page_advanced">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
-      <source>Advanced</source>
-      <translation type="unfinished">Avanceret</translation>
     </message>
     <message id="vebus_device_in_progress">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="80"/>
@@ -4197,15 +3698,15 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <source>DC Current</source>
       <translation>DC Strøm</translation>
     </message>
+    <message id="vebus_device_page_advanced">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
+      <source>Advanced</source>
+      <translation>Avanceret</translation>
+    </message>
     <message id="common_words_alarm_setup">
       <location filename="../../components/CommonWords.qml" line="65"/>
       <source>Alarm setup</source>
       <translation>Alarm opsætning</translation>
-    </message>
-    <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
-      <translation type="unfinished">En VE.Bus BMS slukker automatisk systemet hvis nødvendigt for at beskytte batteriet. Styring af systemet fra en Color Control er derfor ikke muligt,</translation>
     </message>
     <message id="vebus_device_bms_not_found">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="240"/>
@@ -4246,7 +3747,7 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
     <message id="vebus_device_starting">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="117"/>
       <source>Starting...</source>
-      <translation type="unfinished">Starter...</translation>
+      <translation>Starter...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="120"/>
@@ -4312,16 +3813,6 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="260"/>
       <source>ESS Relay test</source>
       <translation>ESS Relæ test</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_completed">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="266"/>
-      <source>Completed</source>
-      <translation type="unfinished">Registreringen er udført</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_pending">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="268"/>
-      <source>Pending</source>
-      <translation type="unfinished">Afventer...</translation>
     </message>
     <message id="cycle_history_completed">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
@@ -4508,6 +3999,7 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
     <message id="rssystemalarms_overload">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
       <source>Overload</source>
+      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
       <translation>Overbelastning</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
@@ -4520,11 +4012,6 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
       <source>Voltage Sensor</source>
       <translation>Volt Sensor</translation>
-    </message>
-    <message id="vebus_device_phase_rotation">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
-      <source>Phase rotation</source>
-      <translation type="unfinished">Fase rotation</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
@@ -4556,12 +4043,6 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <source>VE.Bus BMS version</source>
       <translation>VE.Bus BMS version</translation>
     </message>
-    <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="15"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="52"/>
-      <source>Minimum SOC</source>
-      <translation type="unfinished">Minimum SOC:</translation>
-    </message>
     <message id="ess_unless_grid_fails">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="32"/>
       <source>Unless grid fails</source>
@@ -4581,7 +4062,7 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
     <message id="common_words_ac_input_role">
       <location filename="../../components/CommonWords.qml" line="24"/>
       <source>Role</source>
-      <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
       <translation>Rolle</translation>
     </message>
     <message id="common_words_ac_load">
@@ -4620,18 +4101,6 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <source>Active</source>
       <extracomment>Status is 'active'</extracomment>
       <translation>Aktiv</translation>
-    </message>
-    <message id="common_words_alarm">
-      <location filename="../../components/CommonWords.qml" line="51"/>
-      <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
-      <translation type="unfinished">Alarm</translation>
-    </message>
-    <message id="common_words_alarm_setting_overload">
-      <location filename="../../components/CommonWords.qml" line="58"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation type="unfinished">Overbelastning</translation>
     </message>
     <message id="common_words_alarm_status">
       <location filename="../../components/CommonWords.qml" line="68"/>
@@ -4678,8 +4147,8 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <source>Charge current</source>
       <translation>Opladning</translation>
     </message>
-    <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="125"/>
+    <message id="battery_mode_charging">
+      <location filename="../../src/enums.cpp" line="30"/>
       <source>Charging</source>
       <extracomment>"Charging" state</extracomment>
       <translation>Oplader</translation>
@@ -4693,7 +4162,7 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
     <message id="digitalinputs_state_closed">
       <location filename="../../src/enums.cpp" line="262"/>
       <source>Closed</source>
-      <extracomment>Digital input state</extracomment>
+      <extracomment>Status is 'closed'</extracomment>
       <translation>Lukket</translation>
     </message>
     <message id="evchargers_status_connected">
@@ -4701,8 +4170,8 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <source>Connected</source>
       <translation>Forbundet</translation>
     </message>
-    <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="143"/>
+    <message id="temperature_slider_current">
+      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
       <source>Current</source>
       <extracomment>Electric current, as measured in Amps</extracomment>
       <translation>Strøm</translation>
@@ -4729,9 +4198,10 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <extracomment>Title for device information</extracomment>
       <translation>Enhed</translation>
     </message>
-    <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="172"/>
+    <message id="battery_mode_discharging">
+      <location filename="../../src/enums.cpp" line="34"/>
       <source>Discharging</source>
+      <extracomment>Battery mode</extracomment>
       <translation>Aflader</translation>
     </message>
     <message id="wifimodel_disconnected">
@@ -4817,13 +4287,14 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <source>%1 Hour(s)</source>
       <translation>%1 time(r)</translation>
     </message>
-    <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="251"/>
+    <message id="battery_mode_idle">
+      <location filename="../../src/enums.cpp" line="26"/>
       <source>Idle</source>
+      <extracomment>Battery mode</extracomment>
       <translation>Inaktiv</translation>
     </message>
-    <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="258"/>
+    <message id="scheduled_charge_inactive">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
       <source>Inactive</source>
       <extracomment>Status is 'inactive'</extracomment>
       <translation>Inaktiv</translation>
@@ -4925,8 +4396,8 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <source>Offline</source>
       <translation>Offline</translation>
     </message>
-    <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="17"/>
+    <message id="digitalinputs_state_ok">
+      <location filename="../../src/enums.cpp" line="266"/>
       <source>OK</source>
       <extracomment>Voltage alarm is at "OK" level</extracomment>
       <translation>OK</translation>
@@ -4934,6 +4405,7 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
     <message id="switchable_output_on">
       <location filename="../../src/enums.cpp" line="471"/>
       <source>On</source>
+      <extracomment>Digital input state</extracomment>
       <translation>On</translation>
     </message>
     <message id="common_words_online">
@@ -4944,7 +4416,7 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
     <message id="digitalinputs_state_open">
       <location filename="../../src/enums.cpp" line="258"/>
       <source>Open</source>
-      <extracomment>Digital input open</extracomment>
+      <extracomment>Status is 'open'</extracomment>
       <translation>Åben</translation>
     </message>
     <message id="common_words_password">
@@ -5004,9 +4476,10 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <source>Remove</source>
       <translation>Fjerne</translation>
     </message>
-    <message id="switch_state_running">
-      <location filename="../../src/enums.cpp" line="363"/>
+    <message id="switchable_output_running">
+      <location filename="../../src/enums.cpp" line="468"/>
       <source>Running</source>
+      <extracomment>Status = "running"</extracomment>
       <translation>Kører</translation>
     </message>
     <message id="common_words_scanning">
@@ -5073,7 +4546,7 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
     <message id="pvinverter_statusCode_startup">
       <location filename="../../src/enums.cpp" line="296"/>
       <source>Startup (%1)</source>
-      <extracomment>PV inverter status code. %1 = the startup status number</extracomment>
+      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
       <translation>Opstart (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
@@ -5128,8 +4601,10 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <source>Unique Identity Number</source>
       <translation>Unikt identitetsnummer</translation>
     </message>
-    <message id="settings_radio_button_group_unknown">
-      <location filename="../../components/listitems/core/ListRadioButtonGroup.qml" line="44"/>
+    <message id="Unknown">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
       <source>Unknown</source>
       <translation>Ukendt</translation>
     </message>
@@ -5284,11 +4759,6 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <source>Error while checking for firmware updates</source>
       <translation>Fejl under søgning efter firmwareopdateringer</translation>
     </message>
-    <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation type="unfinished">Fejl under søgning efter firmwareopdateringer</translation>
-    </message>
     <message id="settings_firmware_downloading_and_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="63"/>
       <source>Downloading and installing firmware %1...</source>
@@ -5315,6 +4785,66 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <source>No firmware found</source>
       <translation>Ingen firmware fundet</translation>
     </message>
+    <message id="tank_type_fuel">
+      <location filename="../../src/enums.cpp" line="495"/>
+      <source>Fuel</source>
+      <translation>Brændstof (L)</translation>
+    </message>
+    <message id="tank_type_fresh_water">
+      <location filename="../../src/enums.cpp" line="498"/>
+      <source>Fresh water</source>
+      <translation>Ferskvand</translation>
+    </message>
+    <message id="tank_type_waste_water">
+      <location filename="../../src/enums.cpp" line="501"/>
+      <source>Waste water</source>
+      <translation>Affalds vand</translation>
+    </message>
+    <message id="tank_type_live_well">
+      <location filename="../../src/enums.cpp" line="504"/>
+      <source>Live well</source>
+      <translation>Drikkevand</translation>
+    </message>
+    <message id="tank_type_oil">
+      <location filename="../../src/enums.cpp" line="507"/>
+      <source>Oil</source>
+      <translation>Olie</translation>
+    </message>
+    <message id="tank_type_black_water">
+      <location filename="../../src/enums.cpp" line="510"/>
+      <source>Black water</source>
+      <translation>Sort vand</translation>
+    </message>
+    <message id="tank_type_gasoline">
+      <location filename="../../src/enums.cpp" line="513"/>
+      <source>Gasoline</source>
+      <translation>Benzin</translation>
+    </message>
+    <message id="tank_type_diesel">
+      <location filename="../../src/enums.cpp" line="516"/>
+      <source>Diesel</source>
+      <translation>Diesel</translation>
+    </message>
+    <message id="tank_type_lpg">
+      <location filename="../../src/enums.cpp" line="519"/>
+      <source>LPG</source>
+      <translation>LPG</translation>
+    </message>
+    <message id="tank_type_lng">
+      <location filename="../../src/enums.cpp" line="522"/>
+      <source>LNG</source>
+      <translation>LNG</translation>
+    </message>
+    <message id="tank_type_hydraulic_oil">
+      <location filename="../../src/enums.cpp" line="525"/>
+      <source>Hydraulic oil</source>
+      <translation>Hydraulik olie</translation>
+    </message>
+    <message id="tank_type_raw_water">
+      <location filename="../../src/enums.cpp" line="528"/>
+      <source>Raw water</source>
+      <translation>Rå vand</translation>
+    </message>
     <message id="listItem_no_access">
       <location filename="../../components/listitems/core/ListItem.qml" line="102"/>
       <source>Setting locked for access level</source>
@@ -5328,6 +4858,7 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
     <message id="welcome_brief_title">
       <location filename="../../pages/welcome/WelcomeView.qml" line="81"/>
       <source>Brief</source>
+      <extracomment>The 'Brief' page</extracomment>
       <translation>Kort</translation>
     </message>
     <message id="welcome_overview_title">
@@ -5344,23 +4875,6 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <location filename="../../pages/NotificationsPage.qml" line="13"/>
       <source>Notifications</source>
       <translation>Meddelelser</translation>
-    </message>
-    <message id="notifications_page_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="43"/>
-      <source>Active Notifications</source>
-      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_page_inactive_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="47"/>
-      <source>Inactive Notifications</source>
-      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_no_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="106"/>
-      <source>No active notifications</source>
-      <translation type="unfinished"/>
     </message>
     <message id="utils_formatTimestamp_now">
       <location filename="../../components/Utils.js" line="258"/>
@@ -5465,11 +4979,6 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <source>Self-consumption above limit</source>
       <translation>Eget-forbrug over grænse</translation>
     </message>
-    <message id="cgwacs_battery_schedule_pv">
-      <location filename="../../components/listitems/ListChargeSchedule.qml" line="171"/>
-      <source>PV</source>
-      <translation type="unfinished">PV</translation>
-    </message>
     <message id="settings_multirs_pv">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="185"/>
       <source>PV</source>
@@ -5480,8 +4989,8 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <source>PV &amp; Battery</source>
       <translation>PV &amp; Batteri</translation>
     </message>
-    <message id="settings_firmware_checking">
-      <location filename="../../components/listitems/ListFirmwareCheckButton.qml" line="16"/>
+    <message id="pagesettingssupportstate_firmware_checking">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
       <source>Checking...</source>
       <translation>Tjekker...</translation>
     </message>
@@ -5489,12 +4998,6 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <location filename="../../components/listitems/ListAlarmState.qml" line="11"/>
       <source>Alarm state</source>
       <translation>Alarm tilstand</translation>
-    </message>
-    <message id="devicelist_battery_alarm_state">
-      <location filename="../../components/listitems/ListAlarmState.qml" line="19"/>
-      <source>Alarm</source>
-      <extracomment>Alarm state is active</extracomment>
-      <translation type="unfinished">Alarm</translation>
     </message>
     <message id="clear_history_button_clear_history">
       <location filename="../../components/listitems/ListClearHistoryButton.qml" line="15"/>
@@ -5646,11 +5149,6 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <source>Max Voltage</source>
       <translation>Max volt</translation>
     </message>
-    <message id="charger_history_box_max_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="64"/>
-      <source>Max Voltage</source>
-      <translation type="unfinished">Max volt</translation>
-    </message>
     <message id="charger_history_box_max_current">
       <location filename="../../components/SolarDetailBox.qml" line="70"/>
       <source>Max Current</source>
@@ -5661,24 +5159,6 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <source>Charge time</source>
       <extracomment>Statistics for battery charging time</extracomment>
       <translation>Opladningstid</translation>
-    </message>
-    <message id="charger_history_box_bulk">
-      <location filename="../../components/SolarDetailBox.qml" line="136"/>
-      <source>Bulk</source>
-      <extracomment>Battery: time spent in 'Bulk' mode</extracomment>
-      <translation type="unfinished">Bulk</translation>
-    </message>
-    <message id="charger_history_box_float">
-      <location filename="../../components/SolarDetailBox.qml" line="148"/>
-      <source>Float</source>
-      <extracomment>Battery: time spent in 'Float' mode</extracomment>
-      <translation type="unfinished">Float</translation>
-    </message>
-    <message id="charger_history_hr">
-      <location filename="../../components/SolarDetailBox.qml" line="174"/>
-      <source>hr</source>
-      <extracomment>Abbreviation of "hour"</extracomment>
-      <translation type="unfinished">hr</translation>
     </message>
     <message id="solarchargers_state_bulk">
       <location filename="../../src/enums.cpp" line="337"/>
@@ -5750,11 +5230,6 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <source>Connecting</source>
       <translation>Forbinder...</translation>
     </message>
-    <message id="splash_view_connecting">
-      <location filename="../../components/SplashView.qml" line="288"/>
-      <source>Connecting</source>
-      <translation type="unfinished">Forbinder...</translation>
-    </message>
     <message id="splash_view_connected">
       <location filename="../../components/SplashView.qml" line="290"/>
       <source>Connected, awaiting broker messages</source>
@@ -5810,6 +5285,11 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <source>MQTT protocol level 5 error</source>
       <translation>MQTT-protokol niveau 5 fejl</translation>
     </message>
+    <message id="common_words_silence_alarm">
+      <location filename="../../components/CommonWords.qml" line="476"/>
+      <source>Silence alarm</source>
+      <translation>Sluk for alarmen</translation>
+    </message>
     <message id="vebus_device_page_total_power">
       <location filename="../../components/ThreePhaseQuantityTable.qml" line="47"/>
       <source>Total Power</source>
@@ -5860,20 +5340,10 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <source>Retrieving IP address</source>
       <translation>Henter IP adresse</translation>
     </message>
-    <message id="utils_connman_connected">
-      <location filename="../../components/Utils.js" line="292"/>
-      <source>Connected</source>
-      <translation type="unfinished">Forbundet</translation>
-    </message>
     <message id="utils_connman_disconnect">
       <location filename="../../components/Utils.js" line="295"/>
       <source>Disconnect</source>
       <translation>Afbrudt</translation>
-    </message>
-    <message id="utils_connman_disconnected">
-      <location filename="../../components/Utils.js" line="299"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Afbrudt.</translation>
     </message>
     <message id="overview_widget_acloads_title">
       <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
@@ -5911,11 +5381,6 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <source>Shore current limit</source>
       <translation>Grænse for landstrøm</translation>
     </message>
-    <message id="acInputs_statusCode_stopping">
-      <location filename="../../data/AcInputs.qml" line="170"/>
-      <source>Stopping</source>
-      <translation type="unfinished">Stopper</translation>
-    </message>
     <message id="page_generator_stopping">
       <location filename="../../data/Generators.qml" line="44"/>
       <source>Stopping</source>
@@ -5931,7 +5396,7 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <location filename="../../data/common/TankDescription.qml" line="24"/>
       <location filename="../../src/device.cpp" line="133"/>
       <source>%1 tank (%2)</source>
-      <extracomment>Tank description. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
       <translation>%1 tank (%2)</translation>
     </message>
     <message id="dcMeter_ac_charger">
@@ -5980,11 +5445,6 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <location filename="../../data/Ess.qml" line="20"/>
       <source>Keep batteries charged</source>
       <translation>Hold batterierne opladet</translation>
-    </message>
-    <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="50"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Afbrudt.</translation>
     </message>
     <message id="evchargers_status_charged">
       <location filename="../../data/EvChargers.qml" line="58"/>
@@ -6045,16 +5505,6 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <location filename="../../data/EvChargers.qml" line="97"/>
       <source>Start charging</source>
       <translation>Start opladning</translation>
-    </message>
-    <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="113"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Ukendt</translation>
-    </message>
-    <message id="evchargers_mode_scheduled">
-      <location filename="../../data/EvChargers.qml" line="126"/>
-      <source>Scheduled</source>
-      <translation type="unfinished">Planlagt</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
       <location filename="../../data/System.qml" line="195"/>
@@ -6179,11 +5629,6 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <source>Power supply mode</source>
       <translation>Strømforsyningstilstand</translation>
     </message>
-    <message id="inverters_state_sustain">
-      <location filename="../../data/System.qml" line="158"/>
-      <source>Sustain</source>
-      <translation type="unfinished">Oprethold</translation>
-    </message>
     <message id="inverters_state_wakeup">
       <location filename="../../data/System.qml" line="162"/>
       <source>Wake up</source>
@@ -6218,16 +5663,6 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <location filename="../../data/System.qml" line="180"/>
       <source>Test</source>
       <translation>Test</translation>
-    </message>
-    <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="183"/>
-      <source>External control</source>
-      <translation type="unfinished">Ekstern styring</translation>
-    </message>
-    <message id="inverters_state_dynamic_ess">
-      <location filename="../../data/System.qml" line="198"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">Dynamisk ESS</translation>
     </message>
     <message id="settings_rs_ess_dess">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="97"/>
@@ -6306,16 +5741,13 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
     <message id="ess_recommended">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="73"/>
       <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
       <translation>For litiumbatterier anbefales en opladning på under 10 % ikke. For andre batterityper skal du tjekke databladet for det minimumsniveau, der anbefales af producenten.</translation>
-    </message>
-    <message id="controlcard_generator_label_autostart">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="63"/>
-      <source>Autostart</source>
-      <translation type="unfinished">Autostart</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
       <location filename="../../pages/controlcards/GeneratorCard.qml" line="70"/>
       <source>Start and stop the generator based on the configured autostart conditions.</source>
+      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
       <translation>Start og stop generatoren baseret på de konfigurerede autostartbetingelser.</translation>
     </message>
     <message id="generator_dialog_disabled">
@@ -6338,11 +5770,13 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <location filename="../../pages/controlcards/InverterChargerCard.qml" line="26"/>
       <source>Inverter / Charger (%1)</source>
       <extracomment>%1 = the inverter/charger name</extracomment>
+      <oldsource>Inverter / Charger</oldsource>
       <translation>Inverter/oplader (%1)</translation>
     </message>
     <message id="settings_page_debug_quit_application">
       <location filename="../../pages/settings/debug/PageDebug.qml" line="36"/>
       <source>Quit application</source>
+      <oldsource>Quit Application</oldsource>
       <translation>Afslut applikation</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
@@ -6353,12 +5787,8 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
     <message id="settings_page_relay_generator_run_time">
       <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
       <source>Current run time</source>
+      <oldsource>Run time</oldsource>
       <translation>Nuværende køretid</translation>
-    </message>
-    <message id="settings_page_genset_generator_run_time">
-      <location filename="../../components/PageGensetModel.qml" line="102"/>
-      <source>Current run time</source>
-      <translation type="unfinished">Nuværende køretid</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
       <location filename="../../components/PageGensetModel.qml" line="110"/>
@@ -6385,19 +5815,10 @@ Når opladningsprocessen er afsluttet, vender systemet tilbage til normal drift 
       <source>Remote start mode</source>
       <translation>Fjernstart-tilstand</translation>
     </message>
-    <message id="ac-in-genset_speed">
-      <location filename="../../components/PageGensetModel.qml" line="245"/>
-      <source>Speed</source>
-      <translation type="unfinished">Hastighed</translation>
-    </message>
-    <message id="ac-in-genset_load">
-      <location filename="../../components/PageGensetModel.qml" line="252"/>
-      <source>Load</source>
-      <translation type="unfinished">Indlæs</translation>
-    </message>
     <message id="ac-in-genset_oil_pressure">
       <location filename="../../components/PageGensetModel.qml" line="260"/>
       <source>Oil pressure</source>
+      <oldsource>Oil Pressure</oldsource>
       <translation>Olietryk</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
@@ -6494,11 +5915,13 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
       <source>High starter battery voltage alarms</source>
+      <oldsource>High starter batttery voltage alarms</oldsource>
       <translation>Alarmer for høj startbatterispænding</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
       <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
       <translation>Bemærk, at en ændring af indstillingen Time-to-go discharge floor også ændrer indstillingen Low state-of-charge i relæmenuen.</translation>
     </message>
     <message id="lynxionsystem_cells_per_battery">
@@ -6575,6 +5998,7 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
       <location filename="../../pages/settings/devicelist/delegates/DeviceListDelegate_solarcharger.qml" line="34"/>
       <source>Error: #%1</source>
       <extracomment>%1 = error number</extracomment>
+      <oldsource>Error: %1</oldsource>
       <translation>Fejl: #%1</translation>
     </message>
     <message id="devicelistpage_genset">
@@ -6631,17 +6055,14 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
     <message id="settings_page_relay_generator_auto_start_enabled">
       <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
       <source>Autostart functionality</source>
+      <oldsource>Auto start functionality</oldsource>
       <translation>Autostart-funktionalitet</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="97"/>
       <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
       <translation>Sørg for, at generatoren ikke er tilsluttet AC-indgangen %1, når du bruger denne indstilling.</translation>
-    </message>
-    <message id="page_generator_conditions_inverter_high_temperature">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="139"/>
-      <source>Inverter high temperature</source>
-      <translation type="unfinished">Inverter høj temperatur</translation>
     </message>
     <message id="page_generator_conditions_tank_level">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="159"/>
@@ -6671,30 +6092,34 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
     <message id="settings_generator_function_not_enabled">
       <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
       <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
+      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
       <translation>Generatorens start/stop-funktion er ikke aktiveret, gå til relæindstillinger og sæt funktionen til "Genset start/stop"</translation>
     </message>
     <message id="settings_batteries_intro">
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="45"/>
       <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
       <translation>Brug denne menu til at definere de batteridata, der vises, når du klikker på batteriikonet på oversigtssiden. Det samme valg er også synligt på VRM-portalen.</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
       <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
       <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
       <translation>Kontinuerlig scanning kan forstyrre Wi-Fi-funktionen.</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
       <source>CAN-bus BMS LV (500 kbit/s)</source>
+      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
       <translation>CAN-bus BMS LV (500 kbit/s)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
       <source>CAN-bus BMS HV (500 kbit/s)</source>
       <translation>CAN-bus BMS HV (500 kbit/s)</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
       <source>Up, but no services (500 kbit/s)</source>
       <translation>Op, men ingen tjenester (500 kbit/s)</translation>
     </message>
@@ -6707,41 +6132,6 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="127"/>
       <source>Brief page</source>
       <translation>Kort side</translation>
-    </message>
-    <message id="settings_displayoff_1min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="46"/>
-      <source>1 min</source>
-      <translation type="unfinished">1 min</translation>
-    </message>
-    <message id="settings_displayoff_10min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="48"/>
-      <source>10 min</source>
-      <translation type="unfinished">10 min</translation>
-    </message>
-    <message id="settings_displayoff_30min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="50"/>
-      <source>30 min</source>
-      <translation type="unfinished">30 min</translation>
-    </message>
-    <message id="settings_displayoff_never">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="52"/>
-      <source>Never</source>
-      <translation type="unfinished">Aldrig</translation>
-    </message>
-    <message id="settings_remote_console_appearance_auto">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="112"/>
-      <source>Auto</source>
-      <translation type="unfinished">Auto</translation>
-    </message>
-    <message id="settings_brief_view_start_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="119"/>
-      <source>Start page</source>
-      <translation type="unfinished">Startside</translation>
-    </message>
-    <message id="settings_display_boat_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="135"/>
-      <source>Boat page</source>
-      <translation type="unfinished">Båd-side</translation>
     </message>
     <message id="settings_display_minmax">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="148"/>
@@ -6796,21 +6186,6 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
       <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
       <translation>%1 er indstillet til %2</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_unsupported_device">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="50"/>
-      <source>Unsupported GX device</source>
-      <translation type="unfinished">Ikke-understøttet GX-enhed</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_clean">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="55"/>
-      <source>Clean</source>
-      <translation type="unfinished">Ryd op</translation>
-    </message>
-    <message id="pagesettingsgeneral_firmware">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="112"/>
-      <source>Firmware</source>
-      <translation type="unfinished">Firmware</translation>
-    </message>
     <message id="pagesettingsgeneral_access_and_security">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
       <source>Access &amp; Security</source>
@@ -6844,6 +6219,7 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
     <message id="settings_language_please_wait">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="209"/>
       <source>Please wait while the language is changed.</source>
+      <oldsource>Please wait while the language is changed</oldsource>
       <translation>Vent venligst, mens sproget ændres.</translation>
     </message>
     <message id="settings_briefview_totals">
@@ -6860,11 +6236,6 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="71"/>
       <source>Tank is not connected.</source>
       <translation>Tanken er ikke tilsluttet.</translation>
-    </message>
-    <message id="settings_briefview_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="83"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">Aktiv batteri monitor</translation>
     </message>
     <message id="settings_briefview_individual_batteries">
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="86"/>
@@ -6915,6 +6286,7 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
     <message id="settings_dvcc_charge_current_limits">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="30"/>
       <source>Charge current limits</source>
+      <oldsource>Charge Current limits</oldsource>
       <translation>Grænser for opladningsstrøm</translation>
     </message>
     <message id="settings_firmware_official_release">
@@ -6994,11 +6366,6 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
       <source>No password and the network communication is not encrypted</source>
       <translation>Ingen adgangskode, og netværkskommunikationen er ikke krypteret</translation>
     </message>
-    <message id="settings_logout_now">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
-      <source>Log out now</source>
-      <translation type="unfinished">Log ud nu</translation>
-    </message>
     <message id="settings_security_profile_password_incorrect_length">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="28"/>
       <source>Password needs to be at least 8 characters long</source>
@@ -7049,25 +6416,10 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
       <source>Page will automatically reload in 5 seconds</source>
       <translation>Siden genindlæses automatisk om 5 sekunder</translation>
     </message>
-    <message id="settings_security_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="159"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">Adgangskoden skal være mindst 8 tegn lang</translation>
-    </message>
     <message id="settings_root_password">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="269"/>
       <source>Root password</source>
       <translation>Adgangskode til roden</translation>
-    </message>
-    <message id="settings_root_enter_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="272"/>
-      <source>Enter password</source>
-      <translation type="unfinished">Indtast adgangskode</translation>
-    </message>
-    <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="277"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">Adgangskoden skal være mindst 8 tegn lang</translation>
     </message>
     <message id="settings_root_password_changed_to">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="283"/>
@@ -7083,6 +6435,11 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="321"/>
       <source>Logout</source>
       <translation>Log ud</translation>
+    </message>
+    <message id="settings_logout_now">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
+      <source>Log out now</source>
+      <translation>Log ud nu</translation>
     </message>
     <message id="settings_logout_dialog_title">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="335"/>
@@ -7142,11 +6499,13 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="141"/>
       <source>Alarm when generator is not in autostart mode</source>
+      <oldsource>Alarm when generator is not in auto start mode</oldsource>
       <translation>Alarm, når generatoren ikke er i autostart-tilstand</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="147"/>
       <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
       <translation>En alarm udløses, når autostart-funktionen er deaktiveret i mere end 10 minutter.</translation>
     </message>
     <message id="settings_units_amps_exceptions">
@@ -7162,6 +6521,11 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
     <message id="settings_ess_use_this_option_for_peak_shaving">
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
       <source>Use this option for peak shaving.</source>
+      <oldsource>Use this option for peak shaving.
+
+The peak shaving threshold is set using the AC input current limit setting.
+
+See documentation for further information.</oldsource>
       <translation>Brug denne indstilling til peak shaving.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
@@ -7205,17 +6569,17 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
       <translation>Maksimal systemeksportstrøm (pr. fase)</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="71"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="73"/>
       <source>Self-consumption from battery</source>
       <translation>Selvforbrug fra batteri</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="76"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
       <source>All system loads</source>
       <translation>Alle systembelastninger</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="80"/>
       <source>Only critical loads</source>
       <translation>Kun kritiske belastninger</translation>
     </message>
@@ -7262,7 +6626,7 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
     <message id="pagesettingsintegrations_relays">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="118"/>
       <source>Relays</source>
-      <translation>Du er ved at dreje &lt;b&gt; {isOn} relæ {relayNumber}. Er du sikker på, at du vil fortsætte?</translation>
+      <translation>Relæer</translation>
     </message>
     <message id="pagesettingsintegrations_digital_io">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="132"/>
@@ -7273,26 +6637,6 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="194"/>
       <source>Server Applications</source>
       <translation>Server-applikationer</translation>
-    </message>
-    <message id="pagesettingsintegrations_venus_os_enable_large_features">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
-      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_large_victron_community">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="274"/>
-      <source>Victron Community</source>
-      <translation type="unfinished">Victron fællesskabet</translation>
-    </message>
-    <message id="pagesettingsintegrations_ui_plugins">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
-      <source>UI Plugins</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
-      <source>Integrates with the device list</source>
-      <translation type="unfinished"/>
     </message>
     <message id="pagesettingssupportstate_modbus_tcp_server">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="453"/>
@@ -7395,25 +6739,10 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
       <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
       <translation>Det er ikke muligt at skifte firmwareversion uden at vælge "Netværkssikkerhedsprofil" i "Indstillinger / Generelt".</translation>
     </message>
-    <message id="pagesettingsconnectivity_ethernet">
-      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
-      <source>Ethernet</source>
-      <translation type="unfinished">Ethernet</translation>
-    </message>
     <message id="pagesettingsconnectivity_mobile_network">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="53"/>
       <source>Mobile Network</source>
       <translation>Mobilt netværk</translation>
-    </message>
-    <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Boat</source>
-      <translation type="unfinished">Båd</translation>
-    </message>
-    <message id="settings_system_name_auto">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="32"/>
-      <source>Automatic</source>
-      <translation type="unfinished">Automatisk</translation>
     </message>
     <message id="pagesettingssystem_ac_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
@@ -7444,11 +6773,6 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="89"/>
       <source>Distributed Voltage and Current Control (DVCC)</source>
       <translation>Distribueret spændings- og strømstyring (DVCC)</translation>
-    </message>
-    <message id="settings_system_grid">
-      <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="18"/>
-      <source>Grid</source>
-      <translation type="unfinished">Forsyning</translation>
     </message>
     <message id="settings_system_ac_position">
       <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="58"/>
@@ -7488,16 +6812,19 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
     <message id="settings_system_has_dc_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="97"/>
       <source>Display DC Loads</source>
+      <oldsource>Has DC system</oldsource>
       <translation>Vis DC-belastninger</translation>
     </message>
     <message id="settings_system_battery_measurements">
       <location filename="../../pages/settings/PageSettingsBatteries.qml" line="65"/>
       <source>Battery measurements</source>
+      <oldsource>Battery Measurements</oldsource>
       <translation>Batteri målinger</translation>
     </message>
     <message id="settings_system_system_status">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
       <source>System status</source>
+      <oldsource>System Status</oldsource>
       <translation>Systemstatus</translation>
     </message>
     <message id="settings_tcpip_wired">
@@ -7508,11 +6835,13 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
     <message id="settings_vecan_device_instance">
       <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
       <source>VE.Can Device Instance</source>
+      <oldsource>Device Instance</oldsource>
       <translation>VE.Can-enhedsinstans</translation>
     </message>
     <message id="settings_vecan_device_number">
       <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="32"/>
       <source>VE.Can Instance# %1</source>
+      <oldsource>Device# %1</oldsource>
       <translation>VE.Can Instance# %1</translation>
     </message>
     <message id="settings_tz_antarctica">
@@ -7543,6 +6872,7 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
     <message id="settings_vrm">
       <location filename="../../pages/SettingsPage.qml" line="59"/>
       <source>VRM</source>
+      <extracomment>Forced by %2 to dark</extracomment>
       <translation>VRM</translation>
     </message>
     <message id="settings_remote_monitoring_portal">
@@ -7550,20 +6880,10 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
       <source>Remote monitoring portal</source>
       <translation>Portal til fjernovervågning</translation>
     </message>
-    <message id="settings_advanced">
-      <location filename="../../pages/SettingsPage.qml" line="68"/>
-      <source>Advanced</source>
-      <translation type="unfinished">Avanceret</translation>
-    </message>
-    <message id="settings_integrations">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
+    <message id="pagesettingssupportstate_integrations">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
       <source>Integrations</source>
       <translation>Integrationer</translation>
-    </message>
-    <message id="settings_relays_sensors_tanks">
-      <location filename="../../pages/SettingsPage.qml" line="75"/>
-      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
-      <translation type="unfinished">Relæer, sensorer, tanke, solcelleinvertere, Modbus, MQTT...</translation>
     </message>
     <message id="settings_acdcsystem_ess_dvcc_battery">
       <location filename="../../pages/SettingsPage.qml" line="84"/>
@@ -7583,11 +6903,13 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
     <message id="settings_system_setup">
       <location filename="../../pages/SettingsPage.qml" line="82"/>
       <source>System Setup</source>
+      <oldsource>System setup</oldsource>
       <translation>System opsætning</translation>
     </message>
     <message id="settings_vrm_device_instances">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
       <source>VRM device instances</source>
+      <oldsource>VRM Device Instances</oldsource>
       <translation>VRM-enhedsinstanser</translation>
     </message>
     <message id="solarcharger_not_supported">
@@ -7605,28 +6927,10 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
       <source>The firmware version in the MPPT Solar Charger must be v1.09 or later. Contact Victron Service for update instructions and files.</source>
       <translation>Firmwareversionen i MPPT-solcelleopladeren skal være v1.09 eller nyere. Kontakt Victron Service for at få opdateringsinstruktioner og filer.</translation>
     </message>
-    <message id="solarcharger_pv">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="102"/>
-      <source>PV</source>
-      <extracomment>PV power for solar charger</extracomment>
-      <translation type="unfinished">PV</translation>
-    </message>
     <message id="solarcharger_total_power">
       <location filename="../../pages/solar/PageSolarCharger.qml" line="127"/>
       <source>Total PV power</source>
       <translation>Total PV power</translation>
-    </message>
-    <message id="solarcharger_total_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="211"/>
-      <source>Total yield</source>
-      <extracomment>Solar charger total yield</extracomment>
-      <translation type="unfinished">Total produktion</translation>
-    </message>
-    <message id="solarcharger_system_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="220"/>
-      <source>System yield</source>
-      <extracomment>Solar charger system yield</extracomment>
-      <translation type="unfinished">Systemets produktion</translation>
     </message>
     <message id="settings_multirs_total_yield">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="63"/>
@@ -7662,16 +6966,19 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
     <message id="vebus_device_update_firmware">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="133"/>
       <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
       <translation>Denne funktion kræver firmwareversion 400 eller højere. Kontakt din installatør for at opdatere din Multi/Quattro.</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="139"/>
       <source>Charger not ready, equalization cannot be started</source>
+      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
       <translation>Opladeren er ikke klar, udligning kan ikke startes</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="143"/>
       <source>Equalization cannot be triggered during bulk charge state</source>
+      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
       <translation>Udligning kan ikke udløses under masseopladningstilstand</translation>
     </message>
     <message id="vebus_device_restart_vebus_system_restart_confirmation_description">
@@ -7694,78 +7001,20 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
       <source>Auto-started • %1</source>
       <translation>Startet automatisk - %1</translation>
     </message>
-    <message id="common_words_battery">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery</source>
-      <translation type="unfinished">Batteri</translation>
-    </message>
-    <message id="common_words_boat_page">
-      <location filename="../../components/CommonWords.qml" line="111"/>
-      <source>Boat</source>
-      <extracomment>The 'Boat' page</extracomment>
-      <translation type="unfinished">Båd</translation>
-    </message>
-    <message id="common_words_brief_page">
-      <location filename="../../components/CommonWords.qml" line="115"/>
-      <source>Brief</source>
-      <extracomment>The 'Brief' page</extracomment>
-      <translation type="unfinished">Kort</translation>
-    </message>
-    <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation type="unfinished">Lukket</translation>
-    </message>
-    <message id="common_words_color">
-      <location filename="../../components/CommonWords.qml" line="136"/>
-      <source>Color</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_connected">
-      <location filename="../../components/CommonWords.qml" line="139"/>
-      <source>Connected</source>
-      <translation type="unfinished">Forbundet</translation>
-    </message>
     <message id="common_words_daily_history">
       <location filename="../../components/CommonWords.qml" line="152"/>
       <source>Daily history</source>
       <translation>Daglig historie</translation>
-    </message>
-    <message id="common_words_disabled">
-      <location filename="../../components/CommonWords.qml" line="169"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Deaktiveret</translation>
-    </message>
-    <message id="common_words_disconnected">
-      <location filename="../../components/CommonWords.qml" line="175"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Afbrudt.</translation>
-    </message>
-    <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="191"/>
-      <source>Error</source>
-      <translation type="unfinished">Fejl</translation>
     </message>
     <message id="common_words_error_not_a_number">
       <location filename="../../components/CommonWords.qml" line="200"/>
       <source>'%1' is not a number.</source>
       <translation>'%1' er ikke et tal.</translation>
     </message>
-    <message id="common_words_generator">
-      <location filename="../../components/CommonWords.qml" line="217"/>
-      <source>Generator</source>
-      <translation type="unfinished">Generator</translation>
-    </message>
     <message id="common_words_input_current_limit">
       <location filename="../../components/CommonWords.qml" line="261"/>
       <source>Input current limit</source>
       <translation>Input nuværende grænse</translation>
-    </message>
-    <message id="common_words_inverter_charger">
-      <location filename="../../components/CommonWords.qml" line="264"/>
-      <source>Inverter / Charger</source>
-      <translation type="unfinished">Inverter/oplader</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
       <location filename="../../components/CommonWords.qml" line="268"/>
@@ -7778,12 +7027,6 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
       <source>Manual stop</source>
       <translation>Manuelt stop</translation>
     </message>
-    <message id="common_words_max">
-      <location filename="../../components/CommonWords.qml" line="315"/>
-      <source>Max</source>
-      <extracomment>Short for Maximum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_maximum_current">
       <location filename="../../components/CommonWords.qml" line="318"/>
       <source>Maximum current</source>
@@ -7794,62 +7037,10 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
       <source>Maximum power</source>
       <translation>Maksimal effekt</translation>
     </message>
-    <message id="common_words_min">
-      <location filename="../../components/CommonWords.qml" line="331"/>
-      <source>Min</source>
-      <extracomment>Short for Minimum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_minimum_current">
       <location filename="../../components/CommonWords.qml" line="334"/>
       <source>Minimum current</source>
       <translation>Minimum strømstyrke</translation>
-    </message>
-    <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="433"/>
-      <source>No</source>
-      <translation type="unfinished">Nej</translation>
-    </message>
-    <message id="common_words_none_option">
-      <location filename="../../components/CommonWords.qml" line="364"/>
-      <source>None</source>
-      <translation type="unfinished">Ingen</translation>
-    </message>
-    <message id="common_words_none_errors">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>None</source>
-      <extracomment>Indicates there are no errors</extracomment>
-      <translation type="unfinished">Ingen</translation>
-    </message>
-    <message id="common_words_not_available">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Not available</source>
-      <translation type="unfinished">Ikke tilgængelig</translation>
-    </message>
-    <message id="common_words_off">
-      <location filename="../../components/CommonWords.qml" line="377"/>
-      <source>Off</source>
-      <translation type="unfinished">Fra</translation>
-    </message>
-    <message id="common_words_ok">
-      <location filename="../../components/CommonWords.qml" line="383"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="41"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="45"/>
-      <source>OK</source>
-      <translation type="unfinished">OK</translation>
-    </message>
-    <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="386"/>
-      <source>On</source>
-      <translation type="unfinished">On</translation>
-    </message>
-    <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="393"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation type="unfinished">Åben</translation>
     </message>
     <message id="common_words_open_circuit">
       <location filename="../../components/CommonWords.qml" line="396"/>
@@ -7861,108 +7052,17 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
       <source>Overall history</source>
       <translation>Overordnet historie</translation>
     </message>
-    <message id="common_words_press">
-      <location filename="../../components/CommonWords.qml" line="419"/>
-      <source>Press</source>
-      <translation type="unfinished">Presse</translation>
-    </message>
-    <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation type="unfinished">Kører</translation>
-    </message>
-    <message id="common_words_settings">
-      <location filename="../../components/CommonWords.qml" line="467"/>
-      <source>Settings</source>
-      <translation type="unfinished">Indstillinger</translation>
-    </message>
-    <message id="common_words_silence_alarm">
-      <location filename="../../components/CommonWords.qml" line="476"/>
-      <source>Silence alarm</source>
-      <translation type="unfinished">Sluk for alarmen</translation>
-    </message>
     <message id="common_words_soc">
       <location filename="../../components/CommonWords.qml" line="480"/>
       <source>SOC %1</source>
       <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
       <translation>SOC %1</translation>
     </message>
-    <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation type="unfinished">Hastighed</translation>
-    </message>
-    <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="487"/>
-      <source>Standby</source>
-      <translation type="unfinished">Standby</translation>
-    </message>
-    <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="502"/>
-      <source>State</source>
-      <translation type="unfinished">Tilstand</translation>
-    </message>
-    <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="512"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation type="unfinished">Opstart (%1)</translation>
-    </message>
-    <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>Stopped</source>
-      <translation type="unfinished">Stoppet</translation>
-    </message>
-    <message id="common_words_total_power">
-      <location filename="../../components/CommonWords.qml" line="540"/>
-      <source>Total power</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="547"/>
-      <source>Type</source>
-      <translation type="unfinished">Type</translation>
-    </message>
-    <message id="common_words_unknown_status">
-      <location filename="../../components/CommonWords.qml" line="554"/>
-      <source>Unknown</source>
-      <extracomment>Status = "unknown"</extracomment>
-      <translation type="unfinished">Ukendt</translation>
-    </message>
-    <message id="common_words_value_must_be_greater_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="557"/>
-      <source>Value must be greater than start value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_value_must_be_greater_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="560"/>
-      <source>Value must be greater than stop value</source>
-      <translation type="unfinished">Værdien skal være højere end stop værdien</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="563"/>
-      <source>Value must be lower than start value</source>
-      <translation type="unfinished">Værdien skal være lavere end start værdien</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="566"/>
-      <source>Value must be lower than stop value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="581"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="431"/>
-      <source>Yes</source>
-      <translation type="unfinished">Ja</translation>
-    </message>
     <message id="common_words_yield_today">
       <location filename="../../components/CommonWords.qml" line="592"/>
       <source>Yield Today</source>
       <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+      <oldsource>Yield today</oldsource>
       <translation>Produktion idag</translation>
     </message>
     <message id="common_words_format_error">
@@ -7989,10 +7089,11 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
     <message id="settings_firmware_installed_rebooting">
       <location filename="../../components/FirmwareUpdate.qml" line="79"/>
       <source>Firmware installed, device rebooting</source>
+      <oldsource>Firmware installed, rebooting.</oldsource>
       <translation>Firmware installeret, enheden genstarter</translation>
     </message>
-    <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/RadioButtonListPage.qml" line="121"/>
+    <message id="modaldialog_confirm">
+      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
       <source>Confirm</source>
       <extracomment>Confirm password, and verify it if possible</extracomment>
       <translation>Bekræft</translation>
@@ -8010,11 +7111,13 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
     <message id="cgwacs_battery_schedule_duration">
       <location filename="../../components/listitems/ListChargeSchedule.qml" line="144"/>
       <source>Duration</source>
+      <oldsource>Duration (hh:mm)</oldsource>
       <translation>Varighed</translation>
     </message>
     <message id="settings_relay_deactivation_value">
       <location filename="../../components/TemperatureRelaySettings.qml" line="86"/>
       <source>Deactivation value</source>
+      <oldsource>Deativation value</oldsource>
       <translation>Deaktiverings regel</translation>
     </message>
     <message id="splash_view_device_disconnected">
@@ -8062,29 +7165,6 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
       <source>Temperature warning</source>
       <translation>Advarsel om temperatur</translation>
     </message>
-    <message id="battery_mode_idle">
-      <location filename="../../src/enums.cpp" line="26"/>
-      <source>Idle</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Inaktiv</translation>
-    </message>
-    <message id="battery_mode_charging">
-      <location filename="../../src/enums.cpp" line="30"/>
-      <source>Charging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Oplader</translation>
-    </message>
-    <message id="battery_mode_discharging">
-      <location filename="../../src/enums.cpp" line="34"/>
-      <source>Discharging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Aflader</translation>
-    </message>
-    <message id="dcMeter_bilge_pump">
-      <location filename="../../src/enums.cpp" line="115"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">Sump pumpe</translation>
-    </message>
     <message id="switch_state_channel_fault">
       <location filename="../../src/enums.cpp" line="372"/>
       <source>Channel Fault</source>
@@ -8115,26 +7195,6 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
       <source>Slave of %1</source>
       <translation>Slave af %1</translation>
     </message>
-    <message id="switchable_output_numeric_input">
-      <location filename="../../src/enums.cpp" line="418"/>
-      <source>Numeric input</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bilge_pump">
-      <location filename="../../src/enums.cpp" line="424"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">Sump pumpe</translation>
-    </message>
-    <message id="switchable_output_not_running">
-      <location filename="../../src/enums.cpp" line="448"/>
-      <source>Not running</source>
-      <translation type="unfinished">Kører ikke</translation>
-    </message>
-    <message id="switchable_output_off">
-      <location filename="../../src/enums.cpp" line="451"/>
-      <source>Off</source>
-      <translation type="unfinished">Fra</translation>
-    </message>
     <message id="switchable_output_powered">
       <location filename="../../src/enums.cpp" line="455"/>
       <source>Powered</source>
@@ -8163,16 +7223,19 @@ Reset den hvis systemet er ændret eller der inge BMS er mere.</translation>
     <message id="evchargers_status_welded_contacts_error">
       <location filename="../../data/EvChargers.qml" line="76"/>
       <source>Welded contacts test error (shorted)</source>
+      <oldsource>Welded contacts error</oldsource>
       <translation>Testfejl for svejsede kontakter (kortsluttet)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
       <location filename="../../data/EvChargers.qml" line="100"/>
       <source>Switching to 3 phase</source>
+      <oldsource>Switching to 3-phase</oldsource>
       <translation>Skift til 3-fase</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
       <location filename="../../data/EvChargers.qml" line="103"/>
       <source>Switching to 1 phase</source>
+      <oldsource>Switching to single phase</oldsource>
       <translation>Skift til 1 fase</translation>
     </message>
     <message id="evchargers_status_stop_charging">
@@ -8325,17 +7388,6 @@ Hvis generatoren i øjeblikket kører på grund af en autostart-tilstand, vil de
       <source>Open link</source>
       <translation>Åbn link</translation>
     </message>
-    <message id="listlink_show_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="43"/>
-      <source>Show QR code</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="listlink_scan_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="52"/>
-      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
-      <extracomment>%1 = url text</extracomment>
-      <translation type="unfinished">Scan QR-koden med din bærbare enhed.&lt;br /&gt;Eller indsæt linket: %1</translation>
-    </message>
     <message id="settings_services_mqtt_access">
       <location filename="../../components/listitems/ListMqttAccessSwitch.qml" line="11"/>
       <source>MQTT Access</source>
@@ -8407,12 +7459,6 @@ Hvis generatoren i øjeblikket kører på grund af en autostart-tilstand, vil de
       <extracomment>The 'Brief' page, with the side panel opened</extracomment>
       <translation>Trusse (åbent sidepanel)</translation>
     </message>
-    <message id="startpage_option_overview">
-      <location filename="../../data/StartPageConfiguration.qml" line="37"/>
-      <source>Overview</source>
-      <extracomment>The 'Overview' page</extracomment>
-      <translation type="unfinished">Oversigt</translation>
-    </message>
     <message id="startpage_option_levels_tanks">
       <location filename="../../data/StartPageConfiguration.qml" line="43"/>
       <source>Levels (Tanks)</source>
@@ -8431,12 +7477,12 @@ Hvis generatoren i øjeblikket kører på grund af en autostart-tilstand, vil de
       <translation>Liste over batterier</translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
+      <location filename="../../pages/DialogLayer.qml" line="56"/>
       <source>GX device has been updated</source>
       <translation>GX-enheden er blevet opdateret</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
+      <location filename="../../pages/DialogLayer.qml" line="58"/>
       <source>Page will automatically reload in ten seconds to load the latest version.</source>
       <translation>Siden genindlæses automatisk om ti sekunder for at indlæse den nyeste version.</translation>
     </message>
@@ -8606,8 +7652,8 @@ Bemærk, at denne menu kun viser Carlo Gavazzi-målere, der er tilsluttet via RS
       <source>Unit</source>
       <translation>Enhed</translation>
     </message>
-    <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="61"/>
+    <message id="page_settings_fronius_unitid_invalid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
       <source>%1 is not a valid unit number. Use a number between 1-247.</source>
       <translation>%1 er ikke et gyldigt enhedsnummer. Brug et tal mellem 1-247.</translation>
     </message>
@@ -8722,11 +7768,6 @@ Bemærk, at denne menu kun viser Carlo Gavazzi-målere, der er tilsluttet via RS
       <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="66"/>
       <source>Controller Temperature</source>
       <translation>Controller temperatur</translation>
-    </message>
-    <message id="devicelist_motordrive_motordirectioninverted">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
-      <source>Motor Direction Inverted</source>
-      <translation type="unfinished"/>
     </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
@@ -8918,11 +7959,6 @@ Med strømlinet navigation og et nyt look er alt det, du elsker, nu endnu letter
     <message id="welcome_done">
       <location filename="../../pages/welcome/WelcomeView.qml" line="136"/>
       <source>Done</source>
-      <translation type="unfinished">Færdig</translation>
-    </message>
-    <message id="mk2vsc_state_done">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="20"/>
-      <source>Done</source>
       <translation>Færdig</translation>
     </message>
     <message id="welcome_next">
@@ -8980,6 +8016,7 @@ GX-enheden kan kun styre én tilsluttet generator og tager den med det laveste V
     <message id="settings_tz_etc">
       <location filename="../../pages/settings/PageTzInfo.qml" line="280"/>
       <source>Other</source>
+      <oldsource>Etc</oldsource>
       <translation>Andet</translation>
     </message>
     <message id="ac-in-modeldefault_energy_reverse_x">
@@ -8997,6 +8034,11 @@ GX-enheden kan kun styre én tilsluttet generator og tager den med det laveste V
       <location filename="../../src/enums.cpp" line="438"/>
       <source>Unsupported type: %1</source>
       <translation>Type, der ikke understøttes: %1</translation>
+    </message>
+    <message id="common_words_press">
+      <location filename="../../components/CommonWords.qml" line="419"/>
+      <source>Press</source>
+      <translation>Presse</translation>
     </message>
     <message id="output_aux_battery_service_changed_dcdc">
       <location filename="../../components/listitems/ListOutputBatteryRadioButtonGroup.qml" line="27"/>
@@ -9137,13 +8179,6 @@ GX-enheden kan kun styre én tilsluttet generator og tager den med det laveste V
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="38"/>
       <source>Resetting VE.Bus products</source>
       <translation>Nulstilling af VE.bus-produkter</translation>
-    </message>
-    <message id="Unknown">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Ukendt</translation>
     </message>
     <message id="mk2vsc_error_mk2_mk3_comm">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="47"/>
@@ -9449,11 +8484,6 @@ GX-enheden kan kun styre én tilsluttet generator og tager den med det laveste V
       <source>Changing the GX Password</source>
       <translation>Ændring af GX-adgangskoden</translation>
     </message>
-    <message id="modaldialog_confirm">
-      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
-      <source>Confirm</source>
-      <translation type="unfinished">Bekræft</translation>
-    </message>
     <message id="settings_security_profile_change_password_description">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="83"/>
       <source>Please enter a new GX password:</source>
@@ -9546,21 +8576,6 @@ GX-enheden kan kun styre én tilsluttet generator og tager den med det laveste V
       <source>Modifications installed</source>
       <translation>Installerede modifikationer</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_modbus">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="28"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">Modbus TCP-server</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_signalk">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="32"/>
-      <source>Signal K</source>
-      <translation type="unfinished">Signal K</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_nodered">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="36"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">Node-RED</translation>
-    </message>
     <message id="pagesettingsgeneral_modificationchecks_running_integrations">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="43"/>
       <source>%1 running integrations</source>
@@ -9636,16 +8651,6 @@ GX-enheden kan kun styre én tilsluttet generator og tager den med det laveste V
       <source>Installed and enabled, disables at next boot</source>
       <translation>Installeret og aktiveret, deaktiveres ved næste opstart</translation>
     </message>
-    <message id="pagesettingssupportstate_firmware_checking">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
-      <source>Checking...</source>
-      <translation type="unfinished">Tjekker...</translation>
-    </message>
-    <message id="pagesettingssupportstate_firmware_unknown">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="166"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Ukendt</translation>
-    </message>
     <message id="pagesettingssupportstate_support_status">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="228"/>
       <source>Support status</source>
@@ -9667,11 +8672,6 @@ GX-enheden kan kun styre én tilsluttet generator og tager den med det laveste V
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="288"/>
       <source>Press 'OK' to disable custom startup scripts and reboot</source>
       <translation>Tryk 'OK' for at deaktivere brugerdefinerede opstartsskripter og genstarte</translation>
-    </message>
-    <message id="pagesettingssupportstate_re_enable_custom_startup_scripts">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="309"/>
-      <source>Re-enable custom startup scripts</source>
-      <translation type="unfinished">Genaktiver brugerdefinerede opstartsskripter</translation>
     </message>
     <message id="pagesettingssupportstate_reenable_and_reboot_now">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="322"/>
@@ -9698,11 +8698,6 @@ GX-enheden kan kun styre én tilsluttet generator og tager den med det laveste V
       <source>Disable also custom startup scripts?</source>
       <translation>Deaktiver også brugerdefinerede opstartsskripter?</translation>
     </message>
-    <message id="pagesettingssupportstate_integrations">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
-      <source>Integrations</source>
-      <translation type="unfinished">Integrationer</translation>
-    </message>
     <message id="pagesettingssupportstate_orange_items_description">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="494"/>
       <source>Items colored orange are supported and provided by Victron Energy, but using them incorrectly can affect system stability. In case of troubleshooting, disable those first.</source>
@@ -9714,7 +8709,7 @@ GX-enheden kan kun styre én tilsluttet generator og tager den med det laveste V
       <translation>Tilslut en kompatibel Bluetooth USB-dongle for at aktivere Bluetooth-forbindelse.</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="140"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="142"/>
       <source>BatteryLife state</source>
       <translation>BatteryLife tilstand</translation>
     </message>
@@ -9722,23 +8717,6 @@ GX-enheden kan kun styre én tilsluttet generator og tager den med det laveste V
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="33"/>
       <source>Device Integrations</source>
       <translation>Enhedsintegrationer</translation>
-    </message>
-    <message id="pagesettingsintegrations_modbus_tcp_server">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="201"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">Modbus TCP-server</translation>
-    </message>
-    <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="226"/>
-      <location filename="../../pages/settings/PageSettingsSignalK.qml" line="18"/>
-      <source>Signal K</source>
-      <translation type="unfinished">Signal K</translation>
-    </message>
-    <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="241"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">Node-RED</translation>
     </message>
     <message id="settings_venusos_large_documentation">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="267"/>
@@ -9748,6 +8726,7 @@ GX-enheden kan kun styre én tilsluttet generator og tager den med det laveste V
     <message id="settings_modbus_enable_modbus_tcp">
       <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
       <source>Enable Modbus TCP Server</source>
+      <oldsource>Enable Modbus/TCP</oldsource>
       <translation>Aktiver Modbus TCP-server</translation>
     </message>
     <message id="pagesettingsconnectivity_bluetooth_for_victronconnect_app">
@@ -9841,11 +8820,13 @@ GX-enheden kan kun styre én tilsluttet generator og tager den med det laveste V
     <message id="settings_gps_format_kmh">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="93"/>
       <source>Kilometres per hour</source>
+      <oldsource>Kilometers per hour</oldsource>
       <translation>Kilometer i timen</translation>
     </message>
     <message id="settings_gps_format_ms">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="95"/>
       <source>Metres per second</source>
+      <oldsource>Meters per second</oldsource>
       <translation>Meter i sekundet</translation>
     </message>
     <message id="components_volumeunit_cubic_metres">
@@ -9873,8 +8854,8 @@ GX-enheden kan kun styre én tilsluttet generator og tager den med det laveste V
       <source>The Relay can now be found in the devices list</source>
       <translation>Relæet kan nu findes på listen over enheder</translation>
     </message>
-    <message id="common_words_gx_device_relays">
-      <location filename="../../components/CommonWords.qml" line="223"/>
+    <message id="gx_device_relays">
+      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
       <source>GX device relays</source>
       <translation>GX-enhedsrelæer</translation>
     </message>
@@ -9928,12 +8909,6 @@ GX-enheden kan kun styre én tilsluttet generator og tager den med det laveste V
       <extracomment>Forced by app to %1</extracomment>
       <translation>auto</translation>
     </message>
-    <message id="settings_remote_console_forced_by_vrm">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="94"/>
-      <source>VRM</source>
-      <extracomment>Forced by %2 to dark</extracomment>
-      <translation type="unfinished">VRM</translation>
-    </message>
     <message id="settings_remote_console_forced_by_app">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="97"/>
       <source>app</source>
@@ -9983,6 +8958,7 @@ GX-enheden kan kun styre én tilsluttet generator og tager den med det laveste V
     <message id="settings_large_access_signal_k">
       <location filename="../../pages/settings/PageSettingsSignalK.qml" line="24"/>
       <source>Access Signal K</source>
+      <oldsource>Access Signal K (local network)</oldsource>
       <translation>Adgang til Signal K</translation>
     </message>
     <message id="pagesettingsintegrations_shelly_devices">
@@ -9993,6 +8969,7 @@ GX-enheden kan kun styre én tilsluttet generator og tager den med det laveste V
     <message id="settings_large_access_node_red">
       <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
       <source>Access Node-RED</source>
+      <oldsource>Access Node-RED (local network)</oldsource>
       <translation>Adgang til Node-RED</translation>
     </message>
     <message id="settings_wifi_access_point_password">
@@ -10060,57 +9037,6 @@ GX-enheden kan kun styre én tilsluttet generator og tager den med det laveste V
       <source>Wind charger</source>
       <translation>Vindmøllelader</translation>
     </message>
-    <message id="digitalinputs_type_disabled">
-      <location filename="../../src/enums.cpp" line="192"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Deaktiveret</translation>
-    </message>
-    <message id="digitalinputs_state_off">
-      <location filename="../../src/enums.cpp" line="242"/>
-      <source>Off</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Fra</translation>
-    </message>
-    <message id="digitalinputs_state_on">
-      <location filename="../../src/enums.cpp" line="246"/>
-      <source>On</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">On</translation>
-    </message>
-    <message id="digitalinputs_state_ok">
-      <location filename="../../src/enums.cpp" line="266"/>
-      <source>OK</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">OK</translation>
-    </message>
-    <message id="digitalinputs_state_alarm">
-      <location filename="../../src/enums.cpp" line="270"/>
-      <source>Alarm</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Alarm</translation>
-    </message>
-    <message id="digitalinputs_state_running">
-      <location filename="../../src/enums.cpp" line="274"/>
-      <source>Running</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Kører</translation>
-    </message>
-    <message id="pvinverter_statusCode_running">
-      <location filename="../../src/enums.cpp" line="300"/>
-      <source>Running</source>
-      <extracomment>PV inverter status code</extracomment>
-      <translation type="unfinished">Kører</translation>
-    </message>
-    <message id="solarchargers_state_external control">
-      <location filename="../../src/enums.cpp" line="352"/>
-      <source>External control</source>
-      <translation type="unfinished">Ekstern styring</translation>
-    </message>
-    <message id="switch_state_over_temperature">
-      <location filename="../../src/enums.cpp" line="366"/>
-      <source>Over temperature</source>
-      <translation type="unfinished">Over temperatur</translation>
-    </message>
     <message id="switchable_output_temperature_setpoint">
       <location filename="../../src/enums.cpp" line="398"/>
       <source>Temperature setpoint</source>
@@ -10120,11 +9046,6 @@ GX-enheden kan kun styre én tilsluttet generator og tager den med det laveste V
       <location filename="../../src/enums.cpp" line="401"/>
       <source>Stepped switch</source>
       <translation>Trinvis kontakt</translation>
-    </message>
-    <message id="switchable_output_slave">
-      <location filename="../../src/enums.cpp" line="408"/>
-      <source>Slave</source>
-      <translation type="unfinished">Slave</translation>
     </message>
     <message id="switchable_output_dropdown">
       <location filename="../../src/enums.cpp" line="412"/>
@@ -10136,122 +9057,10 @@ GX-enheden kan kun styre én tilsluttet generator og tager den med det laveste V
       <source>Basic slider</source>
       <translation>Simpel skyder</translation>
     </message>
-    <message id="switchable_output_rgb_color_wheel">
-      <location filename="../../src/enums.cpp" line="427"/>
-      <source>RGB color wheel</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_cct_color_wheel">
-      <location filename="../../src/enums.cpp" line="431"/>
-      <source>CCT color wheel</source>
-      <extracomment>Correlated Color Temperature color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_rgbw_color_wheel">
-      <location filename="../../src/enums.cpp" line="435"/>
-      <source>RGB + W color wheel</source>
-      <extracomment>RGB + white color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bypassed">
-      <location filename="../../src/enums.cpp" line="484"/>
-      <source>Bypassed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="tank_type_fuel">
-      <location filename="../../src/enums.cpp" line="495"/>
-      <source>Fuel</source>
-      <translation type="unfinished">Brændstof (L)</translation>
-    </message>
-    <message id="tank_type_fresh_water">
-      <location filename="../../src/enums.cpp" line="498"/>
-      <source>Fresh water</source>
-      <translation type="unfinished">Ferskvand</translation>
-    </message>
-    <message id="tank_type_waste_water">
-      <location filename="../../src/enums.cpp" line="501"/>
-      <source>Waste water</source>
-      <translation type="unfinished">Affalds vand</translation>
-    </message>
-    <message id="tank_type_live_well">
-      <location filename="../../src/enums.cpp" line="504"/>
-      <source>Live well</source>
-      <translation type="unfinished">Drikkevand</translation>
-    </message>
-    <message id="tank_type_oil">
-      <location filename="../../src/enums.cpp" line="507"/>
-      <source>Oil</source>
-      <translation type="unfinished">Olie</translation>
-    </message>
-    <message id="tank_type_black_water">
-      <location filename="../../src/enums.cpp" line="510"/>
-      <source>Black water</source>
-      <translation type="unfinished">Sort vand</translation>
-    </message>
-    <message id="tank_type_gasoline">
-      <location filename="../../src/enums.cpp" line="513"/>
-      <source>Gasoline</source>
-      <translation type="unfinished">Benzin</translation>
-    </message>
-    <message id="tank_type_diesel">
-      <location filename="../../src/enums.cpp" line="516"/>
-      <source>Diesel</source>
-      <translation type="unfinished">Diesel</translation>
-    </message>
-    <message id="tank_type_lpg">
-      <location filename="../../src/enums.cpp" line="519"/>
-      <source>LPG</source>
-      <translation type="unfinished">LPG</translation>
-    </message>
-    <message id="tank_type_lng">
-      <location filename="../../src/enums.cpp" line="522"/>
-      <source>LNG</source>
-      <translation type="unfinished">LNG</translation>
-    </message>
-    <message id="tank_type_hydraulic_oil">
-      <location filename="../../src/enums.cpp" line="525"/>
-      <source>Hydraulic oil</source>
-      <translation type="unfinished">Hydraulik olie</translation>
-    </message>
-    <message id="tank_type_raw_water">
-      <location filename="../../src/enums.cpp" line="528"/>
-      <source>Raw water</source>
-      <translation type="unfinished">Rå vand</translation>
-    </message>
-    <message id="microgrid_mode_hybrid_droop">
-      <location filename="../../src/enums.cpp" line="539"/>
-      <source>Hybrid droop</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_following">
-      <location filename="../../src/enums.cpp" line="542"/>
-      <source>Grid-following</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_forming">
-      <location filename="../../src/enums.cpp" line="545"/>
-      <source>Grid-forming</source>
-      <translation type="unfinished"/>
-    </message>
     <message id="switchable_output_three_state_switch">
       <location filename="../../src/enums.cpp" line="421"/>
       <source>Three-state switch</source>
       <translation>Tre-trins kontakt</translation>
-    </message>
-    <message id="switchable_output_fault">
-      <location filename="../../src/enums.cpp" line="464"/>
-      <source>Fault</source>
-      <translation type="unfinished">Fejl</translation>
-    </message>
-    <message id="switchable_output_running">
-      <location filename="../../src/enums.cpp" line="468"/>
-      <source>Running</source>
-      <translation type="unfinished">Kører</translation>
-    </message>
-    <message id="switchable_output_trip_low_voltage">
-      <location filename="../../src/enums.cpp" line="481"/>
-      <source>Trip low voltage</source>
-      <translation type="unfinished">Deaktiveret</translation>
     </message>
     <message id="settings_modbus_tcp_unit_id_note">
       <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="41"/>
@@ -10273,281 +9082,1152 @@ GX-enheden kan kun styre én tilsluttet generator og tager den med det laveste V
       <source>Press to refresh</source>
       <translation>Tryk for at opdatere</translation>
     </message>
-    <message id="temperature_type_unknown">
-      <location filename="../../data/EnvironmentInputs.qml" line="65"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Ukendt</translation>
-    </message>
-    <message id="brief_solar_yield">
-      <location filename="../../pages/BriefSidePanel.qml" line="24"/>
-      <source>Solar yield</source>
-      <translation type="unfinished">Sol produktion</translation>
-    </message>
-    <message id="brief_dc_input">
-      <location filename="../../pages/BriefSidePanel.qml" line="214"/>
-      <source>DC input</source>
-      <translation type="unfinished">DC-indgang</translation>
-    </message>
-    <message id="brief_ac_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="257"/>
-      <source>AC Loads</source>
-      <translation type="unfinished">AC forbrug</translation>
-    </message>
-    <message id="brief_dc_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="284"/>
-      <source>DC Loads</source>
-      <translation type="unfinished">DC forbrug</translation>
-    </message>
-    <message id="nav_overview">
-      <location filename="../../pages/OverviewPage.qml" line="450"/>
-      <source>Overview</source>
-      <translation type="unfinished">Oversigt</translation>
-    </message>
-    <message id="settings_state">
-      <location filename="../../pages/settings/PageCanbusStatus.qml" line="116"/>
-      <source>State</source>
-      <translation type="unfinished">Tilstand</translation>
-    </message>
-    <message id="inverter_pv">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="56"/>
-      <source>PV</source>
-      <translation type="unfinished">PV</translation>
-    </message>
-    <message id="inverter_total_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="76"/>
-      <source>Total yield</source>
-      <translation type="unfinished">Total produktion</translation>
-    </message>
-    <message id="inverter_system_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="84"/>
-      <source>System yield</source>
-      <translation type="unfinished">Systemets produktion</translation>
-    </message>
-    <message id="charger_total_pv_power">
-      <location filename="../../pages/solar/SolarDevicePage.qml" line="61"/>
-      <source>Total PV Power</source>
-      <translation type="unfinished">Total PV power</translation>
-    </message>
-    <message id="vebus_device_alarm_only">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
-      <source>Alarm only</source>
-      <translation type="unfinished">Kun alarm</translation>
-    </message>
-    <message id="vebus_device_alarms_and_warnings">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
-      <source>Alarms &amp; warnings</source>
-      <translation type="unfinished">Alarmer &amp; advarsler</translation>
-    </message>
-    <message id="vebus_device_alarm_group_warning">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
-      <source>Warning</source>
-      <translation type="unfinished">Advarsel</translation>
-    </message>
-    <message id="load_delegate_status">
-      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
-      <source>Status: %1</source>
-      <translation type="unfinished"/>
+    <message id="common_words_total_power">
+      <location filename="../../components/CommonWords.qml" line="540"/>
+      <source>Total power</source>
+      <translation>Samlet effekt</translation>
     </message>
     <message id="venus_os_gui">
       <location filename="../../Main.qml" line="17"/>
       <source>Venus OS GUI</source>
       <extracomment>Application title</extracomment>
-      <translation type="unfinished"/>
       <extra-Context>only shown on desktop systems</extra-Context>
+      <translation>Venus OS GUI</translation>
+    </message>
+    <message id="load_delegate_status">
+      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
+      <source>Status: %1</source>
+      <translation>Status: %1</translation>
+    </message>
+    <message id="settings_relay_polarity_relay1">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
+      <source>Polarity (Relay 1)</source>
+      <translation>Polaritet (Relæ 1)</translation>
+    </message>
+    <message id="settings_relay_polarity">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
+      <source>Polarity</source>
+      <translation>Polaritet</translation>
+    </message>
+    <message id="settings_relay_polarity_relay2">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
+      <source>Polarity (Relay 2)</source>
+      <translation>Polaritet (Relæ 2)</translation>
+    </message>
+    <message id="page_settings_wifi_invalid_password">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
+      <source>Password length must be either 0 or between 10 and 63 characters long</source>
+      <translation>Adgangskoden skal enten være 0 eller mellem 10 og 63 tegn lang</translation>
+    </message>
+    <message id="page_settings_wifi_password_updated">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
+      <source>Password updated</source>
+      <translation>Adgangskode opdateret</translation>
+    </message>
+    <message id="common_words_max">
+      <location filename="../../components/CommonWords.qml" line="315"/>
+      <source>Max</source>
+      <extracomment>Short for Maximum</extracomment>
+      <translation>Maks.</translation>
+    </message>
+    <message id="common_words_min">
+      <location filename="../../components/CommonWords.qml" line="331"/>
+      <source>Min</source>
+      <extracomment>Short for Minimum</extracomment>
+      <translation>Min.</translation>
+    </message>
+    <message id="settings_ess_deprecated">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="321"/>
+      <source>Deprecated settings</source>
+      <translation>Udgåede indstillinger</translation>
+    </message>
+    <message id="settings_ess_max_charge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="328"/>
+      <source>Battery charge limit (% of CCL)</source>
+      <translation>Batteriopladningsgrænse (% af CCL)</translation>
+    </message>
+    <message id="settings_ess_max_discharge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="339"/>
+      <source>Battery discharge limit (% of DCL)</source>
+      <translation>Batteriafladningsgrænse (% af DCL)</translation>
+    </message>
+    <message id="vebus_device_bms_message">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
+      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
+      <oldsource>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</oldsource>
+      <translation>Et VE.Bus BMS slukker automatisk systemet, når det er nødvendigt for at beskytte batteriet. Det er derfor ikke muligt at styre systemet fra GX-enheden.</translation>
+    </message>
+    <message id="switchable_output_numeric_input">
+      <location filename="../../src/enums.cpp" line="418"/>
+      <source>Numeric input</source>
+      <translation>Numerisk input</translation>
     </message>
     <message id="autotoggleswitch_disable_auto_mode_info">
       <location filename="../../components/controls/AutoToggleButton.qml" line="34"/>
       <source>Disable Auto mode first</source>
-      <translation type="unfinished"/>
+      <translation>Deaktiver først automatisk tilstand</translation>
+    </message>
+    <message id="pagesettingsintegrations_venus_os_enable_large_features">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
+      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
+      <translation>Aktivér Venus OS Large-firmwaren for at bruge Node-RED eller Signal-K</translation>
+    </message>
+    <message id="settings_relays_sensors_tanks">
+      <location filename="../../pages/SettingsPage.qml" line="75"/>
+      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
+      <oldsource>Relays, Sensors, Tanks, PV Inverters, Modbus, MQTT…</oldsource>
+      <translation>Relæer, sensorer, PV-invertere, Modbus, Node-RED</translation>
+    </message>
+    <message id="vebus_device_page_microgrid_parameters">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
+      <source>Microgrid parameters</source>
+      <translation>Mikronet-parametre</translation>
+    </message>
+    <message id="microgrid_mode_hybrid_droop">
+      <location filename="../../src/enums.cpp" line="539"/>
+      <source>Hybrid droop</source>
+      <translation>Hybrid droop</translation>
+    </message>
+    <message id="microgrid_mode_grid_following">
+      <location filename="../../src/enums.cpp" line="542"/>
+      <source>Grid-following</source>
+      <translation>Netfølgende</translation>
+    </message>
+    <message id="microgrid_mode_grid_forming">
+      <location filename="../../src/enums.cpp" line="545"/>
+      <source>Grid-forming</source>
+      <translation>Netdannende</translation>
+    </message>
+    <message id="switchable_output_trip_low_voltage">
+      <location filename="../../src/enums.cpp" line="481"/>
+      <source>Trip low voltage</source>
+      <oldsource>Disabled</oldsource>
+      <translation>Lavspændingsfrakobling</translation>
     </message>
     <message id="microgrid">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="15"/>
       <source>Microgrid</source>
-      <translation type="unfinished"/>
+      <translation>Mikronet</translation>
     </message>
     <message id="page_microgrid_active_mode">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="19"/>
       <source>Active mode</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_microgrid_from_p1_to_p2">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="34"/>
-      <source>%1 %2 to %3 %4</source>
-      <extracomment>Describes a range from one quantity to another, e.g. "30 W to 60 W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
-      <translation type="unfinished"/>
+      <translation>Aktiv tilstand</translation>
     </message>
     <message id="page_microgrid_hybrid_droop_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="92"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
       <source>Hybrid droop parameters</source>
-      <translation type="unfinished"/>
+      <translation>Hybrid droop-parametre</translation>
     </message>
     <message id="page_microgrid_reference_active_power_p0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="105"/>
       <source>Reference active power (P&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Reference aktiv effekt (P&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_frequency_f0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="108"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="112"/>
       <source>Reference frequency (f&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Referencefrekvens (f&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_frequency_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="117"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="119"/>
       <source>Frequency droop slope (droop&lt;sub&gt;fP&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Frekvens-droop-hældning (droop&lt;sub&gt;fP&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_reactive_power">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="126"/>
       <source>Reference reactive power (Q&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Reference reaktiv effekt (Q&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_voltage">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="135"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="133"/>
       <source>Reference Voltage (U&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Referencespænding (U&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_voltage_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="144"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="140"/>
       <source>Voltage droop slope (droop&lt;sub&gt;UQ&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Spændings-droop-hældning (droop&lt;sub&gt;UQ&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_minimum_and_maximum_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="146"/>
       <source>Minimum and maximum parameters</source>
-      <translation type="unfinished"/>
+      <translation>Minimum- og maksimumparametre</translation>
     </message>
     <message id="page_microgrid_allowed_active_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="156"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
       <source>Allowed active power range</source>
-      <translation type="unfinished"/>
+      <translation>Tilladt aktiv effektområde</translation>
     </message>
     <message id="page_microgrid_allowed_reactive_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="164"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="159"/>
       <source>Allowed reactive power range</source>
-      <translation type="unfinished"/>
+      <translation>Tilladt reaktiv effektområde</translation>
     </message>
     <message id="page_microgrid_p_q_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="176"/>
       <source>P-Q direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>P-Q-direkte drev-indstillinger</translation>
     </message>
     <message id="page_microgrid_active_power_setpoint_p">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="186"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
       <source>Active power setpoint (P)</source>
-      <translation type="unfinished"/>
+      <translation>Aktiv effekt-sætpunkts (P)</translation>
     </message>
     <message id="page_microgrid_reactive_power_setpoint_q">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="194"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="188"/>
       <source>Reactive power setpoint (Q)</source>
-      <translation type="unfinished"/>
+      <translation>Reaktiv effekt-sætpunkts (Q)</translation>
     </message>
     <message id="page_microgrid_allowed_frequency_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="202"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="195"/>
       <source>Allowed frequency range</source>
-      <translation type="unfinished"/>
+      <translation>Tilladt frekvensområde</translation>
     </message>
     <message id="page_microgrid_allowed_voltage_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="210"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="203"/>
       <source>Allowed voltage range</source>
-      <translation type="unfinished"/>
+      <translation>Tilladt spændingsområde</translation>
     </message>
     <message id="page_microgrid_v_f_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="227"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="220"/>
       <source>V-f direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>V-f-direkte drev-indstillinger</translation>
     </message>
     <message id="page_microgrid_voltage_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="225"/>
       <source>Voltage setpoint (U)</source>
-      <translation type="unfinished"/>
+      <translation>Spændingssætpunkts (U)</translation>
     </message>
     <message id="page_microgrid_frequency_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="240"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
       <source>Frequency setpoint (f)</source>
-      <translation type="unfinished"/>
+      <translation>Frekvenssætpunkts (f)</translation>
     </message>
-    <message id="temperature_slider_current">
-      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
-      <source>Current</source>
-      <extracomment>The current temperature measurement</extracomment>
-      <translation type="unfinished">Strøm</translation>
+    <message id="pagesettingsintegrations_canopenmotordrive">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
+      <source>CANopen motor drives</source>
+      <translation>CANopen motordrev</translation>
+    </message>
+    <message id="pagesettingsintegrations_ui_plugins">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
+      <source>UI Plugins</source>
+      <translation>UI-plugins</translation>
+    </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
+      <source>Motor Direction Inverted</source>
+      <translation>Motorretning inverteret</translation>
     </message>
     <message id="page_settings_canopenmotordrive_scan_for_motor_drives">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="31"/>
       <source>Scan for motor drives</source>
-      <translation type="unfinished"/>
+      <translation>Scan efter motordrev</translation>
     </message>
     <message id="page_settings_canopenmotordrive_discovered_motor_drive_ids">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="39"/>
       <source>Discovered motor drive IDs</source>
-      <translation type="unfinished"/>
+      <translation>Fundne motordrevs-ID'er</translation>
     </message>
-    <message id="switchableoutput_gx_device_relays">
-      <location filename="../../src/switchableoutput.cpp" line="388"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">GX-enhedsrelæer</translation>
+    <message id="temperature_pm25">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
+      <source>PM2.5</source>
+      <translation>PM2,5</translation>
     </message>
-    <message id="gx_device_relays">
-      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">GX-enhedsrelæer</translation>
+    <message id="temperature_co2">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+      <source>CO₂</source>
+      <translation>CO₂</translation>
     </message>
-    <message id="color_preset">
-      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
-      <source>Preset</source>
-      <translation type="unfinished"/>
+    <message id="temperature_voc">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
+      <source>VOC index</source>
+      <translation>VOC-indeks</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_location">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
-      <source>Add Modbus port and unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_nox">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
+      <source>NOx index</source>
+      <translation>NOx-indeks</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_unitid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
-      <source>Unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_luminosity">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
+      <source>Luminosity</source>
+      <translation>Lysstyrke</translation>
     </message>
-    <message id="page_settings_fronius_unitid_invalid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation type="unfinished">%1 er ikke et gyldigt enhedsnummer. Brug et tal mellem 1-247.</translation>
-    </message>
-    <message id="page_settings_fronius_add_modbus_location_button">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
-      <source>Add</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_locations_note">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
-      <source>The default modbus port is 502 and the default unit ID is 126.
-Here you can add additional ports and unit IDs to scan for PV inverters.</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_location_number">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
-      <source>Port/Unit ID %1</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location_description">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
-      <source>Port: %1 (Unit %2)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
-      <source>Remove Modbus port and unit ID?</source>
-      <translation type="unfinished"/>
+    <message id="switchable_output_bypassed">
+      <location filename="../../src/enums.cpp" line="484"/>
+      <source>Bypassed</source>
+      <translation>Forbigået</translation>
     </message>
     <message id="switchableoutput_list_delegate_auto_status">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="84"/>
       <source>Auto (%1)</source>
       <extracomment>%1 = 'On' or 'Off'</extracomment>
-      <translation type="unfinished"/>
+      <translation>Auto (%1)</translation>
     </message>
     <message id="switchableoutput_list_delegate_state_forced">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="100"/>
       <source>Forced</source>
-      <translation type="unfinished"/>
+      <translation>Tvunget</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_settings">
+      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
+      <source>Modbus port and unit ID settings</source>
+      <translation>Indstillinger for Modbus-port og enheds-ID</translation>
+    </message>
+    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
+      <source>Integrates with the device list</source>
+      <translation>Integreres med enhedslisten</translation>
+    </message>
+    <message id="common_words_color">
+      <location filename="../../components/CommonWords.qml" line="136"/>
+      <source>Color</source>
+      <translation>Farve</translation>
+    </message>
+    <message id="common_words_value_must_be_greater_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="557"/>
+      <source>Value must be greater than start value</source>
+      <translation>Værdien skal være større end startværdien</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="566"/>
+      <source>Value must be lower than stop value</source>
+      <translation>Værdien skal være lavere end stopværdien</translation>
+    </message>
+    <message id="notifications_page_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="43"/>
+      <source>Active Notifications</source>
+      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
+      <translation>Aktive notifikationer</translation>
+    </message>
+    <message id="notifications_page_inactive_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="47"/>
+      <source>Inactive Notifications</source>
+      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
+      <translation>Inaktive notifikationer</translation>
+    </message>
+    <message id="notifications_no_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="106"/>
+      <source>No active notifications</source>
+      <translation>Ingen aktive notifikationer</translation>
+    </message>
+    <message id="switchable_output_rgb_color_wheel">
+      <location filename="../../src/enums.cpp" line="427"/>
+      <source>RGB color wheel</source>
+      <translation>RGB-farvehjul</translation>
+    </message>
+    <message id="switchable_output_cct_color_wheel">
+      <location filename="../../src/enums.cpp" line="431"/>
+      <source>CCT color wheel</source>
+      <extracomment>Correlated Color Temperature color wheel</extracomment>
+      <translation>CCT-farvehjul</translation>
+    </message>
+    <message id="switchable_output_rgbw_color_wheel">
+      <location filename="../../src/enums.cpp" line="435"/>
+      <source>RGB + W color wheel</source>
+      <extracomment>RGB + white color wheel</extracomment>
+      <translation>RGB + W-farvehjul</translation>
+    </message>
+    <message id="listlink_show_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="43"/>
+      <source>Show QR code</source>
+      <translation>Vis QR-kode</translation>
+    </message>
+    <message id="listlink_scan_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="52"/>
+      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
+      <extracomment>%1 = url text</extracomment>
+      <oldsource>Scan the QR code with your portable device.&lt;br /&gt;Or insert the link: %1</oldsource>
+      <translation>Åbn QR-koden for at scanne den med din bærbare enhed.&lt;br /&gt;Eller indsæt linket: %1</translation>
+    </message>
+    <message id="color_preset">
+      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
+      <source>Preset</source>
+      <translation>Forudindstilling</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
+      <source>Add Modbus port and unit ID</source>
+      <translation>Tilføj Modbus-port og enheds-ID</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_unitid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
+      <source>Unit ID</source>
+      <translation>Enheds-ID</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location_button">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
+      <source>Add</source>
+      <translation>Tilføj</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_locations_note">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
+      <source>The default modbus port is 502 and the default unit ID is 126.
+Here you can add additional ports and unit IDs to scan for PV inverters.</source>
+      <translation>Standard Modbus-porten er 502, og standard enheds-ID'et er 126.
+Her kan du tilføje yderligere porte og enheds-ID'er til at scanne efter PV-invertere.</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_location_number">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
+      <source>Port/Unit ID %1</source>
+      <translation>Port/Enheds-ID %1</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location_description">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
+      <source>Port: %1 (Unit %2)</source>
+      <translation>Port: %1 (Enhed %2)</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
+      <source>Remove Modbus port and unit ID?</source>
+      <translation>Fjern Modbus-port og enheds-ID?</translation>
+    </message>
+    <message id="devicelist_tankshape_edit_point">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="182"/>
+      <source>Edit point %1</source>
+      <extracomment>%1 = which point is being edited, a number like "1" or "2"</extracomment>
+      <translation></translation>
+    </message>
+    <message id="settings_canbus_vecan">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
+      <source>VE.Can (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_250">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <source>VE.Can &amp; CANopen E-drive (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_500">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
+      <source>CANopen E-drive (500 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="page_microgrid_from_p1_to_p2">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="39"/>
+      <source>%1%2 to %3%4</source>
+      <extracomment>Describes a range from one quantity to another, e.g. "30W to 60W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
+      <translation></translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAfricaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
+      <source>Morocco Standard Time</source>
+      <translation>Marokkansk standard tid</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
+      <source>W. Central Africa Standard Time</source>
+      <translation>W. Central Africa Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
+      <source>South Africa Standard Time</source>
+      <translation>South Africa Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
+      <source>Namibia Standard Time</source>
+      <translation>Namibia Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
+      <source>Egypt Standard Time</source>
+      <translation>Egypt Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
+      <source>E. Africa Standard Time</source>
+      <translation>E. Africa Standard Time</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAmericaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
+      <source>Argentina Standard Time</source>
+      <translation>Argentina Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
+      <source>E. South America Standard Time</source>
+      <translation>E. South America Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
+      <source>Greenland Standard Time</source>
+      <translation>Greenland Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
+      <source>Montevideo Standard Time</source>
+      <translation>Montevideo Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
+      <source>Newfoundland Standard Time</source>
+      <translation>Newfoundland Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
+      <source>SA Eastern Standard Time</source>
+      <translation>SA Eastern Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
+      <source>Atlantic Standard Time</source>
+      <translation>Atlantic Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
+      <source>Central Brazilian Standard Time</source>
+      <translation>Central Brazilian Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>Pacific SA Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
+      <source>Paraguay Standard Time</source>
+      <translation>Paraguay Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
+      <source>SA Western Standard Time</source>
+      <translation>SA Western Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
+      <source>Venezuela Standard Time</source>
+      <translation>Venezuela Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
+      <source>Eastern Standard Time</source>
+      <translation>Eastern Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
+      <source>SA Pacific Standard Time</source>
+      <translation>SA Pacific Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
+      <source>US Eastern Standard Time</source>
+      <translation>US Eastern Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
+      <source>Canada Central Standard Time</source>
+      <translation>Canada Central Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
+      <source>Central America Standard Time</source>
+      <translation>Central America Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
+      <source>Central Standard Time (Mexico)</source>
+      <translation>Central Standard Time (Mexico)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
+      <source>Central Standard Time</source>
+      <translation>Central Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
+      <source>Mountain Standard Time (Mexico)</source>
+      <translation>Mountain Standard Time (Mexico)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
+      <source>Mountain Standard Time</source>
+      <translation>Mountain Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
+      <source>US Mountain Standard Time</source>
+      <translation>US Mountain Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
+      <source>Pacific Standard Time (Mexico)</source>
+      <translation>Pacific Standard Time (Mexico)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
+      <source>Pacific Standard Time</source>
+      <translation>Pacific Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
+      <source>Alaskan Standard Time</source>
+      <translation>Alaskan Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
+      <source>Hawaii-Aleutian</source>
+      <translation>Hawaii-Aleutian</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
+      <source>Atlantic Daylight Time</source>
+      <translation>Atlantisk sommertid</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAntarcticaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+      <source>New Zealand Standard Time</source>
+      <translation>New Zealand Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>Central Pacific Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+      <source>West Pacific Standard Time</source>
+      <translation>West Pacific Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+      <source>W. Australia Standard Time</source>
+      <translation>W. Australia Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+      <source>SE Asia Standard Time</source>
+      <translation>SE Asia Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+      <source>Central Asia Standard Time</source>
+      <translation>Central Asia Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+      <source>West Asia Standard Time</source>
+      <translation>West Asia Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+      <source>E. Africa Standard Time</source>
+      <translation>E. Africa Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>Pacific SA Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+      <source>SA Western Standard Time</source>
+      <translation>SA Western Standard Time</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzArcticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
+      <source>W. Europe Standard Time</source>
+      <translation>W. Europe Standard Time</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAsiaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
+      <source>Kamchatka Standard Time</source>
+      <translation>Kamchatka Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
+      <source>Magadan Standard Time</source>
+      <translation>Magadan Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
+      <source>Vladivostok Standard Time</source>
+      <translation>Vladivostok Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
+      <source>Yakutsk Standard Time</source>
+      <translation>Yakutsk Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
+      <source>Tokyo Standard Time</source>
+      <translation>Tokyo Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
+      <source>Korea Standard Time</source>
+      <translation>Korea Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
+      <source>Singapore Standard Time</source>
+      <translation>Singapore Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
+      <source>Ulaanbaatar Standard Time</source>
+      <translation>Ulaanbaatar Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
+      <source>Taipei Standard Time</source>
+      <translation>Taipei Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
+      <source>North Asia East Standard Time</source>
+      <translation>North Asia East Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
+      <source>China Standard Time</source>
+      <translation>China Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
+      <source>SE Asia Standard Time</source>
+      <translation>SE Asia Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
+      <source>North Asia Standard Time</source>
+      <translation>North Asia Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
+      <source>Myanmar Standard Time</source>
+      <translation>Myanmar Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
+      <source>N. Central Asia Standard Time</source>
+      <translation>N. Central Asia Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
+      <source>Central Asia Standard Time</source>
+      <translation>Central Asia Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
+      <source>Bangladesh Standard Time</source>
+      <translation>Bangladesh Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
+      <source>Nepal Standard Time</source>
+      <translation>Nepal Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
+      <source>Sri Lanka Standard Time</source>
+      <translation>Sri Lanka Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
+      <source>India Standard Time</source>
+      <translation>India Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
+      <source>West Asia Standard Time</source>
+      <translation>West Asia Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
+      <source>Pakistan Standard Time</source>
+      <translation>Pakistan Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
+      <source>Ekaterinburg Standard Time</source>
+      <translation>Ekaterinburg Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
+      <source>Georgian Standard Time</source>
+      <translation>Georgian Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
+      <source>Caucasus Standard Time</source>
+      <translation>Caucasus Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
+      <source>Azerbaijan Standard Time</source>
+      <translation>Azerbaijan Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
+      <source>Arabian Standard Time</source>
+      <translation>Arabian Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
+      <source>Afghanistan Standard Time</source>
+      <translation>Afghanistan Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
+      <source>Iran Standard Time</source>
+      <translation>Iran Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
+      <source>Arabic Standard Time</source>
+      <translation>Arabic Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
+      <source>Arab Standard Time</source>
+      <translation>Arab Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
+      <source>Syria Standard Time</source>
+      <translation>Syria Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
+      <source>Middle East Standard Time</source>
+      <translation>Middle East Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
+      <source>Jordan Standard Time</source>
+      <translation>Jordan Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
+      <source>Israel Standard Time</source>
+      <translation>Israel Standard Time</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAtlanticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+      <source>Greenwich Standard Time</source>
+      <translation>Greenwich Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+      <source>Azores Standard Time</source>
+      <translation>Azores Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+      <source>Cape Verde Standard Time</source>
+      <translation>Cape Verde Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
+      <source>Mid-Atlantic Standard Time</source>
+      <translation>Mid-Atlantic Standard Time</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAustraliaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+      <source>Tasmania Standard Time</source>
+      <translation>Tasmania Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+      <source>E. Australia Standard Time</source>
+      <translation>E. Australia Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+      <source>AUS Eastern Standard Time</source>
+      <translation>AUS Eastern Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+      <source>Cen. Australia Standard Time</source>
+      <translation>Cen. Australia Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+      <source>AUS Central Standard Time</source>
+      <translation>AUS Central Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+      <source>W. Australia Standard Time</source>
+      <translation>W. Australia Standard Time</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEtcData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
+      <source>GMT +12</source>
+      <translation>GMT +12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
+      <source>GMT -02</source>
+      <translation>GMT -02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
+      <source>GMT -11</source>
+      <translation>GMT -11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
+      <source>GMT -13</source>
+      <translation>GMT -13</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
+      <source>GMT -12</source>
+      <translation>GMT -12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
+      <source>GMT -10</source>
+      <translation>GMT -10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
+      <source>GMT -09</source>
+      <translation>GMT -09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
+      <source>GMT -08</source>
+      <translation>GMT -08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
+      <source>GMT -07</source>
+      <translation>GMT -07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
+      <source>GMT -06</source>
+      <translation>GMT -06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
+      <source>GMT -05</source>
+      <translation>GMT -05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
+      <source>GMT -04</source>
+      <translation>GMT -04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
+      <source>GMT -03</source>
+      <translation>GMT -03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
+      <source>GMT -01</source>
+      <translation>GMT -01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
+      <source>GMT</source>
+      <translation>GMT</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
+      <source>GMT +01</source>
+      <translation>GMT +01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
+      <source>GMT +02</source>
+      <translation>GMT +02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
+      <source>GMT +03</source>
+      <translation>GMT +03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
+      <source>GMT +04</source>
+      <translation>GMT +04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
+      <source>GMT +05</source>
+      <translation>GMT +05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
+      <source>GMT +06</source>
+      <translation>GMT +06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
+      <source>GMT +07</source>
+      <translation>GMT +07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
+      <source>GMT +08</source>
+      <translation>GMT +08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
+      <source>GMT +09</source>
+      <translation>GMT +09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
+      <source>GMT +10</source>
+      <translation>GMT +10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
+      <source>GMT +11</source>
+      <translation>GMT +11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
+      <source>UTC</source>
+      <translation>UTC</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEuropeData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
+      <source>GMT Standard Time</source>
+      <translation>GMT Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
+      <source>Central Europe Standard Time</source>
+      <translation>Central Europe Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
+      <source>Central European Standard Time</source>
+      <translation>Central European Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
+      <source>Romance Standard Time</source>
+      <translation>Romance Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
+      <source>W. Europe Standard Time</source>
+      <translation>W. Europe Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
+      <source>E. Europe Standard Time</source>
+      <translation>E. Europe Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
+      <source>FLE Standard Time</source>
+      <translation>FLE Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
+      <source>GTB Standard Time</source>
+      <translation>GTB Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
+      <source>Belarus Standard Time</source>
+      <translation>Belarus Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
+      <source>Russian Standard Time</source>
+      <translation>Russian Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
+      <source>Turkey Standard Time</source>
+      <translation>Turkey Standard Time</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzIndianData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
+      <source>Mauritius Standard Time</source>
+      <translation>Mauritius Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
+      <source>Christmas Island Standard Time</source>
+      <translation>Christmas Island Standard Time</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzPacificData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
+      <source>Tonga Standard Time</source>
+      <translation>Tonga Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
+      <source>Fiji Standard Time</source>
+      <translation>Fiji Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
+      <source>New Zealand Standard Time</source>
+      <translation>New Zealand Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>Central Pacific Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
+      <source>West Pacific Standard Time</source>
+      <translation>West Pacific Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
+      <source>Samoa Standard Time</source>
+      <translation>Samoa Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
+      <source>Hawaiian Standard Time</source>
+      <translation>Hawaiian Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
+      <source>Easter Island Standard Time</source>
+      <translation>Easter Island Standard Time</translation>
     </message>
   </context>
   <context>
@@ -12176,838 +11856,6 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
     </message>
   </context>
   <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>Marokkansk standard tid</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>W. Central Africa Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>South Africa Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>Namibia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>Egypt Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>E. Africa Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>Argentina Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>E. South America Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>Greenland Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>Montevideo Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>Newfoundland Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>SA Eastern Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Atlantic Standard Time</source>
-      <translation>Atlantic Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>Central Brazilian Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Pacific SA Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>Paraguay Standard Time</source>
-      <translation>Paraguay Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>SA Western Standard Time</source>
-      <translation>SA Western Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Venezuela Standard Time</source>
-      <translation>Venezuela Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>Eastern Standard Time</source>
-      <translation>Eastern Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>SA Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>US Eastern Standard Time</source>
-      <translation>US Eastern Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Canada Central Standard Time</source>
-      <translation>Canada Central Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central America Standard Time</source>
-      <translation>Central America Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>Central Standard Time (Mexico)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Central Standard Time</source>
-      <translation>Central Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>Mountain Standard Time (Mexico)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>Mountain Standard Time</source>
-      <translation>Mountain Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>US Mountain Standard Time</source>
-      <translation>US Mountain Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>Pacific Standard Time (Mexico)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Pacific Standard Time</source>
-      <translation>Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Alaskan Standard Time</source>
-      <translation>Alaskan Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>Hawaii-Aleutian</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Daylight Time</source>
-      <translation>Atlantisk sommertid</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>New Zealand Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Central Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>West Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>W. Australia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>SE Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Central Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>West Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>E. Africa Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Pacific SA Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>SA Western Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>W. Europe Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>Kamchatka Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>Magadan Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>Vladivostok Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>Yakutsk Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>Tokyo Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>Korea Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>Singapore Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>Ulaanbaatar Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>Taipei Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>North Asia East Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>China Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>SE Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>North Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>Myanmar Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>N. Central Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Central Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>Bangladesh Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>Nepal Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>Sri Lanka Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>India Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>West Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>Pakistan Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>Ekaterinburg Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>Georgian Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>Caucasus Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>Azerbaijan Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>Arabian Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>Afghanistan Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>Iran Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>Arabic Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>Arab Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>Syria Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>Middle East Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>Jordan Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>Israel Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>Greenwich Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>Azores Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>Cape Verde Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>Mid-Atlantic Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>Tasmania Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>E. Australia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>AUS Eastern Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>Cen. Australia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>AUS Central Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>W. Australia Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
-      <source>GMT +12</source>
-      <translation>GMT +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
-      <source>GMT -02</source>
-      <translation>GMT -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT -13</source>
-      <translation>GMT -13</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT -12</source>
-      <translation>GMT -12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -10</source>
-      <translation>GMT -10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -09</source>
-      <translation>GMT -09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>GMT -08</source>
-      <translation>GMT -08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
-      <source>GMT -07</source>
-      <translation>GMT -07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
-      <source>GMT -06</source>
-      <translation>GMT -06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
-      <source>GMT -05</source>
-      <translation>GMT -05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
-      <source>GMT -04</source>
-      <translation>GMT -04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
-      <source>GMT -03</source>
-      <translation>GMT -03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
-      <source>GMT -01</source>
-      <translation>GMT -01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
-      <source>GMT</source>
-      <translation>GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
-      <source>GMT +01</source>
-      <translation>GMT +01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
-      <source>GMT +02</source>
-      <translation>GMT +02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
-      <source>GMT +03</source>
-      <translation>GMT +03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
-      <source>GMT +04</source>
-      <translation>GMT +04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
-      <source>GMT +05</source>
-      <translation>GMT +05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
-      <source>GMT +06</source>
-      <translation>GMT +06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
-      <source>GMT +07</source>
-      <translation>GMT +07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
-      <source>GMT +08</source>
-      <translation>GMT +08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
-      <source>GMT +09</source>
-      <translation>GMT +09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
-      <source>GMT +10</source>
-      <translation>GMT +10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
-      <source>GMT +11</source>
-      <translation>GMT +11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
-      <source>UTC</source>
-      <translation>UTC</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>GMT Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>Central Europe Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>Central European Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>Romance Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>W. Europe Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>E. Europe Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>FLE Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>GTB Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>Belarus Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>Russian Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>Turkey Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>Mauritius Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>Christmas Island Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>Tonga Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>Fiji Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>New Zealand Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Central Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>West Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>Samoa Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>Hawaiian Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>Easter Island Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation type="unfinished">Intern fejl</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation type="unfinished"/>
-    </message>
-  </context>
-  <context>
     <name>Wakespeed</name>
     <message>
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
@@ -13184,6 +12032,119 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
       <source>DC/DC misconfiguration</source>
       <translation>DC/DC fejlkonfiguration</translation>
+    </message>
+  </context>
+  <context>
+    <name>VebusError</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+      <source>Device switched off</source>
+      <translation>Enhed slukket</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+      <source>Mixed old/new MK2</source>
+      <translation>Blandet gammel/ny MK2</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+      <source>Expected devices error</source>
+      <translation>Fejl med forventede enheder</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+      <source>No other device detected</source>
+      <translation>Ingen anden enhed registreret</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+      <source>Overvoltage on AC-out</source>
+      <translation>Overspænding på AC-udgang</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+      <source>DDC program error</source>
+      <translation>DDC programfejl</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+      <source>VE.Bus BMS without assistant</source>
+      <translation>VE.Bus BMS uden assistent</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+      <source>Ground relay test failed</source>
+      <translation>Jordrelætest mislykkedes</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+      <source>System time sync error</source>
+      <translation>Systemtids synkroniseringsfejl</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+      <source>Grid relay test fault</source>
+      <translation>Fejl i netrelætest</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+      <source>Config mismatch with 2nd mcu</source>
+      <translation>Konfigurationsuoverensstemmelse med 2. mcu</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+      <source>Device transmit error</source>
+      <translation>Enhedens transmissionsfejl</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+      <source>Awaiting configuration or dongle missing</source>
+      <translation>Venter på konfiguration eller dongle mangler</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+      <source>Phase master missing</source>
+      <translation>Fasemaster mangler</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+      <source>Overvoltage has occurred</source>
+      <translation>Overspænding er opstået</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+      <source>Slave does not have AC input!</source>
+      <translation>Slaven har ikke AC-indgang!</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+      <source>Device can't be slave</source>
+      <translation>Enheden kan ikke være slave</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+      <source>System protection initiated</source>
+      <translation>Systembeskyttelse startet</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+      <source>Firmware incompatibiltiy</source>
+      <translation>Firmware inkompatibilitet</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+      <source>Internal error</source>
+      <translation>Intern fejl</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+      <source>Failing relay test prevents connection</source>
+      <translation>Fejlende relætest forhindrer forbindelse</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+      <source>VE.Bus error</source>
+      <translation>VE.Bus fejl</translation>
     </message>
   </context>
 </TS>

--- a/i18n/venus-gui-v2_de.ts
+++ b/i18n/venus-gui-v2_de.ts
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="de">
   <context>
-    <name/>
+    <name></name>
     <message id="switchable_output_disabled">
       <location filename="../../src/enums.cpp" line="478"/>
       <source>Disabled</source>
@@ -22,6 +22,7 @@
     <message id="solarchargers_state_off">
       <location filename="../../src/enums.cpp" line="331"/>
       <source>Off</source>
+      <extracomment>Digital input state</extracomment>
       <translation>Aus</translation>
     </message>
     <message id="common_words_auto">
@@ -52,18 +53,25 @@
     <message id="settings_startpage_none">
       <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
       <source>None</source>
+      <extracomment>Indicates no phase</extracomment>
       <translation>Keines</translation>
     </message>
     <message id="common_words_position_ac">
       <location filename="../../components/CommonWords.qml" line="416"/>
       <source>Position</source>
-      <extracomment>AC input or output position</extracomment>
+      <extracomment>EVCS AC input/output position</extracomment>
       <translation>Position</translation>
     </message>
     <message id="settings_minmax_speed">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="193"/>
       <source>Speed</source>
+      <extracomment>A speed measurement value</extracomment>
       <translation>Geschwindigkeit</translation>
+    </message>
+    <message id="common_words_state">
+      <location filename="../../components/CommonWords.qml" line="502"/>
+      <source>State</source>
+      <translation>Zustand</translation>
     </message>
     <message id="settings_firmware_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="67"/>
@@ -101,8 +109,8 @@
       <source>Solar yield</source>
       <translation>Solarertrag</translation>
     </message>
-    <message id="ess_state_external_control">
-      <location filename="../../data/Ess.qml" line="41"/>
+    <message id="inverters_state_externalccontrol">
+      <location filename="../../data/System.qml" line="183"/>
       <source>External control</source>
       <translation>Externe Steuerung</translation>
     </message>
@@ -140,6 +148,11 @@
       <location filename="../../components/CommonWords.qml" line="203"/>
       <source>ESS</source>
       <translation>ESS</translation>
+    </message>
+    <message id="pagesettingsconnectivity_ethernet">
+      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
+      <source>Ethernet</source>
+      <translation>Ethernet</translation>
     </message>
     <message id="pagesettingsconnectivity_wifi">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="28"/>
@@ -262,11 +275,6 @@
       <source>Name</source>
       <translation>Name</translation>
     </message>
-    <message id="settings_deviceinfo_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="38"/>
-      <source>Name</source>
-      <translation type="unfinished">Name</translation>
-    </message>
     <message id="settings_deviceinfo_product_id">
       <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
       <source>Product ID</source>
@@ -327,15 +335,20 @@
       <source>Daily run time</source>
       <translation>Tägl. Laufzeit</translation>
     </message>
+    <message id="common_words_value_must_be_greater_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="560"/>
+      <source>Value must be greater than stop value</source>
+      <translation>Wert muss größer als Stoppwert sein</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="563"/>
+      <source>Value must be lower than start value</source>
+      <translation>Wert muss niedriger als Startwert sein</translation>
+    </message>
     <message id="settings_minmax_acout_max_power">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="124"/>
       <source>AC output</source>
       <translation>AC Ausgang</translation>
-    </message>
-    <message id="ac_output">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="15"/>
-      <source>AC output</source>
-      <translation type="unfinished">AC Ausgang</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
       <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="25"/>
@@ -382,16 +395,6 @@
       <source>Unavailable monitor, set another</source>
       <translation>Wächter nicht verfügb., ander. einr.</translation>
     </message>
-    <message id="page_generator_conditions_battery_monitor">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="42"/>
-      <source>Battery monitor</source>
-      <translation type="unfinished">Batteriewächter</translation>
-    </message>
-    <message id="page_generator_conditions_unavailable_monitor_set_another">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="44"/>
-      <source>Unavailable monitor, set another</source>
-      <translation type="unfinished">Wächter nicht verfügb., ander. einr.</translation>
-    </message>
     <message id="page_generator_conditions_on_loss_of_communication">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="68"/>
       <source>On loss of communication</source>
@@ -416,11 +419,6 @@
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="105"/>
       <source>Battery SOC</source>
       <translation>SOC Batterie</translation>
-    </message>
-    <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="173"/>
-      <source>Periodic run</source>
-      <translation type="unfinished">Periodischer Betrieb</translation>
     </message>
     <message id="settings_inverter_high_temperature">
       <location filename="../../data/Generators.qml" line="83"/>
@@ -505,7 +503,7 @@
     <message id="settings_gps_speed_kmh">
       <location filename="../../pages/settings/PageGps.qml" line="83"/>
       <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometres per hour</extracomment>
+      <extracomment>GPS speed data, in kilometers per hour</extracomment>
       <translation>%1 km/h</translation>
     </message>
     <message id="settings_gps_speed_mph">
@@ -523,7 +521,7 @@
     <message id="settings_gps_speed_ms">
       <location filename="../../pages/settings/PageGps.qml" line="95"/>
       <source>%1 m/s</source>
-      <extracomment>GPS speed data, in metres per second</extracomment>
+      <extracomment>GPS speed data, in meters per second</extracomment>
       <translation>%1 m/s</translation>
     </message>
     <message id="settings_gps_course">
@@ -580,21 +578,6 @@
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="64"/>
       <source>%1 (Output %2)</source>
       <translation>%1 (Ausgang %2)</translation>
-    </message>
-    <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">Aktiver Batteriewächter</translation>
-    </message>
-    <message id="settings_batteries_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="101"/>
-      <source>Name</source>
-      <translation type="unfinished">Name</translation>
-    </message>
-    <message id="settings_batteries_enter_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="103"/>
-      <source>Enter name</source>
-      <translation type="unfinished">Name eingeben</translation>
     </message>
     <message id="settings_briefview_center_active_battery_monitor">
       <location filename="../../components/listitems/ListBriefCenterDetails.qml" line="27"/>
@@ -656,45 +639,25 @@
       <source>CAN-bus profile</source>
       <translation>CAN-Bus-Profil</translation>
     </message>
-    <message id="settings_disabled">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="31"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Deaktiviert</translation>
-    </message>
-    <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; Lynx Ion BMS (250 Kbit/s)</translation>
-    </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
       <location filename="../../pages/settings/CanbusProfile.qml" line="42"/>
       <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
       <translation>VE.Can &amp; CAN-Bus BMS (250 Kbit/s)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
       <source>Oceanvolt (250 kbit/s)</source>
       <translation>Oceanvolt (250 Kbit/s)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
       <source>RV-C (250 kbit/s)</source>
       <translation>RV-C (250 kbit/s)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
       <source>Up, but no services (250 kbit/s)</source>
       <translation>Aufwärts, aber keine Dienste (250 kbit/s)</translation>
-    </message>
-    <message id="settings_canopen_motordrive_250">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
-      <source>CANopen Motor drive (250 kbit/s)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_canopen_motordrive_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
-      <source>CANopen Motor drive (500 kbit/s)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_devices">
       <location filename="../../components/CommonWords.qml" line="166"/>
@@ -731,11 +694,6 @@
       <source>Check Unique id numbers</source>
       <translation>Eindeutige ID-Nummern prüfen</translation>
     </message>
-    <message id="settings_canbus_unique_id_press_to_check">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Press to check</source>
-      <translation type="unfinished">Zur Überprüfung drücken</translation>
-    </message>
     <message id="settings_canbus_unique_id_conflict">
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="125"/>
       <source>There is another device connected with this unique number, please select a new number.</source>
@@ -745,11 +703,6 @@
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="133"/>
       <source>OK: No other device is connected with this unique number.</source>
       <translation>OK: Kein anderes Gerät ist mit dieser eindeutigen Nummer verbunden.</translation>
-    </message>
-    <message id="pagesettingsintegrations_canopenmotordrive">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
-      <source>CANopen motor drives</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_network_status">
       <location filename="../../components/CommonWords.qml" line="349"/>
@@ -884,11 +837,6 @@
       <source>Unavailable sensor, set another</source>
       <translation>Nicht verfügbarer Sensor, einen anderen einstellen</translation>
     </message>
-    <message id="settings_system_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="81"/>
-      <source>Unavailable sensor, set another</source>
-      <translation type="unfinished">Nicht verfügbarer Sensor, einen anderen einstellen</translation>
-    </message>
     <message id="settings_dvcc_used_sensor">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="120"/>
       <source>Used sensor</source>
@@ -945,12 +893,6 @@
       <source>Auto selected</source>
       <translation>Automatisch ausgewählt</translation>
     </message>
-    <message id="settings_dvcc_auto_selected_none">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="208"/>
-      <source>None</source>
-      <extracomment>Indicates no option is selected</extracomment>
-      <translation type="unfinished">Keines</translation>
-    </message>
     <message id="settings_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
       <source>Build date/time</source>
@@ -986,12 +928,6 @@
       <source>Installing %1</source>
       <extracomment>%1 = firmware version</extracomment>
       <translation>Installation von %1</translation>
-    </message>
-    <message id="settings_firmware_offline_press_to_install">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">Drücken zum Aktualisieren auf %1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="90"/>
@@ -1062,12 +998,6 @@
       <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
       <translation>Installiere %1 %2%</translation>
     </message>
-    <message id="settings_firmware_online_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="86"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">Installiere %1...</translation>
-    </message>
     <message id="settings_firmware_update_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="109"/>
       <source>Update build date/time</source>
@@ -1097,11 +1027,6 @@
       <location filename="../../pages/settings/PageSettingsFronius.qml" line="56"/>
       <source>TCP port</source>
       <translation>TCP Port</translation>
-    </message>
-    <message id="page_settings_fronius_modbus_settings">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
-      <source>Modbus port and unit ID settings</source>
-      <translation type="unfinished"/>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
       <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
@@ -1153,16 +1078,6 @@
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="64"/>
       <source>AC-Out MP</source>
       <translation>AC-Ausgang MP</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="52"/>
-      <source>AC-In1 L%1</source>
-      <translation type="unfinished">AC-In1 L%1</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="56"/>
-      <source>AC-In1 --</source>
-      <translation type="unfinished">AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="70"/>
@@ -1330,12 +1245,6 @@
       <source>Reset service timer</source>
       <translation>Service-Timer zurücksetzen</translation>
     </message>
-    <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
-      <source>Volume</source>
-      <extracomment>Title for a list of units of volume (e.g. cubic metres, litres, gallons)</extracomment>
-      <translation type="unfinished">Volumen</translation>
-    </message>
     <message id="settings_gps_format">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="69"/>
       <source>Format</source>
@@ -1438,42 +1347,6 @@ Sollte das nicht funktionieren, überprüfen Sie die Sim-Karte in einem Telefon 
       <source>Wrong PIN</source>
       <translation>Falscher Pin</translation>
     </message>
-    <message id="page_settings_gsm_ok">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>OK</source>
-      <translation type="unfinished">Ok</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="128"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">Unbekannter Fehler</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_state">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="153"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Unbekannt</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_value">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="182"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Unbekannt</translation>
-    </message>
-    <message id="page_settings_gsm_offline">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="173"/>
-      <source>Offline</source>
-      <translation type="unfinished">Offline</translation>
-    </message>
-    <message id="page_settings_gsm_connecting">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="176"/>
-      <source>Connecting</source>
-      <translation type="unfinished">Es wird verbunden</translation>
-    </message>
-    <message id="page_settings_gsm_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="179"/>
-      <source>Connected</source>
-      <translation type="unfinished">Verbunden</translation>
-    </message>
     <message id="page_settings_gsm_pin">
       <location filename="../../pages/settings/PageSettingsGsm.qml" line="191"/>
       <source>PIN</source>
@@ -1530,32 +1403,32 @@ Sollte das nicht funktionieren, überprüfen Sie die Sim-Karte in einem Telefon 
       <translation>Netz-Messung</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
       <source>External meter</source>
       <translation>Externer Zähler</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="67"/>
       <source>Inverter/Charger</source>
       <translation>Wechselrichter/Ladegerät</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
       <source>Multiphase regulation</source>
       <translation>Mehrphasige Regulierung</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="91"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
       <source>Total of all phases</source>
       <translation>Summe aller Phasen</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="95"/>
       <source>Individual phase</source>
       <translation>Einzelne Phase</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="99"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="101"/>
       <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
@@ -1564,68 +1437,13 @@ CAUTION: Use only if required by the utility provider.</source>
 ACHTUNG: Nur verwenden, wenn dies vom Energieversorger verlangt wird.</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="104"/>
       <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
       <translation>Die Summe aller Phasen wird intelligent geregelt, um den Netzsollwert zu erreichen (der Wirkungsgrad der Anlage wird optimiert).
 
 Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
-    </message>
-    <message id="settings_ess_min_soc">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation type="unfinished">SoC Mindestwert Entladung (außer bei Netzausfall)</translation>
-    </message>
-    <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="129"/>
-      <source>Active SOC limit</source>
-      <translation type="unfinished">Aktiver SOC-Grenzwert</translation>
-    </message>
-    <message id="settings_ess_battery_life_sustain">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
-      <source>Sustain</source>
-      <translation type="unfinished">Erhaltung</translation>
-    </message>
-    <message id="settings_ess_battery_life_recharge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="157"/>
-      <source>Recharge</source>
-      <translation type="unfinished">Aufladen</translation>
-    </message>
-    <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <source>Scheduled charge levels</source>
-      <translation type="unfinished">Geplante Ladestufen</translation>
-    </message>
-    <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="257"/>
-      <source>Active (%1)</source>
-      <translation type="unfinished">Aktiv (%1)</translation>
-    </message>
-    <message id="settings_ess_inactive">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="259"/>
-      <source>Inactive</source>
-      <translation type="unfinished">Inaktiv</translation>
-    </message>
-    <message id="settings_ess_dynamic">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="293"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">Dynamic ESS</translation>
-    </message>
-    <message id="settings_ess_deprecated">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="319"/>
-      <source>Deprecated settings</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_charge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="326"/>
-      <source>Battery charge limit (% of CCL)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_discharge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="337"/>
-      <source>Battery discharge limit (% of DCL)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_rs_ess_min_soc">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="40"/>
@@ -1637,13 +1455,8 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <source>Active SOC limit</source>
       <translation>Aktiver SOC-Grenzwert</translation>
     </message>
-    <message id="scheduled_charge_inactive">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
-      <source>Inactive</source>
-      <translation type="unfinished">Inaktiv</translation>
-    </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="245"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="247"/>
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
       <source>Peak shaving</source>
       <translation>Lastspitzenkappung</translation>
@@ -1659,12 +1472,12 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <translation>Immer</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="151"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
       <source>Discharge disabled</source>
       <translation>Entladen deaktiviert</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
       <source>Slow charge</source>
       <translation>Langsames Laden</translation>
     </message>
@@ -1679,32 +1492,32 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <translation>Aufladen</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="165"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="167"/>
       <source>Limit charge power</source>
       <translation>Ladeleistung begrenzen</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="183"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="185"/>
       <source>Maximum charge power</source>
       <translation>Maximale Ladeleistung</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="196"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="198"/>
       <source>Limit inverter power</source>
       <translation>Wechselrichter-Leistung begrenzen</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="214"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="216"/>
       <source>Maximum inverter power</source>
       <translation>Maximale Wechselrichter-Leistung</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="225"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="227"/>
       <source>Grid setpoint</source>
       <translation>Sollwert Netz</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="236"/>
       <source>Grid feed-in</source>
       <translation>Netzeinspeisung</translation>
     </message>
@@ -1743,8 +1556,8 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <source>Door alarm</source>
       <translation>Türalarm</translation>
     </message>
-    <message id="digitalinputs_type_bilgepump">
-      <location filename="../../src/enums.cpp" line="201"/>
+    <message id="switchable_output_bilge_pump">
+      <location filename="../../src/enums.cpp" line="424"/>
       <source>Bilge pump</source>
       <translation>Bilgepumpe</translation>
     </message>
@@ -1796,11 +1609,6 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <source>Deferred by %1s</source>
       <extracomment>%1 = number of seconds</extracomment>
       <translation>Verzögert um %1s</translation>
-    </message>
-    <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="75"/>
-      <source>Are you sure?</source>
-      <translation type="unfinished">Sind Sie sicher?</translation>
     </message>
     <message id="settings_vrm_portal_id">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="87"/>
@@ -1939,11 +1747,6 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <source>External storage</source>
       <translation>Externer Speicher</translation>
     </message>
-    <message id="settings_vrm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="308"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">Unbekannter Fehler</translation>
-    </message>
     <message id="settings_vrm_no_error">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="311"/>
       <source>No Error</source>
@@ -2029,37 +1832,10 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <source>Function</source>
       <translation>Funktion</translation>
     </message>
-    <message id="settings_relay_disabled">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="54"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="98"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Deaktiviert</translation>
-    </message>
     <message id="settings_relay_alarm_relay">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="56"/>
       <source>Alarm relay</source>
       <translation>Alarmrelais</translation>
-    </message>
-    <message id="settings_relay_tank_pump">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="62"/>
-      <source>Tank pump</source>
-      <translation type="unfinished">Tankpumpe</translation>
-    </message>
-    <message id="settings_relay_manual">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="64"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="100"/>
-      <source>Manual</source>
-      <translation type="unfinished">Manuell</translation>
-    </message>
-    <message id="settings_relay_polarity_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
-      <source>Polarity (Relay 1)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_relay_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
-      <source>Polarity</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_normally_open">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="83"/>
@@ -2075,11 +1851,6 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="93"/>
       <source>Function (Relay 2)</source>
       <translation>Funktion (Relais 2)</translation>
-    </message>
-    <message id="settings_relay_polarity_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
-      <source>Polarity (Relay 2)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_temp_control_rules">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="119"/>
@@ -2111,12 +1882,6 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
       <source>Press to boot</source>
       <translation>Zum Hochfahren drücken</translation>
-    </message>
-    <message id="settings_firmware_backup_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
-      <translation type="unfinished">Firmware %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
@@ -2152,6 +1917,7 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
     <message id="nav_boat">
       <location filename="../../pages/boat/BoatPage.qml" line="14"/>
       <source>Boat</source>
+      <extracomment>The 'Boat' page</extracomment>
       <translation>Boot</translation>
     </message>
     <message id="settings_system_name">
@@ -2219,11 +1985,6 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <source>Solar charger current control</source>
       <translation>Stromregelung des Solarladegeräts</translation>
     </message>
-    <message id="settings_system_status_bms_params">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
-      <source>BMS control</source>
-      <translation type="unfinished">BMS-Steuerung</translation>
-    </message>
     <message id="common_words_bms_control">
       <location filename="../../components/CommonWords.qml" line="101"/>
       <source>BMS control</source>
@@ -2238,11 +1999,6 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
       <source>Pump state</source>
       <translation>Status Pumpe</translation>
-    </message>
-    <message id="settings_pump_auto">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="56"/>
-      <source>Auto</source>
-      <translation type="unfinished">Auto</translation>
     </message>
     <message id="settings_tank_sensor">
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
@@ -2271,11 +2027,6 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="35"/>
       <source>Unplugged</source>
       <translation>Ausgesteckt</translation>
-    </message>
-    <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="16"/>
-      <source>Name</source>
-      <translation type="unfinished">Name</translation>
     </message>
     <message id="settings_tcpip_hidden">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="21"/>
@@ -2317,16 +2068,6 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="99"/>
       <source>IP configuration</source>
       <translation>IP-Konfiguration</translation>
-    </message>
-    <message id="settings_tcpip_manual">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="105"/>
-      <source>Manual</source>
-      <translation type="unfinished">Manuell</translation>
-    </message>
-    <message id="settings_tcpip_off">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="107"/>
-      <source>Off</source>
-      <translation type="unfinished">Aus</translation>
     </message>
     <message id="settings_tcpip_fixed">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="109"/>
@@ -2382,21 +2123,6 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="30"/>
       <source>Create access point</source>
       <translation>Access Point erstellen</translation>
-    </message>
-    <message id="settings_wifi_access_point_enter_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="68"/>
-      <source>Enter password</source>
-      <translation type="unfinished">Passwort eingeben</translation>
-    </message>
-    <message id="page_settings_wifi_invalid_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
-      <source>Password length must be either 0 or between 10 and 63 characters long</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_wifi_password_updated">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
-      <source>Password updated</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_wifi_networks">
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="86"/>
@@ -2539,20 +2265,10 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <extracomment>Network status: Standalone</extracomment>
       <translation>Stand-Alone</translation>
     </message>
-    <message id="charger_standalone">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="45"/>
-      <source>Standalone</source>
-      <translation type="unfinished">Stand-Alone</translation>
-    </message>
     <message id="charger_charge">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="48"/>
       <source>Charge</source>
       <translation>Last</translation>
-    </message>
-    <message id="charger_external_control">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="51"/>
-      <source>External control</source>
-      <translation type="unfinished">Externe Steuerung</translation>
     </message>
     <message id="charger_charge_hub_1">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="54"/>
@@ -2584,16 +2300,6 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <source>Master setting</source>
       <translation>Einstellung Master</translation>
     </message>
-    <message id="charger_slave">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="85"/>
-      <source>Slave</source>
-      <translation type="unfinished">Slave</translation>
-    </message>
-    <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation type="unfinished">Ladespannung</translation>
-    </message>
     <message id="systemsettings_networkstatus_slave">
       <location filename="../../data/SystemSettings.qml" line="148"/>
       <source>Slave</source>
@@ -2615,14 +2321,15 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <source>Group &amp; Charge master</source>
       <translation>Group &amp; Lade Master</translation>
     </message>
-    <message id="genset_charge_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="365"/>
+    <message id="charger_charge_voltage">
+      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
       <source>Charge voltage</source>
       <translation>Ladespannung</translation>
     </message>
     <message id="common_words_reset">
       <location filename="../../components/CommonWords.qml" line="448"/>
       <source>Reset</source>
+      <extracomment>Reset the BMS control</extracomment>
       <translation>Zurücksetzen</translation>
     </message>
     <message id="solarcharger_load">
@@ -2651,14 +2358,14 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <extracomment>Voltage alarm is at "Warning" level</extracomment>
       <translation>Warnung</translation>
     </message>
-    <message id="listitems_alarm_level_alarm">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="25"/>
+    <message id="digitalinputs_state_alarm">
+      <location filename="../../src/enums.cpp" line="270"/>
       <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
+      <extracomment>Relay function is 'alarm'</extracomment>
       <translation>Alarm</translation>
     </message>
-    <message id="devicelist_tankshape_volume">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="190"/>
+    <message id="components_volumeunit_volume">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
       <source>Volume</source>
       <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
       <translation>Volumen</translation>
@@ -2808,26 +2515,10 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <source>Relay function</source>
       <translation>Relaisfunktion</translation>
     </message>
-    <message id="batterysettingrelay_alarm">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation type="unfinished">Alarm</translation>
-    </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
       <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
       <source>Charger or generator start/stop</source>
       <translation>Ladegerät oder Generator Start/Stopp</translation>
-    </message>
-    <message id="batterysettingrelay_manual_control">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
-      <source>Manual control</source>
-      <translation type="unfinished">Manuelle Steuerung</translation>
-    </message>
-    <message id="batterysettingrelay_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">Sicherung durchgebrannt</translation>
     </message>
     <message id="common_words_manual_control">
       <location filename="../../components/CommonWords.qml" line="302"/>
@@ -2853,12 +2544,6 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
       <source>Status LEDs</source>
       <translation>Status-LEDs</translation>
-    </message>
-    <message id="batterydiagnostics_none">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
-      <source>None</source>
-      <extracomment>Indicates no alarm is set</extracomment>
-      <translation type="unfinished">Keines</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
@@ -2888,7 +2573,7 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
     <message id="common_words_switch">
       <location filename="../../components/CommonWords.qml" line="525"/>
       <source>Switch</source>
-      <extracomment>Change the mode value</extracomment>
+      <extracomment>Change the battery mode</extracomment>
       <translation>Umschalten</translation>
     </message>
     <message id="devicelist_battery_initializing">
@@ -2956,21 +2641,6 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <source>Top section voltage</source>
       <translation>Spannung oberer Bereich</translation>
     </message>
-    <message id="battery_bank_error_communication">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="96"/>
-      <source>Communication error</source>
-      <translation type="unfinished">Kommunikationsfehler</translation>
-    </message>
-    <message id="battery_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="182"/>
-      <source>State of health</source>
-      <translation type="unfinished">Alterungszustand</translation>
-    </message>
-    <message id="battery_bus_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="212"/>
-      <source>Bus voltage</source>
-      <translation type="unfinished">Busspannung</translation>
-    </message>
     <message id="battery_bottom_section_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="228"/>
       <source>Bottom section voltage</source>
@@ -3016,16 +2686,6 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <source>IO</source>
       <translation>IO</translation>
     </message>
-    <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="391"/>
-      <source>System</source>
-      <translation type="unfinished">System</translation>
-    </message>
-    <message id="battery_press_to_redetect">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="433"/>
-      <source>Press to redetect</source>
-      <translation type="unfinished">Zum erneuten Erkennen drücken</translation>
-    </message>
     <message id="pagesettingsgeneral_system">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="107"/>
       <source>System</source>
@@ -3066,16 +2726,6 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <source>Low SOC</source>
       <translation>Niedriger SOC</translation>
     </message>
-    <message id="batteryalarms_high_battery_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
-      <source>High battery voltage</source>
-      <translation type="unfinished">Batteriespannung hoch</translation>
-    </message>
-    <message id="batteryalarms_low_soc">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low SOC</source>
-      <translation type="unfinished">Niedriger SOC</translation>
-    </message>
     <message id="batteryalarms_low_starter_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="73"/>
       <source>Low starter voltage</source>
@@ -3095,11 +2745,6 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
       <source>Mid-point voltage</source>
       <translation>Mittelpunktspannung</translation>
-    </message>
-    <message id="batteryalarms_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">Sicherung durchgebrannt</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
@@ -3293,11 +2938,6 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <source>Restore factory defaults</source>
       <translation>Fabrikeinst. wiederherst.</translation>
     </message>
-    <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation type="unfinished">Zum Wiederherst. drücken</translation>
-    </message>
     <message id="vebus_backup_press_to_restore">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="362"/>
       <source>Press to restore</source>
@@ -3337,11 +2977,6 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="18"/>
       <source>Capacity</source>
       <translation>Kapazität</translation>
-    </message>
-    <message id="batterysettingsbattery_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
-      <source>Capacity</source>
-      <translation type="unfinished">Kapazität</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
@@ -3418,11 +3053,6 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <source>No power on busbar</source>
       <translation>Kein Strom auf Sammelschiene</translation>
     </message>
-    <message id="lynxdistributor_connection_lost">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
-      <source>Connection lost</source>
-      <translation type="unfinished">Verbindung unterbrochen</translation>
-    </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
       <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
       <source>%n fuse(s) blown</source>
@@ -3458,26 +3088,6 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <source>Shutdowns due error</source>
       <translation>Abschaltungen aufgrund von Fehlern</translation>
     </message>
-    <message id="lynxiondiagnostics_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
-      <source>Last error</source>
-      <translation type="unfinished">Letzter Fehler</translation>
-    </message>
-    <message id="lynxiondiagnostics_2nd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
-      <source>2nd last error</source>
-      <translation type="unfinished">Vorletzter Fehler</translation>
-    </message>
-    <message id="lynxiondiagnostics_3rd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
-      <source>3rd last error</source>
-      <translation type="unfinished">Drittletzter Fehler</translation>
-    </message>
-    <message id="lynxiondiagnostics_4th_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
-      <source>4th last error</source>
-      <translation type="unfinished">Viertletzter Fehler</translation>
-    </message>
     <message id="lynxionio_system_switch">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
       <source>System Switch</source>
@@ -3497,11 +3107,6 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <location filename="../../components/CommonWords.qml" line="54"/>
       <source>Batteries</source>
       <translation>Batterien</translation>
-    </message>
-    <message id="lynxionsystem_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
-      <source>Capacity</source>
-      <translation type="unfinished">Kapazität</translation>
     </message>
     <message id="lynxionsystem_parallel">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="30"/>
@@ -3523,20 +3128,10 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <source>Min/max cell temperature</source>
       <translation>Min./Max. Zellentemperatur</translation>
     </message>
-    <message id="lynxionsystem_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="92"/>
-      <source>Balancing</source>
-      <translation type="unfinished">Ausgleich läuft</translation>
-    </message>
     <message id="lynxionsystem_balancer_balancing">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
       <source>Balancing</source>
       <translation>Ausgleich läuft</translation>
-    </message>
-    <message id="lynxionsystem_balancer_unknown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="117"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Unbekannt</translation>
     </message>
     <message id="dc_output">
       <location filename="../../components/listitems/ListDcOutputQuantityGroup.qml" line="16"/>
@@ -3644,11 +3239,6 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <source>Remaining</source>
       <translation>Noch ausstehend</translation>
     </message>
-    <message id="devicelist_tanksensor_sensor_battery">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="51"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">Sensor-Batteriespannung</translation>
-    </message>
     <message id="temperature_sensor_battery">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="112"/>
       <source>Sensor battery</source>
@@ -3677,7 +3267,7 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
     <message id="devicelist_tanksetup_custom">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="53"/>
       <source>Custom</source>
-      <translation type="unfinished">Benutzerdefiniert</translation>
+      <translation>Benutzerdefiniert</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="59"/>
@@ -3710,34 +3300,34 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <translation>Sensorwert</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="75"/>
       <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
       <translation>Keine eigene Form definiert. Sie können eine Form mit bis zu zehn Punkten definieren. Beachten Sie, dass 0% und 100% implizit sind.</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="91"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="89"/>
       <source>Point %1</source>
       <extracomment>%1 = the point number</extracomment>
       <translation>Punkt %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="133"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="179"/>
       <source>Add point</source>
       <translation>Punkt hinzufügen</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="156"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="205"/>
       <source>Sensor level</source>
       <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
       <translation>Sensorniveau</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="256"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="311"/>
       <source>Duplicate sensor level values are not allowed.</source>
       <translation>Doppelte Sensorpegelwerte sind nicht zulässig.</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="262"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="317"/>
       <source>Volume values must be increasing.</source>
       <translation>Die Volumenwerte müssen steigen.</translation>
     </message>
@@ -3777,11 +3367,6 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <source>Switch position</source>
       <translation>Schalterstellung</translation>
     </message>
-    <message id="ac-in-setup_single_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="142"/>
-      <source>Single phase</source>
-      <translation type="unfinished">Einphasig</translation>
-    </message>
     <message id="ac-in-setup_two_phase">
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="144"/>
       <source>2-phase</source>
@@ -3791,11 +3376,6 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="146"/>
       <source>3-phase</source>
       <translation>3-phasig</translation>
-    </message>
-    <message id="ac-in-setup_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="161"/>
-      <source>Devices</source>
-      <translation type="unfinished">Geräte</translation>
     </message>
     <message id="ac-in-genset_ac">
       <location filename="../../components/PageGensetModel.qml" line="194"/>
@@ -3889,12 +3469,6 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <extracomment>%1 = CT device number</extracomment>
       <translation>CT %1</translation>
     </message>
-    <message id="smappeect_phase_none">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation type="unfinished">Keines</translation>
-    </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
       <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
       <source>Flashing LED indicates this CT</source>
@@ -3908,11 +3482,13 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
     <message id="common_words_setting_disabled_when_dmc_connected">
       <location filename="../../components/CommonWords.qml" line="355"/>
       <source>This setting is disabled when a Digital Multi Control is connected.</source>
+      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>Diese Einstellung ist deaktiviert, wenn ein Digital Multi Control angeschlossen ist.</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
       <location filename="../../components/CommonWords.qml" line="358"/>
       <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>Diese Einstellung ist deaktiviert, wenn ein VE.Bus BMS angeschlossen ist.</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
@@ -3930,16 +3506,6 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="21"/>
       <source>Inverted</source>
       <translation>Invertiert</translation>
-    </message>
-    <message id="digitalinput_enable_alarm">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="48"/>
-      <source>Enable alarm</source>
-      <translation type="unfinished">Alarm aktivieren</translation>
-    </message>
-    <message id="digitalinput_inverted">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="54"/>
-      <source>Inverted</source>
-      <translation type="unfinished">Invertiert</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
       <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="60"/>
@@ -3976,16 +3542,6 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <source>Wind speed</source>
       <translation>Windgeschwindigkeit</translation>
     </message>
-    <message id="page_meteo_battery_voltage">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="99"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">Sensor-Batteriespannung</translation>
-    </message>
-    <message id="meteo_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="120"/>
-      <source>Low</source>
-      <translation type="unfinished">Niedrig</translation>
-    </message>
     <message id="page_meteo_settings_auto_detect">
       <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
       <source>Auto-detect</source>
@@ -4016,16 +3572,6 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <source>Reset counter</source>
       <translation>Zähler zurücksetzen</translation>
     </message>
-    <message id="temperature_short_circuited">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="32"/>
-      <source>Short circuited</source>
-      <translation type="unfinished">Kurzgeschlossen</translation>
-    </message>
-    <message id="temperature_reverse_polarity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="35"/>
-      <source>Reverse polarity</source>
-      <translation type="unfinished">Umgekehrte Polarität</translation>
-    </message>
     <message id="temperature_sensor_battery_low">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
       <source>Sensor battery low</source>
@@ -4040,36 +3586,6 @@ Verwendung, sofern nicht vom Energieversorger untersagt.</translation>
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="62"/>
       <source>Pressure</source>
       <translation>Luftdruck</translation>
-    </message>
-    <message id="temperature_pm25">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
-      <source>PM2.5</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_co2">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>CO₂</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_voc">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
-      <source>VOC index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_nox">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
-      <source>NOx index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_luminosity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
-      <source>Luminosity</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="133"/>
-      <source>Low</source>
-      <translation type="unfinished">Niedrig</translation>
     </message>
     <message id="temperature_offset">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
@@ -4123,25 +3639,10 @@ HINWEIS: Das Update kann das System vorübergehend anhalten.</translation>
       <source>Updating the MK3, values will reappear after the update is complete</source>
       <translation>Aktualisieren des MK3. Werte werden nach Abschluss des Updates wieder angezeigt</translation>
     </message>
-    <message id="vebus_device_charging_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="78"/>
-      <source>Charging the battery to 100%</source>
-      <translation type="unfinished">Batterie auf 100% aufladen</translation>
-    </message>
     <message id="vebus_device_charging_the_battery_to_100">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="93"/>
       <source>Charging the battery to 100%</source>
       <translation>Batterie auf 100% aufladen</translation>
-    </message>
-    <message id="vebus_device_page_microgrid_parameters">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
-      <source>Microgrid parameters</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="vebus_device_page_advanced">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
-      <source>Advanced</source>
-      <translation type="unfinished">Erweitert</translation>
     </message>
     <message id="vebus_device_in_progress">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="80"/>
@@ -4197,15 +3698,15 @@ Möchtest Sie fortfahren?</translation>
       <source>DC Current</source>
       <translation>DC-Strom</translation>
     </message>
+    <message id="vebus_device_page_advanced">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
+      <source>Advanced</source>
+      <translation>Erweitert</translation>
+    </message>
     <message id="common_words_alarm_setup">
       <location filename="../../components/CommonWords.qml" line="65"/>
       <source>Alarm setup</source>
       <translation>Alarm-Setup</translation>
-    </message>
-    <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
-      <translation type="unfinished">Ein VE.Bus BMS schaltet das System automatisch aus, wenn dies zum Schutz der Batterie notwendig ist. Die Steuerung des Systems über das Color Control ist daher nicht möglich.</translation>
     </message>
     <message id="vebus_device_bms_not_found">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="240"/>
@@ -4246,7 +3747,7 @@ Möchtest Sie fortfahren?</translation>
     <message id="vebus_device_starting">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="117"/>
       <source>Starting...</source>
-      <translation type="unfinished">Es wird gestartet...</translation>
+      <translation>Es wird gestartet...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="120"/>
@@ -4312,16 +3813,6 @@ Möchtest Sie fortfahren?</translation>
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="260"/>
       <source>ESS Relay test</source>
       <translation>ESS-Relais-Test</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_completed">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="266"/>
-      <source>Completed</source>
-      <translation type="unfinished">Abgeschlossen</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_pending">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="268"/>
-      <source>Pending</source>
-      <translation type="unfinished">Ausstehend</translation>
     </message>
     <message id="cycle_history_completed">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
@@ -4508,6 +3999,7 @@ Möchtest Sie fortfahren?</translation>
     <message id="rssystemalarms_overload">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
       <source>Overload</source>
+      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
       <translation>Überlastung</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
@@ -4520,11 +4012,6 @@ Möchtest Sie fortfahren?</translation>
       <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
       <source>Voltage Sensor</source>
       <translation>Spannungssensor</translation>
-    </message>
-    <message id="vebus_device_phase_rotation">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
-      <source>Phase rotation</source>
-      <translation type="unfinished">Phasendrehung</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
@@ -4556,12 +4043,6 @@ Möchtest Sie fortfahren?</translation>
       <source>VE.Bus BMS version</source>
       <translation>VE.Bus BMS Version</translation>
     </message>
-    <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="15"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="52"/>
-      <source>Minimum SOC</source>
-      <translation type="unfinished">Mindest-SoC</translation>
-    </message>
     <message id="ess_unless_grid_fails">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="32"/>
       <source>Unless grid fails</source>
@@ -4581,7 +4062,7 @@ Möchtest Sie fortfahren?</translation>
     <message id="common_words_ac_input_role">
       <location filename="../../components/CommonWords.qml" line="24"/>
       <source>Role</source>
-      <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
       <translation>Funktion</translation>
     </message>
     <message id="common_words_ac_load">
@@ -4620,18 +4101,6 @@ Möchtest Sie fortfahren?</translation>
       <source>Active</source>
       <extracomment>Status is 'active'</extracomment>
       <translation>Aktiv</translation>
-    </message>
-    <message id="common_words_alarm">
-      <location filename="../../components/CommonWords.qml" line="51"/>
-      <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
-      <translation type="unfinished">Alarm</translation>
-    </message>
-    <message id="common_words_alarm_setting_overload">
-      <location filename="../../components/CommonWords.qml" line="58"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation type="unfinished">Überlastung</translation>
     </message>
     <message id="common_words_alarm_status">
       <location filename="../../components/CommonWords.qml" line="68"/>
@@ -4678,8 +4147,8 @@ Möchtest Sie fortfahren?</translation>
       <source>Charge current</source>
       <translation>Ladestrom</translation>
     </message>
-    <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="125"/>
+    <message id="battery_mode_charging">
+      <location filename="../../src/enums.cpp" line="30"/>
       <source>Charging</source>
       <extracomment>"Charging" state</extracomment>
       <translation>Aufladen</translation>
@@ -4693,7 +4162,7 @@ Möchtest Sie fortfahren?</translation>
     <message id="digitalinputs_state_closed">
       <location filename="../../src/enums.cpp" line="262"/>
       <source>Closed</source>
-      <extracomment>Digital input state</extracomment>
+      <extracomment>Status is 'closed'</extracomment>
       <translation>Geschlossen</translation>
     </message>
     <message id="evchargers_status_connected">
@@ -4701,8 +4170,8 @@ Möchtest Sie fortfahren?</translation>
       <source>Connected</source>
       <translation>Verbunden</translation>
     </message>
-    <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="143"/>
+    <message id="temperature_slider_current">
+      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
       <source>Current</source>
       <extracomment>Electric current, as measured in Amps</extracomment>
       <translation>Strom</translation>
@@ -4729,9 +4198,10 @@ Möchtest Sie fortfahren?</translation>
       <extracomment>Title for device information</extracomment>
       <translation>Gerät</translation>
     </message>
-    <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="172"/>
+    <message id="battery_mode_discharging">
+      <location filename="../../src/enums.cpp" line="34"/>
       <source>Discharging</source>
+      <extracomment>Battery mode</extracomment>
       <translation>Entladen</translation>
     </message>
     <message id="wifimodel_disconnected">
@@ -4817,13 +4287,14 @@ Möchtest Sie fortfahren?</translation>
       <source>%1 Hour(s)</source>
       <translation>%1 Stunde(n)</translation>
     </message>
-    <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="251"/>
+    <message id="battery_mode_idle">
+      <location filename="../../src/enums.cpp" line="26"/>
       <source>Idle</source>
+      <extracomment>Battery mode</extracomment>
       <translation>Idle</translation>
     </message>
-    <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="258"/>
+    <message id="scheduled_charge_inactive">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
       <source>Inactive</source>
       <extracomment>Status is 'inactive'</extracomment>
       <translation>Inaktiv</translation>
@@ -4925,8 +4396,8 @@ Möchtest Sie fortfahren?</translation>
       <source>Offline</source>
       <translation>Offline</translation>
     </message>
-    <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="17"/>
+    <message id="digitalinputs_state_ok">
+      <location filename="../../src/enums.cpp" line="266"/>
       <source>OK</source>
       <extracomment>Voltage alarm is at "OK" level</extracomment>
       <translation>Ok</translation>
@@ -4934,6 +4405,7 @@ Möchtest Sie fortfahren?</translation>
     <message id="switchable_output_on">
       <location filename="../../src/enums.cpp" line="471"/>
       <source>On</source>
+      <extracomment>Digital input state</extracomment>
       <translation>Ein</translation>
     </message>
     <message id="common_words_online">
@@ -4944,7 +4416,7 @@ Möchtest Sie fortfahren?</translation>
     <message id="digitalinputs_state_open">
       <location filename="../../src/enums.cpp" line="258"/>
       <source>Open</source>
-      <extracomment>Digital input open</extracomment>
+      <extracomment>Status is 'open'</extracomment>
       <translation>Offen</translation>
     </message>
     <message id="common_words_password">
@@ -5004,9 +4476,10 @@ Möchtest Sie fortfahren?</translation>
       <source>Remove</source>
       <translation>Entfernen</translation>
     </message>
-    <message id="switch_state_running">
-      <location filename="../../src/enums.cpp" line="363"/>
+    <message id="switchable_output_running">
+      <location filename="../../src/enums.cpp" line="468"/>
       <source>Running</source>
+      <extracomment>Status = "running"</extracomment>
       <translation>In Betrieb</translation>
     </message>
     <message id="common_words_scanning">
@@ -5073,7 +4546,7 @@ Möchtest Sie fortfahren?</translation>
     <message id="pvinverter_statusCode_startup">
       <location filename="../../src/enums.cpp" line="296"/>
       <source>Startup (%1)</source>
-      <extracomment>PV inverter status code. %1 = the startup status number</extracomment>
+      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
       <translation>Inbetriebnahme (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
@@ -5128,8 +4601,10 @@ Möchtest Sie fortfahren?</translation>
       <source>Unique Identity Number</source>
       <translation>Unique Identity Number</translation>
     </message>
-    <message id="settings_radio_button_group_unknown">
-      <location filename="../../components/listitems/core/ListRadioButtonGroup.qml" line="44"/>
+    <message id="Unknown">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
       <source>Unknown</source>
       <translation>Unbekannt</translation>
     </message>
@@ -5284,11 +4759,6 @@ Möchtest Sie fortfahren?</translation>
       <source>Error while checking for firmware updates</source>
       <translation>Fehler bei der Prüfung auf Firmware-Updates</translation>
     </message>
-    <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation type="unfinished">Fehler bei der Prüfung auf Firmware-Updates</translation>
-    </message>
     <message id="settings_firmware_downloading_and_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="63"/>
       <source>Downloading and installing firmware %1...</source>
@@ -5315,6 +4785,66 @@ Möchtest Sie fortfahren?</translation>
       <source>No firmware found</source>
       <translation>Keine Firmware gefunden</translation>
     </message>
+    <message id="tank_type_fuel">
+      <location filename="../../src/enums.cpp" line="495"/>
+      <source>Fuel</source>
+      <translation>Treibstoff</translation>
+    </message>
+    <message id="tank_type_fresh_water">
+      <location filename="../../src/enums.cpp" line="498"/>
+      <source>Fresh water</source>
+      <translation>Frischwasser</translation>
+    </message>
+    <message id="tank_type_waste_water">
+      <location filename="../../src/enums.cpp" line="501"/>
+      <source>Waste water</source>
+      <translation>Abwasser</translation>
+    </message>
+    <message id="tank_type_live_well">
+      <location filename="../../src/enums.cpp" line="504"/>
+      <source>Live well</source>
+      <translation>Fischkasten</translation>
+    </message>
+    <message id="tank_type_oil">
+      <location filename="../../src/enums.cpp" line="507"/>
+      <source>Oil</source>
+      <translation>Öl</translation>
+    </message>
+    <message id="tank_type_black_water">
+      <location filename="../../src/enums.cpp" line="510"/>
+      <source>Black water</source>
+      <translation>Schwarzwasser</translation>
+    </message>
+    <message id="tank_type_gasoline">
+      <location filename="../../src/enums.cpp" line="513"/>
+      <source>Gasoline</source>
+      <translation>Benzin</translation>
+    </message>
+    <message id="tank_type_diesel">
+      <location filename="../../src/enums.cpp" line="516"/>
+      <source>Diesel</source>
+      <translation>Diesel</translation>
+    </message>
+    <message id="tank_type_lpg">
+      <location filename="../../src/enums.cpp" line="519"/>
+      <source>LPG</source>
+      <translation>LPG</translation>
+    </message>
+    <message id="tank_type_lng">
+      <location filename="../../src/enums.cpp" line="522"/>
+      <source>LNG</source>
+      <translation>LNG</translation>
+    </message>
+    <message id="tank_type_hydraulic_oil">
+      <location filename="../../src/enums.cpp" line="525"/>
+      <source>Hydraulic oil</source>
+      <translation>Hydrauliköl</translation>
+    </message>
+    <message id="tank_type_raw_water">
+      <location filename="../../src/enums.cpp" line="528"/>
+      <source>Raw water</source>
+      <translation>Rohwasser</translation>
+    </message>
     <message id="listItem_no_access">
       <location filename="../../components/listitems/core/ListItem.qml" line="102"/>
       <source>Setting locked for access level</source>
@@ -5328,6 +4858,7 @@ Möchtest Sie fortfahren?</translation>
     <message id="welcome_brief_title">
       <location filename="../../pages/welcome/WelcomeView.qml" line="81"/>
       <source>Brief</source>
+      <extracomment>The 'Brief' page</extracomment>
       <translation>Kurzansicht</translation>
     </message>
     <message id="welcome_overview_title">
@@ -5344,23 +4875,6 @@ Möchtest Sie fortfahren?</translation>
       <location filename="../../pages/NotificationsPage.qml" line="13"/>
       <source>Notifications</source>
       <translation>Benachrichtigungen</translation>
-    </message>
-    <message id="notifications_page_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="43"/>
-      <source>Active Notifications</source>
-      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_page_inactive_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="47"/>
-      <source>Inactive Notifications</source>
-      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_no_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="106"/>
-      <source>No active notifications</source>
-      <translation type="unfinished"/>
     </message>
     <message id="utils_formatTimestamp_now">
       <location filename="../../components/Utils.js" line="258"/>
@@ -5465,11 +4979,6 @@ Möchtest Sie fortfahren?</translation>
       <source>Self-consumption above limit</source>
       <translation>Eigenverbrauch über Limit</translation>
     </message>
-    <message id="cgwacs_battery_schedule_pv">
-      <location filename="../../components/listitems/ListChargeSchedule.qml" line="171"/>
-      <source>PV</source>
-      <translation type="unfinished">PV</translation>
-    </message>
     <message id="settings_multirs_pv">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="185"/>
       <source>PV</source>
@@ -5480,8 +4989,8 @@ Möchtest Sie fortfahren?</translation>
       <source>PV &amp; Battery</source>
       <translation>PV &amp; Batterie</translation>
     </message>
-    <message id="settings_firmware_checking">
-      <location filename="../../components/listitems/ListFirmwareCheckButton.qml" line="16"/>
+    <message id="pagesettingssupportstate_firmware_checking">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
       <source>Checking...</source>
       <translation>Überprüfe...</translation>
     </message>
@@ -5489,12 +4998,6 @@ Möchtest Sie fortfahren?</translation>
       <location filename="../../components/listitems/ListAlarmState.qml" line="11"/>
       <source>Alarm state</source>
       <translation>Alarmstatus</translation>
-    </message>
-    <message id="devicelist_battery_alarm_state">
-      <location filename="../../components/listitems/ListAlarmState.qml" line="19"/>
-      <source>Alarm</source>
-      <extracomment>Alarm state is active</extracomment>
-      <translation type="unfinished">Alarm</translation>
     </message>
     <message id="clear_history_button_clear_history">
       <location filename="../../components/listitems/ListClearHistoryButton.qml" line="15"/>
@@ -5646,11 +5149,6 @@ Möchtest Sie fortfahren?</translation>
       <source>Max Voltage</source>
       <translation>Max Spannung</translation>
     </message>
-    <message id="charger_history_box_max_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="64"/>
-      <source>Max Voltage</source>
-      <translation type="unfinished">Max Spannung</translation>
-    </message>
     <message id="charger_history_box_max_current">
       <location filename="../../components/SolarDetailBox.qml" line="70"/>
       <source>Max Current</source>
@@ -5661,24 +5159,6 @@ Möchtest Sie fortfahren?</translation>
       <source>Charge time</source>
       <extracomment>Statistics for battery charging time</extracomment>
       <translation>Dauer der Aufladung</translation>
-    </message>
-    <message id="charger_history_box_bulk">
-      <location filename="../../components/SolarDetailBox.qml" line="136"/>
-      <source>Bulk</source>
-      <extracomment>Battery: time spent in 'Bulk' mode</extracomment>
-      <translation type="unfinished">Bulk</translation>
-    </message>
-    <message id="charger_history_box_float">
-      <location filename="../../components/SolarDetailBox.qml" line="148"/>
-      <source>Float</source>
-      <extracomment>Battery: time spent in 'Float' mode</extracomment>
-      <translation type="unfinished">Float</translation>
-    </message>
-    <message id="charger_history_hr">
-      <location filename="../../components/SolarDetailBox.qml" line="174"/>
-      <source>hr</source>
-      <extracomment>Abbreviation of "hour"</extracomment>
-      <translation type="unfinished">hr</translation>
     </message>
     <message id="solarchargers_state_bulk">
       <location filename="../../src/enums.cpp" line="337"/>
@@ -5750,11 +5230,6 @@ Möchtest Sie fortfahren?</translation>
       <source>Connecting</source>
       <translation>Es wird verbunden</translation>
     </message>
-    <message id="splash_view_connecting">
-      <location filename="../../components/SplashView.qml" line="288"/>
-      <source>Connecting</source>
-      <translation type="unfinished">Es wird verbunden</translation>
-    </message>
     <message id="splash_view_connected">
       <location filename="../../components/SplashView.qml" line="290"/>
       <source>Connected, awaiting broker messages</source>
@@ -5810,6 +5285,11 @@ Möchtest Sie fortfahren?</translation>
       <source>MQTT protocol level 5 error</source>
       <translation>MQTT-Protokoll Level 5 Fehler</translation>
     </message>
+    <message id="common_words_silence_alarm">
+      <location filename="../../components/CommonWords.qml" line="476"/>
+      <source>Silence alarm</source>
+      <translation>Alarm stummschalten</translation>
+    </message>
     <message id="vebus_device_page_total_power">
       <location filename="../../components/ThreePhaseQuantityTable.qml" line="47"/>
       <source>Total Power</source>
@@ -5860,20 +5340,10 @@ Möchtest Sie fortfahren?</translation>
       <source>Retrieving IP address</source>
       <translation>IP Adresse wird ermittelt</translation>
     </message>
-    <message id="utils_connman_connected">
-      <location filename="../../components/Utils.js" line="292"/>
-      <source>Connected</source>
-      <translation type="unfinished">Verbunden</translation>
-    </message>
     <message id="utils_connman_disconnect">
       <location filename="../../components/Utils.js" line="295"/>
       <source>Disconnect</source>
       <translation>Verbindung trennen</translation>
-    </message>
-    <message id="utils_connman_disconnected">
-      <location filename="../../components/Utils.js" line="299"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Getrennt</translation>
     </message>
     <message id="overview_widget_acloads_title">
       <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
@@ -5911,11 +5381,6 @@ Möchtest Sie fortfahren?</translation>
       <source>Shore current limit</source>
       <translation>Landstrombegrenzung</translation>
     </message>
-    <message id="acInputs_statusCode_stopping">
-      <location filename="../../data/AcInputs.qml" line="170"/>
-      <source>Stopping</source>
-      <translation type="unfinished">Es wird gestoppt</translation>
-    </message>
     <message id="page_generator_stopping">
       <location filename="../../data/Generators.qml" line="44"/>
       <source>Stopping</source>
@@ -5931,7 +5396,7 @@ Möchtest Sie fortfahren?</translation>
       <location filename="../../data/common/TankDescription.qml" line="24"/>
       <location filename="../../src/device.cpp" line="133"/>
       <source>%1 tank (%2)</source>
-      <extracomment>Tank description. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
       <translation>%1 Tank (%2)</translation>
     </message>
     <message id="dcMeter_ac_charger">
@@ -5980,11 +5445,6 @@ Möchtest Sie fortfahren?</translation>
       <location filename="../../data/Ess.qml" line="20"/>
       <source>Keep batteries charged</source>
       <translation>Batterien im gelad. Zustand halten</translation>
-    </message>
-    <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="50"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Getrennt</translation>
     </message>
     <message id="evchargers_status_charged">
       <location filename="../../data/EvChargers.qml" line="58"/>
@@ -6045,16 +5505,6 @@ Möchtest Sie fortfahren?</translation>
       <location filename="../../data/EvChargers.qml" line="97"/>
       <source>Start charging</source>
       <translation>Ladevorgang starten</translation>
-    </message>
-    <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="113"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Unbekannt</translation>
-    </message>
-    <message id="evchargers_mode_scheduled">
-      <location filename="../../data/EvChargers.qml" line="126"/>
-      <source>Scheduled</source>
-      <translation type="unfinished">Zeitgeplant</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
       <location filename="../../data/System.qml" line="195"/>
@@ -6179,11 +5629,6 @@ Möchtest Sie fortfahren?</translation>
       <source>Power supply mode</source>
       <translation>Stromversorgungsmodus</translation>
     </message>
-    <message id="inverters_state_sustain">
-      <location filename="../../data/System.qml" line="158"/>
-      <source>Sustain</source>
-      <translation type="unfinished">Erhaltung</translation>
-    </message>
     <message id="inverters_state_wakeup">
       <location filename="../../data/System.qml" line="162"/>
       <source>Wake up</source>
@@ -6218,16 +5663,6 @@ Möchtest Sie fortfahren?</translation>
       <location filename="../../data/System.qml" line="180"/>
       <source>Test</source>
       <translation>Test</translation>
-    </message>
-    <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="183"/>
-      <source>External control</source>
-      <translation type="unfinished">Externe Steuerung</translation>
-    </message>
-    <message id="inverters_state_dynamic_ess">
-      <location filename="../../data/System.qml" line="198"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">Dynamic ESS</translation>
     </message>
     <message id="settings_rs_ess_dess">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="97"/>
@@ -6306,16 +5741,13 @@ Möchtest Sie fortfahren?</translation>
     <message id="ess_recommended">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="73"/>
       <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
       <translation>Für Lithiumbatterien wird eine Ladung unter 10 % nicht empfohlen. Bei anderen Batterietypen finden Sie im Datenblatt den vom Hersteller empfohlenen Mindestladezustand.</translation>
-    </message>
-    <message id="controlcard_generator_label_autostart">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="63"/>
-      <source>Autostart</source>
-      <translation type="unfinished">Autostart</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
       <location filename="../../pages/controlcards/GeneratorCard.qml" line="70"/>
       <source>Start and stop the generator based on the configured autostart conditions.</source>
+      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
       <translation>Starten und stoppen Sie den Generator basierend auf den konfigurierten Autostart-Bedingungen.</translation>
     </message>
     <message id="generator_dialog_disabled">
@@ -6338,11 +5770,13 @@ Möchtest Sie fortfahren?</translation>
       <location filename="../../pages/controlcards/InverterChargerCard.qml" line="26"/>
       <source>Inverter / Charger (%1)</source>
       <extracomment>%1 = the inverter/charger name</extracomment>
+      <oldsource>Inverter / Charger</oldsource>
       <translation>Wechselrichter/Ladegerät (%1)</translation>
     </message>
     <message id="settings_page_debug_quit_application">
       <location filename="../../pages/settings/debug/PageDebug.qml" line="36"/>
       <source>Quit application</source>
+      <oldsource>Quit Application</oldsource>
       <translation>Beenden der Anwendung</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
@@ -6353,12 +5787,8 @@ Möchtest Sie fortfahren?</translation>
     <message id="settings_page_relay_generator_run_time">
       <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
       <source>Current run time</source>
+      <oldsource>Run time</oldsource>
       <translation>Aktuelle Laufzeit</translation>
-    </message>
-    <message id="settings_page_genset_generator_run_time">
-      <location filename="../../components/PageGensetModel.qml" line="102"/>
-      <source>Current run time</source>
-      <translation type="unfinished">Aktuelle Laufzeit</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
       <location filename="../../components/PageGensetModel.qml" line="110"/>
@@ -6385,19 +5815,10 @@ Möchtest Sie fortfahren?</translation>
       <source>Remote start mode</source>
       <translation>Fernstart-Modus</translation>
     </message>
-    <message id="ac-in-genset_speed">
-      <location filename="../../components/PageGensetModel.qml" line="245"/>
-      <source>Speed</source>
-      <translation type="unfinished">Geschwindigkeit</translation>
-    </message>
-    <message id="ac-in-genset_load">
-      <location filename="../../components/PageGensetModel.qml" line="252"/>
-      <source>Load</source>
-      <translation type="unfinished">Last</translation>
-    </message>
     <message id="ac-in-genset_oil_pressure">
       <location filename="../../components/PageGensetModel.qml" line="260"/>
       <source>Oil pressure</source>
+      <oldsource>Oil Pressure</oldsource>
       <translation>Öldruck</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
@@ -6493,11 +5914,13 @@ Möchtest Sie fortfahren?</translation>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
       <source>High starter battery voltage alarms</source>
+      <oldsource>High starter batttery voltage alarms</oldsource>
       <translation>Alarm bei hoher Spannung der Starterbatterie</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
       <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
       <translation>Beachten Sie, dass eine Änderung der Einstellung für die Entladezeit auch die Einstellung für den niedrigen Ladezustand im Relaismenü ändert.</translation>
     </message>
     <message id="lynxionsystem_cells_per_battery">
@@ -6574,6 +5997,7 @@ Möchtest Sie fortfahren?</translation>
       <location filename="../../pages/settings/devicelist/delegates/DeviceListDelegate_solarcharger.qml" line="34"/>
       <source>Error: #%1</source>
       <extracomment>%1 = error number</extracomment>
+      <oldsource>Error: %1</oldsource>
       <translation>Fehler: #%1</translation>
     </message>
     <message id="devicelistpage_genset">
@@ -6630,17 +6054,14 @@ Möchtest Sie fortfahren?</translation>
     <message id="settings_page_relay_generator_auto_start_enabled">
       <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
       <source>Autostart functionality</source>
+      <oldsource>Auto start functionality</oldsource>
       <translation>Autostart-Funktionalität</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="97"/>
       <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
       <translation>Stellen Sie sicher, dass der Generator nicht an den AC-Eingang %1 angeschlossen ist, wenn Sie diese Option verwenden.</translation>
-    </message>
-    <message id="page_generator_conditions_inverter_high_temperature">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="139"/>
-      <source>Inverter high temperature</source>
-      <translation type="unfinished">Hohe Temp. Wechselricht.</translation>
     </message>
     <message id="page_generator_conditions_tank_level">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="159"/>
@@ -6670,30 +6091,34 @@ Möchtest Sie fortfahren?</translation>
     <message id="settings_generator_function_not_enabled">
       <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
       <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
+      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
       <translation>Die Start-/Stoppfunktion des Generators ist nicht aktiviert. Gehen Sie zu den Relaiseinstellungen und stellen Sie die Funktion auf „Generator Start/Stopp“ ein.</translation>
     </message>
     <message id="settings_batteries_intro">
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="45"/>
       <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
       <translation>Verwenden Sie dieses Menü, um die Batteriedaten festzulegen, die angezeigt werden, wenn Sie auf der Übersichtsseite auf das Batteriesymbol klicken. Die gleiche Auswahl ist auch auf dem VRM Portal sichtbar.</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
       <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
       <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
       <translation>Kontinuierliches Scannen kann den Wi-Fi-Betrieb stören.</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
       <source>CAN-bus BMS LV (500 kbit/s)</source>
+      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
       <translation>CAN-Bus BMS LV (500 kbit/s)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
       <source>CAN-bus BMS HV (500 kbit/s)</source>
       <translation>CAN-Bus BMS HV (500 kbit/s)</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
       <source>Up, but no services (500 kbit/s)</source>
       <translation>Verfügbar, aber keine Dienste (500 kbit/s)</translation>
     </message>
@@ -6706,41 +6131,6 @@ Möchtest Sie fortfahren?</translation>
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="127"/>
       <source>Brief page</source>
       <translation>Kurzansicht</translation>
-    </message>
-    <message id="settings_displayoff_1min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="46"/>
-      <source>1 min</source>
-      <translation type="unfinished">1 min</translation>
-    </message>
-    <message id="settings_displayoff_10min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="48"/>
-      <source>10 min</source>
-      <translation type="unfinished">10 min</translation>
-    </message>
-    <message id="settings_displayoff_30min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="50"/>
-      <source>30 min</source>
-      <translation type="unfinished">30 min</translation>
-    </message>
-    <message id="settings_displayoff_never">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="52"/>
-      <source>Never</source>
-      <translation type="unfinished">Nie</translation>
-    </message>
-    <message id="settings_remote_console_appearance_auto">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="112"/>
-      <source>Auto</source>
-      <translation type="unfinished">Auto</translation>
-    </message>
-    <message id="settings_brief_view_start_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="119"/>
-      <source>Start page</source>
-      <translation type="unfinished">Startseite</translation>
-    </message>
-    <message id="settings_display_boat_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="135"/>
-      <source>Boat page</source>
-      <translation type="unfinished">Bootsseite</translation>
     </message>
     <message id="settings_display_minmax">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="148"/>
@@ -6795,21 +6185,6 @@ Möchtest Sie fortfahren?</translation>
       <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
       <translation>%1 wird auf %2 gesetzt</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_unsupported_device">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="50"/>
-      <source>Unsupported GX device</source>
-      <translation type="unfinished">Nicht unterstütztes GX-Gerät</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_clean">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="55"/>
-      <source>Clean</source>
-      <translation type="unfinished">Bereinigen</translation>
-    </message>
-    <message id="pagesettingsgeneral_firmware">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="112"/>
-      <source>Firmware</source>
-      <translation type="unfinished">Firmware</translation>
-    </message>
     <message id="pagesettingsgeneral_access_and_security">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
       <source>Access &amp; Security</source>
@@ -6843,6 +6218,7 @@ Möchtest Sie fortfahren?</translation>
     <message id="settings_language_please_wait">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="209"/>
       <source>Please wait while the language is changed.</source>
+      <oldsource>Please wait while the language is changed</oldsource>
       <translation>Bitte warten Sie, während die Sprache geändert wird.</translation>
     </message>
     <message id="settings_briefview_totals">
@@ -6859,11 +6235,6 @@ Möchtest Sie fortfahren?</translation>
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="71"/>
       <source>Tank is not connected.</source>
       <translation>Der Tank ist nicht angeschlossen.</translation>
-    </message>
-    <message id="settings_briefview_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="83"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">Aktiver Batteriewächter</translation>
     </message>
     <message id="settings_briefview_individual_batteries">
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="86"/>
@@ -6914,6 +6285,7 @@ Möchtest Sie fortfahren?</translation>
     <message id="settings_dvcc_charge_current_limits">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="30"/>
       <source>Charge current limits</source>
+      <oldsource>Charge Current limits</oldsource>
       <translation>Ladestromgrenzwerte</translation>
     </message>
     <message id="settings_firmware_official_release">
@@ -6993,11 +6365,6 @@ Möchtest Sie fortfahren?</translation>
       <source>No password and the network communication is not encrypted</source>
       <translation>Kein Passwort und die Netzwerkkommunikation ist nicht verschlüsselt</translation>
     </message>
-    <message id="settings_logout_now">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
-      <source>Log out now</source>
-      <translation type="unfinished">Jetzt abmelden</translation>
-    </message>
     <message id="settings_security_profile_password_incorrect_length">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="28"/>
       <source>Password needs to be at least 8 characters long</source>
@@ -7048,25 +6415,10 @@ Möchtest Sie fortfahren?</translation>
       <source>Page will automatically reload in 5 seconds</source>
       <translation>Die Seite wird in 5 Sekunden automatisch neu geladen</translation>
     </message>
-    <message id="settings_security_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="159"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">Das Passwort muss mindestens 8 Zeichen lang sein.</translation>
-    </message>
     <message id="settings_root_password">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="269"/>
       <source>Root password</source>
       <translation>Root-Passwort</translation>
-    </message>
-    <message id="settings_root_enter_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="272"/>
-      <source>Enter password</source>
-      <translation type="unfinished">Passwort eingeben</translation>
-    </message>
-    <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="277"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">Das Passwort muss mindestens 8 Zeichen lang sein.</translation>
     </message>
     <message id="settings_root_password_changed_to">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="283"/>
@@ -7082,6 +6434,11 @@ Möchtest Sie fortfahren?</translation>
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="321"/>
       <source>Logout</source>
       <translation>Abmelden</translation>
+    </message>
+    <message id="settings_logout_now">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
+      <source>Log out now</source>
+      <translation>Jetzt abmelden</translation>
     </message>
     <message id="settings_logout_dialog_title">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="335"/>
@@ -7141,11 +6498,13 @@ Möchtest Sie fortfahren?</translation>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="141"/>
       <source>Alarm when generator is not in autostart mode</source>
+      <oldsource>Alarm when generator is not in auto start mode</oldsource>
       <translation>Alarm, wenn der Generator nicht im Autostart-Modus ist</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="147"/>
       <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
       <translation>Ein Alarm wird ausgelöst, wenn die Autostart-Funktion für mehr als 10 Minuten deaktiviert bleibt.</translation>
     </message>
     <message id="settings_units_amps_exceptions">
@@ -7161,6 +6520,11 @@ Möchtest Sie fortfahren?</translation>
     <message id="settings_ess_use_this_option_for_peak_shaving">
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
       <source>Use this option for peak shaving.</source>
+      <oldsource>Use this option for peak shaving.
+
+The peak shaving threshold is set using the AC input current limit setting.
+
+See documentation for further information.</oldsource>
       <translation>Verwenden Sie diese Option für die Spitzenrasur.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
@@ -7204,17 +6568,17 @@ Möchtest Sie fortfahren?</translation>
       <translation>Maximaler Systemausgangsstrom (pro Phase)</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="71"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="73"/>
       <source>Self-consumption from battery</source>
       <translation>Eigenverbrauch aus Batterie</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="76"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
       <source>All system loads</source>
       <translation>Alle Systemlasten</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="80"/>
       <source>Only critical loads</source>
       <translation>Nur kritische Lasten</translation>
     </message>
@@ -7261,7 +6625,7 @@ Möchtest Sie fortfahren?</translation>
     <message id="pagesettingsintegrations_relays">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="118"/>
       <source>Relays</source>
-      <translation>Sie sind dabei, das Relais {relayNumber} von &lt;b&gt; {isOn} einzuschalten. Möchten Sie wirklich fortfahren?</translation>
+      <translation>Relais</translation>
     </message>
     <message id="pagesettingsintegrations_digital_io">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="132"/>
@@ -7272,26 +6636,6 @@ Möchtest Sie fortfahren?</translation>
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="194"/>
       <source>Server Applications</source>
       <translation>Server-Anwendungen</translation>
-    </message>
-    <message id="pagesettingsintegrations_venus_os_enable_large_features">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
-      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_large_victron_community">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="274"/>
-      <source>Victron Community</source>
-      <translation type="unfinished">Victron-Community</translation>
-    </message>
-    <message id="pagesettingsintegrations_ui_plugins">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
-      <source>UI Plugins</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
-      <source>Integrates with the device list</source>
-      <translation type="unfinished"/>
     </message>
     <message id="pagesettingssupportstate_modbus_tcp_server">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="453"/>
@@ -7394,25 +6738,10 @@ Möchtest Sie fortfahren?</translation>
       <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
       <translation>Ein Wechsel der Firmware-Version ist nicht möglich, ohne dass "Netzwerksicherheitsprofil" unter "Einstellungen / Allgemein" ausgewählt ist.</translation>
     </message>
-    <message id="pagesettingsconnectivity_ethernet">
-      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
-      <source>Ethernet</source>
-      <translation type="unfinished">Ethernet</translation>
-    </message>
     <message id="pagesettingsconnectivity_mobile_network">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="53"/>
       <source>Mobile Network</source>
       <translation>Mobiles Netz</translation>
-    </message>
-    <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Boat</source>
-      <translation type="unfinished">Boot</translation>
-    </message>
-    <message id="settings_system_name_auto">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="32"/>
-      <source>Automatic</source>
-      <translation type="unfinished">Automatisch</translation>
     </message>
     <message id="pagesettingssystem_ac_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
@@ -7443,11 +6772,6 @@ Möchtest Sie fortfahren?</translation>
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="89"/>
       <source>Distributed Voltage and Current Control (DVCC)</source>
       <translation>Verteilte Spannungs- und Stromregelung (DVCC)</translation>
-    </message>
-    <message id="settings_system_grid">
-      <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="18"/>
-      <source>Grid</source>
-      <translation type="unfinished">Netz</translation>
     </message>
     <message id="settings_system_ac_position">
       <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="58"/>
@@ -7487,16 +6811,19 @@ Möchtest Sie fortfahren?</translation>
     <message id="settings_system_has_dc_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="97"/>
       <source>Display DC Loads</source>
+      <oldsource>Has DC system</oldsource>
       <translation>DC-Lasten anzeigen</translation>
     </message>
     <message id="settings_system_battery_measurements">
       <location filename="../../pages/settings/PageSettingsBatteries.qml" line="65"/>
       <source>Battery measurements</source>
+      <oldsource>Battery Measurements</oldsource>
       <translation>Batteriemessungen</translation>
     </message>
     <message id="settings_system_system_status">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
       <source>System status</source>
+      <oldsource>System Status</oldsource>
       <translation>Systemstatus</translation>
     </message>
     <message id="settings_tcpip_wired">
@@ -7507,11 +6834,13 @@ Möchtest Sie fortfahren?</translation>
     <message id="settings_vecan_device_instance">
       <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
       <source>VE.Can Device Instance</source>
+      <oldsource>Device Instance</oldsource>
       <translation>VE.Can Device Instance</translation>
     </message>
     <message id="settings_vecan_device_number">
       <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="32"/>
       <source>VE.Can Instance# %1</source>
+      <oldsource>Device# %1</oldsource>
       <translation>VE.Can Instance# %1</translation>
     </message>
     <message id="settings_tz_antarctica">
@@ -7542,6 +6871,7 @@ Möchtest Sie fortfahren?</translation>
     <message id="settings_vrm">
       <location filename="../../pages/SettingsPage.qml" line="59"/>
       <source>VRM</source>
+      <extracomment>Forced by %2 to dark</extracomment>
       <translation>VRM</translation>
     </message>
     <message id="settings_remote_monitoring_portal">
@@ -7549,20 +6879,10 @@ Möchtest Sie fortfahren?</translation>
       <source>Remote monitoring portal</source>
       <translation>Portal zur Fernüberwachung</translation>
     </message>
-    <message id="settings_advanced">
-      <location filename="../../pages/SettingsPage.qml" line="68"/>
-      <source>Advanced</source>
-      <translation type="unfinished">Erweitert</translation>
-    </message>
-    <message id="settings_integrations">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
+    <message id="pagesettingssupportstate_integrations">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
       <source>Integrations</source>
       <translation>Integrationen</translation>
-    </message>
-    <message id="settings_relays_sensors_tanks">
-      <location filename="../../pages/SettingsPage.qml" line="75"/>
-      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
-      <translation type="unfinished">Relais, Sensoren, Tanks, PV-Wechselrichter, Modbus, MQTT …</translation>
     </message>
     <message id="settings_acdcsystem_ess_dvcc_battery">
       <location filename="../../pages/SettingsPage.qml" line="84"/>
@@ -7582,11 +6902,13 @@ Möchtest Sie fortfahren?</translation>
     <message id="settings_system_setup">
       <location filename="../../pages/SettingsPage.qml" line="82"/>
       <source>System Setup</source>
+      <oldsource>System setup</oldsource>
       <translation>System-Setup</translation>
     </message>
     <message id="settings_vrm_device_instances">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
       <source>VRM device instances</source>
+      <oldsource>VRM Device Instances</oldsource>
       <translation>VRM-Geräte-Instanzen</translation>
     </message>
     <message id="solarcharger_not_supported">
@@ -7604,28 +6926,10 @@ Möchtest Sie fortfahren?</translation>
       <source>The firmware version in the MPPT Solar Charger must be v1.09 or later. Contact Victron Service for update instructions and files.</source>
       <translation>Die Firmware-Version im MPPT-Solarladegerät muss v1.09 oder höher sein. Wenden Sie sich für Update-Anweisungen und -Dateien an den Victron-Service.</translation>
     </message>
-    <message id="solarcharger_pv">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="102"/>
-      <source>PV</source>
-      <extracomment>PV power for solar charger</extracomment>
-      <translation type="unfinished">PV</translation>
-    </message>
     <message id="solarcharger_total_power">
       <location filename="../../pages/solar/PageSolarCharger.qml" line="127"/>
       <source>Total PV power</source>
       <translation>PV Leistung insgesamt</translation>
-    </message>
-    <message id="solarcharger_total_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="211"/>
-      <source>Total yield</source>
-      <extracomment>Solar charger total yield</extracomment>
-      <translation type="unfinished">Gesamtertrag</translation>
-    </message>
-    <message id="solarcharger_system_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="220"/>
-      <source>System yield</source>
-      <extracomment>Solar charger system yield</extracomment>
-      <translation type="unfinished">Systemertrag</translation>
     </message>
     <message id="settings_multirs_total_yield">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="63"/>
@@ -7661,16 +6965,19 @@ Möchtest Sie fortfahren?</translation>
     <message id="vebus_device_update_firmware">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="133"/>
       <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
       <translation>Diese Funktion erfordert Firmware-Version 400 oder höher. Wenden Sie sich an Ihren Installateur, um Ihr Multi/Quattro zu aktualisieren.</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="139"/>
       <source>Charger not ready, equalization cannot be started</source>
+      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
       <translation>Ladegerät nicht bereit, Ausgleichsvorgang kann nicht gestartet werden</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="143"/>
       <source>Equalization cannot be triggered during bulk charge state</source>
+      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
       <translation>Der Ausgleich kann nicht während der Hauptladephase ausgelöst werden.</translation>
     </message>
     <message id="vebus_device_restart_vebus_system_restart_confirmation_description">
@@ -7693,78 +7000,20 @@ Möchtest Sie fortfahren?</translation>
       <source>Auto-started • %1</source>
       <translation>Automatisch gestartet - %1</translation>
     </message>
-    <message id="common_words_battery">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery</source>
-      <translation type="unfinished">Batterie</translation>
-    </message>
-    <message id="common_words_boat_page">
-      <location filename="../../components/CommonWords.qml" line="111"/>
-      <source>Boat</source>
-      <extracomment>The 'Boat' page</extracomment>
-      <translation type="unfinished">Boot</translation>
-    </message>
-    <message id="common_words_brief_page">
-      <location filename="../../components/CommonWords.qml" line="115"/>
-      <source>Brief</source>
-      <extracomment>The 'Brief' page</extracomment>
-      <translation type="unfinished">Kurzansicht</translation>
-    </message>
-    <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation type="unfinished">Geschlossen</translation>
-    </message>
-    <message id="common_words_color">
-      <location filename="../../components/CommonWords.qml" line="136"/>
-      <source>Color</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_connected">
-      <location filename="../../components/CommonWords.qml" line="139"/>
-      <source>Connected</source>
-      <translation type="unfinished">Verbunden</translation>
-    </message>
     <message id="common_words_daily_history">
       <location filename="../../components/CommonWords.qml" line="152"/>
       <source>Daily history</source>
       <translation>Täglicher Verlauf</translation>
-    </message>
-    <message id="common_words_disabled">
-      <location filename="../../components/CommonWords.qml" line="169"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Deaktiviert</translation>
-    </message>
-    <message id="common_words_disconnected">
-      <location filename="../../components/CommonWords.qml" line="175"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Getrennt</translation>
-    </message>
-    <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="191"/>
-      <source>Error</source>
-      <translation type="unfinished">Fehler</translation>
     </message>
     <message id="common_words_error_not_a_number">
       <location filename="../../components/CommonWords.qml" line="200"/>
       <source>'%1' is not a number.</source>
       <translation>%1' ist keine Zahl.</translation>
     </message>
-    <message id="common_words_generator">
-      <location filename="../../components/CommonWords.qml" line="217"/>
-      <source>Generator</source>
-      <translation type="unfinished">Generator</translation>
-    </message>
     <message id="common_words_input_current_limit">
       <location filename="../../components/CommonWords.qml" line="261"/>
       <source>Input current limit</source>
       <translation>Eingangsstrombegrenzung</translation>
-    </message>
-    <message id="common_words_inverter_charger">
-      <location filename="../../components/CommonWords.qml" line="264"/>
-      <source>Inverter / Charger</source>
-      <translation type="unfinished">Wechselrichter/Ladegerät</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
       <location filename="../../components/CommonWords.qml" line="268"/>
@@ -7777,12 +7026,6 @@ Möchtest Sie fortfahren?</translation>
       <source>Manual stop</source>
       <translation>Manuelles Anhalten</translation>
     </message>
-    <message id="common_words_max">
-      <location filename="../../components/CommonWords.qml" line="315"/>
-      <source>Max</source>
-      <extracomment>Short for Maximum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_maximum_current">
       <location filename="../../components/CommonWords.qml" line="318"/>
       <source>Maximum current</source>
@@ -7793,62 +7036,10 @@ Möchtest Sie fortfahren?</translation>
       <source>Maximum power</source>
       <translation>Maximale Leistung</translation>
     </message>
-    <message id="common_words_min">
-      <location filename="../../components/CommonWords.qml" line="331"/>
-      <source>Min</source>
-      <extracomment>Short for Minimum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_minimum_current">
       <location filename="../../components/CommonWords.qml" line="334"/>
       <source>Minimum current</source>
       <translation>Minimaler Strom</translation>
-    </message>
-    <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="433"/>
-      <source>No</source>
-      <translation type="unfinished">Nein</translation>
-    </message>
-    <message id="common_words_none_option">
-      <location filename="../../components/CommonWords.qml" line="364"/>
-      <source>None</source>
-      <translation type="unfinished">Keines</translation>
-    </message>
-    <message id="common_words_none_errors">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>None</source>
-      <extracomment>Indicates there are no errors</extracomment>
-      <translation type="unfinished">Keines</translation>
-    </message>
-    <message id="common_words_not_available">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Not available</source>
-      <translation type="unfinished">Nicht verfügbar</translation>
-    </message>
-    <message id="common_words_off">
-      <location filename="../../components/CommonWords.qml" line="377"/>
-      <source>Off</source>
-      <translation type="unfinished">Aus</translation>
-    </message>
-    <message id="common_words_ok">
-      <location filename="../../components/CommonWords.qml" line="383"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="41"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="45"/>
-      <source>OK</source>
-      <translation type="unfinished">Ok</translation>
-    </message>
-    <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="386"/>
-      <source>On</source>
-      <translation type="unfinished">Ein</translation>
-    </message>
-    <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="393"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation type="unfinished">Offen</translation>
     </message>
     <message id="common_words_open_circuit">
       <location filename="../../components/CommonWords.qml" line="396"/>
@@ -7860,108 +7051,17 @@ Möchtest Sie fortfahren?</translation>
       <source>Overall history</source>
       <translation>Gesamter Verlauf</translation>
     </message>
-    <message id="common_words_press">
-      <location filename="../../components/CommonWords.qml" line="419"/>
-      <source>Press</source>
-      <translation type="unfinished">Drücken</translation>
-    </message>
-    <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation type="unfinished">In Betrieb</translation>
-    </message>
-    <message id="common_words_settings">
-      <location filename="../../components/CommonWords.qml" line="467"/>
-      <source>Settings</source>
-      <translation type="unfinished">Einstellungen</translation>
-    </message>
-    <message id="common_words_silence_alarm">
-      <location filename="../../components/CommonWords.qml" line="476"/>
-      <source>Silence alarm</source>
-      <translation type="unfinished">Alarm stummschalten</translation>
-    </message>
     <message id="common_words_soc">
       <location filename="../../components/CommonWords.qml" line="480"/>
       <source>SOC %1</source>
       <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
       <translation>SOC %1</translation>
     </message>
-    <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation type="unfinished">Geschwindigkeit</translation>
-    </message>
-    <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="487"/>
-      <source>Standby</source>
-      <translation type="unfinished">Standby</translation>
-    </message>
-    <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="502"/>
-      <source>State</source>
-      <translation type="unfinished">Zustand</translation>
-    </message>
-    <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="512"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation type="unfinished">Inbetriebnahme (%1)</translation>
-    </message>
-    <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>Stopped</source>
-      <translation type="unfinished">Angehalten</translation>
-    </message>
-    <message id="common_words_total_power">
-      <location filename="../../components/CommonWords.qml" line="540"/>
-      <source>Total power</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="547"/>
-      <source>Type</source>
-      <translation type="unfinished">Typ</translation>
-    </message>
-    <message id="common_words_unknown_status">
-      <location filename="../../components/CommonWords.qml" line="554"/>
-      <source>Unknown</source>
-      <extracomment>Status = "unknown"</extracomment>
-      <translation type="unfinished">Unbekannt</translation>
-    </message>
-    <message id="common_words_value_must_be_greater_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="557"/>
-      <source>Value must be greater than start value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_value_must_be_greater_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="560"/>
-      <source>Value must be greater than stop value</source>
-      <translation type="unfinished">Wert muss größer als Stoppwert sein</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="563"/>
-      <source>Value must be lower than start value</source>
-      <translation type="unfinished">Wert muss niedriger als Startwert sein</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="566"/>
-      <source>Value must be lower than stop value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="581"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="431"/>
-      <source>Yes</source>
-      <translation type="unfinished">Ja</translation>
-    </message>
     <message id="common_words_yield_today">
       <location filename="../../components/CommonWords.qml" line="592"/>
       <source>Yield Today</source>
       <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+      <oldsource>Yield today</oldsource>
       <translation>Heutiger Ertrag</translation>
     </message>
     <message id="common_words_format_error">
@@ -7988,10 +7088,11 @@ Möchtest Sie fortfahren?</translation>
     <message id="settings_firmware_installed_rebooting">
       <location filename="../../components/FirmwareUpdate.qml" line="79"/>
       <source>Firmware installed, device rebooting</source>
+      <oldsource>Firmware installed, rebooting.</oldsource>
       <translation>Firmware installiert, Gerät wird neu gebootet</translation>
     </message>
-    <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/RadioButtonListPage.qml" line="121"/>
+    <message id="modaldialog_confirm">
+      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
       <source>Confirm</source>
       <extracomment>Confirm password, and verify it if possible</extracomment>
       <translation>Bestätigen</translation>
@@ -8009,11 +7110,13 @@ Möchtest Sie fortfahren?</translation>
     <message id="cgwacs_battery_schedule_duration">
       <location filename="../../components/listitems/ListChargeSchedule.qml" line="144"/>
       <source>Duration</source>
+      <oldsource>Duration (hh:mm)</oldsource>
       <translation>Dauer</translation>
     </message>
     <message id="settings_relay_deactivation_value">
       <location filename="../../components/TemperatureRelaySettings.qml" line="86"/>
       <source>Deactivation value</source>
+      <oldsource>Deativation value</oldsource>
       <translation>Deaktivierungswert</translation>
     </message>
     <message id="splash_view_device_disconnected">
@@ -8061,29 +7164,6 @@ Möchtest Sie fortfahren?</translation>
       <source>Temperature warning</source>
       <translation>Temperatur-Warnung</translation>
     </message>
-    <message id="battery_mode_idle">
-      <location filename="../../src/enums.cpp" line="26"/>
-      <source>Idle</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Idle</translation>
-    </message>
-    <message id="battery_mode_charging">
-      <location filename="../../src/enums.cpp" line="30"/>
-      <source>Charging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Aufladen</translation>
-    </message>
-    <message id="battery_mode_discharging">
-      <location filename="../../src/enums.cpp" line="34"/>
-      <source>Discharging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Entladen</translation>
-    </message>
-    <message id="dcMeter_bilge_pump">
-      <location filename="../../src/enums.cpp" line="115"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">Bilgepumpe</translation>
-    </message>
     <message id="switch_state_channel_fault">
       <location filename="../../src/enums.cpp" line="372"/>
       <source>Channel Fault</source>
@@ -8114,26 +7194,6 @@ Möchtest Sie fortfahren?</translation>
       <source>Slave of %1</source>
       <translation>Sklave von %1</translation>
     </message>
-    <message id="switchable_output_numeric_input">
-      <location filename="../../src/enums.cpp" line="418"/>
-      <source>Numeric input</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bilge_pump">
-      <location filename="../../src/enums.cpp" line="424"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">Bilgepumpe</translation>
-    </message>
-    <message id="switchable_output_not_running">
-      <location filename="../../src/enums.cpp" line="448"/>
-      <source>Not running</source>
-      <translation type="unfinished">Läuft nicht</translation>
-    </message>
-    <message id="switchable_output_off">
-      <location filename="../../src/enums.cpp" line="451"/>
-      <source>Off</source>
-      <translation type="unfinished">Aus</translation>
-    </message>
     <message id="switchable_output_powered">
       <location filename="../../src/enums.cpp" line="455"/>
       <source>Powered</source>
@@ -8162,16 +7222,19 @@ Möchtest Sie fortfahren?</translation>
     <message id="evchargers_status_welded_contacts_error">
       <location filename="../../data/EvChargers.qml" line="76"/>
       <source>Welded contacts test error (shorted)</source>
+      <oldsource>Welded contacts error</oldsource>
       <translation>Testfehler geschweißte Kontakte (Kurzschluss)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
       <location filename="../../data/EvChargers.qml" line="100"/>
       <source>Switching to 3 phase</source>
+      <oldsource>Switching to 3-phase</oldsource>
       <translation>Umschaltung auf 3 Phasen</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
       <location filename="../../data/EvChargers.qml" line="103"/>
       <source>Switching to 1 phase</source>
+      <oldsource>Switching to single phase</oldsource>
       <translation>Umschalten auf 1 Phase</translation>
     </message>
     <message id="evchargers_status_stop_charging">
@@ -8324,17 +7387,6 @@ Wenn der Generator derzeit aufgrund einer Autostart-Bedingung läuft, wird er du
       <source>Open link</source>
       <translation>Link öffnen</translation>
     </message>
-    <message id="listlink_show_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="43"/>
-      <source>Show QR code</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="listlink_scan_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="52"/>
-      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
-      <extracomment>%1 = url text</extracomment>
-      <translation type="unfinished">Scannen Sie den QR-Code mit Ihrem tragbaren Gerät.&lt;br /&gt;Oder fügen Sie den Link ein: %1</translation>
-    </message>
     <message id="settings_services_mqtt_access">
       <location filename="../../components/listitems/ListMqttAccessSwitch.qml" line="11"/>
       <source>MQTT Access</source>
@@ -8406,12 +7458,6 @@ Wenn der Generator derzeit aufgrund einer Autostart-Bedingung läuft, wird er du
       <extracomment>The 'Brief' page, with the side panel opened</extracomment>
       <translation>Brief (Seitenwand offen)</translation>
     </message>
-    <message id="startpage_option_overview">
-      <location filename="../../data/StartPageConfiguration.qml" line="37"/>
-      <source>Overview</source>
-      <extracomment>The 'Overview' page</extracomment>
-      <translation type="unfinished">Übersicht</translation>
-    </message>
     <message id="startpage_option_levels_tanks">
       <location filename="../../data/StartPageConfiguration.qml" line="43"/>
       <source>Levels (Tanks)</source>
@@ -8430,12 +7476,12 @@ Wenn der Generator derzeit aufgrund einer Autostart-Bedingung läuft, wird er du
       <translation>Batterieliste</translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
+      <location filename="../../pages/DialogLayer.qml" line="56"/>
       <source>GX device has been updated</source>
       <translation>Das GX-Gerät wurde aktualisiert</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
+      <location filename="../../pages/DialogLayer.qml" line="58"/>
       <source>Page will automatically reload in ten seconds to load the latest version.</source>
       <translation>Die Seite wird in zehn Sekunden automatisch neu geladen, um die neueste Version zu laden.</translation>
     </message>
@@ -8605,8 +7651,8 @@ Beachten Sie, dass dieses Menü nur Carlo Gavazzi Zähler anzeigt, die über RS4
       <source>Unit</source>
       <translation>Einheit</translation>
     </message>
-    <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="61"/>
+    <message id="page_settings_fronius_unitid_invalid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
       <source>%1 is not a valid unit number. Use a number between 1-247.</source>
       <translation>%1 ist keine gültige Einheitennummer. Verwenden Sie eine Zahl zwischen 1-247.</translation>
     </message>
@@ -8721,11 +7767,6 @@ Beachten Sie, dass dieses Menü nur Carlo Gavazzi Zähler anzeigt, die über RS4
       <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="66"/>
       <source>Controller Temperature</source>
       <translation>Temperatur Wächter</translation>
-    </message>
-    <message id="devicelist_motordrive_motordirectioninverted">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
-      <source>Motor Direction Inverted</source>
-      <translation type="unfinished"/>
     </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
@@ -8917,11 +7958,6 @@ Dank optimierter Navigation und neuem Look ist alles, was Sie lieben, jetzt noch
     <message id="welcome_done">
       <location filename="../../pages/welcome/WelcomeView.qml" line="136"/>
       <source>Done</source>
-      <translation type="unfinished">Erledigt</translation>
-    </message>
-    <message id="mk2vsc_state_done">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="20"/>
-      <source>Done</source>
       <translation>Erledigt</translation>
     </message>
     <message id="welcome_next">
@@ -8979,6 +8015,7 @@ Das GX-Gerät kann nur ein angeschlossenes Genset steuern und nimmt dasjenige mi
     <message id="settings_tz_etc">
       <location filename="../../pages/settings/PageTzInfo.qml" line="280"/>
       <source>Other</source>
+      <oldsource>Etc</oldsource>
       <translation>Sonstiges</translation>
     </message>
     <message id="ac-in-modeldefault_energy_reverse_x">
@@ -8996,6 +8033,11 @@ Das GX-Gerät kann nur ein angeschlossenes Genset steuern und nimmt dasjenige mi
       <location filename="../../src/enums.cpp" line="438"/>
       <source>Unsupported type: %1</source>
       <translation>Nicht unterstützter Typ: %1</translation>
+    </message>
+    <message id="common_words_press">
+      <location filename="../../components/CommonWords.qml" line="419"/>
+      <source>Press</source>
+      <translation>Drücken</translation>
     </message>
     <message id="output_aux_battery_service_changed_dcdc">
       <location filename="../../components/listitems/ListOutputBatteryRadioButtonGroup.qml" line="27"/>
@@ -9136,13 +8178,6 @@ Das GX-Gerät kann nur ein angeschlossenes Genset steuern und nimmt dasjenige mi
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="38"/>
       <source>Resetting VE.Bus products</source>
       <translation>VE.Bus-Produkte zurücksetzen</translation>
-    </message>
-    <message id="Unknown">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Unbekannt</translation>
     </message>
     <message id="mk2vsc_error_mk2_mk3_comm">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="47"/>
@@ -9448,11 +8483,6 @@ Das GX-Gerät kann nur ein angeschlossenes Genset steuern und nimmt dasjenige mi
       <source>Changing the GX Password</source>
       <translation>Ändern des GX-Passworts</translation>
     </message>
-    <message id="modaldialog_confirm">
-      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
-      <source>Confirm</source>
-      <translation type="unfinished">Bestätigen</translation>
-    </message>
     <message id="settings_security_profile_change_password_description">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="83"/>
       <source>Please enter a new GX password:</source>
@@ -9545,21 +8575,6 @@ Das GX-Gerät kann nur ein angeschlossenes Genset steuern und nimmt dasjenige mi
       <source>Modifications installed</source>
       <translation>Modifikationen installiert</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_modbus">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="28"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">Modbus TCP-Server</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_signalk">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="32"/>
-      <source>Signal K</source>
-      <translation type="unfinished">Signal K</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_nodered">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="36"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">Node-RED</translation>
-    </message>
     <message id="pagesettingsgeneral_modificationchecks_running_integrations">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="43"/>
       <source>%1 running integrations</source>
@@ -9635,16 +8650,6 @@ Das GX-Gerät kann nur ein angeschlossenes Genset steuern und nimmt dasjenige mi
       <source>Installed and enabled, disables at next boot</source>
       <translation>Installiert und aktiviert, wird beim nächsten Start deaktiviert</translation>
     </message>
-    <message id="pagesettingssupportstate_firmware_checking">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
-      <source>Checking...</source>
-      <translation type="unfinished">Überprüfe...</translation>
-    </message>
-    <message id="pagesettingssupportstate_firmware_unknown">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="166"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Unbekannt</translation>
-    </message>
     <message id="pagesettingssupportstate_support_status">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="228"/>
       <source>Support status</source>
@@ -9666,11 +8671,6 @@ Das GX-Gerät kann nur ein angeschlossenes Genset steuern und nimmt dasjenige mi
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="288"/>
       <source>Press 'OK' to disable custom startup scripts and reboot</source>
       <translation>Drücken Sie „OK“, um benutzerdefinierte Startskripte zu deaktivieren und das System neu zu starten</translation>
-    </message>
-    <message id="pagesettingssupportstate_re_enable_custom_startup_scripts">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="309"/>
-      <source>Re-enable custom startup scripts</source>
-      <translation type="unfinished">Benutzerdefinierte Startskripte wieder aktivieren</translation>
     </message>
     <message id="pagesettingssupportstate_reenable_and_reboot_now">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="322"/>
@@ -9697,11 +8697,6 @@ Das GX-Gerät kann nur ein angeschlossenes Genset steuern und nimmt dasjenige mi
       <source>Disable also custom startup scripts?</source>
       <translation>Benutzerdefinierte Startskripte ebenfalls deaktivieren?</translation>
     </message>
-    <message id="pagesettingssupportstate_integrations">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
-      <source>Integrations</source>
-      <translation type="unfinished">Integrationen</translation>
-    </message>
     <message id="pagesettingssupportstate_orange_items_description">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="494"/>
       <source>Items colored orange are supported and provided by Victron Energy, but using them incorrectly can affect system stability. In case of troubleshooting, disable those first.</source>
@@ -9710,10 +8705,10 @@ Das GX-Gerät kann nur ein angeschlossenes Genset steuern und nimmt dasjenige mi
     <message id="settings_bluetooth_unavailable_message">
       <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="26"/>
       <source>Connect a compatible Bluetooth USB dongle to enable Bluetooth connectivity.</source>
-      <translation>Schließen Sie einen kompatiblen Bluetooth-USB-Dongle an, um die Bluetooth-Verbindung zu aktivieren.</translation>
+      <translation>Schließen Sie einen kompatiblen Bluetooth-USB-Dongle an, um Bluetooth zu aktivieren.</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="140"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="142"/>
       <source>BatteryLife state</source>
       <translation>BatteryLife-Status</translation>
     </message>
@@ -9721,23 +8716,6 @@ Das GX-Gerät kann nur ein angeschlossenes Genset steuern und nimmt dasjenige mi
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="33"/>
       <source>Device Integrations</source>
       <translation>Geräteintegrationen</translation>
-    </message>
-    <message id="pagesettingsintegrations_modbus_tcp_server">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="201"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">Modbus TCP-Server</translation>
-    </message>
-    <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="226"/>
-      <location filename="../../pages/settings/PageSettingsSignalK.qml" line="18"/>
-      <source>Signal K</source>
-      <translation type="unfinished">Signal K</translation>
-    </message>
-    <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="241"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">Node-RED</translation>
     </message>
     <message id="settings_venusos_large_documentation">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="267"/>
@@ -9747,6 +8725,7 @@ Das GX-Gerät kann nur ein angeschlossenes Genset steuern und nimmt dasjenige mi
     <message id="settings_modbus_enable_modbus_tcp">
       <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
       <source>Enable Modbus TCP Server</source>
+      <oldsource>Enable Modbus/TCP</oldsource>
       <translation>Modbus TCP-Server aktivieren</translation>
     </message>
     <message id="pagesettingsconnectivity_bluetooth_for_victronconnect_app">
@@ -9802,12 +8781,12 @@ Das GX-Gerät kann nur ein angeschlossenes Genset steuern und nimmt dasjenige mi
     <message id="pagesettingssupportstate_disable_and_reboot_now">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="277"/>
       <source>Disable and reboot now</source>
-      <translation>Jetzt deaktivieren und neu starten</translation>
+      <translation>Deaktivieren und jetzt neu starten</translation>
     </message>
     <message id="pagesettingssupportstate_re_enable_and_reboot_now">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="311"/>
       <source>Re-enable and reboot now</source>
-      <translation>Jetzt wieder aktivieren und neu starten</translation>
+      <translation>Erneut aktivieren und jetzt neu starten</translation>
     </message>
     <message id="pagesettingssupportstate_update_firmware_to_fix_modified_state">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="375"/>
@@ -9819,32 +8798,34 @@ Das GX-Gerät kann nur ein angeschlossenes Genset steuern und nimmt dasjenige mi
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="381"/>
       <source>Updating %1 %2%</source>
       <extracomment>Firmware update firmwareProgressItem. %1 = firmware version, %2 = current update progress</extracomment>
-      <translation>Aktualisierung %1 %2%</translation>
+      <translation>Aktualisiere %1 %2%</translation>
     </message>
     <message id="pagesettingssupportstate_updating">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="385"/>
       <source>Updating %1...</source>
       <extracomment>%1 = firmware version</extracomment>
-      <translation>Aktualisierung %1...</translation>
+      <translation>Aktualisiere %1...</translation>
     </message>
     <message id="pagesettingssupportstate_press_to_update">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="389"/>
       <source>Press to update to</source>
-      <translation>Zum Aktualisieren auf tippen:</translation>
+      <translation>Drücken Sie, um zu aktualisieren auf</translation>
     </message>
     <message id="pagesettingssupportstate_update_firmware_to_fix_modified_state_description">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="404"/>
       <source>This will download and update rootfs with the latest official firmware.&lt;br&gt;Internet connectivity is required.&lt;br&gt;Press 'OK' to continue.</source>
-      <translation>Dadurch wird das Root-Dateisystem mit der neuesten offiziellen Firmware heruntergeladen und aktualisiert.&lt;br&gt;Eine Internetverbindung ist erforderlich.&lt;br&gt;Zum Fortfahren auf 'OK' tippen.</translation>
+      <translation>Dies wird das Rootfs mit der neuesten offiziellen Firmware herunterladen und aktualisieren.&lt;br&gt;Internetverbindung erforderlich.&lt;br&gt;Drücken Sie „OK“, um fortzufahren.</translation>
     </message>
     <message id="settings_gps_format_kmh">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="93"/>
       <source>Kilometres per hour</source>
+      <oldsource>Kilometers per hour</oldsource>
       <translation>Kilometer pro Stunde</translation>
     </message>
     <message id="settings_gps_format_ms">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="95"/>
       <source>Metres per second</source>
+      <oldsource>Meters per second</oldsource>
       <translation>Meter pro Sekunde</translation>
     </message>
     <message id="components_volumeunit_cubic_metres">
@@ -9872,8 +8853,8 @@ Das GX-Gerät kann nur ein angeschlossenes Genset steuern und nimmt dasjenige mi
       <source>The Relay can now be found in the devices list</source>
       <translation>Das Relais befindet sich nun in der Geräteliste</translation>
     </message>
-    <message id="common_words_gx_device_relays">
-      <location filename="../../components/CommonWords.qml" line="223"/>
+    <message id="gx_device_relays">
+      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
       <source>GX device relays</source>
       <translation>GX-Geräterelais</translation>
     </message>
@@ -9885,7 +8866,7 @@ Das GX-Gerät kann nur ein angeschlossenes Genset steuern und nimmt dasjenige mi
     <message id="settings_canbus_rvc_reverse_current_polarity">
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="69"/>
       <source>Reverse current polarity</source>
-      <translation>Polarität des Rückstroms umkehren</translation>
+      <translation>Strompolarität umkehren</translation>
     </message>
     <message id="settings_canbus_rvc_reverse_current_polarity_description">
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="73"/>
@@ -9895,13 +8876,13 @@ Das GX-Gerät kann nur ein angeschlossenes Genset steuern und nimmt dasjenige mi
     <message id="settings_gx_display_appearance">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="59"/>
       <source>GX display appearance</source>
-      <translation>GX-Display-Erscheinungsbild</translation>
+      <translation>GX-Displaydarstellung</translation>
     </message>
     <message id="settings_remote_console_appearance">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="74"/>
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="105"/>
       <source>Remote Console appearance</source>
-      <translation>Erscheinungsbild der Remote-Konsole</translation>
+      <translation>Darstellung der Remote-Konsole</translation>
     </message>
     <message id="settings_remote_console_forced">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="78"/>
@@ -9926,12 +8907,6 @@ Das GX-Gerät kann nur ein angeschlossenes Genset steuern und nimmt dasjenige mi
       <source>auto</source>
       <extracomment>Forced by app to %1</extracomment>
       <translation>Auto</translation>
-    </message>
-    <message id="settings_remote_console_forced_by_vrm">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="94"/>
-      <source>VRM</source>
-      <extracomment>Forced by %2 to dark</extracomment>
-      <translation type="unfinished">VRM</translation>
     </message>
     <message id="settings_remote_console_forced_by_app">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="97"/>
@@ -9982,6 +8957,7 @@ Das GX-Gerät kann nur ein angeschlossenes Genset steuern und nimmt dasjenige mi
     <message id="settings_large_access_signal_k">
       <location filename="../../pages/settings/PageSettingsSignalK.qml" line="24"/>
       <source>Access Signal K</source>
+      <oldsource>Access Signal K (local network)</oldsource>
       <translation>Zugriff auf Signal K</translation>
     </message>
     <message id="pagesettingsintegrations_shelly_devices">
@@ -9992,6 +8968,7 @@ Das GX-Gerät kann nur ein angeschlossenes Genset steuern und nimmt dasjenige mi
     <message id="settings_large_access_node_red">
       <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
       <source>Access Node-RED</source>
+      <oldsource>Access Node-RED (local network)</oldsource>
       <translation>Zugriff auf Node-RED</translation>
     </message>
     <message id="settings_wifi_access_point_password">
@@ -10059,57 +9036,6 @@ Das GX-Gerät kann nur ein angeschlossenes Genset steuern und nimmt dasjenige mi
       <source>Wind charger</source>
       <translation>Windgenerator</translation>
     </message>
-    <message id="digitalinputs_type_disabled">
-      <location filename="../../src/enums.cpp" line="192"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Deaktiviert</translation>
-    </message>
-    <message id="digitalinputs_state_off">
-      <location filename="../../src/enums.cpp" line="242"/>
-      <source>Off</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Aus</translation>
-    </message>
-    <message id="digitalinputs_state_on">
-      <location filename="../../src/enums.cpp" line="246"/>
-      <source>On</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Ein</translation>
-    </message>
-    <message id="digitalinputs_state_ok">
-      <location filename="../../src/enums.cpp" line="266"/>
-      <source>OK</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Ok</translation>
-    </message>
-    <message id="digitalinputs_state_alarm">
-      <location filename="../../src/enums.cpp" line="270"/>
-      <source>Alarm</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Alarm</translation>
-    </message>
-    <message id="digitalinputs_state_running">
-      <location filename="../../src/enums.cpp" line="274"/>
-      <source>Running</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">In Betrieb</translation>
-    </message>
-    <message id="pvinverter_statusCode_running">
-      <location filename="../../src/enums.cpp" line="300"/>
-      <source>Running</source>
-      <extracomment>PV inverter status code</extracomment>
-      <translation type="unfinished">In Betrieb</translation>
-    </message>
-    <message id="solarchargers_state_external control">
-      <location filename="../../src/enums.cpp" line="352"/>
-      <source>External control</source>
-      <translation type="unfinished">Externe Steuerung</translation>
-    </message>
-    <message id="switch_state_over_temperature">
-      <location filename="../../src/enums.cpp" line="366"/>
-      <source>Over temperature</source>
-      <translation type="unfinished">Übertemperatur</translation>
-    </message>
     <message id="switchable_output_temperature_setpoint">
       <location filename="../../src/enums.cpp" line="398"/>
       <source>Temperature setpoint</source>
@@ -10119,11 +9045,6 @@ Das GX-Gerät kann nur ein angeschlossenes Genset steuern und nimmt dasjenige mi
       <location filename="../../src/enums.cpp" line="401"/>
       <source>Stepped switch</source>
       <translation>Stufenschalter</translation>
-    </message>
-    <message id="switchable_output_slave">
-      <location filename="../../src/enums.cpp" line="408"/>
-      <source>Slave</source>
-      <translation type="unfinished">Slave</translation>
     </message>
     <message id="switchable_output_dropdown">
       <location filename="../../src/enums.cpp" line="412"/>
@@ -10135,127 +9056,15 @@ Das GX-Gerät kann nur ein angeschlossenes Genset steuern und nimmt dasjenige mi
       <source>Basic slider</source>
       <translation>Einfacher Schieberegler</translation>
     </message>
-    <message id="switchable_output_rgb_color_wheel">
-      <location filename="../../src/enums.cpp" line="427"/>
-      <source>RGB color wheel</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_cct_color_wheel">
-      <location filename="../../src/enums.cpp" line="431"/>
-      <source>CCT color wheel</source>
-      <extracomment>Correlated Color Temperature color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_rgbw_color_wheel">
-      <location filename="../../src/enums.cpp" line="435"/>
-      <source>RGB + W color wheel</source>
-      <extracomment>RGB + white color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bypassed">
-      <location filename="../../src/enums.cpp" line="484"/>
-      <source>Bypassed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="tank_type_fuel">
-      <location filename="../../src/enums.cpp" line="495"/>
-      <source>Fuel</source>
-      <translation type="unfinished">Treibstoff</translation>
-    </message>
-    <message id="tank_type_fresh_water">
-      <location filename="../../src/enums.cpp" line="498"/>
-      <source>Fresh water</source>
-      <translation type="unfinished">Frischwasser</translation>
-    </message>
-    <message id="tank_type_waste_water">
-      <location filename="../../src/enums.cpp" line="501"/>
-      <source>Waste water</source>
-      <translation type="unfinished">Abwasser</translation>
-    </message>
-    <message id="tank_type_live_well">
-      <location filename="../../src/enums.cpp" line="504"/>
-      <source>Live well</source>
-      <translation type="unfinished">Fischkasten</translation>
-    </message>
-    <message id="tank_type_oil">
-      <location filename="../../src/enums.cpp" line="507"/>
-      <source>Oil</source>
-      <translation type="unfinished">Öl</translation>
-    </message>
-    <message id="tank_type_black_water">
-      <location filename="../../src/enums.cpp" line="510"/>
-      <source>Black water</source>
-      <translation type="unfinished">Schwarzwasser</translation>
-    </message>
-    <message id="tank_type_gasoline">
-      <location filename="../../src/enums.cpp" line="513"/>
-      <source>Gasoline</source>
-      <translation type="unfinished">Benzin</translation>
-    </message>
-    <message id="tank_type_diesel">
-      <location filename="../../src/enums.cpp" line="516"/>
-      <source>Diesel</source>
-      <translation type="unfinished">Diesel</translation>
-    </message>
-    <message id="tank_type_lpg">
-      <location filename="../../src/enums.cpp" line="519"/>
-      <source>LPG</source>
-      <translation type="unfinished">LPG</translation>
-    </message>
-    <message id="tank_type_lng">
-      <location filename="../../src/enums.cpp" line="522"/>
-      <source>LNG</source>
-      <translation type="unfinished">LNG</translation>
-    </message>
-    <message id="tank_type_hydraulic_oil">
-      <location filename="../../src/enums.cpp" line="525"/>
-      <source>Hydraulic oil</source>
-      <translation type="unfinished">Hydrauliköl</translation>
-    </message>
-    <message id="tank_type_raw_water">
-      <location filename="../../src/enums.cpp" line="528"/>
-      <source>Raw water</source>
-      <translation type="unfinished">Rohwasser</translation>
-    </message>
-    <message id="microgrid_mode_hybrid_droop">
-      <location filename="../../src/enums.cpp" line="539"/>
-      <source>Hybrid droop</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_following">
-      <location filename="../../src/enums.cpp" line="542"/>
-      <source>Grid-following</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_forming">
-      <location filename="../../src/enums.cpp" line="545"/>
-      <source>Grid-forming</source>
-      <translation type="unfinished"/>
-    </message>
     <message id="switchable_output_three_state_switch">
       <location filename="../../src/enums.cpp" line="421"/>
       <source>Three-state switch</source>
-      <translation>Drei-Zustands-Schalter</translation>
-    </message>
-    <message id="switchable_output_fault">
-      <location filename="../../src/enums.cpp" line="464"/>
-      <source>Fault</source>
-      <translation type="unfinished">Störung</translation>
-    </message>
-    <message id="switchable_output_running">
-      <location filename="../../src/enums.cpp" line="468"/>
-      <source>Running</source>
-      <translation type="unfinished">In Betrieb</translation>
-    </message>
-    <message id="switchable_output_trip_low_voltage">
-      <location filename="../../src/enums.cpp" line="481"/>
-      <source>Trip low voltage</source>
-      <translation type="unfinished">Deaktiviert</translation>
+      <translation>Dreistellungsschalter</translation>
     </message>
     <message id="settings_modbus_tcp_unit_id_note">
       <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="41"/>
       <source>See the Settings → VRM → VRM device instances menu to change the Modbus-TCP unit IDs.</source>
-      <translation>Um die Modbus-TCP Unit-IDs zu ändern, siehe Einstellungen → VRM → VRM-Geräteinstanzen.</translation>
+      <translation>Um die Modbus-TCP Unit-IDs zu ändern, siehe Einstellungen → VRM → VRM-Geräte-Instanzen.</translation>
     </message>
     <message id="device_page_switches">
       <location filename="../../components/DevicePage.qml" line="49"/>
@@ -10272,281 +9081,1152 @@ Das GX-Gerät kann nur ein angeschlossenes Genset steuern und nimmt dasjenige mi
       <source>Press to refresh</source>
       <translation>Zum Aktualisieren drücken</translation>
     </message>
-    <message id="temperature_type_unknown">
-      <location filename="../../data/EnvironmentInputs.qml" line="65"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Unbekannt</translation>
-    </message>
-    <message id="brief_solar_yield">
-      <location filename="../../pages/BriefSidePanel.qml" line="24"/>
-      <source>Solar yield</source>
-      <translation type="unfinished">Solarertrag</translation>
-    </message>
-    <message id="brief_dc_input">
-      <location filename="../../pages/BriefSidePanel.qml" line="214"/>
-      <source>DC input</source>
-      <translation type="unfinished">DC-Eingang</translation>
-    </message>
-    <message id="brief_ac_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="257"/>
-      <source>AC Loads</source>
-      <translation type="unfinished">AC-Lasten</translation>
-    </message>
-    <message id="brief_dc_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="284"/>
-      <source>DC Loads</source>
-      <translation type="unfinished">DC-Lasten</translation>
-    </message>
-    <message id="nav_overview">
-      <location filename="../../pages/OverviewPage.qml" line="450"/>
-      <source>Overview</source>
-      <translation type="unfinished">Übersicht</translation>
-    </message>
-    <message id="settings_state">
-      <location filename="../../pages/settings/PageCanbusStatus.qml" line="116"/>
-      <source>State</source>
-      <translation type="unfinished">Zustand</translation>
-    </message>
-    <message id="inverter_pv">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="56"/>
-      <source>PV</source>
-      <translation type="unfinished">PV</translation>
-    </message>
-    <message id="inverter_total_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="76"/>
-      <source>Total yield</source>
-      <translation type="unfinished">Gesamtertrag</translation>
-    </message>
-    <message id="inverter_system_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="84"/>
-      <source>System yield</source>
-      <translation type="unfinished">Systemertrag</translation>
-    </message>
-    <message id="charger_total_pv_power">
-      <location filename="../../pages/solar/SolarDevicePage.qml" line="61"/>
-      <source>Total PV Power</source>
-      <translation type="unfinished">PV Leistung gesamt</translation>
-    </message>
-    <message id="vebus_device_alarm_only">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
-      <source>Alarm only</source>
-      <translation type="unfinished">Nur Alarm</translation>
-    </message>
-    <message id="vebus_device_alarms_and_warnings">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
-      <source>Alarms &amp; warnings</source>
-      <translation type="unfinished">Alarme &amp; Warnungen</translation>
-    </message>
-    <message id="vebus_device_alarm_group_warning">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
-      <source>Warning</source>
-      <translation type="unfinished">Warnung</translation>
-    </message>
-    <message id="load_delegate_status">
-      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
-      <source>Status: %1</source>
-      <translation type="unfinished"/>
+    <message id="common_words_total_power">
+      <location filename="../../components/CommonWords.qml" line="540"/>
+      <source>Total power</source>
+      <translation>Gesamtleistung</translation>
     </message>
     <message id="venus_os_gui">
       <location filename="../../Main.qml" line="17"/>
       <source>Venus OS GUI</source>
       <extracomment>Application title</extracomment>
-      <translation type="unfinished"/>
       <extra-Context>only shown on desktop systems</extra-Context>
+      <translation>Venus OS GUI</translation>
+    </message>
+    <message id="load_delegate_status">
+      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
+      <source>Status: %1</source>
+      <translation>Status: %1</translation>
+    </message>
+    <message id="settings_relay_polarity_relay1">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
+      <source>Polarity (Relay 1)</source>
+      <translation>Polarität (Relais 1)</translation>
+    </message>
+    <message id="settings_relay_polarity">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
+      <source>Polarity</source>
+      <translation>Polarität</translation>
+    </message>
+    <message id="settings_relay_polarity_relay2">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
+      <source>Polarity (Relay 2)</source>
+      <translation>Polarität (Relais 2)</translation>
+    </message>
+    <message id="page_settings_wifi_invalid_password">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
+      <source>Password length must be either 0 or between 10 and 63 characters long</source>
+      <translation>Die Passwortlänge muss entweder 0 oder zwischen 10 und 63 Zeichen betragen</translation>
+    </message>
+    <message id="page_settings_wifi_password_updated">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
+      <source>Password updated</source>
+      <translation>Passwort aktualisiert</translation>
+    </message>
+    <message id="common_words_max">
+      <location filename="../../components/CommonWords.qml" line="315"/>
+      <source>Max</source>
+      <extracomment>Short for Maximum</extracomment>
+      <translation>Max</translation>
+    </message>
+    <message id="common_words_min">
+      <location filename="../../components/CommonWords.qml" line="331"/>
+      <source>Min</source>
+      <extracomment>Short for Minimum</extracomment>
+      <translation>Min</translation>
+    </message>
+    <message id="settings_ess_deprecated">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="321"/>
+      <source>Deprecated settings</source>
+      <translation>Veraltete Einstellungen</translation>
+    </message>
+    <message id="settings_ess_max_charge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="328"/>
+      <source>Battery charge limit (% of CCL)</source>
+      <translation>Batterieladegrenze (% der CCL)</translation>
+    </message>
+    <message id="settings_ess_max_discharge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="339"/>
+      <source>Battery discharge limit (% of DCL)</source>
+      <translation>Batterieentladungsgrenze (% der DCL)</translation>
+    </message>
+    <message id="vebus_device_bms_message">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
+      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
+      <oldsource>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</oldsource>
+      <translation>Ein VE.Bus BMS schaltet das System bei Bedarf automatisch ab, um die Batterie zu schützen. Die Steuerung des Systems vom GX-Gerät aus ist daher nicht möglich.</translation>
+    </message>
+    <message id="switchable_output_numeric_input">
+      <location filename="../../src/enums.cpp" line="418"/>
+      <source>Numeric input</source>
+      <translation>Numerische Eingabe</translation>
     </message>
     <message id="autotoggleswitch_disable_auto_mode_info">
       <location filename="../../components/controls/AutoToggleButton.qml" line="34"/>
       <source>Disable Auto mode first</source>
-      <translation type="unfinished"/>
+      <translation>Deaktivieren Sie zuerst den Auto-Modus</translation>
+    </message>
+    <message id="pagesettingsintegrations_venus_os_enable_large_features">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
+      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
+      <translation>Aktiviere die Venus OS Large Firmware, um Node-RED oder Signal-K zu verwenden</translation>
+    </message>
+    <message id="settings_relays_sensors_tanks">
+      <location filename="../../pages/SettingsPage.qml" line="75"/>
+      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
+      <oldsource>Relays, Sensors, Tanks, PV Inverters, Modbus, MQTT…</oldsource>
+      <translation>Relais, Sensoren, PV-Wechselrichter, Modbus, Node-RED</translation>
+    </message>
+    <message id="vebus_device_page_microgrid_parameters">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
+      <source>Microgrid parameters</source>
+      <translation>Microgrid-Parameter</translation>
+    </message>
+    <message id="microgrid_mode_hybrid_droop">
+      <location filename="../../src/enums.cpp" line="539"/>
+      <source>Hybrid droop</source>
+      <translation>Hybrider Droop</translation>
+    </message>
+    <message id="microgrid_mode_grid_following">
+      <location filename="../../src/enums.cpp" line="542"/>
+      <source>Grid-following</source>
+      <translation>Netzfolgend</translation>
+    </message>
+    <message id="microgrid_mode_grid_forming">
+      <location filename="../../src/enums.cpp" line="545"/>
+      <source>Grid-forming</source>
+      <translation>Netzbildend</translation>
+    </message>
+    <message id="switchable_output_trip_low_voltage">
+      <location filename="../../src/enums.cpp" line="481"/>
+      <source>Trip low voltage</source>
+      <oldsource>Disabled</oldsource>
+      <translation>Abschaltung bei Unterspannung</translation>
     </message>
     <message id="microgrid">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="15"/>
       <source>Microgrid</source>
-      <translation type="unfinished"/>
+      <translation>Microgrid</translation>
     </message>
     <message id="page_microgrid_active_mode">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="19"/>
       <source>Active mode</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_microgrid_from_p1_to_p2">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="34"/>
-      <source>%1 %2 to %3 %4</source>
-      <extracomment>Describes a range from one quantity to another, e.g. "30 W to 60 W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
-      <translation type="unfinished"/>
+      <translation>Aktiver Modus</translation>
     </message>
     <message id="page_microgrid_hybrid_droop_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="92"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
       <source>Hybrid droop parameters</source>
-      <translation type="unfinished"/>
+      <translation>Parameter für hybriden Droop</translation>
     </message>
     <message id="page_microgrid_reference_active_power_p0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="105"/>
       <source>Reference active power (P&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Referenz-Wirkleistung (P&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_frequency_f0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="108"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="112"/>
       <source>Reference frequency (f&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Referenz-Frequenz (f&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_frequency_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="117"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="119"/>
       <source>Frequency droop slope (droop&lt;sub&gt;fP&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Frequenz-Droop-Steigung (droop&lt;sub&gt;fP&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_reactive_power">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="126"/>
       <source>Reference reactive power (Q&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Referenz-Blindleistung (Q&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_voltage">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="135"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="133"/>
       <source>Reference Voltage (U&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Referenz-Spannung (U&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_voltage_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="144"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="140"/>
       <source>Voltage droop slope (droop&lt;sub&gt;UQ&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Spannungs-Droop-Steigung (droop&lt;sub&gt;UQ&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_minimum_and_maximum_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="146"/>
       <source>Minimum and maximum parameters</source>
-      <translation type="unfinished"/>
+      <translation>Minimale und maximale Parameter</translation>
     </message>
     <message id="page_microgrid_allowed_active_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="156"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
       <source>Allowed active power range</source>
-      <translation type="unfinished"/>
+      <translation>Zulässiger Wirkleistungsbereich</translation>
     </message>
     <message id="page_microgrid_allowed_reactive_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="164"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="159"/>
       <source>Allowed reactive power range</source>
-      <translation type="unfinished"/>
+      <translation>Zulässiger Blindleistungsbereich</translation>
     </message>
     <message id="page_microgrid_p_q_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="176"/>
       <source>P-Q direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>P-Q-Direktantriebseinstellungen</translation>
     </message>
     <message id="page_microgrid_active_power_setpoint_p">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="186"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
       <source>Active power setpoint (P)</source>
-      <translation type="unfinished"/>
+      <translation>Sollwert für Wirkleistung (P)</translation>
     </message>
     <message id="page_microgrid_reactive_power_setpoint_q">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="194"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="188"/>
       <source>Reactive power setpoint (Q)</source>
-      <translation type="unfinished"/>
+      <translation>Sollwert für Blindleistung (Q)</translation>
     </message>
     <message id="page_microgrid_allowed_frequency_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="202"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="195"/>
       <source>Allowed frequency range</source>
-      <translation type="unfinished"/>
+      <translation>Zulässiger Frequenzbereich</translation>
     </message>
     <message id="page_microgrid_allowed_voltage_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="210"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="203"/>
       <source>Allowed voltage range</source>
-      <translation type="unfinished"/>
+      <translation>Zulässiger Spannungsbereich</translation>
     </message>
     <message id="page_microgrid_v_f_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="227"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="220"/>
       <source>V-f direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>V-f-Direktantriebseinstellungen</translation>
     </message>
     <message id="page_microgrid_voltage_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="225"/>
       <source>Voltage setpoint (U)</source>
-      <translation type="unfinished"/>
+      <translation>Sollwert für Spannung (U)</translation>
     </message>
     <message id="page_microgrid_frequency_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="240"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
       <source>Frequency setpoint (f)</source>
-      <translation type="unfinished"/>
+      <translation>Sollwert für Frequenz (f)</translation>
     </message>
-    <message id="temperature_slider_current">
-      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
-      <source>Current</source>
-      <extracomment>The current temperature measurement</extracomment>
-      <translation type="unfinished">Strom</translation>
+    <message id="pagesettingsintegrations_canopenmotordrive">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
+      <source>CANopen motor drives</source>
+      <translation>CANopen Motorantriebe</translation>
+    </message>
+    <message id="pagesettingsintegrations_ui_plugins">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
+      <source>UI Plugins</source>
+      <translation>UI Plugins</translation>
+    </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
+      <source>Motor Direction Inverted</source>
+      <translation>Motorrichtung invertiert</translation>
     </message>
     <message id="page_settings_canopenmotordrive_scan_for_motor_drives">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="31"/>
       <source>Scan for motor drives</source>
-      <translation type="unfinished"/>
+      <translation>Suche nach Motorantrieben</translation>
     </message>
     <message id="page_settings_canopenmotordrive_discovered_motor_drive_ids">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="39"/>
       <source>Discovered motor drive IDs</source>
-      <translation type="unfinished"/>
+      <translation>Gefundene Motorantriebs-IDs</translation>
     </message>
-    <message id="switchableoutput_gx_device_relays">
-      <location filename="../../src/switchableoutput.cpp" line="388"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">GX-Geräterelais</translation>
+    <message id="temperature_pm25">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
+      <source>PM2.5</source>
+      <translation>PM2.5</translation>
     </message>
-    <message id="gx_device_relays">
-      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">GX-Geräterelais</translation>
+    <message id="temperature_co2">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+      <source>CO₂</source>
+      <translation>CO₂</translation>
     </message>
-    <message id="color_preset">
-      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
-      <source>Preset</source>
-      <translation type="unfinished"/>
+    <message id="temperature_voc">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
+      <source>VOC index</source>
+      <translation>VOC-Index</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_location">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
-      <source>Add Modbus port and unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_nox">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
+      <source>NOx index</source>
+      <translation>NOx-Index</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_unitid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
-      <source>Unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_luminosity">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
+      <source>Luminosity</source>
+      <translation>Leuchtkraft</translation>
     </message>
-    <message id="page_settings_fronius_unitid_invalid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation type="unfinished">%1 ist keine gültige Einheitennummer. Verwenden Sie eine Zahl zwischen 1-247.</translation>
-    </message>
-    <message id="page_settings_fronius_add_modbus_location_button">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
-      <source>Add</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_locations_note">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
-      <source>The default modbus port is 502 and the default unit ID is 126.
-Here you can add additional ports and unit IDs to scan for PV inverters.</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_location_number">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
-      <source>Port/Unit ID %1</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location_description">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
-      <source>Port: %1 (Unit %2)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
-      <source>Remove Modbus port and unit ID?</source>
-      <translation type="unfinished"/>
+    <message id="switchable_output_bypassed">
+      <location filename="../../src/enums.cpp" line="484"/>
+      <source>Bypassed</source>
+      <translation>Überbrückt</translation>
     </message>
     <message id="switchableoutput_list_delegate_auto_status">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="84"/>
       <source>Auto (%1)</source>
       <extracomment>%1 = 'On' or 'Off'</extracomment>
-      <translation type="unfinished"/>
+      <translation>Auto (%1)</translation>
     </message>
     <message id="switchableoutput_list_delegate_state_forced">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="100"/>
       <source>Forced</source>
-      <translation type="unfinished"/>
+      <translation>Erzwungen</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_settings">
+      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
+      <source>Modbus port and unit ID settings</source>
+      <translation>Modbus-Anschluss und Geräte-ID-Einstellungen</translation>
+    </message>
+    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
+      <source>Integrates with the device list</source>
+      <translation>Integriert sich in die Geräteliste</translation>
+    </message>
+    <message id="common_words_color">
+      <location filename="../../components/CommonWords.qml" line="136"/>
+      <source>Color</source>
+      <translation>Farbe</translation>
+    </message>
+    <message id="common_words_value_must_be_greater_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="557"/>
+      <source>Value must be greater than start value</source>
+      <translation>Wert muss größer als Startwert sein</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="566"/>
+      <source>Value must be lower than stop value</source>
+      <translation>Wert muss niedriger als Stoppwert sein</translation>
+    </message>
+    <message id="notifications_page_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="43"/>
+      <source>Active Notifications</source>
+      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
+      <translation>Aktive Benachrichtigungen</translation>
+    </message>
+    <message id="notifications_page_inactive_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="47"/>
+      <source>Inactive Notifications</source>
+      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
+      <translation>Inaktive Benachrichtigungen</translation>
+    </message>
+    <message id="notifications_no_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="106"/>
+      <source>No active notifications</source>
+      <translation>Keine aktiven Benachrichtigungen</translation>
+    </message>
+    <message id="switchable_output_rgb_color_wheel">
+      <location filename="../../src/enums.cpp" line="427"/>
+      <source>RGB color wheel</source>
+      <translation>RGB-Farbrad</translation>
+    </message>
+    <message id="switchable_output_cct_color_wheel">
+      <location filename="../../src/enums.cpp" line="431"/>
+      <source>CCT color wheel</source>
+      <extracomment>Correlated Color Temperature color wheel</extracomment>
+      <translation>CCT-Farbrad</translation>
+    </message>
+    <message id="switchable_output_rgbw_color_wheel">
+      <location filename="../../src/enums.cpp" line="435"/>
+      <source>RGB + W color wheel</source>
+      <extracomment>RGB + white color wheel</extracomment>
+      <translation>RGB + W Farbrad</translation>
+    </message>
+    <message id="listlink_show_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="43"/>
+      <source>Show QR code</source>
+      <translation>QR-Code anzeigen</translation>
+    </message>
+    <message id="listlink_scan_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="52"/>
+      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
+      <extracomment>%1 = url text</extracomment>
+      <oldsource>Scan the QR code with your portable device.&lt;br /&gt;Or insert the link: %1</oldsource>
+      <translation>Öffnen Sie den QR-Code, um ihn mit Ihrem mobilen Gerät zu scannen.&lt;br /&gt;Oder fügen Sie den Link ein: %1</translation>
+    </message>
+    <message id="color_preset">
+      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
+      <source>Preset</source>
+      <translation>Voreinstellung</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
+      <source>Add Modbus port and unit ID</source>
+      <translation>Modbus-Anschluss und Geräte-ID hinzufügen</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_unitid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
+      <source>Unit ID</source>
+      <translation>Geräte-ID</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location_button">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
+      <source>Add</source>
+      <translation>Hinzufügen</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_locations_note">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
+      <source>The default modbus port is 502 and the default unit ID is 126.
+Here you can add additional ports and unit IDs to scan for PV inverters.</source>
+      <translation>Der Standard-Modbus-Anschluss ist 502 und die Standard-Geräte-ID ist 126.
+Hier können Sie zusätzliche Anschlüsse und Geräte-IDs hinzufügen, um nach PV-Wechselrichtern zu suchen.</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_location_number">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
+      <source>Port/Unit ID %1</source>
+      <translation>Anschluss/Geräte-ID %1</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location_description">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
+      <source>Port: %1 (Unit %2)</source>
+      <translation>Anschluss: %1 (Gerät %2)</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
+      <source>Remove Modbus port and unit ID?</source>
+      <translation>Modbus-Port und Unit-ID entfernen?</translation>
+    </message>
+    <message id="devicelist_tankshape_edit_point">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="182"/>
+      <source>Edit point %1</source>
+      <extracomment>%1 = which point is being edited, a number like "1" or "2"</extracomment>
+      <translation>Punkt %1 bearbeiten</translation>
+    </message>
+    <message id="settings_canbus_vecan">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
+      <source>VE.Can (250 kbit/s)</source>
+      <translation>VE.Can (250 kbit/s)</translation>
+    </message>
+    <message id="settings_canopen_motordrive_250">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <source>VE.Can &amp; CANopen E-drive (250 kbit/s)</source>
+      <translation>VE.Can &amp; CANopen E-drive (250 kbit/s)</translation>
+    </message>
+    <message id="settings_canopen_motordrive_500">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
+      <source>CANopen E-drive (500 kbit/s)</source>
+      <translation>CANopen E-drive (500 kbit/s)</translation>
+    </message>
+    <message id="page_microgrid_from_p1_to_p2">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="39"/>
+      <source>%1%2 to %3%4</source>
+      <extracomment>Describes a range from one quantity to another, e.g. "30W to 60W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
+      <translation>%1%2 to %3%4</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAfricaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
+      <source>Morocco Standard Time</source>
+      <translation>Morocco Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
+      <source>W. Central Africa Standard Time</source>
+      <translation>W. Central Africa Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
+      <source>South Africa Standard Time</source>
+      <translation>South Africa Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
+      <source>Namibia Standard Time</source>
+      <translation>Namibia Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
+      <source>Egypt Standard Time</source>
+      <translation>Egypt Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
+      <source>E. Africa Standard Time</source>
+      <translation>E. Africa Standard Time</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAmericaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
+      <source>Argentina Standard Time</source>
+      <translation>Argentina Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
+      <source>E. South America Standard Time</source>
+      <translation>E. South America Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
+      <source>Greenland Standard Time</source>
+      <translation>Greenland Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
+      <source>Montevideo Standard Time</source>
+      <translation>Montevideo Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
+      <source>Newfoundland Standard Time</source>
+      <translation>Newfoundland Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
+      <source>SA Eastern Standard Time</source>
+      <translation>SA Eastern Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
+      <source>Atlantic Standard Time</source>
+      <translation>Atlantic Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
+      <source>Central Brazilian Standard Time</source>
+      <translation>Central Brazilian Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>Pacific SA Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
+      <source>Paraguay Standard Time</source>
+      <translation>Paraguay Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
+      <source>SA Western Standard Time</source>
+      <translation>SA Western Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
+      <source>Venezuela Standard Time</source>
+      <translation>Venezuela Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
+      <source>Eastern Standard Time</source>
+      <translation>Eastern Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
+      <source>SA Pacific Standard Time</source>
+      <translation>SA Pacific Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
+      <source>US Eastern Standard Time</source>
+      <translation>US Eastern Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
+      <source>Canada Central Standard Time</source>
+      <translation>Canada Central Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
+      <source>Central America Standard Time</source>
+      <translation>Central America Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
+      <source>Central Standard Time (Mexico)</source>
+      <translation>Central Standard Time (Mexico)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
+      <source>Central Standard Time</source>
+      <translation>Zentrale Standardzeit CST</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
+      <source>Mountain Standard Time (Mexico)</source>
+      <translation>Mountain Standard Time (Mexico)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
+      <source>Mountain Standard Time</source>
+      <translation>Mountain Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
+      <source>US Mountain Standard Time</source>
+      <translation>US Mountain Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
+      <source>Pacific Standard Time (Mexico)</source>
+      <translation>Pacific Standard Time (Mexico)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
+      <source>Pacific Standard Time</source>
+      <translation>Pacific Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
+      <source>Alaskan Standard Time</source>
+      <translation>Alaskan Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
+      <source>Hawaii-Aleutian</source>
+      <translation>Hawaii-Aleutian</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
+      <source>Atlantic Daylight Time</source>
+      <translation>Atlantische Sommerzeit</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAntarcticaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+      <source>New Zealand Standard Time</source>
+      <translation>New Zealand Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>Central Pacific Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+      <source>West Pacific Standard Time</source>
+      <translation>West Pacific Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+      <source>W. Australia Standard Time</source>
+      <translation>W. Australia Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+      <source>SE Asia Standard Time</source>
+      <translation>SE Asia Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+      <source>Central Asia Standard Time</source>
+      <translation>Central Asia Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+      <source>West Asia Standard Time</source>
+      <translation>West Asia Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+      <source>E. Africa Standard Time</source>
+      <translation>E. Africa Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>Pacific SA Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+      <source>SA Western Standard Time</source>
+      <translation>SA Western Standard Time</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzArcticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
+      <source>W. Europe Standard Time</source>
+      <translation>W. Europe Standard Time</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAsiaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
+      <source>Kamchatka Standard Time</source>
+      <translation>Kamchatka Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
+      <source>Magadan Standard Time</source>
+      <translation>Magadan Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
+      <source>Vladivostok Standard Time</source>
+      <translation>Vladivostok Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
+      <source>Yakutsk Standard Time</source>
+      <translation>Yakutsk Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
+      <source>Tokyo Standard Time</source>
+      <translation>Tokyo Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
+      <source>Korea Standard Time</source>
+      <translation>Korea Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
+      <source>Singapore Standard Time</source>
+      <translation>Singapore Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
+      <source>Ulaanbaatar Standard Time</source>
+      <translation>Ulaanbaatar Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
+      <source>Taipei Standard Time</source>
+      <translation>Taipei Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
+      <source>North Asia East Standard Time</source>
+      <translation>North Asia East Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
+      <source>China Standard Time</source>
+      <translation>China Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
+      <source>SE Asia Standard Time</source>
+      <translation>SE Asia Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
+      <source>North Asia Standard Time</source>
+      <translation>North Asia Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
+      <source>Myanmar Standard Time</source>
+      <translation>Myanmar Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
+      <source>N. Central Asia Standard Time</source>
+      <translation>N. Central Asia Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
+      <source>Central Asia Standard Time</source>
+      <translation>Central Asia Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
+      <source>Bangladesh Standard Time</source>
+      <translation>Bangladesh Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
+      <source>Nepal Standard Time</source>
+      <translation>Nepal Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
+      <source>Sri Lanka Standard Time</source>
+      <translation>Sri Lanka Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
+      <source>India Standard Time</source>
+      <translation>India Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
+      <source>West Asia Standard Time</source>
+      <translation>West Asia Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
+      <source>Pakistan Standard Time</source>
+      <translation>Pakistan Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
+      <source>Ekaterinburg Standard Time</source>
+      <translation>Ekaterinburg Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
+      <source>Georgian Standard Time</source>
+      <translation>Georgian Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
+      <source>Caucasus Standard Time</source>
+      <translation>Caucasus Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
+      <source>Azerbaijan Standard Time</source>
+      <translation>Azerbaijan Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
+      <source>Arabian Standard Time</source>
+      <translation>Arabian Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
+      <source>Afghanistan Standard Time</source>
+      <translation>Afghanistan Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
+      <source>Iran Standard Time</source>
+      <translation>Iran Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
+      <source>Arabic Standard Time</source>
+      <translation>Arabic Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
+      <source>Arab Standard Time</source>
+      <translation>Arab Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
+      <source>Syria Standard Time</source>
+      <translation>Syria Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
+      <source>Middle East Standard Time</source>
+      <translation>Middle East Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
+      <source>Jordan Standard Time</source>
+      <translation>Jordan Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
+      <source>Israel Standard Time</source>
+      <translation>Israel Standard Time</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAtlanticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+      <source>Greenwich Standard Time</source>
+      <translation>Greenwich Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+      <source>Azores Standard Time</source>
+      <translation>Azores Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+      <source>Cape Verde Standard Time</source>
+      <translation>Cape Verde Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
+      <source>Mid-Atlantic Standard Time</source>
+      <translation>Mid-Atlantic Standard Time</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAustraliaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+      <source>Tasmania Standard Time</source>
+      <translation>Tasmania Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+      <source>E. Australia Standard Time</source>
+      <translation>E. Australia Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+      <source>AUS Eastern Standard Time</source>
+      <translation>AUS Eastern Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+      <source>Cen. Australia Standard Time</source>
+      <translation>Cen. Australia Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+      <source>AUS Central Standard Time</source>
+      <translation>AUS Central Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+      <source>W. Australia Standard Time</source>
+      <translation>W. Australia Standard Time</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEtcData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
+      <source>GMT +12</source>
+      <translation>GMT +12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
+      <source>GMT -02</source>
+      <translation>GMT -02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
+      <source>GMT -11</source>
+      <translation>GMT -11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
+      <source>GMT -13</source>
+      <translation>GMT -13</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
+      <source>GMT -12</source>
+      <translation>GMT -12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
+      <source>GMT -10</source>
+      <translation>GMT -10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
+      <source>GMT -09</source>
+      <translation>GMT -09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
+      <source>GMT -08</source>
+      <translation>GMT -08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
+      <source>GMT -07</source>
+      <translation>GMT -07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
+      <source>GMT -06</source>
+      <translation>GMT -06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
+      <source>GMT -05</source>
+      <translation>GMT -05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
+      <source>GMT -04</source>
+      <translation>GMT -04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
+      <source>GMT -03</source>
+      <translation>GMT -03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
+      <source>GMT -01</source>
+      <translation>GMT -01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
+      <source>GMT</source>
+      <translation>GMT</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
+      <source>GMT +01</source>
+      <translation>GMT +01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
+      <source>GMT +02</source>
+      <translation>GMT +02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
+      <source>GMT +03</source>
+      <translation>GMT +03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
+      <source>GMT +04</source>
+      <translation>GMT +04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
+      <source>GMT +05</source>
+      <translation>GMT +05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
+      <source>GMT +06</source>
+      <translation>GMT +06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
+      <source>GMT +07</source>
+      <translation>GMT +07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
+      <source>GMT +08</source>
+      <translation>GMT +08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
+      <source>GMT +09</source>
+      <translation>GMT +09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
+      <source>GMT +10</source>
+      <translation>GMT +10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
+      <source>GMT +11</source>
+      <translation>GMT +11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
+      <source>UTC</source>
+      <translation>UTC</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEuropeData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
+      <source>GMT Standard Time</source>
+      <translation>GMT Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
+      <source>Central Europe Standard Time</source>
+      <translation>Mitteleuropäische Standardzeit</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
+      <source>Central European Standard Time</source>
+      <translation>Mitteleuropäische Standardzeit</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
+      <source>Romance Standard Time</source>
+      <translation>Romance Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
+      <source>W. Europe Standard Time</source>
+      <translation>W. Europe Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
+      <source>E. Europe Standard Time</source>
+      <translation>E. Europe Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
+      <source>FLE Standard Time</source>
+      <translation>FLE Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
+      <source>GTB Standard Time</source>
+      <translation>GTB Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
+      <source>Belarus Standard Time</source>
+      <translation>Weißrussische Standardzeit</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
+      <source>Russian Standard Time</source>
+      <translation>Russian Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
+      <source>Turkey Standard Time</source>
+      <translation>Türkei Standardzeit</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzIndianData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
+      <source>Mauritius Standard Time</source>
+      <translation>Mauritius Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
+      <source>Christmas Island Standard Time</source>
+      <translation>Weihnachtsinsel Standardzeit</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzPacificData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
+      <source>Tonga Standard Time</source>
+      <translation>Tonga Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
+      <source>Fiji Standard Time</source>
+      <translation>Fiji Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
+      <source>New Zealand Standard Time</source>
+      <translation>New Zealand Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>Central Pacific Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
+      <source>West Pacific Standard Time</source>
+      <translation>West Pacific Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
+      <source>Samoa Standard Time</source>
+      <translation>Samoa Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
+      <source>Hawaiian Standard Time</source>
+      <translation>Hawaiian Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
+      <source>Easter Island Standard Time</source>
+      <translation>Osterinsel Normalzeit</translation>
     </message>
   </context>
   <context>
@@ -12160,850 +11840,18 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
       <location filename="../../src/main.cpp" line="203"/>
       <source>url</source>
       <comment>Signal K URL</comment>
-      <translation>URL</translation>
+      <translation>url</translation>
     </message>
     <message>
       <location filename="../../src/main.cpp" line="208"/>
       <source>Color scheme (dark, light, auto, default)</source>
-      <translation>Farbschema (dunkel, hell, auto, standard)</translation>
+      <translation>Farbschema (dunkel, hell, automatisch, Standard)</translation>
     </message>
     <message>
       <location filename="../../src/main.cpp" line="209"/>
       <source>scheme</source>
       <comment>Color scheme value</comment>
       <translation>Schema</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>Morocco Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>W. Central Africa Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>South Africa Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>Namibia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>Egypt Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>E. Africa Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>Argentina Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>E. South America Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>Greenland Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>Montevideo Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>Newfoundland Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>SA Eastern Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Atlantic Standard Time</source>
-      <translation>Atlantic Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>Central Brazilian Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Pacific SA Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>Paraguay Standard Time</source>
-      <translation>Paraguay Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>SA Western Standard Time</source>
-      <translation>SA Western Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Venezuela Standard Time</source>
-      <translation>Venezuela Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>Eastern Standard Time</source>
-      <translation>Eastern Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>SA Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>US Eastern Standard Time</source>
-      <translation>US Eastern Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Canada Central Standard Time</source>
-      <translation>Canada Central Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central America Standard Time</source>
-      <translation>Central America Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>Central Standard Time (Mexico)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Central Standard Time</source>
-      <translation>Zentrale Standardzeit CST</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>Mountain Standard Time (Mexico)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>Mountain Standard Time</source>
-      <translation>Mountain Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>US Mountain Standard Time</source>
-      <translation>US Mountain Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>Pacific Standard Time (Mexico)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Pacific Standard Time</source>
-      <translation>Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Alaskan Standard Time</source>
-      <translation>Alaskan Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>Hawaii-Aleutian</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Daylight Time</source>
-      <translation>Atlantische Sommerzeit</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>New Zealand Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Central Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>West Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>W. Australia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>SE Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Central Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>West Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>E. Africa Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Pacific SA Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>SA Western Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>W. Europe Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>Kamchatka Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>Magadan Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>Vladivostok Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>Yakutsk Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>Tokyo Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>Korea Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>Singapore Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>Ulaanbaatar Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>Taipei Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>North Asia East Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>China Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>SE Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>North Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>Myanmar Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>N. Central Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Central Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>Bangladesh Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>Nepal Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>Sri Lanka Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>India Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>West Asia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>Pakistan Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>Ekaterinburg Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>Georgian Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>Caucasus Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>Azerbaijan Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>Arabian Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>Afghanistan Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>Iran Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>Arabic Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>Arab Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>Syria Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>Middle East Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>Jordan Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>Israel Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>Greenwich Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>Azores Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>Cape Verde Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>Mid-Atlantic Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>Tasmania Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>E. Australia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>AUS Eastern Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>Cen. Australia Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>AUS Central Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>W. Australia Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
-      <source>GMT +12</source>
-      <translation>GMT +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
-      <source>GMT -02</source>
-      <translation>GMT -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT -13</source>
-      <translation>GMT -13</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT -12</source>
-      <translation>GMT -12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -10</source>
-      <translation>GMT -10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -09</source>
-      <translation>GMT -09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>GMT -08</source>
-      <translation>GMT -08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
-      <source>GMT -07</source>
-      <translation>GMT -07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
-      <source>GMT -06</source>
-      <translation>GMT -06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
-      <source>GMT -05</source>
-      <translation>GMT -05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
-      <source>GMT -04</source>
-      <translation>GMT -04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
-      <source>GMT -03</source>
-      <translation>GMT -03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
-      <source>GMT -01</source>
-      <translation>GMT -01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
-      <source>GMT</source>
-      <translation>GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
-      <source>GMT +01</source>
-      <translation>GMT +01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
-      <source>GMT +02</source>
-      <translation>GMT +02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
-      <source>GMT +03</source>
-      <translation>GMT +03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
-      <source>GMT +04</source>
-      <translation>GMT +04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
-      <source>GMT +05</source>
-      <translation>GMT +05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
-      <source>GMT +06</source>
-      <translation>GMT +06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
-      <source>GMT +07</source>
-      <translation>GMT +07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
-      <source>GMT +08</source>
-      <translation>GMT +08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
-      <source>GMT +09</source>
-      <translation>GMT +09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
-      <source>GMT +10</source>
-      <translation>GMT +10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
-      <source>GMT +11</source>
-      <translation>GMT +11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
-      <source>UTC</source>
-      <translation>UTC</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>GMT Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>Mitteleuropäische Standardzeit</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>Mitteleuropäische Standardzeit</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>Romance Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>W. Europe Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>E. Europe Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>FLE Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>GTB Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>Weißrussische Standardzeit</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>Russian Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>Türkei Standardzeit</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>Mauritius Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>Weihnachtsinsel Standardzeit</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>Tonga Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>Fiji Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>New Zealand Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Central Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>West Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>Samoa Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>Hawaiian Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>Osterinsel Normalzeit</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation type="unfinished">Interner Fehler</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation type="unfinished"/>
     </message>
   </context>
   <context>
@@ -13183,6 +12031,119 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
       <source>DC/DC misconfiguration</source>
       <translation>DC/DC-Fehlkonfiguration</translation>
+    </message>
+  </context>
+  <context>
+    <name>VebusError</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+      <source>Device switched off</source>
+      <translation>Gerät ausgeschaltet</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+      <source>Mixed old/new MK2</source>
+      <translation>Gemischtes altes/neues MK2</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+      <source>Expected devices error</source>
+      <translation>Erwartete Gerätefehler</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+      <source>No other device detected</source>
+      <translation>Kein weiteres Gerät erkannt</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+      <source>Overvoltage on AC-out</source>
+      <translation>Überspannung am AC-Ausgang</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+      <source>DDC program error</source>
+      <translation>DDC-Programmfehler</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+      <source>VE.Bus BMS without assistant</source>
+      <translation>VE.Bus BMS ohne Assistenten</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+      <source>Ground relay test failed</source>
+      <translation>Erdungsrelais-Test fehlgeschlagen</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+      <source>System time sync error</source>
+      <translation>Systemzeitsynchronisationsfehler</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+      <source>Grid relay test fault</source>
+      <translation>Netzrelais-Testfehler</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+      <source>Config mismatch with 2nd mcu</source>
+      <translation>Konfigurationskonflikt mit 2. MCU</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+      <source>Device transmit error</source>
+      <translation>Geräteübertragungsfehler</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+      <source>Awaiting configuration or dongle missing</source>
+      <translation>Warte auf Konfiguration oder Dongle fehlt</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+      <source>Phase master missing</source>
+      <translation>Phasenmaster fehlt</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+      <source>Overvoltage has occurred</source>
+      <translation>Überspannung ist aufgetreten</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+      <source>Slave does not have AC input!</source>
+      <translation>Slave hat keinen AC-Eingang!</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+      <source>Device can't be slave</source>
+      <translation>Gerät kann kein Slave sein</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+      <source>System protection initiated</source>
+      <translation>Systemschutz wurde aktiviert</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+      <source>Firmware incompatibiltiy</source>
+      <translation>Firmware-Inkompatibilität</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+      <source>Internal error</source>
+      <translation>Interner Fehler</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+      <source>Failing relay test prevents connection</source>
+      <translation>Fehlgeschlagener Relais-Test verhindert Verbindung</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+      <source>VE.Bus error</source>
+      <translation>VE.Bus-Fehler</translation>
     </message>
   </context>
 </TS>

--- a/i18n/venus-gui-v2_es.ts
+++ b/i18n/venus-gui-v2_es.ts
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="es">
   <context>
-    <name/>
+    <name></name>
     <message id="switchable_output_disabled">
       <location filename="../../src/enums.cpp" line="478"/>
       <source>Disabled</source>
@@ -22,6 +22,7 @@
     <message id="solarchargers_state_off">
       <location filename="../../src/enums.cpp" line="331"/>
       <source>Off</source>
+      <extracomment>Digital input state</extracomment>
       <translation>Apagado</translation>
     </message>
     <message id="common_words_auto">
@@ -52,18 +53,25 @@
     <message id="settings_startpage_none">
       <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
       <source>None</source>
+      <extracomment>Indicates no phase</extracomment>
       <translation>Ninguno</translation>
     </message>
     <message id="common_words_position_ac">
       <location filename="../../components/CommonWords.qml" line="416"/>
       <source>Position</source>
-      <extracomment>AC input or output position</extracomment>
+      <extracomment>EVCS AC input/output position</extracomment>
       <translation>Posición</translation>
     </message>
     <message id="settings_minmax_speed">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="193"/>
       <source>Speed</source>
+      <extracomment>A speed measurement value</extracomment>
       <translation>Velocidad</translation>
+    </message>
+    <message id="common_words_state">
+      <location filename="../../components/CommonWords.qml" line="502"/>
+      <source>State</source>
+      <translation>Estado</translation>
     </message>
     <message id="settings_firmware_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="67"/>
@@ -101,8 +109,8 @@
       <source>Solar yield</source>
       <translation>Rendimiento solar</translation>
     </message>
-    <message id="ess_state_external_control">
-      <location filename="../../data/Ess.qml" line="41"/>
+    <message id="inverters_state_externalccontrol">
+      <location filename="../../data/System.qml" line="183"/>
       <source>External control</source>
       <translation>Control externo</translation>
     </message>
@@ -140,6 +148,11 @@
       <location filename="../../components/CommonWords.qml" line="203"/>
       <source>ESS</source>
       <translation>ESS</translation>
+    </message>
+    <message id="pagesettingsconnectivity_ethernet">
+      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
+      <source>Ethernet</source>
+      <translation>Ethernet</translation>
     </message>
     <message id="pagesettingsconnectivity_wifi">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="28"/>
@@ -262,11 +275,6 @@
       <source>Name</source>
       <translation>Nombre</translation>
     </message>
-    <message id="settings_deviceinfo_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="38"/>
-      <source>Name</source>
-      <translation type="unfinished">Nombre</translation>
-    </message>
     <message id="settings_deviceinfo_product_id">
       <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
       <source>Product ID</source>
@@ -327,15 +335,20 @@
       <source>Daily run time</source>
       <translation>Tiempo de funcionamiento diario</translation>
     </message>
+    <message id="common_words_value_must_be_greater_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="560"/>
+      <source>Value must be greater than stop value</source>
+      <translation>El valor debe ser mayor que el valor de parada</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="563"/>
+      <source>Value must be lower than start value</source>
+      <translation>El valor debe de ser menor que el valor de arranque</translation>
+    </message>
     <message id="settings_minmax_acout_max_power">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="124"/>
       <source>AC output</source>
       <translation>Salida CA</translation>
-    </message>
-    <message id="ac_output">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="15"/>
-      <source>AC output</source>
-      <translation type="unfinished">Salida CA</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
       <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="25"/>
@@ -382,16 +395,6 @@
       <source>Unavailable monitor, set another</source>
       <translation>Monitor no disponible, selecciona otro</translation>
     </message>
-    <message id="page_generator_conditions_battery_monitor">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="42"/>
-      <source>Battery monitor</source>
-      <translation type="unfinished">Monitor de batería</translation>
-    </message>
-    <message id="page_generator_conditions_unavailable_monitor_set_another">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="44"/>
-      <source>Unavailable monitor, set another</source>
-      <translation type="unfinished">Monitor no disponible, selecciona otro</translation>
-    </message>
     <message id="page_generator_conditions_on_loss_of_communication">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="68"/>
       <source>On loss of communication</source>
@@ -416,11 +419,6 @@
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="105"/>
       <source>Battery SOC</source>
       <translation>Estado de carga de la batería</translation>
-    </message>
-    <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="173"/>
-      <source>Periodic run</source>
-      <translation type="unfinished">Funcionamiento periódico</translation>
     </message>
     <message id="settings_inverter_high_temperature">
       <location filename="../../data/Generators.qml" line="83"/>
@@ -505,7 +503,7 @@
     <message id="settings_gps_speed_kmh">
       <location filename="../../pages/settings/PageGps.qml" line="83"/>
       <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometres per hour</extracomment>
+      <extracomment>GPS speed data, in kilometers per hour</extracomment>
       <translation>%1 km/h</translation>
     </message>
     <message id="settings_gps_speed_mph">
@@ -523,7 +521,7 @@
     <message id="settings_gps_speed_ms">
       <location filename="../../pages/settings/PageGps.qml" line="95"/>
       <source>%1 m/s</source>
-      <extracomment>GPS speed data, in metres per second</extracomment>
+      <extracomment>GPS speed data, in meters per second</extracomment>
       <translation>%1 m/s</translation>
     </message>
     <message id="settings_gps_course">
@@ -580,21 +578,6 @@
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="64"/>
       <source>%1 (Output %2)</source>
       <translation>%1 (Salida %2)</translation>
-    </message>
-    <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">Monitor de baterías activo</translation>
-    </message>
-    <message id="settings_batteries_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="101"/>
-      <source>Name</source>
-      <translation type="unfinished">Nombre</translation>
-    </message>
-    <message id="settings_batteries_enter_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="103"/>
-      <source>Enter name</source>
-      <translation type="unfinished">Introduzca el nombre</translation>
     </message>
     <message id="settings_briefview_center_active_battery_monitor">
       <location filename="../../components/listitems/ListBriefCenterDetails.qml" line="27"/>
@@ -656,45 +639,25 @@
       <source>CAN-bus profile</source>
       <translation>Perfil de CAN-bus</translation>
     </message>
-    <message id="settings_disabled">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="31"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Deshabilitado</translation>
-    </message>
-    <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can y Lynx Ion BMS (250 kbit/s)</translation>
-    </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
       <location filename="../../pages/settings/CanbusProfile.qml" line="42"/>
       <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
       <translation>VE.Can y CAN-bus BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
       <source>Oceanvolt (250 kbit/s)</source>
       <translation>Oceanvolt (250 kbit/s)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
       <source>RV-C (250 kbit/s)</source>
       <translation>RV-C (250 kbit/s)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
       <source>Up, but no services (250 kbit/s)</source>
       <translation>Activo, pero sin servicios (250 kbit/s)</translation>
-    </message>
-    <message id="settings_canopen_motordrive_250">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
-      <source>CANopen Motor drive (250 kbit/s)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_canopen_motordrive_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
-      <source>CANopen Motor drive (500 kbit/s)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_devices">
       <location filename="../../components/CommonWords.qml" line="166"/>
@@ -731,11 +694,6 @@
       <source>Check Unique id numbers</source>
       <translation>Compruebe los números de identificación únicos</translation>
     </message>
-    <message id="settings_canbus_unique_id_press_to_check">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Press to check</source>
-      <translation type="unfinished">Pulsar para comprobar</translation>
-    </message>
     <message id="settings_canbus_unique_id_conflict">
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="125"/>
       <source>There is another device connected with this unique number, please select a new number.</source>
@@ -745,11 +703,6 @@
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="133"/>
       <source>OK: No other device is connected with this unique number.</source>
       <translation>OK: No hay ningún otro dispositivo conectado con este número único.</translation>
-    </message>
-    <message id="pagesettingsintegrations_canopenmotordrive">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
-      <source>CANopen motor drives</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_network_status">
       <location filename="../../components/CommonWords.qml" line="349"/>
@@ -884,11 +837,6 @@
       <source>Unavailable sensor, set another</source>
       <translation>Sensor no disponible, ponga otro</translation>
     </message>
-    <message id="settings_system_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="81"/>
-      <source>Unavailable sensor, set another</source>
-      <translation type="unfinished">Sensor no disponible, ponga otro</translation>
-    </message>
     <message id="settings_dvcc_used_sensor">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="120"/>
       <source>Used sensor</source>
@@ -945,12 +893,6 @@
       <source>Auto selected</source>
       <translation>Seleccionado automáticamente</translation>
     </message>
-    <message id="settings_dvcc_auto_selected_none">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="208"/>
-      <source>None</source>
-      <extracomment>Indicates no option is selected</extracomment>
-      <translation type="unfinished">Ninguno</translation>
-    </message>
     <message id="settings_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
       <source>Build date/time</source>
@@ -986,12 +928,6 @@
       <source>Installing %1</source>
       <extracomment>%1 = firmware version</extracomment>
       <translation>Instalando %1</translation>
-    </message>
-    <message id="settings_firmware_offline_press_to_install">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">Presiona para actualizar a %1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="90"/>
@@ -1062,12 +998,6 @@
       <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
       <translation>Instalando %1 %2%</translation>
     </message>
-    <message id="settings_firmware_online_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="86"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">Instalando %1...</translation>
-    </message>
     <message id="settings_firmware_update_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="109"/>
       <source>Update build date/time</source>
@@ -1097,11 +1027,6 @@
       <location filename="../../pages/settings/PageSettingsFronius.qml" line="56"/>
       <source>TCP port</source>
       <translation>Puerto TCP</translation>
-    </message>
-    <message id="page_settings_fronius_modbus_settings">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
-      <source>Modbus port and unit ID settings</source>
-      <translation type="unfinished"/>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
       <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
@@ -1153,16 +1078,6 @@
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="64"/>
       <source>AC-Out MP</source>
       <translation>AC-Out MP</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="52"/>
-      <source>AC-In1 L%1</source>
-      <translation type="unfinished">AC-In1 L%1</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="56"/>
-      <source>AC-In1 --</source>
-      <translation type="unfinished">AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="70"/>
@@ -1330,12 +1245,6 @@
       <source>Reset service timer</source>
       <translation>Reiniciar el temporizador de mantenimiento</translation>
     </message>
-    <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
-      <source>Volume</source>
-      <extracomment>Title for a list of units of volume (e.g. cubic metres, litres, gallons)</extracomment>
-      <translation type="unfinished">Volumen</translation>
-    </message>
     <message id="settings_gps_format">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="69"/>
       <source>Format</source>
@@ -1438,42 +1347,6 @@ Si esto no funcionara, compruebe el buen funcionamiento de la tarjeta SIM en un 
       <source>Wrong PIN</source>
       <translation>Pin erróneo</translation>
     </message>
-    <message id="page_settings_gsm_ok">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>OK</source>
-      <translation type="unfinished">OK</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="128"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">Error desconocido</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_state">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="153"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Desconocido</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_value">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="182"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Desconocido</translation>
-    </message>
-    <message id="page_settings_gsm_offline">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="173"/>
-      <source>Offline</source>
-      <translation type="unfinished">Fuera de línea</translation>
-    </message>
-    <message id="page_settings_gsm_connecting">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="176"/>
-      <source>Connecting</source>
-      <translation type="unfinished">Conectando</translation>
-    </message>
-    <message id="page_settings_gsm_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="179"/>
-      <source>Connected</source>
-      <translation type="unfinished">Conectado</translation>
-    </message>
     <message id="page_settings_gsm_pin">
       <location filename="../../pages/settings/PageSettingsGsm.qml" line="191"/>
       <source>PIN</source>
@@ -1530,32 +1403,32 @@ Si esto no funcionara, compruebe el buen funcionamiento de la tarjeta SIM en un 
       <translation>Contador de red</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
       <source>External meter</source>
       <translation>Contador externo</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="67"/>
       <source>Inverter/Charger</source>
       <translation>Inversor/cargador</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
       <source>Multiphase regulation</source>
       <translation>Regulación multifásica</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="91"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
       <source>Total of all phases</source>
       <translation>Total de todas las fases</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="95"/>
       <source>Individual phase</source>
       <translation>Fase individual</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="99"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="101"/>
       <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
@@ -1564,68 +1437,13 @@ CAUTION: Use only if required by the utility provider.</source>
 PRECAUCIÓN: Úselo solo si lo requiere el proveedor de suministros.</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="104"/>
       <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
       <translation>El total de todas las fases está regulado de forma inteligente para alcanzar el punto de referencia de la red (se optimiza la eficiencia del sistema).
 
 Úselo a menos que el proveedor de suministros lo prohíba.</translation>
-    </message>
-    <message id="settings_ess_min_soc">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation type="unfinished">Estado de carga (SoC) mínimo (salvo fallo de red)</translation>
-    </message>
-    <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="129"/>
-      <source>Active SOC limit</source>
-      <translation type="unfinished">Límite real de estado de carga</translation>
-    </message>
-    <message id="settings_ess_battery_life_sustain">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
-      <source>Sustain</source>
-      <translation type="unfinished">Sostener</translation>
-    </message>
-    <message id="settings_ess_battery_life_recharge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="157"/>
-      <source>Recharge</source>
-      <translation type="unfinished">Cargando</translation>
-    </message>
-    <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <source>Scheduled charge levels</source>
-      <translation type="unfinished">Niveles de carga programados</translation>
-    </message>
-    <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="257"/>
-      <source>Active (%1)</source>
-      <translation type="unfinished">Activo (%1)</translation>
-    </message>
-    <message id="settings_ess_inactive">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="259"/>
-      <source>Inactive</source>
-      <translation type="unfinished">Inactivo</translation>
-    </message>
-    <message id="settings_ess_dynamic">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="293"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">ESS dinámico</translation>
-    </message>
-    <message id="settings_ess_deprecated">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="319"/>
-      <source>Deprecated settings</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_charge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="326"/>
-      <source>Battery charge limit (% of CCL)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_discharge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="337"/>
-      <source>Battery discharge limit (% of DCL)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_rs_ess_min_soc">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="40"/>
@@ -1637,13 +1455,8 @@ Use unless prohibited by the utility provider.</source>
       <source>Active SOC limit</source>
       <translation>Límite real de estado de carga</translation>
     </message>
-    <message id="scheduled_charge_inactive">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
-      <source>Inactive</source>
-      <translation type="unfinished">Inactivo</translation>
-    </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="245"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="247"/>
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
       <source>Peak shaving</source>
       <translation>Recorte de picos (peak shaving)</translation>
@@ -1659,12 +1472,12 @@ Use unless prohibited by the utility provider.</source>
       <translation>Siempre</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="151"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
       <source>Discharge disabled</source>
       <translation>Descarga deshabilitada</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
       <source>Slow charge</source>
       <translation>Carga lenta</translation>
     </message>
@@ -1679,32 +1492,32 @@ Use unless prohibited by the utility provider.</source>
       <translation>Cargando</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="165"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="167"/>
       <source>Limit charge power</source>
       <translation>Limitar potencia de carga</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="183"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="185"/>
       <source>Maximum charge power</source>
       <translation>Máxima potencia de carga</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="196"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="198"/>
       <source>Limit inverter power</source>
       <translation>Limitar la potencia del inversor</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="214"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="216"/>
       <source>Maximum inverter power</source>
       <translation>Potencia máxima del inversor</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="225"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="227"/>
       <source>Grid setpoint</source>
       <translation>Objetivo red</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="236"/>
       <source>Grid feed-in</source>
       <translation>Inyección a red</translation>
     </message>
@@ -1743,8 +1556,8 @@ Use unless prohibited by the utility provider.</source>
       <source>Door alarm</source>
       <translation>Alarma de puerta</translation>
     </message>
-    <message id="digitalinputs_type_bilgepump">
-      <location filename="../../src/enums.cpp" line="201"/>
+    <message id="switchable_output_bilge_pump">
+      <location filename="../../src/enums.cpp" line="424"/>
       <source>Bilge pump</source>
       <translation>Bomba de sentina</translation>
     </message>
@@ -1796,11 +1609,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Deferred by %1s</source>
       <extracomment>%1 = number of seconds</extracomment>
       <translation>Retrasado %1s</translation>
-    </message>
-    <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="75"/>
-      <source>Are you sure?</source>
-      <translation type="unfinished">¿Está seguro?</translation>
     </message>
     <message id="settings_vrm_portal_id">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="87"/>
@@ -1939,11 +1747,6 @@ Use unless prohibited by the utility provider.</source>
       <source>External storage</source>
       <translation>Almacenamiento externo</translation>
     </message>
-    <message id="settings_vrm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="308"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">Error desconocido</translation>
-    </message>
     <message id="settings_vrm_no_error">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="311"/>
       <source>No Error</source>
@@ -2029,37 +1832,10 @@ Use unless prohibited by the utility provider.</source>
       <source>Function</source>
       <translation>Función</translation>
     </message>
-    <message id="settings_relay_disabled">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="54"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="98"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Deshabilitado</translation>
-    </message>
     <message id="settings_relay_alarm_relay">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="56"/>
       <source>Alarm relay</source>
       <translation>Relé de alarma</translation>
-    </message>
-    <message id="settings_relay_tank_pump">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="62"/>
-      <source>Tank pump</source>
-      <translation type="unfinished">Bomba del depósito</translation>
-    </message>
-    <message id="settings_relay_manual">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="64"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="100"/>
-      <source>Manual</source>
-      <translation type="unfinished">Manual</translation>
-    </message>
-    <message id="settings_relay_polarity_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
-      <source>Polarity (Relay 1)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_relay_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
-      <source>Polarity</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_normally_open">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="83"/>
@@ -2075,11 +1851,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="93"/>
       <source>Function (Relay 2)</source>
       <translation>Función (Relé 2)</translation>
-    </message>
-    <message id="settings_relay_polarity_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
-      <source>Polarity (Relay 2)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_temp_control_rules">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="119"/>
@@ -2111,12 +1882,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
       <source>Press to boot</source>
       <translation>Presiona para iniciar</translation>
-    </message>
-    <message id="settings_firmware_backup_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
-      <translation type="unfinished">Firmware %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
@@ -2152,6 +1917,7 @@ Use unless prohibited by the utility provider.</source>
     <message id="nav_boat">
       <location filename="../../pages/boat/BoatPage.qml" line="14"/>
       <source>Boat</source>
+      <extracomment>The 'Boat' page</extracomment>
       <translation>Barco</translation>
     </message>
     <message id="settings_system_name">
@@ -2219,11 +1985,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Solar charger current control</source>
       <translation>Control de corriente del cargador solar</translation>
     </message>
-    <message id="settings_system_status_bms_params">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
-      <source>BMS control</source>
-      <translation type="unfinished">Control por BMS</translation>
-    </message>
     <message id="common_words_bms_control">
       <location filename="../../components/CommonWords.qml" line="101"/>
       <source>BMS control</source>
@@ -2238,11 +1999,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
       <source>Pump state</source>
       <translation>Estado de la bomba</translation>
-    </message>
-    <message id="settings_pump_auto">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="56"/>
-      <source>Auto</source>
-      <translation type="unfinished">Automático</translation>
     </message>
     <message id="settings_tank_sensor">
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
@@ -2271,11 +2027,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="35"/>
       <source>Unplugged</source>
       <translation>Desconectado</translation>
-    </message>
-    <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="16"/>
-      <source>Name</source>
-      <translation type="unfinished">Nombre</translation>
     </message>
     <message id="settings_tcpip_hidden">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="21"/>
@@ -2317,16 +2068,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="99"/>
       <source>IP configuration</source>
       <translation>Configuración IP</translation>
-    </message>
-    <message id="settings_tcpip_manual">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="105"/>
-      <source>Manual</source>
-      <translation type="unfinished">Manual</translation>
-    </message>
-    <message id="settings_tcpip_off">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="107"/>
-      <source>Off</source>
-      <translation type="unfinished">Apagado</translation>
     </message>
     <message id="settings_tcpip_fixed">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="109"/>
@@ -2382,21 +2123,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="30"/>
       <source>Create access point</source>
       <translation>Crear punto de acceso</translation>
-    </message>
-    <message id="settings_wifi_access_point_enter_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="68"/>
-      <source>Enter password</source>
-      <translation type="unfinished">Introducir contraseña</translation>
-    </message>
-    <message id="page_settings_wifi_invalid_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
-      <source>Password length must be either 0 or between 10 and 63 characters long</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_wifi_password_updated">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
-      <source>Password updated</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_wifi_networks">
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="86"/>
@@ -2539,20 +2265,10 @@ Use unless prohibited by the utility provider.</source>
       <extracomment>Network status: Standalone</extracomment>
       <translation>Autónomo</translation>
     </message>
-    <message id="charger_standalone">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="45"/>
-      <source>Standalone</source>
-      <translation type="unfinished">Autónomo</translation>
-    </message>
     <message id="charger_charge">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="48"/>
       <source>Charge</source>
       <translation>Carga</translation>
-    </message>
-    <message id="charger_external_control">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="51"/>
-      <source>External control</source>
-      <translation type="unfinished">Control externo</translation>
     </message>
     <message id="charger_charge_hub_1">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="54"/>
@@ -2584,16 +2300,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Master setting</source>
       <translation>Configuración del maestro</translation>
     </message>
-    <message id="charger_slave">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="85"/>
-      <source>Slave</source>
-      <translation type="unfinished">Esclavo</translation>
-    </message>
-    <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation type="unfinished">Tensión de carga</translation>
-    </message>
     <message id="systemsettings_networkstatus_slave">
       <location filename="../../data/SystemSettings.qml" line="148"/>
       <source>Slave</source>
@@ -2615,14 +2321,15 @@ Use unless prohibited by the utility provider.</source>
       <source>Group &amp; Charge master</source>
       <translation>Maestro Grupo y Carga</translation>
     </message>
-    <message id="genset_charge_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="365"/>
+    <message id="charger_charge_voltage">
+      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
       <source>Charge voltage</source>
       <translation>Tensión de carga</translation>
     </message>
     <message id="common_words_reset">
       <location filename="../../components/CommonWords.qml" line="448"/>
       <source>Reset</source>
+      <extracomment>Reset the BMS control</extracomment>
       <translation>Restablecer</translation>
     </message>
     <message id="solarcharger_load">
@@ -2651,14 +2358,14 @@ Use unless prohibited by the utility provider.</source>
       <extracomment>Voltage alarm is at "Warning" level</extracomment>
       <translation>Advertencia</translation>
     </message>
-    <message id="listitems_alarm_level_alarm">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="25"/>
+    <message id="digitalinputs_state_alarm">
+      <location filename="../../src/enums.cpp" line="270"/>
       <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
+      <extracomment>Relay function is 'alarm'</extracomment>
       <translation>Alarma</translation>
     </message>
-    <message id="devicelist_tankshape_volume">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="190"/>
+    <message id="components_volumeunit_volume">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
       <source>Volume</source>
       <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
       <translation>Volumen</translation>
@@ -2808,26 +2515,10 @@ Use unless prohibited by the utility provider.</source>
       <source>Relay function</source>
       <translation>Función del relé</translation>
     </message>
-    <message id="batterysettingrelay_alarm">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation type="unfinished">Alarma</translation>
-    </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
       <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
       <source>Charger or generator start/stop</source>
       <translation>Arranque/parada cargador o generador</translation>
-    </message>
-    <message id="batterysettingrelay_manual_control">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
-      <source>Manual control</source>
-      <translation type="unfinished">Control manual</translation>
-    </message>
-    <message id="batterysettingrelay_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">Fusible fundido</translation>
     </message>
     <message id="common_words_manual_control">
       <location filename="../../components/CommonWords.qml" line="302"/>
@@ -2853,12 +2544,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
       <source>Status LEDs</source>
       <translation>LED de estado</translation>
-    </message>
-    <message id="batterydiagnostics_none">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
-      <source>None</source>
-      <extracomment>Indicates no alarm is set</extracomment>
-      <translation type="unfinished">Ninguno</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
@@ -2888,7 +2573,7 @@ Use unless prohibited by the utility provider.</source>
     <message id="common_words_switch">
       <location filename="../../components/CommonWords.qml" line="525"/>
       <source>Switch</source>
-      <extracomment>Change the mode value</extracomment>
+      <extracomment>Change the battery mode</extracomment>
       <translation>Interruptor</translation>
     </message>
     <message id="devicelist_battery_initializing">
@@ -2956,21 +2641,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Top section voltage</source>
       <translation>Tensión sección superior</translation>
     </message>
-    <message id="battery_bank_error_communication">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="96"/>
-      <source>Communication error</source>
-      <translation type="unfinished">Error de comunicación</translation>
-    </message>
-    <message id="battery_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="182"/>
-      <source>State of health</source>
-      <translation type="unfinished">Estado de salud</translation>
-    </message>
-    <message id="battery_bus_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="212"/>
-      <source>Bus voltage</source>
-      <translation type="unfinished">Tensión del bus</translation>
-    </message>
     <message id="battery_bottom_section_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="228"/>
       <source>Bottom section voltage</source>
@@ -3016,16 +2686,6 @@ Use unless prohibited by the utility provider.</source>
       <source>IO</source>
       <translation>IO</translation>
     </message>
-    <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="391"/>
-      <source>System</source>
-      <translation type="unfinished">Sistema</translation>
-    </message>
-    <message id="battery_press_to_redetect">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="433"/>
-      <source>Press to redetect</source>
-      <translation type="unfinished">Presiona para detectar</translation>
-    </message>
     <message id="pagesettingsgeneral_system">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="107"/>
       <source>System</source>
@@ -3066,16 +2726,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Low SOC</source>
       <translation>SOC bajo</translation>
     </message>
-    <message id="batteryalarms_high_battery_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
-      <source>High battery voltage</source>
-      <translation type="unfinished">Alta tensión de la batería</translation>
-    </message>
-    <message id="batteryalarms_low_soc">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low SOC</source>
-      <translation type="unfinished">SOC bajo</translation>
-    </message>
     <message id="batteryalarms_low_starter_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="73"/>
       <source>Low starter voltage</source>
@@ -3095,11 +2745,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
       <source>Mid-point voltage</source>
       <translation>Tensión punto medio</translation>
-    </message>
-    <message id="batteryalarms_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">Fusible fundido</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
@@ -3293,11 +2938,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Restore factory defaults</source>
       <translation>Restablecer ajustes de fábrica</translation>
     </message>
-    <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation type="unfinished">Presiona para restablecer</translation>
-    </message>
     <message id="vebus_backup_press_to_restore">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="362"/>
       <source>Press to restore</source>
@@ -3337,11 +2977,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="18"/>
       <source>Capacity</source>
       <translation>Capacidad</translation>
-    </message>
-    <message id="batterysettingsbattery_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
-      <source>Capacity</source>
-      <translation type="unfinished">Capacidad</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
@@ -3418,11 +3053,6 @@ Use unless prohibited by the utility provider.</source>
       <source>No power on busbar</source>
       <translation>No hay alimentación en el embarrado</translation>
     </message>
-    <message id="lynxdistributor_connection_lost">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
-      <source>Connection lost</source>
-      <translation type="unfinished">Conexión perdida</translation>
-    </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
       <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
       <source>%n fuse(s) blown</source>
@@ -3458,26 +3088,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Shutdowns due error</source>
       <translation>Paradas debidas a un error</translation>
     </message>
-    <message id="lynxiondiagnostics_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
-      <source>Last error</source>
-      <translation type="unfinished">Último error</translation>
-    </message>
-    <message id="lynxiondiagnostics_2nd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
-      <source>2nd last error</source>
-      <translation type="unfinished">2º ultimo error</translation>
-    </message>
-    <message id="lynxiondiagnostics_3rd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
-      <source>3rd last error</source>
-      <translation type="unfinished">3&lt;sup&gt;er&lt;/sup&gt; ultimo error</translation>
-    </message>
-    <message id="lynxiondiagnostics_4th_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
-      <source>4th last error</source>
-      <translation type="unfinished">4º ultimo error</translation>
-    </message>
     <message id="lynxionio_system_switch">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
       <source>System Switch</source>
@@ -3497,11 +3107,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../components/CommonWords.qml" line="54"/>
       <source>Batteries</source>
       <translation>Baterías</translation>
-    </message>
-    <message id="lynxionsystem_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
-      <source>Capacity</source>
-      <translation type="unfinished">Capacidad</translation>
     </message>
     <message id="lynxionsystem_parallel">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="30"/>
@@ -3523,20 +3128,10 @@ Use unless prohibited by the utility provider.</source>
       <source>Min/max cell temperature</source>
       <translation>Temperatura de celda mín/máx</translation>
     </message>
-    <message id="lynxionsystem_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="92"/>
-      <source>Balancing</source>
-      <translation type="unfinished">Equilibrando</translation>
-    </message>
     <message id="lynxionsystem_balancer_balancing">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
       <source>Balancing</source>
       <translation>Equilibrando</translation>
-    </message>
-    <message id="lynxionsystem_balancer_unknown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="117"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Desconocido</translation>
     </message>
     <message id="dc_output">
       <location filename="../../components/listitems/ListDcOutputQuantityGroup.qml" line="16"/>
@@ -3644,11 +3239,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Remaining</source>
       <translation>Restante</translation>
     </message>
-    <message id="devicelist_tanksensor_sensor_battery">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="51"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">Sensor batería</translation>
-    </message>
     <message id="temperature_sensor_battery">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="112"/>
       <source>Sensor battery</source>
@@ -3677,7 +3267,7 @@ Use unless prohibited by the utility provider.</source>
     <message id="devicelist_tanksetup_custom">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="53"/>
       <source>Custom</source>
-      <translation type="unfinished">Personalizado</translation>
+      <translation>Personalizado</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="59"/>
@@ -3710,34 +3300,34 @@ Use unless prohibited by the utility provider.</source>
       <translation>Valor del sensor</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="75"/>
       <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
       <translation>No se ha definido una forma personalizada. Puede definir una con hasta diez puntos. Tenga en cuenta que 0 % y 100 % están implícitos.</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="91"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="89"/>
       <source>Point %1</source>
       <extracomment>%1 = the point number</extracomment>
       <translation>Punto %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="133"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="179"/>
       <source>Add point</source>
       <translation>Añadir punto</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="156"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="205"/>
       <source>Sensor level</source>
       <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
       <translation>Nivel del sensor</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="256"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="311"/>
       <source>Duplicate sensor level values are not allowed.</source>
       <translation>No se permiten valores duplicados del nivel del sensor.</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="262"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="317"/>
       <source>Volume values must be increasing.</source>
       <translation>Los valores de volumen deben ser crecientes.</translation>
     </message>
@@ -3777,11 +3367,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Switch position</source>
       <translation>Posición del interruptor</translation>
     </message>
-    <message id="ac-in-setup_single_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="142"/>
-      <source>Single phase</source>
-      <translation type="unfinished">Monofase</translation>
-    </message>
     <message id="ac-in-setup_two_phase">
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="144"/>
       <source>2-phase</source>
@@ -3791,11 +3376,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="146"/>
       <source>3-phase</source>
       <translation>Trifásica</translation>
-    </message>
-    <message id="ac-in-setup_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="161"/>
-      <source>Devices</source>
-      <translation type="unfinished">Dispositivos</translation>
     </message>
     <message id="ac-in-genset_ac">
       <location filename="../../components/PageGensetModel.qml" line="194"/>
@@ -3889,12 +3469,6 @@ Use unless prohibited by the utility provider.</source>
       <extracomment>%1 = CT device number</extracomment>
       <translation>CT %1</translation>
     </message>
-    <message id="smappeect_phase_none">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation type="unfinished">Ninguno</translation>
-    </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
       <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
       <source>Flashing LED indicates this CT</source>
@@ -3908,11 +3482,13 @@ Use unless prohibited by the utility provider.</source>
     <message id="common_words_setting_disabled_when_dmc_connected">
       <location filename="../../components/CommonWords.qml" line="355"/>
       <source>This setting is disabled when a Digital Multi Control is connected.</source>
+      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>Este ajuste se deshabilita cuando se conecta un Digital Multi Control.</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
       <location filename="../../components/CommonWords.qml" line="358"/>
       <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>Este ajuste se deshabilita cuando se conecta un VE.Bus BMS.</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
@@ -3930,16 +3506,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="21"/>
       <source>Inverted</source>
       <translation>Invertido</translation>
-    </message>
-    <message id="digitalinput_enable_alarm">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="48"/>
-      <source>Enable alarm</source>
-      <translation type="unfinished">Habilitar alarma</translation>
-    </message>
-    <message id="digitalinput_inverted">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="54"/>
-      <source>Inverted</source>
-      <translation type="unfinished">Invertido</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
       <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="60"/>
@@ -3976,16 +3542,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Wind speed</source>
       <translation>Velocidad del viento</translation>
     </message>
-    <message id="page_meteo_battery_voltage">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="99"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">Sensor batería</translation>
-    </message>
-    <message id="meteo_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="120"/>
-      <source>Low</source>
-      <translation type="unfinished">Baja</translation>
-    </message>
     <message id="page_meteo_settings_auto_detect">
       <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
       <source>Auto-detect</source>
@@ -4016,16 +3572,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Reset counter</source>
       <translation>Restablecer contador</translation>
     </message>
-    <message id="temperature_short_circuited">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="32"/>
-      <source>Short circuited</source>
-      <translation type="unfinished">Cortocircuito</translation>
-    </message>
-    <message id="temperature_reverse_polarity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="35"/>
-      <source>Reverse polarity</source>
-      <translation type="unfinished">Polaridad inversa</translation>
-    </message>
     <message id="temperature_sensor_battery_low">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
       <source>Sensor battery low</source>
@@ -4040,36 +3586,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="62"/>
       <source>Pressure</source>
       <translation>Presión</translation>
-    </message>
-    <message id="temperature_pm25">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
-      <source>PM2.5</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_co2">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>CO₂</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_voc">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
-      <source>VOC index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_nox">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
-      <source>NOx index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_luminosity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
-      <source>Luminosity</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="133"/>
-      <source>Low</source>
-      <translation type="unfinished">Baja</translation>
     </message>
     <message id="temperature_offset">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
@@ -4123,25 +3639,10 @@ NOTE: La actualización podría interrumpir temporalmente el sistema.</translati
       <source>Updating the MK3, values will reappear after the update is complete</source>
       <translation>Actualizando el MK3, los valores volverán a aparecer una vez terminada la actualización</translation>
     </message>
-    <message id="vebus_device_charging_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="78"/>
-      <source>Charging the battery to 100%</source>
-      <translation type="unfinished">Cargando la batería hasta el 100 %</translation>
-    </message>
     <message id="vebus_device_charging_the_battery_to_100">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="93"/>
       <source>Charging the battery to 100%</source>
       <translation>Cargando la batería hasta el 100 %</translation>
-    </message>
-    <message id="vebus_device_page_microgrid_parameters">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
-      <source>Microgrid parameters</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="vebus_device_page_advanced">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
-      <source>Advanced</source>
-      <translation type="unfinished">Avanzado</translation>
     </message>
     <message id="vebus_device_in_progress">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="80"/>
@@ -4196,15 +3697,15 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>DC Current</source>
       <translation>Corriente CC</translation>
     </message>
+    <message id="vebus_device_page_advanced">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
+      <source>Advanced</source>
+      <translation>Avanzado</translation>
+    </message>
     <message id="common_words_alarm_setup">
       <location filename="../../components/CommonWords.qml" line="65"/>
       <source>Alarm setup</source>
       <translation>Configuración de la alarma</translation>
-    </message>
-    <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
-      <translation type="unfinished">Un VE.Bus BMS automáticamente apaga el sistema cuando necesita proteger la batería. Entonces, controlar el sistema desde el Color Control no es posible.</translation>
     </message>
     <message id="vebus_device_bms_not_found">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="240"/>
@@ -4245,7 +3746,7 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
     <message id="vebus_device_starting">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="117"/>
       <source>Starting...</source>
-      <translation type="unfinished">Iniciando...</translation>
+      <translation>Iniciando...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="120"/>
@@ -4311,16 +3812,6 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="260"/>
       <source>ESS Relay test</source>
       <translation>Prueba del relé ESS</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_completed">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="266"/>
-      <source>Completed</source>
-      <translation type="unfinished">Completado</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_pending">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="268"/>
-      <source>Pending</source>
-      <translation type="unfinished">Pendiente...</translation>
     </message>
     <message id="cycle_history_completed">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
@@ -4507,6 +3998,7 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
     <message id="rssystemalarms_overload">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
       <source>Overload</source>
+      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
       <translation>Sobrecarga</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
@@ -4519,11 +4011,6 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
       <source>Voltage Sensor</source>
       <translation>Sensor tensión</translation>
-    </message>
-    <message id="vebus_device_phase_rotation">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
-      <source>Phase rotation</source>
-      <translation type="unfinished">Rotación de fase</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
@@ -4555,12 +4042,6 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>VE.Bus BMS version</source>
       <translation>Versión VE.Bus BMS</translation>
     </message>
-    <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="15"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="52"/>
-      <source>Minimum SOC</source>
-      <translation type="unfinished">Estado de carga mínimo</translation>
-    </message>
     <message id="ess_unless_grid_fails">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="32"/>
       <source>Unless grid fails</source>
@@ -4580,7 +4061,7 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
     <message id="common_words_ac_input_role">
       <location filename="../../components/CommonWords.qml" line="24"/>
       <source>Role</source>
-      <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
       <translation>Rol</translation>
     </message>
     <message id="common_words_ac_load">
@@ -4619,18 +4100,6 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>Active</source>
       <extracomment>Status is 'active'</extracomment>
       <translation>Activo</translation>
-    </message>
-    <message id="common_words_alarm">
-      <location filename="../../components/CommonWords.qml" line="51"/>
-      <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
-      <translation type="unfinished">Alarma</translation>
-    </message>
-    <message id="common_words_alarm_setting_overload">
-      <location filename="../../components/CommonWords.qml" line="58"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation type="unfinished">Sobrecarga</translation>
     </message>
     <message id="common_words_alarm_status">
       <location filename="../../components/CommonWords.qml" line="68"/>
@@ -4677,8 +4146,8 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>Charge current</source>
       <translation>Corriente de carga</translation>
     </message>
-    <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="125"/>
+    <message id="battery_mode_charging">
+      <location filename="../../src/enums.cpp" line="30"/>
       <source>Charging</source>
       <extracomment>"Charging" state</extracomment>
       <translation>Cargando</translation>
@@ -4692,7 +4161,7 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
     <message id="digitalinputs_state_closed">
       <location filename="../../src/enums.cpp" line="262"/>
       <source>Closed</source>
-      <extracomment>Digital input state</extracomment>
+      <extracomment>Status is 'closed'</extracomment>
       <translation>Cerrado</translation>
     </message>
     <message id="evchargers_status_connected">
@@ -4700,8 +4169,8 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>Connected</source>
       <translation>Conectado</translation>
     </message>
-    <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="143"/>
+    <message id="temperature_slider_current">
+      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
       <source>Current</source>
       <extracomment>Electric current, as measured in Amps</extracomment>
       <translation>Corriente</translation>
@@ -4728,9 +4197,10 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <extracomment>Title for device information</extracomment>
       <translation>Dispositivo</translation>
     </message>
-    <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="172"/>
+    <message id="battery_mode_discharging">
+      <location filename="../../src/enums.cpp" line="34"/>
       <source>Discharging</source>
+      <extracomment>Battery mode</extracomment>
       <translation>Descargando</translation>
     </message>
     <message id="wifimodel_disconnected">
@@ -4816,13 +4286,14 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>%1 Hour(s)</source>
       <translation>%1 Hora(s)</translation>
     </message>
-    <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="251"/>
+    <message id="battery_mode_idle">
+      <location filename="../../src/enums.cpp" line="26"/>
       <source>Idle</source>
+      <extracomment>Battery mode</extracomment>
       <translation>En reposo</translation>
     </message>
-    <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="258"/>
+    <message id="scheduled_charge_inactive">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
       <source>Inactive</source>
       <extracomment>Status is 'inactive'</extracomment>
       <translation>Inactivo</translation>
@@ -4924,8 +4395,8 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>Offline</source>
       <translation>Fuera de línea</translation>
     </message>
-    <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="17"/>
+    <message id="digitalinputs_state_ok">
+      <location filename="../../src/enums.cpp" line="266"/>
       <source>OK</source>
       <extracomment>Voltage alarm is at "OK" level</extracomment>
       <translation>OK</translation>
@@ -4933,6 +4404,7 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
     <message id="switchable_output_on">
       <location filename="../../src/enums.cpp" line="471"/>
       <source>On</source>
+      <extracomment>Digital input state</extracomment>
       <translation>Encendido</translation>
     </message>
     <message id="common_words_online">
@@ -4943,7 +4415,7 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
     <message id="digitalinputs_state_open">
       <location filename="../../src/enums.cpp" line="258"/>
       <source>Open</source>
-      <extracomment>Digital input open</extracomment>
+      <extracomment>Status is 'open'</extracomment>
       <translation>Abierto</translation>
     </message>
     <message id="common_words_password">
@@ -5003,9 +4475,10 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>Remove</source>
       <translation>Eliminar</translation>
     </message>
-    <message id="switch_state_running">
-      <location filename="../../src/enums.cpp" line="363"/>
+    <message id="switchable_output_running">
+      <location filename="../../src/enums.cpp" line="468"/>
       <source>Running</source>
+      <extracomment>Status = "running"</extracomment>
       <translation>En marcha</translation>
     </message>
     <message id="common_words_scanning">
@@ -5072,7 +4545,7 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
     <message id="pvinverter_statusCode_startup">
       <location filename="../../src/enums.cpp" line="296"/>
       <source>Startup (%1)</source>
-      <extracomment>PV inverter status code. %1 = the startup status number</extracomment>
+      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
       <translation>Arranque (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
@@ -5127,8 +4600,10 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>Unique Identity Number</source>
       <translation>Número de identidad único</translation>
     </message>
-    <message id="settings_radio_button_group_unknown">
-      <location filename="../../components/listitems/core/ListRadioButtonGroup.qml" line="44"/>
+    <message id="Unknown">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
       <source>Unknown</source>
       <translation>Desconocido</translation>
     </message>
@@ -5283,11 +4758,6 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>Error while checking for firmware updates</source>
       <translation>Error al buscar actualizaciones de firmware</translation>
     </message>
-    <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation type="unfinished">Error al buscar actualizaciones de firmware</translation>
-    </message>
     <message id="settings_firmware_downloading_and_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="63"/>
       <source>Downloading and installing firmware %1...</source>
@@ -5314,6 +4784,66 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>No firmware found</source>
       <translation>Ningún firmware encontrado</translation>
     </message>
+    <message id="tank_type_fuel">
+      <location filename="../../src/enums.cpp" line="495"/>
+      <source>Fuel</source>
+      <translation>Combustible</translation>
+    </message>
+    <message id="tank_type_fresh_water">
+      <location filename="../../src/enums.cpp" line="498"/>
+      <source>Fresh water</source>
+      <translation>Agua potable</translation>
+    </message>
+    <message id="tank_type_waste_water">
+      <location filename="../../src/enums.cpp" line="501"/>
+      <source>Waste water</source>
+      <translation>Aguas grises</translation>
+    </message>
+    <message id="tank_type_live_well">
+      <location filename="../../src/enums.cpp" line="504"/>
+      <source>Live well</source>
+      <translation>Vivero</translation>
+    </message>
+    <message id="tank_type_oil">
+      <location filename="../../src/enums.cpp" line="507"/>
+      <source>Oil</source>
+      <translation>Aceite</translation>
+    </message>
+    <message id="tank_type_black_water">
+      <location filename="../../src/enums.cpp" line="510"/>
+      <source>Black water</source>
+      <translation>AGUAS NEGRAS</translation>
+    </message>
+    <message id="tank_type_gasoline">
+      <location filename="../../src/enums.cpp" line="513"/>
+      <source>Gasoline</source>
+      <translation>Gasolina</translation>
+    </message>
+    <message id="tank_type_diesel">
+      <location filename="../../src/enums.cpp" line="516"/>
+      <source>Diesel</source>
+      <translation>Diésel</translation>
+    </message>
+    <message id="tank_type_lpg">
+      <location filename="../../src/enums.cpp" line="519"/>
+      <source>LPG</source>
+      <translation>GLP</translation>
+    </message>
+    <message id="tank_type_lng">
+      <location filename="../../src/enums.cpp" line="522"/>
+      <source>LNG</source>
+      <translation>GNL</translation>
+    </message>
+    <message id="tank_type_hydraulic_oil">
+      <location filename="../../src/enums.cpp" line="525"/>
+      <source>Hydraulic oil</source>
+      <translation>Aceite hidráulico</translation>
+    </message>
+    <message id="tank_type_raw_water">
+      <location filename="../../src/enums.cpp" line="528"/>
+      <source>Raw water</source>
+      <translation>Agua sin tratar</translation>
+    </message>
     <message id="listItem_no_access">
       <location filename="../../components/listitems/core/ListItem.qml" line="102"/>
       <source>Setting locked for access level</source>
@@ -5327,6 +4857,7 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
     <message id="welcome_brief_title">
       <location filename="../../pages/welcome/WelcomeView.qml" line="81"/>
       <source>Brief</source>
+      <extracomment>The 'Brief' page</extracomment>
       <translation>Breve</translation>
     </message>
     <message id="welcome_overview_title">
@@ -5343,23 +4874,6 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <location filename="../../pages/NotificationsPage.qml" line="13"/>
       <source>Notifications</source>
       <translation>Notificaciones</translation>
-    </message>
-    <message id="notifications_page_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="43"/>
-      <source>Active Notifications</source>
-      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_page_inactive_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="47"/>
-      <source>Inactive Notifications</source>
-      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_no_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="106"/>
-      <source>No active notifications</source>
-      <translation type="unfinished"/>
     </message>
     <message id="utils_formatTimestamp_now">
       <location filename="../../components/Utils.js" line="258"/>
@@ -5464,11 +4978,6 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>Self-consumption above limit</source>
       <translation>Autoconsumo superior al límite</translation>
     </message>
-    <message id="cgwacs_battery_schedule_pv">
-      <location filename="../../components/listitems/ListChargeSchedule.qml" line="171"/>
-      <source>PV</source>
-      <translation type="unfinished">FV</translation>
-    </message>
     <message id="settings_multirs_pv">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="185"/>
       <source>PV</source>
@@ -5479,8 +4988,8 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>PV &amp; Battery</source>
       <translation>FV y batería</translation>
     </message>
-    <message id="settings_firmware_checking">
-      <location filename="../../components/listitems/ListFirmwareCheckButton.qml" line="16"/>
+    <message id="pagesettingssupportstate_firmware_checking">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
       <source>Checking...</source>
       <translation>Comprobando...</translation>
     </message>
@@ -5488,12 +4997,6 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <location filename="../../components/listitems/ListAlarmState.qml" line="11"/>
       <source>Alarm state</source>
       <translation>Estado alarma</translation>
-    </message>
-    <message id="devicelist_battery_alarm_state">
-      <location filename="../../components/listitems/ListAlarmState.qml" line="19"/>
-      <source>Alarm</source>
-      <extracomment>Alarm state is active</extracomment>
-      <translation type="unfinished">Alarma</translation>
     </message>
     <message id="clear_history_button_clear_history">
       <location filename="../../components/listitems/ListClearHistoryButton.qml" line="15"/>
@@ -5645,11 +5148,6 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>Max Voltage</source>
       <translation>Tensión max.</translation>
     </message>
-    <message id="charger_history_box_max_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="64"/>
-      <source>Max Voltage</source>
-      <translation type="unfinished">Tensión max.</translation>
-    </message>
     <message id="charger_history_box_max_current">
       <location filename="../../components/SolarDetailBox.qml" line="70"/>
       <source>Max Current</source>
@@ -5660,24 +5158,6 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>Charge time</source>
       <extracomment>Statistics for battery charging time</extracomment>
       <translation>Tiempo del proceso de carga</translation>
-    </message>
-    <message id="charger_history_box_bulk">
-      <location filename="../../components/SolarDetailBox.qml" line="136"/>
-      <source>Bulk</source>
-      <extracomment>Battery: time spent in 'Bulk' mode</extracomment>
-      <translation type="unfinished">Carga inicial</translation>
-    </message>
-    <message id="charger_history_box_float">
-      <location filename="../../components/SolarDetailBox.qml" line="148"/>
-      <source>Float</source>
-      <extracomment>Battery: time spent in 'Float' mode</extracomment>
-      <translation type="unfinished">Flotación</translation>
-    </message>
-    <message id="charger_history_hr">
-      <location filename="../../components/SolarDetailBox.qml" line="174"/>
-      <source>hr</source>
-      <extracomment>Abbreviation of "hour"</extracomment>
-      <translation type="unfinished">h</translation>
     </message>
     <message id="solarchargers_state_bulk">
       <location filename="../../src/enums.cpp" line="337"/>
@@ -5749,11 +5229,6 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>Connecting</source>
       <translation>Conectando</translation>
     </message>
-    <message id="splash_view_connecting">
-      <location filename="../../components/SplashView.qml" line="288"/>
-      <source>Connecting</source>
-      <translation type="unfinished">Conectando</translation>
-    </message>
     <message id="splash_view_connected">
       <location filename="../../components/SplashView.qml" line="290"/>
       <source>Connected, awaiting broker messages</source>
@@ -5809,6 +5284,11 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>MQTT protocol level 5 error</source>
       <translation>Error de nivel 5 del protocolo MQTT </translation>
     </message>
+    <message id="common_words_silence_alarm">
+      <location filename="../../components/CommonWords.qml" line="476"/>
+      <source>Silence alarm</source>
+      <translation>Alarma de silencio</translation>
+    </message>
     <message id="vebus_device_page_total_power">
       <location filename="../../components/ThreePhaseQuantityTable.qml" line="47"/>
       <source>Total Power</source>
@@ -5859,20 +5339,10 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>Retrieving IP address</source>
       <translation>Obteniendo dirección IP</translation>
     </message>
-    <message id="utils_connman_connected">
-      <location filename="../../components/Utils.js" line="292"/>
-      <source>Connected</source>
-      <translation type="unfinished">Conectado</translation>
-    </message>
     <message id="utils_connman_disconnect">
       <location filename="../../components/Utils.js" line="295"/>
       <source>Disconnect</source>
       <translation>Desconectar</translation>
-    </message>
-    <message id="utils_connman_disconnected">
-      <location filename="../../components/Utils.js" line="299"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Desconectado</translation>
     </message>
     <message id="overview_widget_acloads_title">
       <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
@@ -5910,11 +5380,6 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>Shore current limit</source>
       <translation>Límite de corriente del pantalán</translation>
     </message>
-    <message id="acInputs_statusCode_stopping">
-      <location filename="../../data/AcInputs.qml" line="170"/>
-      <source>Stopping</source>
-      <translation type="unfinished">Parando</translation>
-    </message>
     <message id="page_generator_stopping">
       <location filename="../../data/Generators.qml" line="44"/>
       <source>Stopping</source>
@@ -5930,7 +5395,7 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <location filename="../../data/common/TankDescription.qml" line="24"/>
       <location filename="../../src/device.cpp" line="133"/>
       <source>%1 tank (%2)</source>
-      <extracomment>Tank description. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
       <translation>%1 depósito (%2)</translation>
     </message>
     <message id="dcMeter_ac_charger">
@@ -5979,11 +5444,6 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <location filename="../../data/Ess.qml" line="20"/>
       <source>Keep batteries charged</source>
       <translation>Mantener baterías cargadas</translation>
-    </message>
-    <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="50"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Desconectado</translation>
     </message>
     <message id="evchargers_status_charged">
       <location filename="../../data/EvChargers.qml" line="58"/>
@@ -6044,16 +5504,6 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <location filename="../../data/EvChargers.qml" line="97"/>
       <source>Start charging</source>
       <translation>Iniciar el proceso de carga</translation>
-    </message>
-    <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="113"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Desconocido</translation>
-    </message>
-    <message id="evchargers_mode_scheduled">
-      <location filename="../../data/EvChargers.qml" line="126"/>
-      <source>Scheduled</source>
-      <translation type="unfinished">Programado</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
       <location filename="../../data/System.qml" line="195"/>
@@ -6178,11 +5628,6 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>Power supply mode</source>
       <translation>Modo fuente de alimentación</translation>
     </message>
-    <message id="inverters_state_sustain">
-      <location filename="../../data/System.qml" line="158"/>
-      <source>Sustain</source>
-      <translation type="unfinished">Sostener</translation>
-    </message>
     <message id="inverters_state_wakeup">
       <location filename="../../data/System.qml" line="162"/>
       <source>Wake up</source>
@@ -6217,16 +5662,6 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <location filename="../../data/System.qml" line="180"/>
       <source>Test</source>
       <translation>Prueba</translation>
-    </message>
-    <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="183"/>
-      <source>External control</source>
-      <translation type="unfinished">Control externo</translation>
-    </message>
-    <message id="inverters_state_dynamic_ess">
-      <location filename="../../data/System.qml" line="198"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">ESS dinámico</translation>
     </message>
     <message id="settings_rs_ess_dess">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="97"/>
@@ -6305,16 +5740,13 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
     <message id="ess_recommended">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="73"/>
       <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
       <translation>Para las baterías de litio, no se recomienda una carga inferior al 10 %. Para otros tipos de baterías, consulte en la ficha técnica el nivel mínimo recomendado por el fabricante.</translation>
-    </message>
-    <message id="controlcard_generator_label_autostart">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="63"/>
-      <source>Autostart</source>
-      <translation type="unfinished">Arranque automático</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
       <location filename="../../pages/controlcards/GeneratorCard.qml" line="70"/>
       <source>Start and stop the generator based on the configured autostart conditions.</source>
+      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
       <translation>Arranque y parada del generador según las condiciones de arranque automático configuradas.</translation>
     </message>
     <message id="generator_dialog_disabled">
@@ -6337,11 +5769,13 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <location filename="../../pages/controlcards/InverterChargerCard.qml" line="26"/>
       <source>Inverter / Charger (%1)</source>
       <extracomment>%1 = the inverter/charger name</extracomment>
+      <oldsource>Inverter / Charger</oldsource>
       <translation>Inversor / cargador (%1)</translation>
     </message>
     <message id="settings_page_debug_quit_application">
       <location filename="../../pages/settings/debug/PageDebug.qml" line="36"/>
       <source>Quit application</source>
+      <oldsource>Quit Application</oldsource>
       <translation>Salir de la aplicación</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
@@ -6352,12 +5786,8 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
     <message id="settings_page_relay_generator_run_time">
       <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
       <source>Current run time</source>
+      <oldsource>Run time</oldsource>
       <translation>Tiempo de funcionamiento actual</translation>
-    </message>
-    <message id="settings_page_genset_generator_run_time">
-      <location filename="../../components/PageGensetModel.qml" line="102"/>
-      <source>Current run time</source>
-      <translation type="unfinished">Tiempo de funcionamiento actual</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
       <location filename="../../components/PageGensetModel.qml" line="110"/>
@@ -6384,19 +5814,10 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>Remote start mode</source>
       <translation>Modo de arranque a distancia</translation>
     </message>
-    <message id="ac-in-genset_speed">
-      <location filename="../../components/PageGensetModel.qml" line="245"/>
-      <source>Speed</source>
-      <translation type="unfinished">Velocidad</translation>
-    </message>
-    <message id="ac-in-genset_load">
-      <location filename="../../components/PageGensetModel.qml" line="252"/>
-      <source>Load</source>
-      <translation type="unfinished">Carga</translation>
-    </message>
     <message id="ac-in-genset_oil_pressure">
       <location filename="../../components/PageGensetModel.qml" line="260"/>
       <source>Oil pressure</source>
+      <oldsource>Oil Pressure</oldsource>
       <translation>Presión del aceite</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
@@ -6492,11 +5913,13 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
       <source>High starter battery voltage alarms</source>
+      <oldsource>High starter batttery voltage alarms</oldsource>
       <translation>Alarmas por tensión de la batería arranque alta</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
       <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
       <translation>Tenga en cuenta que cambiando el ajuste del Límite de descarga del tiempo restante también cambia el ajuste de Estado de carga bajo en el menú del relé.</translation>
     </message>
     <message id="lynxionsystem_cells_per_battery">
@@ -6573,6 +5996,7 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <location filename="../../pages/settings/devicelist/delegates/DeviceListDelegate_solarcharger.qml" line="34"/>
       <source>Error: #%1</source>
       <extracomment>%1 = error number</extracomment>
+      <oldsource>Error: %1</oldsource>
       <translation>Error: #%1</translation>
     </message>
     <message id="devicelistpage_genset">
@@ -6629,17 +6053,14 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
     <message id="settings_page_relay_generator_auto_start_enabled">
       <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
       <source>Autostart functionality</source>
+      <oldsource>Auto start functionality</oldsource>
       <translation>Función de arranque automático</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="97"/>
       <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
       <translation>Asegúrese de que el generador no está conectado a la entrada CA %1 cuando utilice esta opción</translation>
-    </message>
-    <message id="page_generator_conditions_inverter_high_temperature">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="139"/>
-      <source>Inverter high temperature</source>
-      <translation type="unfinished">Alta temperatura inversor</translation>
     </message>
     <message id="page_generator_conditions_tank_level">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="159"/>
@@ -6669,30 +6090,34 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
     <message id="settings_generator_function_not_enabled">
       <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
       <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
+      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
       <translation>La funcion de arranque/parada de generador no esta habilitada, vaya a los ajustes de relé y seleccione la funcion "Arranque/parada generador"</translation>
     </message>
     <message id="settings_batteries_intro">
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="45"/>
       <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
       <translation>Utilice este menú para definir los datos de la batería que se muestran al hacer clic en el icono Batería de la página Vista general. Esto mismo también puede verse en el Portal VRM.</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
       <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
       <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
       <translation>La detección continua puede interferir con el funcionamiento de la WiFi.</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
       <source>CAN-bus BMS LV (500 kbit/s)</source>
+      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
       <translation>CAN-bus BMS LV (500 kbit/s)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
       <source>CAN-bus BMS HV (500 kbit/s)</source>
       <translation>CAN-bus BMS HV (500 kbit/s)</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
       <source>Up, but no services (500 kbit/s)</source>
       <translation>Activo, pero sin servicios (500 kbit/s)</translation>
     </message>
@@ -6705,41 +6130,6 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="127"/>
       <source>Brief page</source>
       <translation>Página resumen</translation>
-    </message>
-    <message id="settings_displayoff_1min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="46"/>
-      <source>1 min</source>
-      <translation type="unfinished">1 min</translation>
-    </message>
-    <message id="settings_displayoff_10min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="48"/>
-      <source>10 min</source>
-      <translation type="unfinished">10 min</translation>
-    </message>
-    <message id="settings_displayoff_30min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="50"/>
-      <source>30 min</source>
-      <translation type="unfinished">30 min</translation>
-    </message>
-    <message id="settings_displayoff_never">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="52"/>
-      <source>Never</source>
-      <translation type="unfinished">Nunca</translation>
-    </message>
-    <message id="settings_remote_console_appearance_auto">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="112"/>
-      <source>Auto</source>
-      <translation type="unfinished">Automático</translation>
-    </message>
-    <message id="settings_brief_view_start_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="119"/>
-      <source>Start page</source>
-      <translation type="unfinished">Página de inicio</translation>
-    </message>
-    <message id="settings_display_boat_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="135"/>
-      <source>Boat page</source>
-      <translation type="unfinished">Página de la embarcación</translation>
     </message>
     <message id="settings_display_minmax">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="148"/>
@@ -6794,21 +6184,6 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
       <translation>%1 está fijado en %2</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_unsupported_device">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="50"/>
-      <source>Unsupported GX device</source>
-      <translation type="unfinished">Dispositivo GX no compatible</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_clean">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="55"/>
-      <source>Clean</source>
-      <translation type="unfinished">Limpiar</translation>
-    </message>
-    <message id="pagesettingsgeneral_firmware">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="112"/>
-      <source>Firmware</source>
-      <translation type="unfinished">Firmware</translation>
-    </message>
     <message id="pagesettingsgeneral_access_and_security">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
       <source>Access &amp; Security</source>
@@ -6842,6 +6217,7 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
     <message id="settings_language_please_wait">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="209"/>
       <source>Please wait while the language is changed.</source>
+      <oldsource>Please wait while the language is changed</oldsource>
       <translation>Espere mientras se cambia el idioma.</translation>
     </message>
     <message id="settings_briefview_totals">
@@ -6858,11 +6234,6 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="71"/>
       <source>Tank is not connected.</source>
       <translation>El depósito no está conectado.</translation>
-    </message>
-    <message id="settings_briefview_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="83"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">Monitor de baterías activo</translation>
     </message>
     <message id="settings_briefview_individual_batteries">
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="86"/>
@@ -6913,6 +6284,7 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
     <message id="settings_dvcc_charge_current_limits">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="30"/>
       <source>Charge current limits</source>
+      <oldsource>Charge Current limits</oldsource>
       <translation>Límites de corriente de carga</translation>
     </message>
     <message id="settings_firmware_official_release">
@@ -6992,11 +6364,6 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>No password and the network communication is not encrypted</source>
       <translation>Sin contraseña y la comunicación de red no está encriptada</translation>
     </message>
-    <message id="settings_logout_now">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
-      <source>Log out now</source>
-      <translation type="unfinished">Cerrar sesión ahora</translation>
-    </message>
     <message id="settings_security_profile_password_incorrect_length">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="28"/>
       <source>Password needs to be at least 8 characters long</source>
@@ -7047,25 +6414,10 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>Page will automatically reload in 5 seconds</source>
       <translation>La página se volverá a cargar automáticamente en 5 segundos</translation>
     </message>
-    <message id="settings_security_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="159"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">La contraseña ha tener al menos ocho caracteres</translation>
-    </message>
     <message id="settings_root_password">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="269"/>
       <source>Root password</source>
       <translation>Contraseña raíz</translation>
-    </message>
-    <message id="settings_root_enter_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="272"/>
-      <source>Enter password</source>
-      <translation type="unfinished">Introducir contraseña</translation>
-    </message>
-    <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="277"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">La contraseña ha tener al menos ocho caracteres</translation>
     </message>
     <message id="settings_root_password_changed_to">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="283"/>
@@ -7081,6 +6433,11 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="321"/>
       <source>Logout</source>
       <translation>Cerrar sesión</translation>
+    </message>
+    <message id="settings_logout_now">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
+      <source>Log out now</source>
+      <translation>Cerrar sesión ahora</translation>
     </message>
     <message id="settings_logout_dialog_title">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="335"/>
@@ -7140,11 +6497,13 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="141"/>
       <source>Alarm when generator is not in autostart mode</source>
+      <oldsource>Alarm when generator is not in auto start mode</oldsource>
       <translation>Alarma cuando el generador no esté en modo arranque automático</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="147"/>
       <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
       <translation>Saltará una alarma cuando la función de arranque automático permanezca deshabilitada durante más de 10 minutos</translation>
     </message>
     <message id="settings_units_amps_exceptions">
@@ -7160,6 +6519,11 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
     <message id="settings_ess_use_this_option_for_peak_shaving">
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
       <source>Use this option for peak shaving.</source>
+      <oldsource>Use this option for peak shaving.
+
+The peak shaving threshold is set using the AC input current limit setting.
+
+See documentation for further information.</oldsource>
       <translation>Utilice esta opción para recorte de picos.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
@@ -7203,17 +6567,17 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <translation>Máxima corriente de exportación del sistema (por fase)</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="71"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="73"/>
       <source>Self-consumption from battery</source>
       <translation>Autoconsumo de la batería</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="76"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
       <source>All system loads</source>
       <translation>Todas las cargas del sistema</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="80"/>
       <source>Only critical loads</source>
       <translation>Solo las cargas críticas</translation>
     </message>
@@ -7271,26 +6635,6 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="194"/>
       <source>Server Applications</source>
       <translation>Aplicaciones del servidor</translation>
-    </message>
-    <message id="pagesettingsintegrations_venus_os_enable_large_features">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
-      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_large_victron_community">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="274"/>
-      <source>Victron Community</source>
-      <translation type="unfinished">Victron Community</translation>
-    </message>
-    <message id="pagesettingsintegrations_ui_plugins">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
-      <source>UI Plugins</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
-      <source>Integrates with the device list</source>
-      <translation type="unfinished"/>
     </message>
     <message id="pagesettingssupportstate_modbus_tcp_server">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="453"/>
@@ -7393,25 +6737,10 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
       <translation>No se puede cambiar la versión de firmware si no se selecciona "Perfil de seguridad de la red " en "Ajustes / General".</translation>
     </message>
-    <message id="pagesettingsconnectivity_ethernet">
-      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
-      <source>Ethernet</source>
-      <translation type="unfinished">Ethernet</translation>
-    </message>
     <message id="pagesettingsconnectivity_mobile_network">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="53"/>
       <source>Mobile Network</source>
       <translation>Red móvil</translation>
-    </message>
-    <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Boat</source>
-      <translation type="unfinished">Barco</translation>
-    </message>
-    <message id="settings_system_name_auto">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="32"/>
-      <source>Automatic</source>
-      <translation type="unfinished">Automático</translation>
     </message>
     <message id="pagesettingssystem_ac_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
@@ -7442,11 +6771,6 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="89"/>
       <source>Distributed Voltage and Current Control (DVCC)</source>
       <translation>Control de corriente y tensión distribuido (DVCC)</translation>
-    </message>
-    <message id="settings_system_grid">
-      <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="18"/>
-      <source>Grid</source>
-      <translation type="unfinished">Red eléctrica</translation>
     </message>
     <message id="settings_system_ac_position">
       <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="58"/>
@@ -7486,16 +6810,19 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
     <message id="settings_system_has_dc_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="97"/>
       <source>Display DC Loads</source>
+      <oldsource>Has DC system</oldsource>
       <translation>Mostrar cargas CC</translation>
     </message>
     <message id="settings_system_battery_measurements">
       <location filename="../../pages/settings/PageSettingsBatteries.qml" line="65"/>
       <source>Battery measurements</source>
+      <oldsource>Battery Measurements</oldsource>
       <translation>Mediciones de la batería</translation>
     </message>
     <message id="settings_system_system_status">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
       <source>System status</source>
+      <oldsource>System Status</oldsource>
       <translation>Estado del sistema</translation>
     </message>
     <message id="settings_tcpip_wired">
@@ -7506,11 +6833,13 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
     <message id="settings_vecan_device_instance">
       <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
       <source>VE.Can Device Instance</source>
+      <oldsource>Device Instance</oldsource>
       <translation>Instancia de dispositivo VE.Can</translation>
     </message>
     <message id="settings_vecan_device_number">
       <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="32"/>
       <source>VE.Can Instance# %1</source>
+      <oldsource>Device# %1</oldsource>
       <translation>#Instancia de VE.Can %1</translation>
     </message>
     <message id="settings_tz_antarctica">
@@ -7541,6 +6870,7 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
     <message id="settings_vrm">
       <location filename="../../pages/SettingsPage.qml" line="59"/>
       <source>VRM</source>
+      <extracomment>Forced by %2 to dark</extracomment>
       <translation>VRM</translation>
     </message>
     <message id="settings_remote_monitoring_portal">
@@ -7548,20 +6878,10 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>Remote monitoring portal</source>
       <translation>Portal de monitorización a distancia</translation>
     </message>
-    <message id="settings_advanced">
-      <location filename="../../pages/SettingsPage.qml" line="68"/>
-      <source>Advanced</source>
-      <translation type="unfinished">Avanzado</translation>
-    </message>
-    <message id="settings_integrations">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
+    <message id="pagesettingssupportstate_integrations">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
       <source>Integrations</source>
       <translation>Integraciones</translation>
-    </message>
-    <message id="settings_relays_sensors_tanks">
-      <location filename="../../pages/SettingsPage.qml" line="75"/>
-      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
-      <translation type="unfinished">Relés, sensores, depósitos, inversores FV, Modbus, MQTT...</translation>
     </message>
     <message id="settings_acdcsystem_ess_dvcc_battery">
       <location filename="../../pages/SettingsPage.qml" line="84"/>
@@ -7581,11 +6901,13 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
     <message id="settings_system_setup">
       <location filename="../../pages/SettingsPage.qml" line="82"/>
       <source>System Setup</source>
+      <oldsource>System setup</oldsource>
       <translation>Configuración sistema</translation>
     </message>
     <message id="settings_vrm_device_instances">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
       <source>VRM device instances</source>
+      <oldsource>VRM Device Instances</oldsource>
       <translation>Instancias de dispositivo VRM</translation>
     </message>
     <message id="solarcharger_not_supported">
@@ -7603,28 +6925,10 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>The firmware version in the MPPT Solar Charger must be v1.09 or later. Contact Victron Service for update instructions and files.</source>
       <translation>La versión de firmware del cargador solar MPPT debe ser v1.09 o posterior. Póngase en contacto con el servicio de asistencia de Victron para actualizar las instrucciones y los archivos.</translation>
     </message>
-    <message id="solarcharger_pv">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="102"/>
-      <source>PV</source>
-      <extracomment>PV power for solar charger</extracomment>
-      <translation type="unfinished">FV</translation>
-    </message>
     <message id="solarcharger_total_power">
       <location filename="../../pages/solar/PageSolarCharger.qml" line="127"/>
       <source>Total PV power</source>
       <translation>Potencia FV total</translation>
-    </message>
-    <message id="solarcharger_total_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="211"/>
-      <source>Total yield</source>
-      <extracomment>Solar charger total yield</extracomment>
-      <translation type="unfinished">Rendimiento total</translation>
-    </message>
-    <message id="solarcharger_system_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="220"/>
-      <source>System yield</source>
-      <extracomment>Solar charger system yield</extracomment>
-      <translation type="unfinished">Rendimiento del sistema</translation>
     </message>
     <message id="settings_multirs_total_yield">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="63"/>
@@ -7660,16 +6964,19 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
     <message id="vebus_device_update_firmware">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="133"/>
       <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
       <translation>Para esta función se necesita la versión de firmware 400 o superior. Póngase en contacto con su instalador para actualizar su Multi/Quattro.</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="139"/>
       <source>Charger not ready, equalization cannot be started</source>
+      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
       <translation>El cargador no está listo, no se puede iniciar la ecualización</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="143"/>
       <source>Equalization cannot be triggered during bulk charge state</source>
+      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
       <translation>La ecualización no puede activarse durante la carga inicial</translation>
     </message>
     <message id="vebus_device_restart_vebus_system_restart_confirmation_description">
@@ -7692,78 +6999,20 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>Auto-started • %1</source>
       <translation>Arrancado automáticamente • %1</translation>
     </message>
-    <message id="common_words_battery">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery</source>
-      <translation type="unfinished">Batería</translation>
-    </message>
-    <message id="common_words_boat_page">
-      <location filename="../../components/CommonWords.qml" line="111"/>
-      <source>Boat</source>
-      <extracomment>The 'Boat' page</extracomment>
-      <translation type="unfinished">Barco</translation>
-    </message>
-    <message id="common_words_brief_page">
-      <location filename="../../components/CommonWords.qml" line="115"/>
-      <source>Brief</source>
-      <extracomment>The 'Brief' page</extracomment>
-      <translation type="unfinished">Breve</translation>
-    </message>
-    <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation type="unfinished">Cerrado</translation>
-    </message>
-    <message id="common_words_color">
-      <location filename="../../components/CommonWords.qml" line="136"/>
-      <source>Color</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_connected">
-      <location filename="../../components/CommonWords.qml" line="139"/>
-      <source>Connected</source>
-      <translation type="unfinished">Conectado</translation>
-    </message>
     <message id="common_words_daily_history">
       <location filename="../../components/CommonWords.qml" line="152"/>
       <source>Daily history</source>
       <translation>Historial diario</translation>
-    </message>
-    <message id="common_words_disabled">
-      <location filename="../../components/CommonWords.qml" line="169"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Deshabilitado</translation>
-    </message>
-    <message id="common_words_disconnected">
-      <location filename="../../components/CommonWords.qml" line="175"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Desconectado</translation>
-    </message>
-    <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="191"/>
-      <source>Error</source>
-      <translation type="unfinished">Error</translation>
     </message>
     <message id="common_words_error_not_a_number">
       <location filename="../../components/CommonWords.qml" line="200"/>
       <source>'%1' is not a number.</source>
       <translation>'%1' no es un número.</translation>
     </message>
-    <message id="common_words_generator">
-      <location filename="../../components/CommonWords.qml" line="217"/>
-      <source>Generator</source>
-      <translation type="unfinished">Generador</translation>
-    </message>
     <message id="common_words_input_current_limit">
       <location filename="../../components/CommonWords.qml" line="261"/>
       <source>Input current limit</source>
       <translation>Límite de corriente de entrada</translation>
-    </message>
-    <message id="common_words_inverter_charger">
-      <location filename="../../components/CommonWords.qml" line="264"/>
-      <source>Inverter / Charger</source>
-      <translation type="unfinished">Inversor / cargador</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
       <location filename="../../components/CommonWords.qml" line="268"/>
@@ -7776,12 +7025,6 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>Manual stop</source>
       <translation>Parada manual</translation>
     </message>
-    <message id="common_words_max">
-      <location filename="../../components/CommonWords.qml" line="315"/>
-      <source>Max</source>
-      <extracomment>Short for Maximum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_maximum_current">
       <location filename="../../components/CommonWords.qml" line="318"/>
       <source>Maximum current</source>
@@ -7792,62 +7035,10 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>Maximum power</source>
       <translation>Potencia máxima</translation>
     </message>
-    <message id="common_words_min">
-      <location filename="../../components/CommonWords.qml" line="331"/>
-      <source>Min</source>
-      <extracomment>Short for Minimum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_minimum_current">
       <location filename="../../components/CommonWords.qml" line="334"/>
       <source>Minimum current</source>
       <translation>Corriente mínima</translation>
-    </message>
-    <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="433"/>
-      <source>No</source>
-      <translation type="unfinished">No</translation>
-    </message>
-    <message id="common_words_none_option">
-      <location filename="../../components/CommonWords.qml" line="364"/>
-      <source>None</source>
-      <translation type="unfinished">Ninguno</translation>
-    </message>
-    <message id="common_words_none_errors">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>None</source>
-      <extracomment>Indicates there are no errors</extracomment>
-      <translation type="unfinished">Ninguno</translation>
-    </message>
-    <message id="common_words_not_available">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Not available</source>
-      <translation type="unfinished">No disponible</translation>
-    </message>
-    <message id="common_words_off">
-      <location filename="../../components/CommonWords.qml" line="377"/>
-      <source>Off</source>
-      <translation type="unfinished">Apagado</translation>
-    </message>
-    <message id="common_words_ok">
-      <location filename="../../components/CommonWords.qml" line="383"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="41"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="45"/>
-      <source>OK</source>
-      <translation type="unfinished">OK</translation>
-    </message>
-    <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="386"/>
-      <source>On</source>
-      <translation type="unfinished">Encendido</translation>
-    </message>
-    <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="393"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation type="unfinished">Abierto</translation>
     </message>
     <message id="common_words_open_circuit">
       <location filename="../../components/CommonWords.qml" line="396"/>
@@ -7859,108 +7050,17 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>Overall history</source>
       <translation>Historial general</translation>
     </message>
-    <message id="common_words_press">
-      <location filename="../../components/CommonWords.qml" line="419"/>
-      <source>Press</source>
-      <translation type="unfinished">Prensa</translation>
-    </message>
-    <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation type="unfinished">En marcha</translation>
-    </message>
-    <message id="common_words_settings">
-      <location filename="../../components/CommonWords.qml" line="467"/>
-      <source>Settings</source>
-      <translation type="unfinished">Ajustes</translation>
-    </message>
-    <message id="common_words_silence_alarm">
-      <location filename="../../components/CommonWords.qml" line="476"/>
-      <source>Silence alarm</source>
-      <translation type="unfinished">Alarma de silencio</translation>
-    </message>
     <message id="common_words_soc">
       <location filename="../../components/CommonWords.qml" line="480"/>
       <source>SOC %1</source>
       <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
       <translation>Estado de carga %1</translation>
     </message>
-    <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation type="unfinished">Velocidad</translation>
-    </message>
-    <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="487"/>
-      <source>Standby</source>
-      <translation type="unfinished">En espera</translation>
-    </message>
-    <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="502"/>
-      <source>State</source>
-      <translation type="unfinished">Estado</translation>
-    </message>
-    <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="512"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation type="unfinished">Arranque (%1)</translation>
-    </message>
-    <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>Stopped</source>
-      <translation type="unfinished">Parado</translation>
-    </message>
-    <message id="common_words_total_power">
-      <location filename="../../components/CommonWords.qml" line="540"/>
-      <source>Total power</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="547"/>
-      <source>Type</source>
-      <translation type="unfinished">Tipo</translation>
-    </message>
-    <message id="common_words_unknown_status">
-      <location filename="../../components/CommonWords.qml" line="554"/>
-      <source>Unknown</source>
-      <extracomment>Status = "unknown"</extracomment>
-      <translation type="unfinished">Desconocido</translation>
-    </message>
-    <message id="common_words_value_must_be_greater_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="557"/>
-      <source>Value must be greater than start value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_value_must_be_greater_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="560"/>
-      <source>Value must be greater than stop value</source>
-      <translation type="unfinished">El valor debe ser mayor que el valor de parada</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="563"/>
-      <source>Value must be lower than start value</source>
-      <translation type="unfinished">El valor debe de ser menor que el valor de arranque</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="566"/>
-      <source>Value must be lower than stop value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="581"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="431"/>
-      <source>Yes</source>
-      <translation type="unfinished">Sí</translation>
-    </message>
     <message id="common_words_yield_today">
       <location filename="../../components/CommonWords.qml" line="592"/>
       <source>Yield Today</source>
       <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+      <oldsource>Yield today</oldsource>
       <translation>Producción hoy</translation>
     </message>
     <message id="common_words_format_error">
@@ -7987,10 +7087,11 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
     <message id="settings_firmware_installed_rebooting">
       <location filename="../../components/FirmwareUpdate.qml" line="79"/>
       <source>Firmware installed, device rebooting</source>
+      <oldsource>Firmware installed, rebooting.</oldsource>
       <translation>Firmware instalado, reiniciando dispositivo</translation>
     </message>
-    <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/RadioButtonListPage.qml" line="121"/>
+    <message id="modaldialog_confirm">
+      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
       <source>Confirm</source>
       <extracomment>Confirm password, and verify it if possible</extracomment>
       <translation>Confirmar</translation>
@@ -8008,11 +7109,13 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
     <message id="cgwacs_battery_schedule_duration">
       <location filename="../../components/listitems/ListChargeSchedule.qml" line="144"/>
       <source>Duration</source>
+      <oldsource>Duration (hh:mm)</oldsource>
       <translation>Duración</translation>
     </message>
     <message id="settings_relay_deactivation_value">
       <location filename="../../components/TemperatureRelaySettings.qml" line="86"/>
       <source>Deactivation value</source>
+      <oldsource>Deativation value</oldsource>
       <translation>Valor de desactivación</translation>
     </message>
     <message id="splash_view_device_disconnected">
@@ -8060,29 +7163,6 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>Temperature warning</source>
       <translation>Aviso de temperatura</translation>
     </message>
-    <message id="battery_mode_idle">
-      <location filename="../../src/enums.cpp" line="26"/>
-      <source>Idle</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">En reposo</translation>
-    </message>
-    <message id="battery_mode_charging">
-      <location filename="../../src/enums.cpp" line="30"/>
-      <source>Charging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Cargando</translation>
-    </message>
-    <message id="battery_mode_discharging">
-      <location filename="../../src/enums.cpp" line="34"/>
-      <source>Discharging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Descargando</translation>
-    </message>
-    <message id="dcMeter_bilge_pump">
-      <location filename="../../src/enums.cpp" line="115"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">Bomba de sentina</translation>
-    </message>
     <message id="switch_state_channel_fault">
       <location filename="../../src/enums.cpp" line="372"/>
       <source>Channel Fault</source>
@@ -8113,26 +7193,6 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
       <source>Slave of %1</source>
       <translation>Esclavo de %1</translation>
     </message>
-    <message id="switchable_output_numeric_input">
-      <location filename="../../src/enums.cpp" line="418"/>
-      <source>Numeric input</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bilge_pump">
-      <location filename="../../src/enums.cpp" line="424"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">Bomba de sentina</translation>
-    </message>
-    <message id="switchable_output_not_running">
-      <location filename="../../src/enums.cpp" line="448"/>
-      <source>Not running</source>
-      <translation type="unfinished">No está funcionando</translation>
-    </message>
-    <message id="switchable_output_off">
-      <location filename="../../src/enums.cpp" line="451"/>
-      <source>Off</source>
-      <translation type="unfinished">Apagado</translation>
-    </message>
     <message id="switchable_output_powered">
       <location filename="../../src/enums.cpp" line="455"/>
       <source>Powered</source>
@@ -8161,16 +7221,19 @@ Cuando se complete el proceso de carga, el sistema volverá al funcionamiento no
     <message id="evchargers_status_welded_contacts_error">
       <location filename="../../data/EvChargers.qml" line="76"/>
       <source>Welded contacts test error (shorted)</source>
+      <oldsource>Welded contacts error</oldsource>
       <translation>Error de prueba de contactos soldados (cortocircuitado)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
       <location filename="../../data/EvChargers.qml" line="100"/>
       <source>Switching to 3 phase</source>
+      <oldsource>Switching to 3-phase</oldsource>
       <translation>Pasando a trifásica</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
       <location filename="../../data/EvChargers.qml" line="103"/>
       <source>Switching to 1 phase</source>
+      <oldsource>Switching to single phase</oldsource>
       <translation>Pasando a monofásica</translation>
     </message>
     <message id="evchargers_status_stop_charging">
@@ -8323,17 +7386,6 @@ If el generador está funcionando en este momento por una condición de arranque
       <source>Open link</source>
       <translation>Abrir enlace</translation>
     </message>
-    <message id="listlink_show_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="43"/>
-      <source>Show QR code</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="listlink_scan_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="52"/>
-      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
-      <extracomment>%1 = url text</extracomment>
-      <translation type="unfinished">Escanee el código QR con su dispositivo portátil.&lt;br /&gt;O introduzca el enlace: %1</translation>
-    </message>
     <message id="settings_services_mqtt_access">
       <location filename="../../components/listitems/ListMqttAccessSwitch.qml" line="11"/>
       <source>MQTT Access</source>
@@ -8405,12 +7457,6 @@ If el generador está funcionando en este momento por una condición de arranque
       <extracomment>The 'Brief' page, with the side panel opened</extracomment>
       <translation>Resumen (panel lateral abierto)</translation>
     </message>
-    <message id="startpage_option_overview">
-      <location filename="../../data/StartPageConfiguration.qml" line="37"/>
-      <source>Overview</source>
-      <extracomment>The 'Overview' page</extracomment>
-      <translation type="unfinished">Resumen</translation>
-    </message>
     <message id="startpage_option_levels_tanks">
       <location filename="../../data/StartPageConfiguration.qml" line="43"/>
       <source>Levels (Tanks)</source>
@@ -8429,12 +7475,12 @@ If el generador está funcionando en este momento por una condición de arranque
       <translation>Lista de baterías</translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
+      <location filename="../../pages/DialogLayer.qml" line="56"/>
       <source>GX device has been updated</source>
       <translation>Se ha actualizado el dispositivo GX</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
+      <location filename="../../pages/DialogLayer.qml" line="58"/>
       <source>Page will automatically reload in ten seconds to load the latest version.</source>
       <translation>La página se volverá a cargar automáticamente en diez segundos para cargar la última versión.</translation>
     </message>
@@ -8604,8 +7650,8 @@ Tenga en cuenta que este menú solo muestra contadores de Carlo Gavazzi conectad
       <source>Unit</source>
       <translation>Unidad</translation>
     </message>
-    <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="61"/>
+    <message id="page_settings_fronius_unitid_invalid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
       <source>%1 is not a valid unit number. Use a number between 1-247.</source>
       <translation>%1 no es un número válido. Utilice un número entre 1-247.</translation>
     </message>
@@ -8720,11 +7766,6 @@ Tenga en cuenta que este menú solo muestra contadores de Carlo Gavazzi conectad
       <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="66"/>
       <source>Controller Temperature</source>
       <translation>Temperatura controlador</translation>
-    </message>
-    <message id="devicelist_motordrive_motordirectioninverted">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
-      <source>Motor Direction Inverted</source>
-      <translation type="unfinished"/>
     </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
@@ -8916,11 +7957,6 @@ With streamlined navigation and a fresh look, everything you love is now even ea
     <message id="welcome_done">
       <location filename="../../pages/welcome/WelcomeView.qml" line="136"/>
       <source>Done</source>
-      <translation type="unfinished">Hecho</translation>
-    </message>
-    <message id="mk2vsc_state_done">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="20"/>
-      <source>Done</source>
       <translation>Hecho</translation>
     </message>
     <message id="welcome_next">
@@ -8978,6 +8014,7 @@ El dispositivo GX solo puede controlar un generador conectado y elige el que tie
     <message id="settings_tz_etc">
       <location filename="../../pages/settings/PageTzInfo.qml" line="280"/>
       <source>Other</source>
+      <oldsource>Etc</oldsource>
       <translation>Otros</translation>
     </message>
     <message id="ac-in-modeldefault_energy_reverse_x">
@@ -8995,6 +8032,11 @@ El dispositivo GX solo puede controlar un generador conectado y elige el que tie
       <location filename="../../src/enums.cpp" line="438"/>
       <source>Unsupported type: %1</source>
       <translation>Tipo no compatible: %1</translation>
+    </message>
+    <message id="common_words_press">
+      <location filename="../../components/CommonWords.qml" line="419"/>
+      <source>Press</source>
+      <translation>Prensa</translation>
     </message>
     <message id="output_aux_battery_service_changed_dcdc">
       <location filename="../../components/listitems/ListOutputBatteryRadioButtonGroup.qml" line="27"/>
@@ -9135,13 +8177,6 @@ El dispositivo GX solo puede controlar un generador conectado y elige el que tie
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="38"/>
       <source>Resetting VE.Bus products</source>
       <translation>Restablecimiento de productos VE.Bus</translation>
-    </message>
-    <message id="Unknown">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Desconocido</translation>
     </message>
     <message id="mk2vsc_error_mk2_mk3_comm">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="47"/>
@@ -9447,11 +8482,6 @@ El dispositivo GX solo puede controlar un generador conectado y elige el que tie
       <source>Changing the GX Password</source>
       <translation>Cambiando la contraseña GX</translation>
     </message>
-    <message id="modaldialog_confirm">
-      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
-      <source>Confirm</source>
-      <translation type="unfinished">Confirmar</translation>
-    </message>
     <message id="settings_security_profile_change_password_description">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="83"/>
       <source>Please enter a new GX password:</source>
@@ -9544,21 +8574,6 @@ El dispositivo GX solo puede controlar un generador conectado y elige el que tie
       <source>Modifications installed</source>
       <translation>Modificaciones instaladas</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_modbus">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="28"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">Servidor Modbus TCP</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_signalk">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="32"/>
-      <source>Signal K</source>
-      <translation type="unfinished">Signal K</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_nodered">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="36"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">Node-RED</translation>
-    </message>
     <message id="pagesettingsgeneral_modificationchecks_running_integrations">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="43"/>
       <source>%1 running integrations</source>
@@ -9634,16 +8649,6 @@ El dispositivo GX solo puede controlar un generador conectado y elige el que tie
       <source>Installed and enabled, disables at next boot</source>
       <translation>Instalado y habilitado, se deshabilitará en el próximo arranque</translation>
     </message>
-    <message id="pagesettingssupportstate_firmware_checking">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
-      <source>Checking...</source>
-      <translation type="unfinished">Comprobando...</translation>
-    </message>
-    <message id="pagesettingssupportstate_firmware_unknown">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="166"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Desconocido</translation>
-    </message>
     <message id="pagesettingssupportstate_support_status">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="228"/>
       <source>Support status</source>
@@ -9665,11 +8670,6 @@ El dispositivo GX solo puede controlar un generador conectado y elige el que tie
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="288"/>
       <source>Press 'OK' to disable custom startup scripts and reboot</source>
       <translation>Pulse 'OK' para deshabilitar los scripts de inicio personalizados y reiniciar</translation>
-    </message>
-    <message id="pagesettingssupportstate_re_enable_custom_startup_scripts">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="309"/>
-      <source>Re-enable custom startup scripts</source>
-      <translation type="unfinished">Reactivar los scripts de inicio personalizados</translation>
     </message>
     <message id="pagesettingssupportstate_reenable_and_reboot_now">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="322"/>
@@ -9696,11 +8696,6 @@ El dispositivo GX solo puede controlar un generador conectado y elige el que tie
       <source>Disable also custom startup scripts?</source>
       <translation>¿Deshabilitar también los scripts de inicio personalizados?</translation>
     </message>
-    <message id="pagesettingssupportstate_integrations">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
-      <source>Integrations</source>
-      <translation type="unfinished">Integraciones</translation>
-    </message>
     <message id="pagesettingssupportstate_orange_items_description">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="494"/>
       <source>Items colored orange are supported and provided by Victron Energy, but using them incorrectly can affect system stability. In case of troubleshooting, disable those first.</source>
@@ -9712,7 +8707,7 @@ El dispositivo GX solo puede controlar un generador conectado y elige el que tie
       <translation>Conecte un dongle USB Bluetooth compatible para habilitar la conectividad Bluetooth.</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="140"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="142"/>
       <source>BatteryLife state</source>
       <translation>Estado de BatteryLife</translation>
     </message>
@@ -9720,23 +8715,6 @@ El dispositivo GX solo puede controlar un generador conectado y elige el que tie
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="33"/>
       <source>Device Integrations</source>
       <translation>Integraciones de dispositivos</translation>
-    </message>
-    <message id="pagesettingsintegrations_modbus_tcp_server">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="201"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">Servidor Modbus TCP</translation>
-    </message>
-    <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="226"/>
-      <location filename="../../pages/settings/PageSettingsSignalK.qml" line="18"/>
-      <source>Signal K</source>
-      <translation type="unfinished">Signal K</translation>
-    </message>
-    <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="241"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">Node-RED</translation>
     </message>
     <message id="settings_venusos_large_documentation">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="267"/>
@@ -9746,6 +8724,7 @@ El dispositivo GX solo puede controlar un generador conectado y elige el que tie
     <message id="settings_modbus_enable_modbus_tcp">
       <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
       <source>Enable Modbus TCP Server</source>
+      <oldsource>Enable Modbus/TCP</oldsource>
       <translation>Activar el servidor Modbus TCP</translation>
     </message>
     <message id="pagesettingsconnectivity_bluetooth_for_victronconnect_app">
@@ -9839,11 +8818,13 @@ El dispositivo GX solo puede controlar un generador conectado y elige el que tie
     <message id="settings_gps_format_kmh">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="93"/>
       <source>Kilometres per hour</source>
+      <oldsource>Kilometers per hour</oldsource>
       <translation>Kilómetros por hora</translation>
     </message>
     <message id="settings_gps_format_ms">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="95"/>
       <source>Metres per second</source>
+      <oldsource>Meters per second</oldsource>
       <translation>Metros por segundo</translation>
     </message>
     <message id="components_volumeunit_cubic_metres">
@@ -9871,8 +8852,8 @@ El dispositivo GX solo puede controlar un generador conectado y elige el que tie
       <source>The Relay can now be found in the devices list</source>
       <translation>El relé ahora se puede encontrar en la lista de dispositivos</translation>
     </message>
-    <message id="common_words_gx_device_relays">
-      <location filename="../../components/CommonWords.qml" line="223"/>
+    <message id="gx_device_relays">
+      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
       <source>GX device relays</source>
       <translation>Relés del dispositivo GX</translation>
     </message>
@@ -9926,12 +8907,6 @@ El dispositivo GX solo puede controlar un generador conectado y elige el que tie
       <extracomment>Forced by app to %1</extracomment>
       <translation>automático</translation>
     </message>
-    <message id="settings_remote_console_forced_by_vrm">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="94"/>
-      <source>VRM</source>
-      <extracomment>Forced by %2 to dark</extracomment>
-      <translation type="unfinished">VRM</translation>
-    </message>
     <message id="settings_remote_console_forced_by_app">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="97"/>
       <source>app</source>
@@ -9981,6 +8956,7 @@ El dispositivo GX solo puede controlar un generador conectado y elige el que tie
     <message id="settings_large_access_signal_k">
       <location filename="../../pages/settings/PageSettingsSignalK.qml" line="24"/>
       <source>Access Signal K</source>
+      <oldsource>Access Signal K (local network)</oldsource>
       <translation>Acceder a Signal K</translation>
     </message>
     <message id="pagesettingsintegrations_shelly_devices">
@@ -9991,6 +8967,7 @@ El dispositivo GX solo puede controlar un generador conectado y elige el que tie
     <message id="settings_large_access_node_red">
       <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
       <source>Access Node-RED</source>
+      <oldsource>Access Node-RED (local network)</oldsource>
       <translation>Acceder a Node-RED</translation>
     </message>
     <message id="settings_wifi_access_point_password">
@@ -10058,57 +9035,6 @@ El dispositivo GX solo puede controlar un generador conectado y elige el que tie
       <source>Wind charger</source>
       <translation>Cargador eólico</translation>
     </message>
-    <message id="digitalinputs_type_disabled">
-      <location filename="../../src/enums.cpp" line="192"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Deshabilitado</translation>
-    </message>
-    <message id="digitalinputs_state_off">
-      <location filename="../../src/enums.cpp" line="242"/>
-      <source>Off</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Apagado</translation>
-    </message>
-    <message id="digitalinputs_state_on">
-      <location filename="../../src/enums.cpp" line="246"/>
-      <source>On</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Encendido</translation>
-    </message>
-    <message id="digitalinputs_state_ok">
-      <location filename="../../src/enums.cpp" line="266"/>
-      <source>OK</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">OK</translation>
-    </message>
-    <message id="digitalinputs_state_alarm">
-      <location filename="../../src/enums.cpp" line="270"/>
-      <source>Alarm</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Alarma</translation>
-    </message>
-    <message id="digitalinputs_state_running">
-      <location filename="../../src/enums.cpp" line="274"/>
-      <source>Running</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">En marcha</translation>
-    </message>
-    <message id="pvinverter_statusCode_running">
-      <location filename="../../src/enums.cpp" line="300"/>
-      <source>Running</source>
-      <extracomment>PV inverter status code</extracomment>
-      <translation type="unfinished">En marcha</translation>
-    </message>
-    <message id="solarchargers_state_external control">
-      <location filename="../../src/enums.cpp" line="352"/>
-      <source>External control</source>
-      <translation type="unfinished">Control externo</translation>
-    </message>
-    <message id="switch_state_over_temperature">
-      <location filename="../../src/enums.cpp" line="366"/>
-      <source>Over temperature</source>
-      <translation type="unfinished">Exceso temperatura</translation>
-    </message>
     <message id="switchable_output_temperature_setpoint">
       <location filename="../../src/enums.cpp" line="398"/>
       <source>Temperature setpoint</source>
@@ -10118,11 +9044,6 @@ El dispositivo GX solo puede controlar un generador conectado y elige el que tie
       <location filename="../../src/enums.cpp" line="401"/>
       <source>Stepped switch</source>
       <translation>Interruptor escalonado</translation>
-    </message>
-    <message id="switchable_output_slave">
-      <location filename="../../src/enums.cpp" line="408"/>
-      <source>Slave</source>
-      <translation type="unfinished">Esclavo</translation>
     </message>
     <message id="switchable_output_dropdown">
       <location filename="../../src/enums.cpp" line="412"/>
@@ -10134,122 +9055,10 @@ El dispositivo GX solo puede controlar un generador conectado y elige el que tie
       <source>Basic slider</source>
       <translation>Control deslizante básico</translation>
     </message>
-    <message id="switchable_output_rgb_color_wheel">
-      <location filename="../../src/enums.cpp" line="427"/>
-      <source>RGB color wheel</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_cct_color_wheel">
-      <location filename="../../src/enums.cpp" line="431"/>
-      <source>CCT color wheel</source>
-      <extracomment>Correlated Color Temperature color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_rgbw_color_wheel">
-      <location filename="../../src/enums.cpp" line="435"/>
-      <source>RGB + W color wheel</source>
-      <extracomment>RGB + white color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bypassed">
-      <location filename="../../src/enums.cpp" line="484"/>
-      <source>Bypassed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="tank_type_fuel">
-      <location filename="../../src/enums.cpp" line="495"/>
-      <source>Fuel</source>
-      <translation type="unfinished">Combustible</translation>
-    </message>
-    <message id="tank_type_fresh_water">
-      <location filename="../../src/enums.cpp" line="498"/>
-      <source>Fresh water</source>
-      <translation type="unfinished">Agua potable</translation>
-    </message>
-    <message id="tank_type_waste_water">
-      <location filename="../../src/enums.cpp" line="501"/>
-      <source>Waste water</source>
-      <translation type="unfinished">Aguas grises</translation>
-    </message>
-    <message id="tank_type_live_well">
-      <location filename="../../src/enums.cpp" line="504"/>
-      <source>Live well</source>
-      <translation type="unfinished">Vivero</translation>
-    </message>
-    <message id="tank_type_oil">
-      <location filename="../../src/enums.cpp" line="507"/>
-      <source>Oil</source>
-      <translation type="unfinished">Aceite</translation>
-    </message>
-    <message id="tank_type_black_water">
-      <location filename="../../src/enums.cpp" line="510"/>
-      <source>Black water</source>
-      <translation type="unfinished">AGUAS NEGRAS</translation>
-    </message>
-    <message id="tank_type_gasoline">
-      <location filename="../../src/enums.cpp" line="513"/>
-      <source>Gasoline</source>
-      <translation type="unfinished">Gasolina</translation>
-    </message>
-    <message id="tank_type_diesel">
-      <location filename="../../src/enums.cpp" line="516"/>
-      <source>Diesel</source>
-      <translation type="unfinished">Diésel</translation>
-    </message>
-    <message id="tank_type_lpg">
-      <location filename="../../src/enums.cpp" line="519"/>
-      <source>LPG</source>
-      <translation type="unfinished">GLP</translation>
-    </message>
-    <message id="tank_type_lng">
-      <location filename="../../src/enums.cpp" line="522"/>
-      <source>LNG</source>
-      <translation type="unfinished">GNL</translation>
-    </message>
-    <message id="tank_type_hydraulic_oil">
-      <location filename="../../src/enums.cpp" line="525"/>
-      <source>Hydraulic oil</source>
-      <translation type="unfinished">Aceite hidráulico</translation>
-    </message>
-    <message id="tank_type_raw_water">
-      <location filename="../../src/enums.cpp" line="528"/>
-      <source>Raw water</source>
-      <translation type="unfinished">Agua sin tratar</translation>
-    </message>
-    <message id="microgrid_mode_hybrid_droop">
-      <location filename="../../src/enums.cpp" line="539"/>
-      <source>Hybrid droop</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_following">
-      <location filename="../../src/enums.cpp" line="542"/>
-      <source>Grid-following</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_forming">
-      <location filename="../../src/enums.cpp" line="545"/>
-      <source>Grid-forming</source>
-      <translation type="unfinished"/>
-    </message>
     <message id="switchable_output_three_state_switch">
       <location filename="../../src/enums.cpp" line="421"/>
       <source>Three-state switch</source>
       <translation>Interruptor de tres estados</translation>
-    </message>
-    <message id="switchable_output_fault">
-      <location filename="../../src/enums.cpp" line="464"/>
-      <source>Fault</source>
-      <translation type="unfinished">Fallo</translation>
-    </message>
-    <message id="switchable_output_running">
-      <location filename="../../src/enums.cpp" line="468"/>
-      <source>Running</source>
-      <translation type="unfinished">En marcha</translation>
-    </message>
-    <message id="switchable_output_trip_low_voltage">
-      <location filename="../../src/enums.cpp" line="481"/>
-      <source>Trip low voltage</source>
-      <translation type="unfinished">Deshabilitado</translation>
     </message>
     <message id="settings_modbus_tcp_unit_id_note">
       <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="41"/>
@@ -10271,281 +9080,1152 @@ El dispositivo GX solo puede controlar un generador conectado y elige el que tie
       <source>Press to refresh</source>
       <translation>Pulse para actualizar</translation>
     </message>
-    <message id="temperature_type_unknown">
-      <location filename="../../data/EnvironmentInputs.qml" line="65"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Desconocido</translation>
-    </message>
-    <message id="brief_solar_yield">
-      <location filename="../../pages/BriefSidePanel.qml" line="24"/>
-      <source>Solar yield</source>
-      <translation type="unfinished">Rendimiento solar</translation>
-    </message>
-    <message id="brief_dc_input">
-      <location filename="../../pages/BriefSidePanel.qml" line="214"/>
-      <source>DC input</source>
-      <translation type="unfinished">Entrada CC</translation>
-    </message>
-    <message id="brief_ac_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="257"/>
-      <source>AC Loads</source>
-      <translation type="unfinished">Cargas CA</translation>
-    </message>
-    <message id="brief_dc_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="284"/>
-      <source>DC Loads</source>
-      <translation type="unfinished">Cargas CC</translation>
-    </message>
-    <message id="nav_overview">
-      <location filename="../../pages/OverviewPage.qml" line="450"/>
-      <source>Overview</source>
-      <translation type="unfinished">Resumen</translation>
-    </message>
-    <message id="settings_state">
-      <location filename="../../pages/settings/PageCanbusStatus.qml" line="116"/>
-      <source>State</source>
-      <translation type="unfinished">Estado</translation>
-    </message>
-    <message id="inverter_pv">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="56"/>
-      <source>PV</source>
-      <translation type="unfinished">FV</translation>
-    </message>
-    <message id="inverter_total_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="76"/>
-      <source>Total yield</source>
-      <translation type="unfinished">Rendimiento total</translation>
-    </message>
-    <message id="inverter_system_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="84"/>
-      <source>System yield</source>
-      <translation type="unfinished">Rendimiento del sistema</translation>
-    </message>
-    <message id="charger_total_pv_power">
-      <location filename="../../pages/solar/SolarDevicePage.qml" line="61"/>
-      <source>Total PV Power</source>
-      <translation type="unfinished">Potencia FV total</translation>
-    </message>
-    <message id="vebus_device_alarm_only">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
-      <source>Alarm only</source>
-      <translation type="unfinished">Solo alarma</translation>
-    </message>
-    <message id="vebus_device_alarms_and_warnings">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
-      <source>Alarms &amp; warnings</source>
-      <translation type="unfinished">Alarmas &amp; avisos</translation>
-    </message>
-    <message id="vebus_device_alarm_group_warning">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
-      <source>Warning</source>
-      <translation type="unfinished">Advertencia</translation>
-    </message>
-    <message id="load_delegate_status">
-      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
-      <source>Status: %1</source>
-      <translation type="unfinished"/>
+    <message id="common_words_total_power">
+      <location filename="../../components/CommonWords.qml" line="540"/>
+      <source>Total power</source>
+      <translation>Potencia total</translation>
     </message>
     <message id="venus_os_gui">
       <location filename="../../Main.qml" line="17"/>
       <source>Venus OS GUI</source>
       <extracomment>Application title</extracomment>
-      <translation type="unfinished"/>
       <extra-Context>only shown on desktop systems</extra-Context>
+      <translation>GUI de Venus OS</translation>
+    </message>
+    <message id="load_delegate_status">
+      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
+      <source>Status: %1</source>
+      <translation>Estado: %1</translation>
+    </message>
+    <message id="settings_relay_polarity_relay1">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
+      <source>Polarity (Relay 1)</source>
+      <translation>Polaridad (Relé 1)</translation>
+    </message>
+    <message id="settings_relay_polarity">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
+      <source>Polarity</source>
+      <translation>Polaridad</translation>
+    </message>
+    <message id="settings_relay_polarity_relay2">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
+      <source>Polarity (Relay 2)</source>
+      <translation>Polaridad (Relé 2)</translation>
+    </message>
+    <message id="page_settings_wifi_invalid_password">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
+      <source>Password length must be either 0 or between 10 and 63 characters long</source>
+      <translation>La longitud de la contraseña debe ser 0 o entre 10 y 63 caracteres</translation>
+    </message>
+    <message id="page_settings_wifi_password_updated">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
+      <source>Password updated</source>
+      <translation>Contraseña actualizada</translation>
+    </message>
+    <message id="common_words_max">
+      <location filename="../../components/CommonWords.qml" line="315"/>
+      <source>Max</source>
+      <extracomment>Short for Maximum</extracomment>
+      <translation>Máx.</translation>
+    </message>
+    <message id="common_words_min">
+      <location filename="../../components/CommonWords.qml" line="331"/>
+      <source>Min</source>
+      <extracomment>Short for Minimum</extracomment>
+      <translation>Mín.</translation>
+    </message>
+    <message id="settings_ess_deprecated">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="321"/>
+      <source>Deprecated settings</source>
+      <translation>Ajustes obsoletos</translation>
+    </message>
+    <message id="settings_ess_max_charge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="328"/>
+      <source>Battery charge limit (% of CCL)</source>
+      <translation>Límite de carga de la batería (% de CCL)</translation>
+    </message>
+    <message id="settings_ess_max_discharge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="339"/>
+      <source>Battery discharge limit (% of DCL)</source>
+      <translation>Límite de descarga de la batería (% de DCL)</translation>
+    </message>
+    <message id="vebus_device_bms_message">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
+      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
+      <oldsource>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</oldsource>
+      <translation>Un VE.Bus BMS apaga automáticamente el sistema cuando es necesario para proteger la batería. Por lo tanto, no es posible controlar el sistema desde el dispositivo GX.</translation>
+    </message>
+    <message id="switchable_output_numeric_input">
+      <location filename="../../src/enums.cpp" line="418"/>
+      <source>Numeric input</source>
+      <translation>Entrada numérica</translation>
     </message>
     <message id="autotoggleswitch_disable_auto_mode_info">
       <location filename="../../components/controls/AutoToggleButton.qml" line="34"/>
       <source>Disable Auto mode first</source>
-      <translation type="unfinished"/>
+      <translation>Desactive primero el modo automático</translation>
+    </message>
+    <message id="pagesettingsintegrations_venus_os_enable_large_features">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
+      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
+      <translation>Activar el firmware Venus OS Large para usar Node-RED o Signal-K</translation>
+    </message>
+    <message id="settings_relays_sensors_tanks">
+      <location filename="../../pages/SettingsPage.qml" line="75"/>
+      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
+      <oldsource>Relays, Sensors, Tanks, PV Inverters, Modbus, MQTT…</oldsource>
+      <translation>Relés, Sensores, Inversores FV, Modbus, Node-RED</translation>
+    </message>
+    <message id="vebus_device_page_microgrid_parameters">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
+      <source>Microgrid parameters</source>
+      <translation>Parámetros de microrred</translation>
+    </message>
+    <message id="microgrid_mode_hybrid_droop">
+      <location filename="../../src/enums.cpp" line="539"/>
+      <source>Hybrid droop</source>
+      <translation>Caída híbrida</translation>
+    </message>
+    <message id="microgrid_mode_grid_following">
+      <location filename="../../src/enums.cpp" line="542"/>
+      <source>Grid-following</source>
+      <translation>Seguidor de red</translation>
+    </message>
+    <message id="microgrid_mode_grid_forming">
+      <location filename="../../src/enums.cpp" line="545"/>
+      <source>Grid-forming</source>
+      <translation>Formador de red</translation>
+    </message>
+    <message id="switchable_output_trip_low_voltage">
+      <location filename="../../src/enums.cpp" line="481"/>
+      <source>Trip low voltage</source>
+      <oldsource>Disabled</oldsource>
+      <translation>Disparo por bajo voltaje</translation>
     </message>
     <message id="microgrid">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="15"/>
       <source>Microgrid</source>
-      <translation type="unfinished"/>
+      <translation>Microrred</translation>
     </message>
     <message id="page_microgrid_active_mode">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="19"/>
       <source>Active mode</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_microgrid_from_p1_to_p2">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="34"/>
-      <source>%1 %2 to %3 %4</source>
-      <extracomment>Describes a range from one quantity to another, e.g. "30 W to 60 W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
-      <translation type="unfinished"/>
+      <translation>Modo activo</translation>
     </message>
     <message id="page_microgrid_hybrid_droop_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="92"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
       <source>Hybrid droop parameters</source>
-      <translation type="unfinished"/>
+      <translation>Parámetros de caída híbrida</translation>
     </message>
     <message id="page_microgrid_reference_active_power_p0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="105"/>
       <source>Reference active power (P&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Potencia activa de referencia (P&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_frequency_f0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="108"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="112"/>
       <source>Reference frequency (f&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Frecuencia de referencia (f&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_frequency_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="117"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="119"/>
       <source>Frequency droop slope (droop&lt;sub&gt;fP&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Pendiente de caída de frecuencia (droop&lt;sub&gt;fP&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_reactive_power">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="126"/>
       <source>Reference reactive power (Q&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Potencia reactiva de referencia (Q&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_voltage">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="135"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="133"/>
       <source>Reference Voltage (U&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Voltaje de referencia (U&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_voltage_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="144"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="140"/>
       <source>Voltage droop slope (droop&lt;sub&gt;UQ&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Pendiente de caída de voltaje (droop&lt;sub&gt;UQ&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_minimum_and_maximum_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="146"/>
       <source>Minimum and maximum parameters</source>
-      <translation type="unfinished"/>
+      <translation>Parámetros mínimos y máximos</translation>
     </message>
     <message id="page_microgrid_allowed_active_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="156"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
       <source>Allowed active power range</source>
-      <translation type="unfinished"/>
+      <translation>Rango de potencia activa permitido</translation>
     </message>
     <message id="page_microgrid_allowed_reactive_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="164"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="159"/>
       <source>Allowed reactive power range</source>
-      <translation type="unfinished"/>
+      <translation>Rango de potencia reactiva permitido</translation>
     </message>
     <message id="page_microgrid_p_q_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="176"/>
       <source>P-Q direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>Ajustes de accionamiento directo P-Q</translation>
     </message>
     <message id="page_microgrid_active_power_setpoint_p">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="186"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
       <source>Active power setpoint (P)</source>
-      <translation type="unfinished"/>
+      <translation>Punto de ajuste de potencia activa (P)</translation>
     </message>
     <message id="page_microgrid_reactive_power_setpoint_q">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="194"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="188"/>
       <source>Reactive power setpoint (Q)</source>
-      <translation type="unfinished"/>
+      <translation>Punto de ajuste de potencia reactiva (Q)</translation>
     </message>
     <message id="page_microgrid_allowed_frequency_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="202"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="195"/>
       <source>Allowed frequency range</source>
-      <translation type="unfinished"/>
+      <translation>Rango de frecuencia permitido</translation>
     </message>
     <message id="page_microgrid_allowed_voltage_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="210"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="203"/>
       <source>Allowed voltage range</source>
-      <translation type="unfinished"/>
+      <translation>Rango de voltaje permitido</translation>
     </message>
     <message id="page_microgrid_v_f_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="227"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="220"/>
       <source>V-f direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>Ajustes de accionamiento directo V-f</translation>
     </message>
     <message id="page_microgrid_voltage_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="225"/>
       <source>Voltage setpoint (U)</source>
-      <translation type="unfinished"/>
+      <translation>Punto de ajuste de voltaje (U)</translation>
     </message>
     <message id="page_microgrid_frequency_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="240"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
       <source>Frequency setpoint (f)</source>
-      <translation type="unfinished"/>
+      <translation>Punto de ajuste de frecuencia (f)</translation>
     </message>
-    <message id="temperature_slider_current">
-      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
-      <source>Current</source>
-      <extracomment>The current temperature measurement</extracomment>
-      <translation type="unfinished">Corriente</translation>
+    <message id="pagesettingsintegrations_canopenmotordrive">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
+      <source>CANopen motor drives</source>
+      <translation>Accionamientos de motor CANopen</translation>
+    </message>
+    <message id="pagesettingsintegrations_ui_plugins">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
+      <source>UI Plugins</source>
+      <translation>Plugins de IU</translation>
+    </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
+      <source>Motor Direction Inverted</source>
+      <translation>Dirección del motor invertida</translation>
     </message>
     <message id="page_settings_canopenmotordrive_scan_for_motor_drives">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="31"/>
       <source>Scan for motor drives</source>
-      <translation type="unfinished"/>
+      <translation>Buscar accionamientos de motor</translation>
     </message>
     <message id="page_settings_canopenmotordrive_discovered_motor_drive_ids">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="39"/>
       <source>Discovered motor drive IDs</source>
-      <translation type="unfinished"/>
+      <translation>IDs de accionamiento de motor descubiertos</translation>
     </message>
-    <message id="switchableoutput_gx_device_relays">
-      <location filename="../../src/switchableoutput.cpp" line="388"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">Relés del dispositivo GX</translation>
+    <message id="temperature_pm25">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
+      <source>PM2.5</source>
+      <translation>PM2.5</translation>
     </message>
-    <message id="gx_device_relays">
-      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">Relés del dispositivo GX</translation>
+    <message id="temperature_co2">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+      <source>CO₂</source>
+      <translation>CO₂</translation>
     </message>
-    <message id="color_preset">
-      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
-      <source>Preset</source>
-      <translation type="unfinished"/>
+    <message id="temperature_voc">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
+      <source>VOC index</source>
+      <translation>Índice VOC</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_location">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
-      <source>Add Modbus port and unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_nox">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
+      <source>NOx index</source>
+      <translation>Índice NOx</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_unitid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
-      <source>Unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_luminosity">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
+      <source>Luminosity</source>
+      <translation>Luminosidad</translation>
     </message>
-    <message id="page_settings_fronius_unitid_invalid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation type="unfinished">%1 no es un número válido. Utilice un número entre 1-247.</translation>
-    </message>
-    <message id="page_settings_fronius_add_modbus_location_button">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
-      <source>Add</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_locations_note">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
-      <source>The default modbus port is 502 and the default unit ID is 126.
-Here you can add additional ports and unit IDs to scan for PV inverters.</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_location_number">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
-      <source>Port/Unit ID %1</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location_description">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
-      <source>Port: %1 (Unit %2)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
-      <source>Remove Modbus port and unit ID?</source>
-      <translation type="unfinished"/>
+    <message id="switchable_output_bypassed">
+      <location filename="../../src/enums.cpp" line="484"/>
+      <source>Bypassed</source>
+      <translation>Derivado</translation>
     </message>
     <message id="switchableoutput_list_delegate_auto_status">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="84"/>
       <source>Auto (%1)</source>
       <extracomment>%1 = 'On' or 'Off'</extracomment>
-      <translation type="unfinished"/>
+      <translation>Automático (%1)</translation>
     </message>
     <message id="switchableoutput_list_delegate_state_forced">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="100"/>
       <source>Forced</source>
-      <translation type="unfinished"/>
+      <translation>Forzado</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_settings">
+      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
+      <source>Modbus port and unit ID settings</source>
+      <translation>Ajustes del puerto Modbus y del ID de unidad</translation>
+    </message>
+    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
+      <source>Integrates with the device list</source>
+      <translation>Se integra con la lista de dispositivos</translation>
+    </message>
+    <message id="common_words_color">
+      <location filename="../../components/CommonWords.qml" line="136"/>
+      <source>Color</source>
+      <translation>Color</translation>
+    </message>
+    <message id="common_words_value_must_be_greater_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="557"/>
+      <source>Value must be greater than start value</source>
+      <translation>El valor debe ser mayor que el valor de inicio</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="566"/>
+      <source>Value must be lower than stop value</source>
+      <translation>El valor debe ser menor que el valor de parada</translation>
+    </message>
+    <message id="notifications_page_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="43"/>
+      <source>Active Notifications</source>
+      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
+      <translation>Notificaciones activas</translation>
+    </message>
+    <message id="notifications_page_inactive_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="47"/>
+      <source>Inactive Notifications</source>
+      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
+      <translation>Notificaciones inactivas</translation>
+    </message>
+    <message id="notifications_no_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="106"/>
+      <source>No active notifications</source>
+      <translation>No hay notificaciones activas</translation>
+    </message>
+    <message id="switchable_output_rgb_color_wheel">
+      <location filename="../../src/enums.cpp" line="427"/>
+      <source>RGB color wheel</source>
+      <translation>Rueda de color RGB</translation>
+    </message>
+    <message id="switchable_output_cct_color_wheel">
+      <location filename="../../src/enums.cpp" line="431"/>
+      <source>CCT color wheel</source>
+      <extracomment>Correlated Color Temperature color wheel</extracomment>
+      <translation>Rueda de color CCT</translation>
+    </message>
+    <message id="switchable_output_rgbw_color_wheel">
+      <location filename="../../src/enums.cpp" line="435"/>
+      <source>RGB + W color wheel</source>
+      <extracomment>RGB + white color wheel</extracomment>
+      <translation>Rueda de color RGB + W</translation>
+    </message>
+    <message id="listlink_show_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="43"/>
+      <source>Show QR code</source>
+      <translation>Mostrar código QR</translation>
+    </message>
+    <message id="listlink_scan_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="52"/>
+      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
+      <extracomment>%1 = url text</extracomment>
+      <oldsource>Scan the QR code with your portable device.&lt;br /&gt;Or insert the link: %1</oldsource>
+      <translation>Abra el código QR para escanearlo con su dispositivo portátil.&lt;br /&gt;O inserte el enlace: %1</translation>
+    </message>
+    <message id="color_preset">
+      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
+      <source>Preset</source>
+      <translation>Preestablecido</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
+      <source>Add Modbus port and unit ID</source>
+      <translation>Añadir puerto Modbus e ID de unidad</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_unitid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
+      <source>Unit ID</source>
+      <translation>ID de unidad</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location_button">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
+      <source>Add</source>
+      <translation>Añadir</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_locations_note">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
+      <source>The default modbus port is 502 and the default unit ID is 126.
+Here you can add additional ports and unit IDs to scan for PV inverters.</source>
+      <translation>El puerto Modbus predeterminado es 502 y el ID de unidad predeterminado es 126.
+Aquí puede añadir puertos e ID de unidad adicionales para buscar inversores FV.</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_location_number">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
+      <source>Port/Unit ID %1</source>
+      <translation>Puerto/ID de unidad %1</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location_description">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
+      <source>Port: %1 (Unit %2)</source>
+      <translation>Puerto: %1 (Unidad %2)</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
+      <source>Remove Modbus port and unit ID?</source>
+      <translation>¿Eliminar el puerto Modbus y el ID de unidad?</translation>
+    </message>
+    <message id="devicelist_tankshape_edit_point">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="182"/>
+      <source>Edit point %1</source>
+      <extracomment>%1 = which point is being edited, a number like "1" or "2"</extracomment>
+      <translation></translation>
+    </message>
+    <message id="settings_canbus_vecan">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
+      <source>VE.Can (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_250">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <source>VE.Can &amp; CANopen E-drive (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_500">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
+      <source>CANopen E-drive (500 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="page_microgrid_from_p1_to_p2">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="39"/>
+      <source>%1%2 to %3%4</source>
+      <extracomment>Describes a range from one quantity to another, e.g. "30W to 60W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
+      <translation></translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAfricaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
+      <source>Morocco Standard Time</source>
+      <translation>Hora estándar Marruecos</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
+      <source>W. Central Africa Standard Time</source>
+      <translation>Hora estándar de África Central Occidental</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
+      <source>South Africa Standard Time</source>
+      <translation>Hora estándar de Sudáfrica</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
+      <source>Namibia Standard Time</source>
+      <translation>Hora estándar de Namibia</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
+      <source>Egypt Standard Time</source>
+      <translation>Hora estándar de Egipto</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
+      <source>E. Africa Standard Time</source>
+      <translation>Hora estándar de África Oriental</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAmericaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
+      <source>Argentina Standard Time</source>
+      <translation>Hora estándar de Argentina</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
+      <source>E. South America Standard Time</source>
+      <translation>Hora estándar de Sudamérica E.</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
+      <source>Greenland Standard Time</source>
+      <translation>Hora estándar de Groenlandia</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
+      <source>Montevideo Standard Time</source>
+      <translation>Hora estándar de Montevideo</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
+      <source>Newfoundland Standard Time</source>
+      <translation>Hora estándar de Terranova y Labrador</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
+      <source>SA Eastern Standard Time</source>
+      <translation>Hora estándar del este Sudamérica</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
+      <source>Atlantic Standard Time</source>
+      <translation>Hora estándar del Atlántico</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
+      <source>Central Brazilian Standard Time</source>
+      <translation>Hora estándar de Brasil central</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>Hora estándar del Pacífico Sudamérica</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
+      <source>Paraguay Standard Time</source>
+      <translation>Hora estándar de Paraguay</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
+      <source>SA Western Standard Time</source>
+      <translation>Hora estándar occidental de Sudamérica</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
+      <source>Venezuela Standard Time</source>
+      <translation>Hora estándar de Venezuela</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
+      <source>Eastern Standard Time</source>
+      <translation>Hora estándar oriental</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
+      <source>SA Pacific Standard Time</source>
+      <translation>Hora estándar del Pacífico Sudamérica</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
+      <source>US Eastern Standard Time</source>
+      <translation>Hora estándar este de EE. UU.</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
+      <source>Canada Central Standard Time</source>
+      <translation>Hora estándar de Canadá Central</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
+      <source>Central America Standard Time</source>
+      <translation>Hora estándar de América central</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
+      <source>Central Standard Time (Mexico)</source>
+      <translation>Hora estándar de México</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
+      <source>Central Standard Time</source>
+      <translation>Hora estándar central</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
+      <source>Mountain Standard Time (Mexico)</source>
+      <translation>Hora estándar de México 2</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
+      <source>Mountain Standard Time</source>
+      <translation>Hora estándar de la montaña</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
+      <source>US Mountain Standard Time</source>
+      <translation>Hora estándar de la montaña EE.UU</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
+      <source>Pacific Standard Time (Mexico)</source>
+      <translation>Hora estándar del Pacífico (México)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
+      <source>Pacific Standard Time</source>
+      <translation>Hora estándar del Pacífico</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
+      <source>Alaskan Standard Time</source>
+      <translation>Hora estándar de Alaska</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
+      <source>Hawaii-Aleutian</source>
+      <translation>Hora de Hawái-Aleutiano</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
+      <source>Atlantic Daylight Time</source>
+      <translation>Hora estándar del Atlántico</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAntarcticaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+      <source>New Zealand Standard Time</source>
+      <translation>Hora estándar de Nueva Zelanda</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>Hora estándar del Pacífico central</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+      <source>West Pacific Standard Time</source>
+      <translation>Hora estándar Pacífico occidental</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+      <source>W. Australia Standard Time</source>
+      <translation>Hora estándar de Australia Occidental</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+      <source>SE Asia Standard Time</source>
+      <translation>Hora estándar del Sudeste Asiático</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+      <source>Central Asia Standard Time</source>
+      <translation>Hora estándar de Asia Central</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+      <source>West Asia Standard Time</source>
+      <translation>Hora estándar Asia occidental</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+      <source>E. Africa Standard Time</source>
+      <translation>Hora estándar de África Oriental</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>Hora estándar del Pacífico Sudamérica</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+      <source>SA Western Standard Time</source>
+      <translation>Hora estándar occidental de Sudamérica</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzArcticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
+      <source>W. Europe Standard Time</source>
+      <translation>Hora estándar de Europa Occidental</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAsiaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
+      <source>Kamchatka Standard Time</source>
+      <translation>Hora estándar de Kamchatka</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
+      <source>Magadan Standard Time</source>
+      <translation>Hora estándar Magadán</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
+      <source>Vladivostok Standard Time</source>
+      <translation>Hora estándar de Vladivostok</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
+      <source>Yakutsk Standard Time</source>
+      <translation>Hora estándar de Yakutsk</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
+      <source>Tokyo Standard Time</source>
+      <translation>Hora estándar de Tokio</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
+      <source>Korea Standard Time</source>
+      <translation>Hora estándar de Corea</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
+      <source>Singapore Standard Time</source>
+      <translation>Hora estándar de Singapur</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
+      <source>Ulaanbaatar Standard Time</source>
+      <translation>Hora estándar de Ulán Bator</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
+      <source>Taipei Standard Time</source>
+      <translation>Hora estándar de Taipei</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
+      <source>North Asia East Standard Time</source>
+      <translation>Hora estándar este, Asia Norte</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
+      <source>China Standard Time</source>
+      <translation>Hora estándar de China</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
+      <source>SE Asia Standard Time</source>
+      <translation>Hora estándar del Sudeste Asiático</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
+      <source>North Asia Standard Time</source>
+      <translation>Hora estándar de Asia Norte</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
+      <source>Myanmar Standard Time</source>
+      <translation>Myanmar Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
+      <source>N. Central Asia Standard Time</source>
+      <translation>Hora estándar de Asia Central Norte</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
+      <source>Central Asia Standard Time</source>
+      <translation>Hora estándar de Asia Central</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
+      <source>Bangladesh Standard Time</source>
+      <translation>Hora estándar de Bangladesh</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
+      <source>Nepal Standard Time</source>
+      <translation>Hora estándar de Nepal</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
+      <source>Sri Lanka Standard Time</source>
+      <translation>Hora estándar de Sri Lanka</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
+      <source>India Standard Time</source>
+      <translation>Hora estándar de India</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
+      <source>West Asia Standard Time</source>
+      <translation>Hora estándar Asia occidental</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
+      <source>Pakistan Standard Time</source>
+      <translation>Hora estándar de Pakistán</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
+      <source>Ekaterinburg Standard Time</source>
+      <translation>Hora estándar de Ekaterimburgo</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
+      <source>Georgian Standard Time</source>
+      <translation>Hora estándar de Georgia</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
+      <source>Caucasus Standard Time</source>
+      <translation>Hora estándar del Cáucaso</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
+      <source>Azerbaijan Standard Time</source>
+      <translation>Hora estándar de Azerbaiyán</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
+      <source>Arabian Standard Time</source>
+      <translation>Hora estándar árabe</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
+      <source>Afghanistan Standard Time</source>
+      <translation>Hora estándar de Afganistán</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
+      <source>Iran Standard Time</source>
+      <translation>Hora estándar de Irán</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
+      <source>Arabic Standard Time</source>
+      <translation>Hora estándar árabe</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
+      <source>Arab Standard Time</source>
+      <translation>Hora estándar árabe</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
+      <source>Syria Standard Time</source>
+      <translation>Hora estándar de Siria</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
+      <source>Middle East Standard Time</source>
+      <translation>Hora estándar de Oriente medio</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
+      <source>Jordan Standard Time</source>
+      <translation>Hora estándar de Jordania</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
+      <source>Israel Standard Time</source>
+      <translation>Hora estándar de Israel</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAtlanticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+      <source>Greenwich Standard Time</source>
+      <translation>Hora estándar de Greenwich</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+      <source>Azores Standard Time</source>
+      <translation>Hora estándar de las Azores</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+      <source>Cape Verde Standard Time</source>
+      <translation>Hora estándar de Cabo Verde</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
+      <source>Mid-Atlantic Standard Time</source>
+      <translation>Hora estándar del Atlántico Medio</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAustraliaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+      <source>Tasmania Standard Time</source>
+      <translation>Hora estándar de Tasmania</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+      <source>E. Australia Standard Time</source>
+      <translation>Hora estándar de Australia Oriental</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+      <source>AUS Eastern Standard Time</source>
+      <translation>Hora estándar de Australia Oriental</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+      <source>Cen. Australia Standard Time</source>
+      <translation>Hora estándar de Australia Central</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+      <source>AUS Central Standard Time</source>
+      <translation>Hora estándar de Australia Central</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+      <source>W. Australia Standard Time</source>
+      <translation>Hora estándar de Australia Occidental</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEtcData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
+      <source>GMT +12</source>
+      <translation>GMT +12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
+      <source>GMT -02</source>
+      <translation>GMT -02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
+      <source>GMT -11</source>
+      <translation>GMT -11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
+      <source>GMT -13</source>
+      <translation>GMT -13</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
+      <source>GMT -12</source>
+      <translation>GMT -12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
+      <source>GMT -10</source>
+      <translation>GMT -10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
+      <source>GMT -09</source>
+      <translation>GMT -09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
+      <source>GMT -08</source>
+      <translation>GMT -08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
+      <source>GMT -07</source>
+      <translation>GMT -07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
+      <source>GMT -06</source>
+      <translation>GMT -06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
+      <source>GMT -05</source>
+      <translation>GMT -05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
+      <source>GMT -04</source>
+      <translation>GMT -04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
+      <source>GMT -03</source>
+      <translation>GMT -03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
+      <source>GMT -01</source>
+      <translation>GMT -01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
+      <source>GMT</source>
+      <translation>GMT</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
+      <source>GMT +01</source>
+      <translation>GMT +01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
+      <source>GMT +02</source>
+      <translation>GMT +02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
+      <source>GMT +03</source>
+      <translation>GMT +03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
+      <source>GMT +04</source>
+      <translation>GMT +04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
+      <source>GMT +05</source>
+      <translation>GMT +05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
+      <source>GMT +06</source>
+      <translation>GMT +06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
+      <source>GMT +07</source>
+      <translation>GMT +07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
+      <source>GMT +08</source>
+      <translation>GMT +08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
+      <source>GMT +09</source>
+      <translation>GMT +09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
+      <source>GMT +10</source>
+      <translation>GMT +10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
+      <source>GMT +11</source>
+      <translation>GMT +11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
+      <source>UTC</source>
+      <translation>UTC</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEuropeData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
+      <source>GMT Standard Time</source>
+      <translation>Hora estándar GMT</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
+      <source>Central Europe Standard Time</source>
+      <translation>Hora estándar de Europa central</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
+      <source>Central European Standard Time</source>
+      <translation>Hora estándar de Europa central</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
+      <source>Romance Standard Time</source>
+      <translation>Hora estándar romance</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
+      <source>W. Europe Standard Time</source>
+      <translation>Hora estándar de Europa Occidental</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
+      <source>E. Europe Standard Time</source>
+      <translation>Hora estándar de Europa Oriental</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
+      <source>FLE Standard Time</source>
+      <translation>Hora estándar FLE</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
+      <source>GTB Standard Time</source>
+      <translation>Hora estándar GTB</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
+      <source>Belarus Standard Time</source>
+      <translation>Hora estándar de Bielorrusia</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
+      <source>Russian Standard Time</source>
+      <translation>Hora estándar de Rusia</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
+      <source>Turkey Standard Time</source>
+      <translation>Hora estándar de Turquía</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzIndianData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
+      <source>Mauritius Standard Time</source>
+      <translation>Hora estándar de Mauricio</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
+      <source>Christmas Island Standard Time</source>
+      <translation>Hora estándar de Isla de Navidad</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzPacificData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
+      <source>Tonga Standard Time</source>
+      <translation>Hora estándar de Tonga</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
+      <source>Fiji Standard Time</source>
+      <translation>Hora estándar de las Islas Fiji</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
+      <source>New Zealand Standard Time</source>
+      <translation>Hora estándar de Nueva Zelanda</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>Hora estándar del Pacífico central</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
+      <source>West Pacific Standard Time</source>
+      <translation>Hora estándar Pacífico occidental</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
+      <source>Samoa Standard Time</source>
+      <translation>Hora estándar de Samoa</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
+      <source>Hawaiian Standard Time</source>
+      <translation>Hora estándar de Hawái</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
+      <source>Easter Island Standard Time</source>
+      <translation>Hora estándar de Isla de Pascua</translation>
     </message>
   </context>
   <context>
@@ -12174,838 +11854,6 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
     </message>
   </context>
   <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>Hora estándar Marruecos</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>Hora estándar de África Central Occidental</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>Hora estándar de Sudáfrica</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>Hora estándar de Namibia</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>Hora estándar de Egipto</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Hora estándar de África Oriental</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>Hora estándar de Argentina</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>Hora estándar de Sudamérica E.</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>Hora estándar de Groenlandia</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>Hora estándar de Montevideo</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>Hora estándar de Terranova y Labrador</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>Hora estándar del este Sudamérica</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Atlantic Standard Time</source>
-      <translation>Hora estándar del Atlántico</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>Hora estándar de Brasil central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Hora estándar del Pacífico Sudamérica</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>Paraguay Standard Time</source>
-      <translation>Hora estándar de Paraguay</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>SA Western Standard Time</source>
-      <translation>Hora estándar occidental de Sudamérica</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Venezuela Standard Time</source>
-      <translation>Hora estándar de Venezuela</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>Eastern Standard Time</source>
-      <translation>Hora estándar oriental</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>Hora estándar del Pacífico Sudamérica</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>US Eastern Standard Time</source>
-      <translation>Hora estándar este de EE. UU.</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Canada Central Standard Time</source>
-      <translation>Hora estándar de Canadá Central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central America Standard Time</source>
-      <translation>Hora estándar de América central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>Hora estándar de México</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Central Standard Time</source>
-      <translation>Hora estándar central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>Hora estándar de México 2</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>Mountain Standard Time</source>
-      <translation>Hora estándar de la montaña</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>US Mountain Standard Time</source>
-      <translation>Hora estándar de la montaña EE.UU</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>Hora estándar del Pacífico (México)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Pacific Standard Time</source>
-      <translation>Hora estándar del Pacífico</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Alaskan Standard Time</source>
-      <translation>Hora estándar de Alaska</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>Hora de Hawái-Aleutiano</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Daylight Time</source>
-      <translation>Hora estándar del Atlántico</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Hora estándar de Nueva Zelanda</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Hora estándar del Pacífico central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Hora estándar Pacífico occidental</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Hora estándar de Australia Occidental</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Hora estándar del Sudeste Asiático</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Hora estándar de Asia Central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>Hora estándar Asia occidental</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Hora estándar de África Oriental</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Hora estándar del Pacífico Sudamérica</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>Hora estándar occidental de Sudamérica</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Hora estándar de Europa Occidental</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>Hora estándar de Kamchatka</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>Hora estándar Magadán</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>Hora estándar de Vladivostok</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>Hora estándar de Yakutsk</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>Hora estándar de Tokio</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>Hora estándar de Corea</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>Hora estándar de Singapur</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>Hora estándar de Ulán Bator</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>Hora estándar de Taipei</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>Hora estándar este, Asia Norte</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>Hora estándar de China</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Hora estándar del Sudeste Asiático</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>Hora estándar de Asia Norte</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>Myanmar Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>Hora estándar de Asia Central Norte</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Hora estándar de Asia Central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>Hora estándar de Bangladesh</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>Hora estándar de Nepal</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>Hora estándar de Sri Lanka</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>Hora estándar de India</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>Hora estándar Asia occidental</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>Hora estándar de Pakistán</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>Hora estándar de Ekaterimburgo</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>Hora estándar de Georgia</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>Hora estándar del Cáucaso</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>Hora estándar de Azerbaiyán</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>Hora estándar árabe</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>Hora estándar de Afganistán</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>Hora estándar de Irán</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>Hora estándar árabe</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>Hora estándar árabe</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>Hora estándar de Siria</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>Hora estándar de Oriente medio</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>Hora estándar de Jordania</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>Hora estándar de Israel</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>Hora estándar de Greenwich</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>Hora estándar de las Azores</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>Hora estándar de Cabo Verde</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>Hora estándar del Atlántico Medio</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>Hora estándar de Tasmania</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>Hora estándar de Australia Oriental</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>Hora estándar de Australia Oriental</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>Hora estándar de Australia Central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>Hora estándar de Australia Central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Hora estándar de Australia Occidental</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
-      <source>GMT +12</source>
-      <translation>GMT +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
-      <source>GMT -02</source>
-      <translation>GMT -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT -13</source>
-      <translation>GMT -13</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT -12</source>
-      <translation>GMT -12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -10</source>
-      <translation>GMT -10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -09</source>
-      <translation>GMT -09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>GMT -08</source>
-      <translation>GMT -08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
-      <source>GMT -07</source>
-      <translation>GMT -07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
-      <source>GMT -06</source>
-      <translation>GMT -06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
-      <source>GMT -05</source>
-      <translation>GMT -05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
-      <source>GMT -04</source>
-      <translation>GMT -04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
-      <source>GMT -03</source>
-      <translation>GMT -03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
-      <source>GMT -01</source>
-      <translation>GMT -01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
-      <source>GMT</source>
-      <translation>GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
-      <source>GMT +01</source>
-      <translation>GMT +01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
-      <source>GMT +02</source>
-      <translation>GMT +02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
-      <source>GMT +03</source>
-      <translation>GMT +03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
-      <source>GMT +04</source>
-      <translation>GMT +04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
-      <source>GMT +05</source>
-      <translation>GMT +05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
-      <source>GMT +06</source>
-      <translation>GMT +06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
-      <source>GMT +07</source>
-      <translation>GMT +07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
-      <source>GMT +08</source>
-      <translation>GMT +08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
-      <source>GMT +09</source>
-      <translation>GMT +09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
-      <source>GMT +10</source>
-      <translation>GMT +10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
-      <source>GMT +11</source>
-      <translation>GMT +11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
-      <source>UTC</source>
-      <translation>UTC</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>Hora estándar GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>Hora estándar de Europa central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>Hora estándar de Europa central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>Hora estándar romance</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Hora estándar de Europa Occidental</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>Hora estándar de Europa Oriental</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>Hora estándar FLE</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>Hora estándar GTB</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>Hora estándar de Bielorrusia</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>Hora estándar de Rusia</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>Hora estándar de Turquía</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>Hora estándar de Mauricio</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>Hora estándar de Isla de Navidad</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>Hora estándar de Tonga</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>Hora estándar de las Islas Fiji</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Hora estándar de Nueva Zelanda</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Hora estándar del Pacífico central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Hora estándar Pacífico occidental</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>Hora estándar de Samoa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>Hora estándar de Hawái</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>Hora estándar de Isla de Pascua</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation type="unfinished">Error interno</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation type="unfinished"/>
-    </message>
-  </context>
-  <context>
     <name>Wakespeed</name>
     <message>
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
@@ -13182,6 +12030,119 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
       <source>DC/DC misconfiguration</source>
       <translation>Configuración errónea CC/CC</translation>
+    </message>
+  </context>
+  <context>
+    <name>VebusError</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+      <source>Device switched off</source>
+      <translation>Dispositivo apagado</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+      <source>Mixed old/new MK2</source>
+      <translation>MK2 antiguo/nuevo mezclado</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+      <source>Expected devices error</source>
+      <translation>Error de dispositivos esperados</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+      <source>No other device detected</source>
+      <translation>No se ha detectado ningún otro dispositivo</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+      <source>Overvoltage on AC-out</source>
+      <translation>Sobretensión en la salida de CA</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+      <source>DDC program error</source>
+      <translation>Error de programa DDC</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+      <source>VE.Bus BMS without assistant</source>
+      <translation>VE.Bus BMS sin asistente</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+      <source>Ground relay test failed</source>
+      <translation>Error en la prueba del relé de tierra</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+      <source>System time sync error</source>
+      <translation>Error de sincronización de la hora del sistema</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+      <source>Grid relay test fault</source>
+      <translation>Fallo en la prueba del relé de red</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+      <source>Config mismatch with 2nd mcu</source>
+      <translation>Desajuste de configuración con la 2ª MCU</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+      <source>Device transmit error</source>
+      <translation>Error de transmisión del dispositivo</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+      <source>Awaiting configuration or dongle missing</source>
+      <translation>Esperando configuración o falta el dongle</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+      <source>Phase master missing</source>
+      <translation>Falta la fase maestra</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+      <source>Overvoltage has occurred</source>
+      <translation>Se ha producido una sobretensión</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+      <source>Slave does not have AC input!</source>
+      <translation>¡El esclavo no tiene entrada de CA!</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+      <source>Device can't be slave</source>
+      <translation>El dispositivo no puede ser esclavo</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+      <source>System protection initiated</source>
+      <translation>Protección del sistema iniciada</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+      <source>Firmware incompatibiltiy</source>
+      <translation>Incompatibilidad de firmware</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+      <source>Internal error</source>
+      <translation>Error interno</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+      <source>Failing relay test prevents connection</source>
+      <translation>La prueba de relé fallida impide la conexión</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+      <source>VE.Bus error</source>
+      <translation>Error de VE.Bus</translation>
     </message>
   </context>
 </TS>

--- a/i18n/venus-gui-v2_fr.ts
+++ b/i18n/venus-gui-v2_fr.ts
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="fr">
   <context>
-    <name/>
+    <name></name>
     <message id="switchable_output_disabled">
       <location filename="../../src/enums.cpp" line="478"/>
       <source>Disabled</source>
@@ -22,6 +22,7 @@
     <message id="solarchargers_state_off">
       <location filename="../../src/enums.cpp" line="331"/>
       <source>Off</source>
+      <extracomment>Digital input state</extracomment>
       <translation>Off</translation>
     </message>
     <message id="common_words_auto">
@@ -52,18 +53,25 @@
     <message id="settings_startpage_none">
       <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
       <source>None</source>
+      <extracomment>Indicates no phase</extracomment>
       <translation>Aucune</translation>
     </message>
     <message id="common_words_position_ac">
       <location filename="../../components/CommonWords.qml" line="416"/>
       <source>Position</source>
-      <extracomment>AC input or output position</extracomment>
+      <extracomment>EVCS AC input/output position</extracomment>
       <translation>Position</translation>
     </message>
     <message id="settings_minmax_speed">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="193"/>
       <source>Speed</source>
+      <extracomment>A speed measurement value</extracomment>
       <translation>Vitesse</translation>
+    </message>
+    <message id="common_words_state">
+      <location filename="../../components/CommonWords.qml" line="502"/>
+      <source>State</source>
+      <translation>État</translation>
     </message>
     <message id="settings_firmware_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="67"/>
@@ -101,8 +109,8 @@
       <source>Solar yield</source>
       <translation>Production solaire</translation>
     </message>
-    <message id="ess_state_external_control">
-      <location filename="../../data/Ess.qml" line="41"/>
+    <message id="inverters_state_externalccontrol">
+      <location filename="../../data/System.qml" line="183"/>
       <source>External control</source>
       <translation>Contrôle externe</translation>
     </message>
@@ -140,6 +148,11 @@
       <location filename="../../components/CommonWords.qml" line="203"/>
       <source>ESS</source>
       <translation>ESS</translation>
+    </message>
+    <message id="pagesettingsconnectivity_ethernet">
+      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
+      <source>Ethernet</source>
+      <translation>Ethernet</translation>
     </message>
     <message id="pagesettingsconnectivity_wifi">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="28"/>
@@ -262,11 +275,6 @@
       <source>Name</source>
       <translation>Nom</translation>
     </message>
-    <message id="settings_deviceinfo_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="38"/>
-      <source>Name</source>
-      <translation type="unfinished">Nom</translation>
-    </message>
     <message id="settings_deviceinfo_product_id">
       <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
       <source>Product ID</source>
@@ -327,15 +335,20 @@
       <source>Daily run time</source>
       <translation>Durée de fonctionnement quotidien</translation>
     </message>
+    <message id="common_words_value_must_be_greater_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="560"/>
+      <source>Value must be greater than stop value</source>
+      <translation>La valeur doit être supérieure à la valeur d'arrêt</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="563"/>
+      <source>Value must be lower than start value</source>
+      <translation>La valeur doit être inf. à la valeur de démarrage</translation>
+    </message>
     <message id="settings_minmax_acout_max_power">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="124"/>
       <source>AC output</source>
       <translation>Sortie CA</translation>
-    </message>
-    <message id="ac_output">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="15"/>
-      <source>AC output</source>
-      <translation type="unfinished">Sortie CA</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
       <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="25"/>
@@ -382,16 +395,6 @@
       <source>Unavailable monitor, set another</source>
       <translation>Moniteur indisponible, en sélectionner un autre</translation>
     </message>
-    <message id="page_generator_conditions_battery_monitor">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="42"/>
-      <source>Battery monitor</source>
-      <translation type="unfinished">Moniteur de batterie</translation>
-    </message>
-    <message id="page_generator_conditions_unavailable_monitor_set_another">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="44"/>
-      <source>Unavailable monitor, set another</source>
-      <translation type="unfinished">Moniteur indisponible, en sélectionner un autre</translation>
-    </message>
     <message id="page_generator_conditions_on_loss_of_communication">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="68"/>
       <source>On loss of communication</source>
@@ -416,11 +419,6 @@
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="105"/>
       <source>Battery SOC</source>
       <translation>SOC de batterie</translation>
-    </message>
-    <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="173"/>
-      <source>Periodic run</source>
-      <translation type="unfinished">Mise en marche périodique</translation>
     </message>
     <message id="settings_inverter_high_temperature">
       <location filename="../../data/Generators.qml" line="83"/>
@@ -505,7 +503,7 @@
     <message id="settings_gps_speed_kmh">
       <location filename="../../pages/settings/PageGps.qml" line="83"/>
       <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometres per hour</extracomment>
+      <extracomment>GPS speed data, in kilometers per hour</extracomment>
       <translation>%1 km/h</translation>
     </message>
     <message id="settings_gps_speed_mph">
@@ -523,7 +521,7 @@
     <message id="settings_gps_speed_ms">
       <location filename="../../pages/settings/PageGps.qml" line="95"/>
       <source>%1 m/s</source>
-      <extracomment>GPS speed data, in metres per second</extracomment>
+      <extracomment>GPS speed data, in meters per second</extracomment>
       <translation>%1 m/s</translation>
     </message>
     <message id="settings_gps_course">
@@ -580,21 +578,6 @@
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="64"/>
       <source>%1 (Output %2)</source>
       <translation>%1 (Sortie %2)</translation>
-    </message>
-    <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">Moniteur de batterie actif</translation>
-    </message>
-    <message id="settings_batteries_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="101"/>
-      <source>Name</source>
-      <translation type="unfinished">Nom</translation>
-    </message>
-    <message id="settings_batteries_enter_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="103"/>
-      <source>Enter name</source>
-      <translation type="unfinished">Saisir le nom</translation>
     </message>
     <message id="settings_briefview_center_active_battery_monitor">
       <location filename="../../components/listitems/ListBriefCenterDetails.qml" line="27"/>
@@ -656,45 +639,25 @@
       <source>CAN-bus profile</source>
       <translation>Profil CAN-bus</translation>
     </message>
-    <message id="settings_disabled">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="31"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Désactivé</translation>
-    </message>
-    <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</translation>
-    </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
       <location filename="../../pages/settings/CanbusProfile.qml" line="42"/>
       <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
       <translation>VE.Can &amp; CAN-bus BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
       <source>Oceanvolt (250 kbit/s)</source>
       <translation>Oceanvolt (250 kbit/s)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
       <source>RV-C (250 kbit/s)</source>
       <translation>RV-C (250 kbit/s)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
       <source>Up, but no services (250 kbit/s)</source>
       <translation>Actif, mais pas de services (250 kbit/s)</translation>
-    </message>
-    <message id="settings_canopen_motordrive_250">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
-      <source>CANopen Motor drive (250 kbit/s)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_canopen_motordrive_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
-      <source>CANopen Motor drive (500 kbit/s)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_devices">
       <location filename="../../components/CommonWords.qml" line="166"/>
@@ -731,11 +694,6 @@
       <source>Check Unique id numbers</source>
       <translation>Vérifier les numéros ID uniques</translation>
     </message>
-    <message id="settings_canbus_unique_id_press_to_check">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Press to check</source>
-      <translation type="unfinished">Cliquer pour vérifier</translation>
-    </message>
     <message id="settings_canbus_unique_id_conflict">
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="125"/>
       <source>There is another device connected with this unique number, please select a new number.</source>
@@ -745,11 +703,6 @@
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="133"/>
       <source>OK: No other device is connected with this unique number.</source>
       <translation>OK : aucun autre appareil n'est connecté avec ce numéro unique.</translation>
-    </message>
-    <message id="pagesettingsintegrations_canopenmotordrive">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
-      <source>CANopen motor drives</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_network_status">
       <location filename="../../components/CommonWords.qml" line="349"/>
@@ -884,11 +837,6 @@
       <source>Unavailable sensor, set another</source>
       <translation>Sonde indisponible. Configurez-en une autre</translation>
     </message>
-    <message id="settings_system_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="81"/>
-      <source>Unavailable sensor, set another</source>
-      <translation type="unfinished">Sonde indisponible. Configurez-en une autre</translation>
-    </message>
     <message id="settings_dvcc_used_sensor">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="120"/>
       <source>Used sensor</source>
@@ -945,12 +893,6 @@
       <source>Auto selected</source>
       <translation>Auto sélectionné</translation>
     </message>
-    <message id="settings_dvcc_auto_selected_none">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="208"/>
-      <source>None</source>
-      <extracomment>Indicates no option is selected</extracomment>
-      <translation type="unfinished">Aucune</translation>
-    </message>
     <message id="settings_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
       <source>Build date/time</source>
@@ -986,12 +928,6 @@
       <source>Installing %1</source>
       <extracomment>%1 = firmware version</extracomment>
       <translation>Installation de %1</translation>
-    </message>
-    <message id="settings_firmware_offline_press_to_install">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">Cliquer pour mettre à jour vers %1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="90"/>
@@ -1062,12 +998,6 @@
       <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
       <translation>Installation en cours %1 %2%</translation>
     </message>
-    <message id="settings_firmware_online_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="86"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">Installation en cours %1...</translation>
-    </message>
     <message id="settings_firmware_update_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="109"/>
       <source>Update build date/time</source>
@@ -1097,11 +1027,6 @@
       <location filename="../../pages/settings/PageSettingsFronius.qml" line="56"/>
       <source>TCP port</source>
       <translation>Port TCP</translation>
-    </message>
-    <message id="page_settings_fronius_modbus_settings">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
-      <source>Modbus port and unit ID settings</source>
-      <translation type="unfinished"/>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
       <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
@@ -1153,16 +1078,6 @@
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="64"/>
       <source>AC-Out MP</source>
       <translation>AC-Out MP</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="52"/>
-      <source>AC-In1 L%1</source>
-      <translation type="unfinished">AC-In1 L%1</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="56"/>
-      <source>AC-In1 --</source>
-      <translation type="unfinished">AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="70"/>
@@ -1330,12 +1245,6 @@
       <source>Reset service timer</source>
       <translation>Réinitialisation du compteur horaire de service</translation>
     </message>
-    <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
-      <source>Volume</source>
-      <extracomment>Title for a list of units of volume (e.g. cubic metres, litres, gallons)</extracomment>
-      <translation type="unfinished">Volume</translation>
-    </message>
     <message id="settings_gps_format">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="69"/>
       <source>Format</source>
@@ -1438,42 +1347,6 @@ Si cela ne marche pas, vérifiez la carte SIM dans un téléphone pour vous assu
       <source>Wrong PIN</source>
       <translation>Mauvais code PIN</translation>
     </message>
-    <message id="page_settings_gsm_ok">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>OK</source>
-      <translation type="unfinished">OK</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="128"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">Erreur inconnue</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_state">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="153"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Inconnu</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_value">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="182"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Inconnu</translation>
-    </message>
-    <message id="page_settings_gsm_offline">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="173"/>
-      <source>Offline</source>
-      <translation type="unfinished">Hors ligne</translation>
-    </message>
-    <message id="page_settings_gsm_connecting">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="176"/>
-      <source>Connecting</source>
-      <translation type="unfinished">Connexion en cours</translation>
-    </message>
-    <message id="page_settings_gsm_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="179"/>
-      <source>Connected</source>
-      <translation type="unfinished">Connecté</translation>
-    </message>
     <message id="page_settings_gsm_pin">
       <location filename="../../pages/settings/PageSettingsGsm.qml" line="191"/>
       <source>PIN</source>
@@ -1530,32 +1403,32 @@ Si cela ne marche pas, vérifiez la carte SIM dans un téléphone pour vous assu
       <translation>Comptage réseau</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
       <source>External meter</source>
       <translation>Compteur externe</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="67"/>
       <source>Inverter/Charger</source>
       <translation>Onduleur/chargeur</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
       <source>Multiphase regulation</source>
       <translation>Régulation multiphase</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="91"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
       <source>Total of all phases</source>
       <translation>Total de toutes les phases</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="95"/>
       <source>Individual phase</source>
       <translation>Phase individuelle</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="99"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="101"/>
       <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
@@ -1564,68 +1437,13 @@ CAUTION: Use only if required by the utility provider.</source>
 ATTENTION : A n'utiliser que si le fournisseur d'électricité l'exige.</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="104"/>
       <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
       <translation>Le total de toutes les phases est régulé intelligemment pour atteindre le point de consigne du réseau (l'efficacité du système est optimisée).
 
 A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
-    </message>
-    <message id="settings_ess_min_soc">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation type="unfinished">SOC minimum (Sauf défaillance réseau)</translation>
-    </message>
-    <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="129"/>
-      <source>Active SOC limit</source>
-      <translation type="unfinished">Limite actuelle d'état de charge</translation>
-    </message>
-    <message id="settings_ess_battery_life_sustain">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
-      <source>Sustain</source>
-      <translation type="unfinished">Maintenir</translation>
-    </message>
-    <message id="settings_ess_battery_life_recharge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="157"/>
-      <source>Recharge</source>
-      <translation type="unfinished">Recharge</translation>
-    </message>
-    <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <source>Scheduled charge levels</source>
-      <translation type="unfinished">Niveaux de charge plannifiés</translation>
-    </message>
-    <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="257"/>
-      <source>Active (%1)</source>
-      <translation type="unfinished">Actif (%1)</translation>
-    </message>
-    <message id="settings_ess_inactive">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="259"/>
-      <source>Inactive</source>
-      <translation type="unfinished">Inactif</translation>
-    </message>
-    <message id="settings_ess_dynamic">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="293"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">Dynamic ESS</translation>
-    </message>
-    <message id="settings_ess_deprecated">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="319"/>
-      <source>Deprecated settings</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_charge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="326"/>
-      <source>Battery charge limit (% of CCL)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_discharge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="337"/>
-      <source>Battery discharge limit (% of DCL)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_rs_ess_min_soc">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="40"/>
@@ -1637,13 +1455,8 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <source>Active SOC limit</source>
       <translation>Limite actuelle d'état de charge</translation>
     </message>
-    <message id="scheduled_charge_inactive">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
-      <source>Inactive</source>
-      <translation type="unfinished">Inactif</translation>
-    </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="245"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="247"/>
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
       <source>Peak shaving</source>
       <translation>Ecrêtage</translation>
@@ -1659,12 +1472,12 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <translation>Toujours</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="151"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
       <source>Discharge disabled</source>
       <translation>Décharge désactivée</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
       <source>Slow charge</source>
       <translation>Charge lente</translation>
     </message>
@@ -1679,32 +1492,32 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <translation>Recharge</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="165"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="167"/>
       <source>Limit charge power</source>
       <translation>Limiter puissance de charge</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="183"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="185"/>
       <source>Maximum charge power</source>
       <translation>Puissance de charge maximale</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="196"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="198"/>
       <source>Limit inverter power</source>
       <translation>Limiter puissance convertisseur</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="214"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="216"/>
       <source>Maximum inverter power</source>
       <translation>Puissance maximale convertisseur</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="225"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="227"/>
       <source>Grid setpoint</source>
       <translation>Point de consigne du réseau</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="236"/>
       <source>Grid feed-in</source>
       <translation>Injection dans le réseau</translation>
     </message>
@@ -1743,8 +1556,8 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <source>Door alarm</source>
       <translation>Alarme porte</translation>
     </message>
-    <message id="digitalinputs_type_bilgepump">
-      <location filename="../../src/enums.cpp" line="201"/>
+    <message id="switchable_output_bilge_pump">
+      <location filename="../../src/enums.cpp" line="424"/>
       <source>Bilge pump</source>
       <translation>Pompe de cale</translation>
     </message>
@@ -1796,11 +1609,6 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <source>Deferred by %1s</source>
       <extracomment>%1 = number of seconds</extracomment>
       <translation>Différé par %1s</translation>
-    </message>
-    <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="75"/>
-      <source>Are you sure?</source>
-      <translation type="unfinished">Êtes-vous sûr ?</translation>
     </message>
     <message id="settings_vrm_portal_id">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="87"/>
@@ -1939,11 +1747,6 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <source>External storage</source>
       <translation>Stockage externe</translation>
     </message>
-    <message id="settings_vrm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="308"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">Erreur inconnue</translation>
-    </message>
     <message id="settings_vrm_no_error">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="311"/>
       <source>No Error</source>
@@ -2029,37 +1832,10 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <source>Function</source>
       <translation>Fonction</translation>
     </message>
-    <message id="settings_relay_disabled">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="54"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="98"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Désactivé</translation>
-    </message>
     <message id="settings_relay_alarm_relay">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="56"/>
       <source>Alarm relay</source>
       <translation>Relai d'alarme</translation>
-    </message>
-    <message id="settings_relay_tank_pump">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="62"/>
-      <source>Tank pump</source>
-      <translation type="unfinished">Pompe du réservoir</translation>
-    </message>
-    <message id="settings_relay_manual">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="64"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="100"/>
-      <source>Manual</source>
-      <translation type="unfinished">Manuel</translation>
-    </message>
-    <message id="settings_relay_polarity_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
-      <source>Polarity (Relay 1)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_relay_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
-      <source>Polarity</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_normally_open">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="83"/>
@@ -2075,11 +1851,6 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="93"/>
       <source>Function (Relay 2)</source>
       <translation>Fonction (Relai 2)</translation>
-    </message>
-    <message id="settings_relay_polarity_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
-      <source>Polarity (Relay 2)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_temp_control_rules">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="119"/>
@@ -2111,12 +1882,6 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
       <source>Press to boot</source>
       <translation>Appuyer pour démarrer</translation>
-    </message>
-    <message id="settings_firmware_backup_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
-      <translation type="unfinished">Micrologiciel %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
@@ -2152,6 +1917,7 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
     <message id="nav_boat">
       <location filename="../../pages/boat/BoatPage.qml" line="14"/>
       <source>Boat</source>
+      <extracomment>The 'Boat' page</extracomment>
       <translation>Bateau</translation>
     </message>
     <message id="settings_system_name">
@@ -2219,11 +1985,6 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <source>Solar charger current control</source>
       <translation>Contrôle de courant du chargeur solaire</translation>
     </message>
-    <message id="settings_system_status_bms_params">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
-      <source>BMS control</source>
-      <translation type="unfinished">Contrôle BMS</translation>
-    </message>
     <message id="common_words_bms_control">
       <location filename="../../components/CommonWords.qml" line="101"/>
       <source>BMS control</source>
@@ -2238,11 +1999,6 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
       <source>Pump state</source>
       <translation>État de la pompe</translation>
-    </message>
-    <message id="settings_pump_auto">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="56"/>
-      <source>Auto</source>
-      <translation type="unfinished">Auto</translation>
     </message>
     <message id="settings_tank_sensor">
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
@@ -2271,11 +2027,6 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="35"/>
       <source>Unplugged</source>
       <translation>Débranché</translation>
-    </message>
-    <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="16"/>
-      <source>Name</source>
-      <translation type="unfinished">Nom</translation>
     </message>
     <message id="settings_tcpip_hidden">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="21"/>
@@ -2317,16 +2068,6 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="99"/>
       <source>IP configuration</source>
       <translation>Configuration IP</translation>
-    </message>
-    <message id="settings_tcpip_manual">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="105"/>
-      <source>Manual</source>
-      <translation type="unfinished">Manuel</translation>
-    </message>
-    <message id="settings_tcpip_off">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="107"/>
-      <source>Off</source>
-      <translation type="unfinished">Off</translation>
     </message>
     <message id="settings_tcpip_fixed">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="109"/>
@@ -2382,21 +2123,6 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="30"/>
       <source>Create access point</source>
       <translation>Créer point d'accès</translation>
-    </message>
-    <message id="settings_wifi_access_point_enter_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="68"/>
-      <source>Enter password</source>
-      <translation type="unfinished">Saisir mot de passe</translation>
-    </message>
-    <message id="page_settings_wifi_invalid_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
-      <source>Password length must be either 0 or between 10 and 63 characters long</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_wifi_password_updated">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
-      <source>Password updated</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_wifi_networks">
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="86"/>
@@ -2539,20 +2265,10 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <extracomment>Network status: Standalone</extracomment>
       <translation>Indépendant</translation>
     </message>
-    <message id="charger_standalone">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="45"/>
-      <source>Standalone</source>
-      <translation type="unfinished">Indépendant</translation>
-    </message>
     <message id="charger_charge">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="48"/>
       <source>Charge</source>
       <translation>Charge</translation>
-    </message>
-    <message id="charger_external_control">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="51"/>
-      <source>External control</source>
-      <translation type="unfinished">Contrôle externe</translation>
     </message>
     <message id="charger_charge_hub_1">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="54"/>
@@ -2584,16 +2300,6 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <source>Master setting</source>
       <translation>Configuration Maître</translation>
     </message>
-    <message id="charger_slave">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="85"/>
-      <source>Slave</source>
-      <translation type="unfinished">Esclave</translation>
-    </message>
-    <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation type="unfinished">Tension de charge</translation>
-    </message>
     <message id="systemsettings_networkstatus_slave">
       <location filename="../../data/SystemSettings.qml" line="148"/>
       <source>Slave</source>
@@ -2615,14 +2321,15 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <source>Group &amp; Charge master</source>
       <translation>Maître du groupe et de la charge</translation>
     </message>
-    <message id="genset_charge_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="365"/>
+    <message id="charger_charge_voltage">
+      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
       <source>Charge voltage</source>
       <translation>Tension de charge</translation>
     </message>
     <message id="common_words_reset">
       <location filename="../../components/CommonWords.qml" line="448"/>
       <source>Reset</source>
+      <extracomment>Reset the BMS control</extracomment>
       <translation>Réinitialiser</translation>
     </message>
     <message id="solarcharger_load">
@@ -2651,14 +2358,14 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <extracomment>Voltage alarm is at "Warning" level</extracomment>
       <translation>Avertissement</translation>
     </message>
-    <message id="listitems_alarm_level_alarm">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="25"/>
+    <message id="digitalinputs_state_alarm">
+      <location filename="../../src/enums.cpp" line="270"/>
       <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
+      <extracomment>Relay function is 'alarm'</extracomment>
       <translation>Alarme</translation>
     </message>
-    <message id="devicelist_tankshape_volume">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="190"/>
+    <message id="components_volumeunit_volume">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
       <source>Volume</source>
       <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
       <translation>Volume</translation>
@@ -2808,26 +2515,10 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <source>Relay function</source>
       <translation>Fonction relai</translation>
     </message>
-    <message id="batterysettingrelay_alarm">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation type="unfinished">Alarme</translation>
-    </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
       <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
       <source>Charger or generator start/stop</source>
       <translation>Démarrer/Arrêter Chargeur ou générateur</translation>
-    </message>
-    <message id="batterysettingrelay_manual_control">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
-      <source>Manual control</source>
-      <translation type="unfinished">Contrôle manuel</translation>
-    </message>
-    <message id="batterysettingrelay_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">Fusible grillé</translation>
     </message>
     <message id="common_words_manual_control">
       <location filename="../../components/CommonWords.qml" line="302"/>
@@ -2853,12 +2544,6 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
       <source>Status LEDs</source>
       <translation>LED de statut</translation>
-    </message>
-    <message id="batterydiagnostics_none">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
-      <source>None</source>
-      <extracomment>Indicates no alarm is set</extracomment>
-      <translation type="unfinished">Aucune</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
@@ -2888,7 +2573,7 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
     <message id="common_words_switch">
       <location filename="../../components/CommonWords.qml" line="525"/>
       <source>Switch</source>
-      <extracomment>Change the mode value</extracomment>
+      <extracomment>Change the battery mode</extracomment>
       <translation>Interrupteur</translation>
     </message>
     <message id="devicelist_battery_initializing">
@@ -2956,21 +2641,6 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <source>Top section voltage</source>
       <translation>Tension de section supérieure</translation>
     </message>
-    <message id="battery_bank_error_communication">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="96"/>
-      <source>Communication error</source>
-      <translation type="unfinished">Erreur de communication</translation>
-    </message>
-    <message id="battery_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="182"/>
-      <source>State of health</source>
-      <translation type="unfinished">État de santé</translation>
-    </message>
-    <message id="battery_bus_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="212"/>
-      <source>Bus voltage</source>
-      <translation type="unfinished">Tension Bus</translation>
-    </message>
     <message id="battery_bottom_section_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="228"/>
       <source>Bottom section voltage</source>
@@ -3016,16 +2686,6 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <source>IO</source>
       <translation>IO</translation>
     </message>
-    <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="391"/>
-      <source>System</source>
-      <translation type="unfinished">Système</translation>
-    </message>
-    <message id="battery_press_to_redetect">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="433"/>
-      <source>Press to redetect</source>
-      <translation type="unfinished">Appuyer pour scanner</translation>
-    </message>
     <message id="pagesettingsgeneral_system">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="107"/>
       <source>System</source>
@@ -3066,16 +2726,6 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <source>Low SOC</source>
       <translation>SOC bas</translation>
     </message>
-    <message id="batteryalarms_high_battery_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
-      <source>High battery voltage</source>
-      <translation type="unfinished">Tension de batterie élevée</translation>
-    </message>
-    <message id="batteryalarms_low_soc">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low SOC</source>
-      <translation type="unfinished">SOC bas</translation>
-    </message>
     <message id="batteryalarms_low_starter_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="73"/>
       <source>Low starter voltage</source>
@@ -3095,11 +2745,6 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
       <source>Mid-point voltage</source>
       <translation>Tension médiane</translation>
-    </message>
-    <message id="batteryalarms_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">Fusible grillé</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
@@ -3293,11 +2938,6 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <source>Restore factory defaults</source>
       <translation>Restaurer paramètres d'usine</translation>
     </message>
-    <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation type="unfinished">Appuyer pour restaurer</translation>
-    </message>
     <message id="vebus_backup_press_to_restore">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="362"/>
       <source>Press to restore</source>
@@ -3337,11 +2977,6 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="18"/>
       <source>Capacity</source>
       <translation>Capacité</translation>
-    </message>
-    <message id="batterysettingsbattery_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
-      <source>Capacity</source>
-      <translation type="unfinished">Capacité</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
@@ -3418,17 +3053,13 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <source>No power on busbar</source>
       <translation>Jeu de barres non alimenté</translation>
     </message>
-    <message id="lynxdistributor_connection_lost">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
-      <source>Connection lost</source>
-      <translation type="unfinished">Connexion perdue</translation>
-    </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
       <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
       <source>%n fuse(s) blown</source>
       <extracomment>%n = number of fuses that have blown</extracomment>
       <translation>
         <numerusform>%n fusible grillé</numerusform>
+        <numerusform>%n fusibles grillés</numerusform>
         <numerusform>%n fusibles grillés</numerusform>
       </translation>
     </message>
@@ -3458,26 +3089,6 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <source>Shutdowns due error</source>
       <translation>Arrêt dû à une erreur</translation>
     </message>
-    <message id="lynxiondiagnostics_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
-      <source>Last error</source>
-      <translation type="unfinished">Dernière erreur</translation>
-    </message>
-    <message id="lynxiondiagnostics_2nd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
-      <source>2nd last error</source>
-      <translation type="unfinished">2e dernière erreur</translation>
-    </message>
-    <message id="lynxiondiagnostics_3rd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
-      <source>3rd last error</source>
-      <translation type="unfinished">3e dernière erreur</translation>
-    </message>
-    <message id="lynxiondiagnostics_4th_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
-      <source>4th last error</source>
-      <translation type="unfinished">4e dernière erreur</translation>
-    </message>
     <message id="lynxionio_system_switch">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
       <source>System Switch</source>
@@ -3497,11 +3108,6 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <location filename="../../components/CommonWords.qml" line="54"/>
       <source>Batteries</source>
       <translation>Batteries</translation>
-    </message>
-    <message id="lynxionsystem_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
-      <source>Capacity</source>
-      <translation type="unfinished">Capacité</translation>
     </message>
     <message id="lynxionsystem_parallel">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="30"/>
@@ -3523,20 +3129,10 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <source>Min/max cell temperature</source>
       <translation>Température de cellule min/max</translation>
     </message>
-    <message id="lynxionsystem_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="92"/>
-      <source>Balancing</source>
-      <translation type="unfinished">Équilibrage</translation>
-    </message>
     <message id="lynxionsystem_balancer_balancing">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
       <source>Balancing</source>
       <translation>Équilibrage</translation>
-    </message>
-    <message id="lynxionsystem_balancer_unknown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="117"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Inconnu</translation>
     </message>
     <message id="dc_output">
       <location filename="../../components/listitems/ListDcOutputQuantityGroup.qml" line="16"/>
@@ -3644,11 +3240,6 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <source>Remaining</source>
       <translation>Restant</translation>
     </message>
-    <message id="devicelist_tanksensor_sensor_battery">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="51"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">Capteur Batterie</translation>
-    </message>
     <message id="temperature_sensor_battery">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="112"/>
       <source>Sensor battery</source>
@@ -3677,7 +3268,7 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
     <message id="devicelist_tanksetup_custom">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="53"/>
       <source>Custom</source>
-      <translation type="unfinished">Personnaliser</translation>
+      <translation>Personnaliser</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="59"/>
@@ -3710,34 +3301,34 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <translation>Valeur du capteur</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="75"/>
       <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
       <translation>Aucune forme personnalisée n'a été définie. Vous pouvez en définir une avec un maximum de dix points. Notez que 0 % et 100 % sont implicites.</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="91"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="89"/>
       <source>Point %1</source>
       <extracomment>%1 = the point number</extracomment>
       <translation>Point %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="133"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="179"/>
       <source>Add point</source>
       <translation>Ajouter un point</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="156"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="205"/>
       <source>Sensor level</source>
       <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
       <translation>Niveau du capteur</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="256"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="311"/>
       <source>Duplicate sensor level values are not allowed.</source>
       <translation>Les valeurs de niveau de capteur en double ne sont pas autorisées.</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="262"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="317"/>
       <source>Volume values must be increasing.</source>
       <translation>Les valeurs de volume doivent augmenter.</translation>
     </message>
@@ -3777,11 +3368,6 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <source>Switch position</source>
       <translation>Position de l'interrupteur</translation>
     </message>
-    <message id="ac-in-setup_single_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="142"/>
-      <source>Single phase</source>
-      <translation type="unfinished">Monophasé</translation>
-    </message>
     <message id="ac-in-setup_two_phase">
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="144"/>
       <source>2-phase</source>
@@ -3791,11 +3377,6 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="146"/>
       <source>3-phase</source>
       <translation>Triphasé</translation>
-    </message>
-    <message id="ac-in-setup_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="161"/>
-      <source>Devices</source>
-      <translation type="unfinished">Appareils</translation>
     </message>
     <message id="ac-in-genset_ac">
       <location filename="../../components/PageGensetModel.qml" line="194"/>
@@ -3889,12 +3470,6 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <extracomment>%1 = CT device number</extracomment>
       <translation>CT %1</translation>
     </message>
-    <message id="smappeect_phase_none">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation type="unfinished">Aucune</translation>
-    </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
       <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
       <source>Flashing LED indicates this CT</source>
@@ -3908,11 +3483,13 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
     <message id="common_words_setting_disabled_when_dmc_connected">
       <location filename="../../components/CommonWords.qml" line="355"/>
       <source>This setting is disabled when a Digital Multi Control is connected.</source>
+      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>Ce réglage est désactivé lorsqu'un "Digital Multi Control" est connecté.</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
       <location filename="../../components/CommonWords.qml" line="358"/>
       <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>Ce paramètre est désactivé lorsqu'un BMS VE.Bus est raccordé.</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
@@ -3930,16 +3507,6 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="21"/>
       <source>Inverted</source>
       <translation>Inversé</translation>
-    </message>
-    <message id="digitalinput_enable_alarm">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="48"/>
-      <source>Enable alarm</source>
-      <translation type="unfinished">Activer alarme</translation>
-    </message>
-    <message id="digitalinput_inverted">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="54"/>
-      <source>Inverted</source>
-      <translation type="unfinished">Inversé</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
       <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="60"/>
@@ -3976,16 +3543,6 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <source>Wind speed</source>
       <translation>Vitesse du vent</translation>
     </message>
-    <message id="page_meteo_battery_voltage">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="99"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">Capteur Batterie</translation>
-    </message>
-    <message id="meteo_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="120"/>
-      <source>Low</source>
-      <translation type="unfinished">Basse</translation>
-    </message>
     <message id="page_meteo_settings_auto_detect">
       <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
       <source>Auto-detect</source>
@@ -4016,16 +3573,6 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <source>Reset counter</source>
       <translation>Réinitialiser compteur</translation>
     </message>
-    <message id="temperature_short_circuited">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="32"/>
-      <source>Short circuited</source>
-      <translation type="unfinished">Court-circuité</translation>
-    </message>
-    <message id="temperature_reverse_polarity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="35"/>
-      <source>Reverse polarity</source>
-      <translation type="unfinished">Polarité inversée</translation>
-    </message>
     <message id="temperature_sensor_battery_low">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
       <source>Sensor battery low</source>
@@ -4040,36 +3587,6 @@ A utiliser sauf si le fournisseur d'électricité l'interdit.</translation>
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="62"/>
       <source>Pressure</source>
       <translation>Pression</translation>
-    </message>
-    <message id="temperature_pm25">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
-      <source>PM2.5</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_co2">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>CO₂</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_voc">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
-      <source>VOC index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_nox">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
-      <source>NOx index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_luminosity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
-      <source>Luminosity</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="133"/>
-      <source>Low</source>
-      <translation type="unfinished">Basse</translation>
     </message>
     <message id="temperature_offset">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
@@ -4123,25 +3640,10 @@ NOTE : La mise à jour peut arrêter temporairement le système.</translation>
       <source>Updating the MK3, values will reappear after the update is complete</source>
       <translation>En mettant à jour le MK3, les valeurs réapparaîtront une fois la mise à jour terminée</translation>
     </message>
-    <message id="vebus_device_charging_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="78"/>
-      <source>Charging the battery to 100%</source>
-      <translation type="unfinished">Chargement de la batterie à 100%</translation>
-    </message>
     <message id="vebus_device_charging_the_battery_to_100">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="93"/>
       <source>Charging the battery to 100%</source>
       <translation>Chargement de la batterie à 100%</translation>
-    </message>
-    <message id="vebus_device_page_microgrid_parameters">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
-      <source>Microgrid parameters</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="vebus_device_page_advanced">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
-      <source>Advanced</source>
-      <translation type="unfinished">Avancé</translation>
     </message>
     <message id="vebus_device_in_progress">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="80"/>
@@ -4197,15 +3699,15 @@ Voulez-vous continuer ?</translation>
       <source>DC Current</source>
       <translation>Courant CC</translation>
     </message>
+    <message id="vebus_device_page_advanced">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
+      <source>Advanced</source>
+      <translation>Avancé</translation>
+    </message>
     <message id="common_words_alarm_setup">
       <location filename="../../components/CommonWords.qml" line="65"/>
       <source>Alarm setup</source>
       <translation>Configuration de l'alarme</translation>
-    </message>
-    <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
-      <translation type="unfinished">Un BMS de VE.Bus éteindra automatiquement le système s'il faut protéger la batterie. Le contrôle du système depuis le Color Control sera donc impossible.</translation>
     </message>
     <message id="vebus_device_bms_not_found">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="240"/>
@@ -4246,7 +3748,7 @@ Voulez-vous continuer ?</translation>
     <message id="vebus_device_starting">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="117"/>
       <source>Starting...</source>
-      <translation type="unfinished">Démarrage en cours...</translation>
+      <translation>Démarrage en cours...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="120"/>
@@ -4312,16 +3814,6 @@ Voulez-vous continuer ?</translation>
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="260"/>
       <source>ESS Relay test</source>
       <translation>Test du relai ESS</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_completed">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="266"/>
-      <source>Completed</source>
-      <translation type="unfinished">Terminé</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_pending">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="268"/>
-      <source>Pending</source>
-      <translation type="unfinished">En attente</translation>
     </message>
     <message id="cycle_history_completed">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
@@ -4508,6 +4000,7 @@ Voulez-vous continuer ?</translation>
     <message id="rssystemalarms_overload">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
       <source>Overload</source>
+      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
       <translation>Surcharge</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
@@ -4520,11 +4013,6 @@ Voulez-vous continuer ?</translation>
       <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
       <source>Voltage Sensor</source>
       <translation>Sonde de tension</translation>
-    </message>
-    <message id="vebus_device_phase_rotation">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
-      <source>Phase rotation</source>
-      <translation type="unfinished">Rotation de phase</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
@@ -4556,12 +4044,6 @@ Voulez-vous continuer ?</translation>
       <source>VE.Bus BMS version</source>
       <translation>Version du BMS VE.Bus</translation>
     </message>
-    <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="15"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="52"/>
-      <source>Minimum SOC</source>
-      <translation type="unfinished">SOC minimum</translation>
-    </message>
     <message id="ess_unless_grid_fails">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="32"/>
       <source>Unless grid fails</source>
@@ -4581,7 +4063,7 @@ Voulez-vous continuer ?</translation>
     <message id="common_words_ac_input_role">
       <location filename="../../components/CommonWords.qml" line="24"/>
       <source>Role</source>
-      <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
       <translation>Rôle</translation>
     </message>
     <message id="common_words_ac_load">
@@ -4620,18 +4102,6 @@ Voulez-vous continuer ?</translation>
       <source>Active</source>
       <extracomment>Status is 'active'</extracomment>
       <translation>Actif</translation>
-    </message>
-    <message id="common_words_alarm">
-      <location filename="../../components/CommonWords.qml" line="51"/>
-      <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
-      <translation type="unfinished">Alarme</translation>
-    </message>
-    <message id="common_words_alarm_setting_overload">
-      <location filename="../../components/CommonWords.qml" line="58"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation type="unfinished">Surcharge</translation>
     </message>
     <message id="common_words_alarm_status">
       <location filename="../../components/CommonWords.qml" line="68"/>
@@ -4678,8 +4148,8 @@ Voulez-vous continuer ?</translation>
       <source>Charge current</source>
       <translation>Courant de charge</translation>
     </message>
-    <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="125"/>
+    <message id="battery_mode_charging">
+      <location filename="../../src/enums.cpp" line="30"/>
       <source>Charging</source>
       <extracomment>"Charging" state</extracomment>
       <translation>Chargement</translation>
@@ -4693,7 +4163,7 @@ Voulez-vous continuer ?</translation>
     <message id="digitalinputs_state_closed">
       <location filename="../../src/enums.cpp" line="262"/>
       <source>Closed</source>
-      <extracomment>Digital input state</extracomment>
+      <extracomment>Status is 'closed'</extracomment>
       <translation>Fermé</translation>
     </message>
     <message id="evchargers_status_connected">
@@ -4701,8 +4171,8 @@ Voulez-vous continuer ?</translation>
       <source>Connected</source>
       <translation>Connecté</translation>
     </message>
-    <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="143"/>
+    <message id="temperature_slider_current">
+      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
       <source>Current</source>
       <extracomment>Electric current, as measured in Amps</extracomment>
       <translation>Courant</translation>
@@ -4729,9 +4199,10 @@ Voulez-vous continuer ?</translation>
       <extracomment>Title for device information</extracomment>
       <translation>Appareil</translation>
     </message>
-    <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="172"/>
+    <message id="battery_mode_discharging">
+      <location filename="../../src/enums.cpp" line="34"/>
       <source>Discharging</source>
+      <extracomment>Battery mode</extracomment>
       <translation>Déchargement</translation>
     </message>
     <message id="wifimodel_disconnected">
@@ -4817,13 +4288,14 @@ Voulez-vous continuer ?</translation>
       <source>%1 Hour(s)</source>
       <translation>%1 Heure(s)</translation>
     </message>
-    <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="251"/>
+    <message id="battery_mode_idle">
+      <location filename="../../src/enums.cpp" line="26"/>
       <source>Idle</source>
+      <extracomment>Battery mode</extracomment>
       <translation>En attente</translation>
     </message>
-    <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="258"/>
+    <message id="scheduled_charge_inactive">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
       <source>Inactive</source>
       <extracomment>Status is 'inactive'</extracomment>
       <translation>Inactif</translation>
@@ -4925,8 +4397,8 @@ Voulez-vous continuer ?</translation>
       <source>Offline</source>
       <translation>Hors ligne</translation>
     </message>
-    <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="17"/>
+    <message id="digitalinputs_state_ok">
+      <location filename="../../src/enums.cpp" line="266"/>
       <source>OK</source>
       <extracomment>Voltage alarm is at "OK" level</extracomment>
       <translation>OK</translation>
@@ -4934,6 +4406,7 @@ Voulez-vous continuer ?</translation>
     <message id="switchable_output_on">
       <location filename="../../src/enums.cpp" line="471"/>
       <source>On</source>
+      <extracomment>Digital input state</extracomment>
       <translation>On</translation>
     </message>
     <message id="common_words_online">
@@ -4944,7 +4417,7 @@ Voulez-vous continuer ?</translation>
     <message id="digitalinputs_state_open">
       <location filename="../../src/enums.cpp" line="258"/>
       <source>Open</source>
-      <extracomment>Digital input open</extracomment>
+      <extracomment>Status is 'open'</extracomment>
       <translation>Ouvert</translation>
     </message>
     <message id="common_words_password">
@@ -5004,9 +4477,10 @@ Voulez-vous continuer ?</translation>
       <source>Remove</source>
       <translation>Supprimer</translation>
     </message>
-    <message id="switch_state_running">
-      <location filename="../../src/enums.cpp" line="363"/>
+    <message id="switchable_output_running">
+      <location filename="../../src/enums.cpp" line="468"/>
       <source>Running</source>
+      <extracomment>Status = "running"</extracomment>
       <translation>En marche</translation>
     </message>
     <message id="common_words_scanning">
@@ -5073,7 +4547,7 @@ Voulez-vous continuer ?</translation>
     <message id="pvinverter_statusCode_startup">
       <location filename="../../src/enums.cpp" line="296"/>
       <source>Startup (%1)</source>
-      <extracomment>PV inverter status code. %1 = the startup status number</extracomment>
+      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
       <translation>Démarrer (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
@@ -5128,8 +4602,10 @@ Voulez-vous continuer ?</translation>
       <source>Unique Identity Number</source>
       <translation>Numéro unique d'identité</translation>
     </message>
-    <message id="settings_radio_button_group_unknown">
-      <location filename="../../components/listitems/core/ListRadioButtonGroup.qml" line="44"/>
+    <message id="Unknown">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
       <source>Unknown</source>
       <translation>Inconnu</translation>
     </message>
@@ -5284,11 +4760,6 @@ Voulez-vous continuer ?</translation>
       <source>Error while checking for firmware updates</source>
       <translation>Erreur lors de la recherche de mises à jour micrologiciel</translation>
     </message>
-    <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation type="unfinished">Erreur lors de la recherche de mises à jour micrologiciel</translation>
-    </message>
     <message id="settings_firmware_downloading_and_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="63"/>
       <source>Downloading and installing firmware %1...</source>
@@ -5315,6 +4786,66 @@ Voulez-vous continuer ?</translation>
       <source>No firmware found</source>
       <translation>Aucun micrologiciel trouvé</translation>
     </message>
+    <message id="tank_type_fuel">
+      <location filename="../../src/enums.cpp" line="495"/>
+      <source>Fuel</source>
+      <translation>Carburant</translation>
+    </message>
+    <message id="tank_type_fresh_water">
+      <location filename="../../src/enums.cpp" line="498"/>
+      <source>Fresh water</source>
+      <translation>Eau douce</translation>
+    </message>
+    <message id="tank_type_waste_water">
+      <location filename="../../src/enums.cpp" line="501"/>
+      <source>Waste water</source>
+      <translation>Eaux usées</translation>
+    </message>
+    <message id="tank_type_live_well">
+      <location filename="../../src/enums.cpp" line="504"/>
+      <source>Live well</source>
+      <translation>Vivier</translation>
+    </message>
+    <message id="tank_type_oil">
+      <location filename="../../src/enums.cpp" line="507"/>
+      <source>Oil</source>
+      <translation>Huile</translation>
+    </message>
+    <message id="tank_type_black_water">
+      <location filename="../../src/enums.cpp" line="510"/>
+      <source>Black water</source>
+      <translation>Eaux Noires</translation>
+    </message>
+    <message id="tank_type_gasoline">
+      <location filename="../../src/enums.cpp" line="513"/>
+      <source>Gasoline</source>
+      <translation>Essence</translation>
+    </message>
+    <message id="tank_type_diesel">
+      <location filename="../../src/enums.cpp" line="516"/>
+      <source>Diesel</source>
+      <translation>Diesel</translation>
+    </message>
+    <message id="tank_type_lpg">
+      <location filename="../../src/enums.cpp" line="519"/>
+      <source>LPG</source>
+      <translation>GPL</translation>
+    </message>
+    <message id="tank_type_lng">
+      <location filename="../../src/enums.cpp" line="522"/>
+      <source>LNG</source>
+      <translation>GNL</translation>
+    </message>
+    <message id="tank_type_hydraulic_oil">
+      <location filename="../../src/enums.cpp" line="525"/>
+      <source>Hydraulic oil</source>
+      <translation>Huile hydraulique</translation>
+    </message>
+    <message id="tank_type_raw_water">
+      <location filename="../../src/enums.cpp" line="528"/>
+      <source>Raw water</source>
+      <translation>Eau non traitée</translation>
+    </message>
     <message id="listItem_no_access">
       <location filename="../../components/listitems/core/ListItem.qml" line="102"/>
       <source>Setting locked for access level</source>
@@ -5328,6 +4859,7 @@ Voulez-vous continuer ?</translation>
     <message id="welcome_brief_title">
       <location filename="../../pages/welcome/WelcomeView.qml" line="81"/>
       <source>Brief</source>
+      <extracomment>The 'Brief' page</extracomment>
       <translation>En bref</translation>
     </message>
     <message id="welcome_overview_title">
@@ -5344,23 +4876,6 @@ Voulez-vous continuer ?</translation>
       <location filename="../../pages/NotificationsPage.qml" line="13"/>
       <source>Notifications</source>
       <translation>Notifications</translation>
-    </message>
-    <message id="notifications_page_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="43"/>
-      <source>Active Notifications</source>
-      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_page_inactive_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="47"/>
-      <source>Inactive Notifications</source>
-      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_no_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="106"/>
-      <source>No active notifications</source>
-      <translation type="unfinished"/>
     </message>
     <message id="utils_formatTimestamp_now">
       <location filename="../../components/Utils.js" line="258"/>
@@ -5465,11 +4980,6 @@ Voulez-vous continuer ?</translation>
       <source>Self-consumption above limit</source>
       <translation>Autoconsommation supérieure à la limite</translation>
     </message>
-    <message id="cgwacs_battery_schedule_pv">
-      <location filename="../../components/listitems/ListChargeSchedule.qml" line="171"/>
-      <source>PV</source>
-      <translation type="unfinished">PV</translation>
-    </message>
     <message id="settings_multirs_pv">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="185"/>
       <source>PV</source>
@@ -5480,8 +4990,8 @@ Voulez-vous continuer ?</translation>
       <source>PV &amp; Battery</source>
       <translation>PV &amp; Batterie</translation>
     </message>
-    <message id="settings_firmware_checking">
-      <location filename="../../components/listitems/ListFirmwareCheckButton.qml" line="16"/>
+    <message id="pagesettingssupportstate_firmware_checking">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
       <source>Checking...</source>
       <translation>Vérification en cours...</translation>
     </message>
@@ -5489,12 +4999,6 @@ Voulez-vous continuer ?</translation>
       <location filename="../../components/listitems/ListAlarmState.qml" line="11"/>
       <source>Alarm state</source>
       <translation>État alarme</translation>
-    </message>
-    <message id="devicelist_battery_alarm_state">
-      <location filename="../../components/listitems/ListAlarmState.qml" line="19"/>
-      <source>Alarm</source>
-      <extracomment>Alarm state is active</extracomment>
-      <translation type="unfinished">Alarme</translation>
     </message>
     <message id="clear_history_button_clear_history">
       <location filename="../../components/listitems/ListClearHistoryButton.qml" line="15"/>
@@ -5646,11 +5150,6 @@ Voulez-vous continuer ?</translation>
       <source>Max Voltage</source>
       <translation>Tension Max</translation>
     </message>
-    <message id="charger_history_box_max_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="64"/>
-      <source>Max Voltage</source>
-      <translation type="unfinished">Tension Max</translation>
-    </message>
     <message id="charger_history_box_max_current">
       <location filename="../../components/SolarDetailBox.qml" line="70"/>
       <source>Max Current</source>
@@ -5661,24 +5160,6 @@ Voulez-vous continuer ?</translation>
       <source>Charge time</source>
       <extracomment>Statistics for battery charging time</extracomment>
       <translation>Temps de charge</translation>
-    </message>
-    <message id="charger_history_box_bulk">
-      <location filename="../../components/SolarDetailBox.qml" line="136"/>
-      <source>Bulk</source>
-      <extracomment>Battery: time spent in 'Bulk' mode</extracomment>
-      <translation type="unfinished">Bulk</translation>
-    </message>
-    <message id="charger_history_box_float">
-      <location filename="../../components/SolarDetailBox.qml" line="148"/>
-      <source>Float</source>
-      <extracomment>Battery: time spent in 'Float' mode</extracomment>
-      <translation type="unfinished">Float</translation>
-    </message>
-    <message id="charger_history_hr">
-      <location filename="../../components/SolarDetailBox.qml" line="174"/>
-      <source>hr</source>
-      <extracomment>Abbreviation of "hour"</extracomment>
-      <translation type="unfinished">hr</translation>
     </message>
     <message id="solarchargers_state_bulk">
       <location filename="../../src/enums.cpp" line="337"/>
@@ -5750,11 +5231,6 @@ Voulez-vous continuer ?</translation>
       <source>Connecting</source>
       <translation>Connexion en cours</translation>
     </message>
-    <message id="splash_view_connecting">
-      <location filename="../../components/SplashView.qml" line="288"/>
-      <source>Connecting</source>
-      <translation type="unfinished">Connexion en cours</translation>
-    </message>
     <message id="splash_view_connected">
       <location filename="../../components/SplashView.qml" line="290"/>
       <source>Connected, awaiting broker messages</source>
@@ -5810,6 +5286,11 @@ Voulez-vous continuer ?</translation>
       <source>MQTT protocol level 5 error</source>
       <translation>Erreur protocol MQTT niveau 5</translation>
     </message>
+    <message id="common_words_silence_alarm">
+      <location filename="../../components/CommonWords.qml" line="476"/>
+      <source>Silence alarm</source>
+      <translation>Alarme en silencieux</translation>
+    </message>
     <message id="vebus_device_page_total_power">
       <location filename="../../components/ThreePhaseQuantityTable.qml" line="47"/>
       <source>Total Power</source>
@@ -5860,20 +5341,10 @@ Voulez-vous continuer ?</translation>
       <source>Retrieving IP address</source>
       <translation>Extraction en cours adresse IP</translation>
     </message>
-    <message id="utils_connman_connected">
-      <location filename="../../components/Utils.js" line="292"/>
-      <source>Connected</source>
-      <translation type="unfinished">Connecté</translation>
-    </message>
     <message id="utils_connman_disconnect">
       <location filename="../../components/Utils.js" line="295"/>
       <source>Disconnect</source>
       <translation>Déconnecter</translation>
-    </message>
-    <message id="utils_connman_disconnected">
-      <location filename="../../components/Utils.js" line="299"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Déconnecté</translation>
     </message>
     <message id="overview_widget_acloads_title">
       <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
@@ -5911,11 +5382,6 @@ Voulez-vous continuer ?</translation>
       <source>Shore current limit</source>
       <translation>Limite de courant de quai</translation>
     </message>
-    <message id="acInputs_statusCode_stopping">
-      <location filename="../../data/AcInputs.qml" line="170"/>
-      <source>Stopping</source>
-      <translation type="unfinished">Arrêt en cours</translation>
-    </message>
     <message id="page_generator_stopping">
       <location filename="../../data/Generators.qml" line="44"/>
       <source>Stopping</source>
@@ -5931,7 +5397,7 @@ Voulez-vous continuer ?</translation>
       <location filename="../../data/common/TankDescription.qml" line="24"/>
       <location filename="../../src/device.cpp" line="133"/>
       <source>%1 tank (%2)</source>
-      <extracomment>Tank description. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
       <translation>%1 réservoir (%2)</translation>
     </message>
     <message id="dcMeter_ac_charger">
@@ -5980,11 +5446,6 @@ Voulez-vous continuer ?</translation>
       <location filename="../../data/Ess.qml" line="20"/>
       <source>Keep batteries charged</source>
       <translation>Maintenir les batteries chargées</translation>
-    </message>
-    <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="50"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Déconnecté</translation>
     </message>
     <message id="evchargers_status_charged">
       <location filename="../../data/EvChargers.qml" line="58"/>
@@ -6045,16 +5506,6 @@ Voulez-vous continuer ?</translation>
       <location filename="../../data/EvChargers.qml" line="97"/>
       <source>Start charging</source>
       <translation>Début de la charge</translation>
-    </message>
-    <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="113"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Inconnu</translation>
-    </message>
-    <message id="evchargers_mode_scheduled">
-      <location filename="../../data/EvChargers.qml" line="126"/>
-      <source>Scheduled</source>
-      <translation type="unfinished">Plannifié</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
       <location filename="../../data/System.qml" line="195"/>
@@ -6179,11 +5630,6 @@ Voulez-vous continuer ?</translation>
       <source>Power supply mode</source>
       <translation>Mode Alimentation</translation>
     </message>
-    <message id="inverters_state_sustain">
-      <location filename="../../data/System.qml" line="158"/>
-      <source>Sustain</source>
-      <translation type="unfinished">Maintenir</translation>
-    </message>
     <message id="inverters_state_wakeup">
       <location filename="../../data/System.qml" line="162"/>
       <source>Wake up</source>
@@ -6218,16 +5664,6 @@ Voulez-vous continuer ?</translation>
       <location filename="../../data/System.qml" line="180"/>
       <source>Test</source>
       <translation>Test</translation>
-    </message>
-    <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="183"/>
-      <source>External control</source>
-      <translation type="unfinished">Contrôle externe</translation>
-    </message>
-    <message id="inverters_state_dynamic_ess">
-      <location filename="../../data/System.qml" line="198"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">Dynamic ESS</translation>
     </message>
     <message id="settings_rs_ess_dess">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="97"/>
@@ -6306,16 +5742,13 @@ Voulez-vous continuer ?</translation>
     <message id="ess_recommended">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="73"/>
       <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
       <translation>Pour les piles au lithium, une charge inférieure à 10 % n'est pas recommandée. Pour les autres types de piles, vérifiez la fiche technique pour connaître le niveau minimum recommandé par le fabricant.</translation>
-    </message>
-    <message id="controlcard_generator_label_autostart">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="63"/>
-      <source>Autostart</source>
-      <translation type="unfinished">Démarrage auto</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
       <location filename="../../pages/controlcards/GeneratorCard.qml" line="70"/>
       <source>Start and stop the generator based on the configured autostart conditions.</source>
+      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
       <translation>Démarrer et arrêter le générateur en fonction des conditions de démarrage automatique configurées.</translation>
     </message>
     <message id="generator_dialog_disabled">
@@ -6338,11 +5771,13 @@ Voulez-vous continuer ?</translation>
       <location filename="../../pages/controlcards/InverterChargerCard.qml" line="26"/>
       <source>Inverter / Charger (%1)</source>
       <extracomment>%1 = the inverter/charger name</extracomment>
+      <oldsource>Inverter / Charger</oldsource>
       <translation>Onduleur/Chargeur (%1)</translation>
     </message>
     <message id="settings_page_debug_quit_application">
       <location filename="../../pages/settings/debug/PageDebug.qml" line="36"/>
       <source>Quit application</source>
+      <oldsource>Quit Application</oldsource>
       <translation>Quitter l'application</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
@@ -6353,12 +5788,8 @@ Voulez-vous continuer ?</translation>
     <message id="settings_page_relay_generator_run_time">
       <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
       <source>Current run time</source>
+      <oldsource>Run time</oldsource>
       <translation>Durée d'exécution actuelle</translation>
-    </message>
-    <message id="settings_page_genset_generator_run_time">
-      <location filename="../../components/PageGensetModel.qml" line="102"/>
-      <source>Current run time</source>
-      <translation type="unfinished">Durée d'exécution actuelle</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
       <location filename="../../components/PageGensetModel.qml" line="110"/>
@@ -6385,19 +5816,10 @@ Voulez-vous continuer ?</translation>
       <source>Remote start mode</source>
       <translation>Mode de démarrage à distance</translation>
     </message>
-    <message id="ac-in-genset_speed">
-      <location filename="../../components/PageGensetModel.qml" line="245"/>
-      <source>Speed</source>
-      <translation type="unfinished">Vitesse</translation>
-    </message>
-    <message id="ac-in-genset_load">
-      <location filename="../../components/PageGensetModel.qml" line="252"/>
-      <source>Load</source>
-      <translation type="unfinished">Charge</translation>
-    </message>
     <message id="ac-in-genset_oil_pressure">
       <location filename="../../components/PageGensetModel.qml" line="260"/>
       <source>Oil pressure</source>
+      <oldsource>Oil Pressure</oldsource>
       <translation>Pression d'huile</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
@@ -6493,11 +5915,13 @@ Voulez-vous continuer ?</translation>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
       <source>High starter battery voltage alarms</source>
+      <oldsource>High starter batttery voltage alarms</oldsource>
       <translation>Alarmes de tension élevée de la batterie de démarrage</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
       <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
       <translation>Notez que la modification du réglage de l'étage de décharge Time-to-go modifie également le réglage de l'état de charge bas dans le menu des relais.</translation>
     </message>
     <message id="lynxionsystem_cells_per_battery">
@@ -6574,6 +5998,7 @@ Voulez-vous continuer ?</translation>
       <location filename="../../pages/settings/devicelist/delegates/DeviceListDelegate_solarcharger.qml" line="34"/>
       <source>Error: #%1</source>
       <extracomment>%1 = error number</extracomment>
+      <oldsource>Error: %1</oldsource>
       <translation>Erreur : #%1</translation>
     </message>
     <message id="devicelistpage_genset">
@@ -6630,17 +6055,14 @@ Voulez-vous continuer ?</translation>
     <message id="settings_page_relay_generator_auto_start_enabled">
       <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
       <source>Autostart functionality</source>
+      <oldsource>Auto start functionality</oldsource>
       <translation>Fonctionnalité de démarrage automatique</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="97"/>
       <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
       <translation>Assurez-vous que le générateur n'est pas connecté à l'entrée AC %1 lorsque vous utilisez cette option.</translation>
-    </message>
-    <message id="page_generator_conditions_inverter_high_temperature">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="139"/>
-      <source>Inverter high temperature</source>
-      <translation type="unfinished">Température élevée convertisseur</translation>
     </message>
     <message id="page_generator_conditions_tank_level">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="159"/>
@@ -6670,30 +6092,34 @@ Voulez-vous continuer ?</translation>
     <message id="settings_generator_function_not_enabled">
       <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
       <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
+      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
       <translation>La fonction de démarrage/arrêt du générateur n'est pas activée, allez dans les réglages du relai et réglez la fonction sur "Arrêter/Démarrer Générateur".</translation>
     </message>
     <message id="settings_batteries_intro">
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="45"/>
       <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
       <translation>Ce menu permet de définir les données relatives à la batterie qui s'affichent lorsque l'on clique sur l'icône Batterie de la page Vue d'ensemble. La même sélection est également visible sur le portail VRM.</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
       <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
       <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
       <translation>Le balayage continu peut interférer avec le fonctionnement du Wi-Fi.</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
       <source>CAN-bus BMS LV (500 kbit/s)</source>
+      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
       <translation>CAN-bus BMS LV (500 kbit/s)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
       <source>CAN-bus BMS HV (500 kbit/s)</source>
       <translation>CAN-bus BMS HV (500 kbit/s)</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
       <source>Up, but no services (500 kbit/s)</source>
       <translation>Up, mais pas de services (500 kbit/s)</translation>
     </message>
@@ -6706,41 +6132,6 @@ Voulez-vous continuer ?</translation>
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="127"/>
       <source>Brief page</source>
       <translation>Brève page</translation>
-    </message>
-    <message id="settings_displayoff_1min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="46"/>
-      <source>1 min</source>
-      <translation type="unfinished">1 min</translation>
-    </message>
-    <message id="settings_displayoff_10min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="48"/>
-      <source>10 min</source>
-      <translation type="unfinished">10 min</translation>
-    </message>
-    <message id="settings_displayoff_30min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="50"/>
-      <source>30 min</source>
-      <translation type="unfinished">30 min</translation>
-    </message>
-    <message id="settings_displayoff_never">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="52"/>
-      <source>Never</source>
-      <translation type="unfinished">Jamais</translation>
-    </message>
-    <message id="settings_remote_console_appearance_auto">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="112"/>
-      <source>Auto</source>
-      <translation type="unfinished">Auto</translation>
-    </message>
-    <message id="settings_brief_view_start_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="119"/>
-      <source>Start page</source>
-      <translation type="unfinished">Page d'accueil</translation>
-    </message>
-    <message id="settings_display_boat_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="135"/>
-      <source>Boat page</source>
-      <translation type="unfinished">Page du bateau</translation>
     </message>
     <message id="settings_display_minmax">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="148"/>
@@ -6795,21 +6186,6 @@ Voulez-vous continuer ?</translation>
       <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
       <translation>%1 est réglé sur %2</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_unsupported_device">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="50"/>
-      <source>Unsupported GX device</source>
-      <translation type="unfinished">Dispositif GX non pris en charge</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_clean">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="55"/>
-      <source>Clean</source>
-      <translation type="unfinished">Nettoyer</translation>
-    </message>
-    <message id="pagesettingsgeneral_firmware">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="112"/>
-      <source>Firmware</source>
-      <translation type="unfinished">Micrologiciel</translation>
-    </message>
     <message id="pagesettingsgeneral_access_and_security">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
       <source>Access &amp; Security</source>
@@ -6843,6 +6219,7 @@ Voulez-vous continuer ?</translation>
     <message id="settings_language_please_wait">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="209"/>
       <source>Please wait while the language is changed.</source>
+      <oldsource>Please wait while the language is changed</oldsource>
       <translation>Veuillez patienter pendant le changement de langue.</translation>
     </message>
     <message id="settings_briefview_totals">
@@ -6859,11 +6236,6 @@ Voulez-vous continuer ?</translation>
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="71"/>
       <source>Tank is not connected.</source>
       <translation>Le réservoir n'est pas raccordé.</translation>
-    </message>
-    <message id="settings_briefview_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="83"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">Moniteur de batterie actif</translation>
     </message>
     <message id="settings_briefview_individual_batteries">
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="86"/>
@@ -6914,6 +6286,7 @@ Voulez-vous continuer ?</translation>
     <message id="settings_dvcc_charge_current_limits">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="30"/>
       <source>Charge current limits</source>
+      <oldsource>Charge Current limits</oldsource>
       <translation>Charge Limites de courant</translation>
     </message>
     <message id="settings_firmware_official_release">
@@ -6993,11 +6366,6 @@ Voulez-vous continuer ?</translation>
       <source>No password and the network communication is not encrypted</source>
       <translation>Pas de mot de passe et la communication réseau n'est pas cryptée</translation>
     </message>
-    <message id="settings_logout_now">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
-      <source>Log out now</source>
-      <translation type="unfinished">Se déconnecter</translation>
-    </message>
     <message id="settings_security_profile_password_incorrect_length">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="28"/>
       <source>Password needs to be at least 8 characters long</source>
@@ -7048,25 +6416,10 @@ Voulez-vous continuer ?</translation>
       <source>Page will automatically reload in 5 seconds</source>
       <translation>La page se rechargera automatiquement dans 5 secondes</translation>
     </message>
-    <message id="settings_security_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="159"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">Le mot de passe doit comporter au moins 8 caractères</translation>
-    </message>
     <message id="settings_root_password">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="269"/>
       <source>Root password</source>
       <translation>Mot de passe racine</translation>
-    </message>
-    <message id="settings_root_enter_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="272"/>
-      <source>Enter password</source>
-      <translation type="unfinished">Saisir mot de passe</translation>
-    </message>
-    <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="277"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">Le mot de passe doit comporter au moins 8 caractères</translation>
     </message>
     <message id="settings_root_password_changed_to">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="283"/>
@@ -7082,6 +6435,11 @@ Voulez-vous continuer ?</translation>
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="321"/>
       <source>Logout</source>
       <translation>Déconnexion</translation>
+    </message>
+    <message id="settings_logout_now">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
+      <source>Log out now</source>
+      <translation>Se déconnecter</translation>
     </message>
     <message id="settings_logout_dialog_title">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="335"/>
@@ -7141,11 +6499,13 @@ Voulez-vous continuer ?</translation>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="141"/>
       <source>Alarm when generator is not in autostart mode</source>
+      <oldsource>Alarm when generator is not in auto start mode</oldsource>
       <translation>Alarme lorsque le générateur n'est pas en mode de démarrage automatique</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="147"/>
       <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
       <translation>Une alarme se déclenche lorsque la fonction de démarrage automatique est désactivée pendant plus de 10 minutes.</translation>
     </message>
     <message id="settings_units_amps_exceptions">
@@ -7161,6 +6521,11 @@ Voulez-vous continuer ?</translation>
     <message id="settings_ess_use_this_option_for_peak_shaving">
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
       <source>Use this option for peak shaving.</source>
+      <oldsource>Use this option for peak shaving.
+
+The peak shaving threshold is set using the AC input current limit setting.
+
+See documentation for further information.</oldsource>
       <translation>Utilisez cette option pour l'écrêtement des pointes.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
@@ -7204,17 +6569,17 @@ Voulez-vous continuer ?</translation>
       <translation>Courant d'exportation maximal du système (par phase)</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="71"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="73"/>
       <source>Self-consumption from battery</source>
       <translation>Autoconsommation de la batterie</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="76"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
       <source>All system loads</source>
       <translation>Toutes les charges du système</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="80"/>
       <source>Only critical loads</source>
       <translation>Seulement les charges critiques</translation>
     </message>
@@ -7261,7 +6626,7 @@ Voulez-vous continuer ?</translation>
     <message id="pagesettingsintegrations_relays">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="118"/>
       <source>Relays</source>
-      <translation>Vous êtes sur le point de mettre &lt;b&gt; {isOn} relay {relayNumber}. Voulez-vous vraiment continuer ?</translation>
+      <translation>Relais</translation>
     </message>
     <message id="pagesettingsintegrations_digital_io">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="132"/>
@@ -7272,26 +6637,6 @@ Voulez-vous continuer ?</translation>
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="194"/>
       <source>Server Applications</source>
       <translation>Applications serveur</translation>
-    </message>
-    <message id="pagesettingsintegrations_venus_os_enable_large_features">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
-      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_large_victron_community">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="274"/>
-      <source>Victron Community</source>
-      <translation type="unfinished">Victron community</translation>
-    </message>
-    <message id="pagesettingsintegrations_ui_plugins">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
-      <source>UI Plugins</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
-      <source>Integrates with the device list</source>
-      <translation type="unfinished"/>
     </message>
     <message id="pagesettingssupportstate_modbus_tcp_server">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="453"/>
@@ -7394,25 +6739,10 @@ Voulez-vous continuer ?</translation>
       <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
       <translation>Le changement de version du micrologiciel n'est pas possible si le "Profil de sécurité du réseau" dans "Paramètres / Général" n'est pas sélectionné.</translation>
     </message>
-    <message id="pagesettingsconnectivity_ethernet">
-      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
-      <source>Ethernet</source>
-      <translation type="unfinished">Ethernet</translation>
-    </message>
     <message id="pagesettingsconnectivity_mobile_network">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="53"/>
       <source>Mobile Network</source>
       <translation>Réseau mobile</translation>
-    </message>
-    <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Boat</source>
-      <translation type="unfinished">Bateau</translation>
-    </message>
-    <message id="settings_system_name_auto">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="32"/>
-      <source>Automatic</source>
-      <translation type="unfinished">Automatique</translation>
     </message>
     <message id="pagesettingssystem_ac_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
@@ -7443,11 +6773,6 @@ Voulez-vous continuer ?</translation>
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="89"/>
       <source>Distributed Voltage and Current Control (DVCC)</source>
       <translation>Contrôle distribué de la tension et du courant (DVCC)</translation>
-    </message>
-    <message id="settings_system_grid">
-      <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="18"/>
-      <source>Grid</source>
-      <translation type="unfinished">Réseau</translation>
     </message>
     <message id="settings_system_ac_position">
       <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="58"/>
@@ -7487,16 +6812,19 @@ Voulez-vous continuer ?</translation>
     <message id="settings_system_has_dc_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="97"/>
       <source>Display DC Loads</source>
+      <oldsource>Has DC system</oldsource>
       <translation>Affichage des charges DC</translation>
     </message>
     <message id="settings_system_battery_measurements">
       <location filename="../../pages/settings/PageSettingsBatteries.qml" line="65"/>
       <source>Battery measurements</source>
+      <oldsource>Battery Measurements</oldsource>
       <translation>Mesures de la batterie</translation>
     </message>
     <message id="settings_system_system_status">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
       <source>System status</source>
+      <oldsource>System Status</oldsource>
       <translation>État du système</translation>
     </message>
     <message id="settings_tcpip_wired">
@@ -7507,11 +6835,13 @@ Voulez-vous continuer ?</translation>
     <message id="settings_vecan_device_instance">
       <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
       <source>VE.Can Device Instance</source>
+      <oldsource>Device Instance</oldsource>
       <translation>Instance de l'appareil VE.Can</translation>
     </message>
     <message id="settings_vecan_device_number">
       <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="32"/>
       <source>VE.Can Instance# %1</source>
+      <oldsource>Device# %1</oldsource>
       <translation>Instance VE.Can n° %1</translation>
     </message>
     <message id="settings_tz_antarctica">
@@ -7542,6 +6872,7 @@ Voulez-vous continuer ?</translation>
     <message id="settings_vrm">
       <location filename="../../pages/SettingsPage.qml" line="59"/>
       <source>VRM</source>
+      <extracomment>Forced by %2 to dark</extracomment>
       <translation>VRM</translation>
     </message>
     <message id="settings_remote_monitoring_portal">
@@ -7549,20 +6880,10 @@ Voulez-vous continuer ?</translation>
       <source>Remote monitoring portal</source>
       <translation>Portail de surveillance à distance</translation>
     </message>
-    <message id="settings_advanced">
-      <location filename="../../pages/SettingsPage.qml" line="68"/>
-      <source>Advanced</source>
-      <translation type="unfinished">Avancé</translation>
-    </message>
-    <message id="settings_integrations">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
+    <message id="pagesettingssupportstate_integrations">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
       <source>Integrations</source>
       <translation>Intégrations</translation>
-    </message>
-    <message id="settings_relays_sensors_tanks">
-      <location filename="../../pages/SettingsPage.qml" line="75"/>
-      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
-      <translation type="unfinished">Relais, capteurs, réservoirs, onduleurs PV, Modbus, MQTT...</translation>
     </message>
     <message id="settings_acdcsystem_ess_dvcc_battery">
       <location filename="../../pages/SettingsPage.qml" line="84"/>
@@ -7582,11 +6903,13 @@ Voulez-vous continuer ?</translation>
     <message id="settings_system_setup">
       <location filename="../../pages/SettingsPage.qml" line="82"/>
       <source>System Setup</source>
+      <oldsource>System setup</oldsource>
       <translation>Configuration Système</translation>
     </message>
     <message id="settings_vrm_device_instances">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
       <source>VRM device instances</source>
+      <oldsource>VRM Device Instances</oldsource>
       <translation>Instances du dispositif VRM</translation>
     </message>
     <message id="solarcharger_not_supported">
@@ -7604,28 +6927,10 @@ Voulez-vous continuer ?</translation>
       <source>The firmware version in the MPPT Solar Charger must be v1.09 or later. Contact Victron Service for update instructions and files.</source>
       <translation>La version du micrologiciel du chargeur solaire MPPT doit être v1.09 ou ultérieure. Contactez le service après-vente Victron pour obtenir les instructions et les fichiers de mise à jour.</translation>
     </message>
-    <message id="solarcharger_pv">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="102"/>
-      <source>PV</source>
-      <extracomment>PV power for solar charger</extracomment>
-      <translation type="unfinished">PV</translation>
-    </message>
     <message id="solarcharger_total_power">
       <location filename="../../pages/solar/PageSolarCharger.qml" line="127"/>
       <source>Total PV power</source>
       <translation>Puissance PV totale</translation>
-    </message>
-    <message id="solarcharger_total_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="211"/>
-      <source>Total yield</source>
-      <extracomment>Solar charger total yield</extracomment>
-      <translation type="unfinished">Production totale</translation>
-    </message>
-    <message id="solarcharger_system_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="220"/>
-      <source>System yield</source>
-      <extracomment>Solar charger system yield</extracomment>
-      <translation type="unfinished">Champ système</translation>
     </message>
     <message id="settings_multirs_total_yield">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="63"/>
@@ -7661,16 +6966,19 @@ Voulez-vous continuer ?</translation>
     <message id="vebus_device_update_firmware">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="133"/>
       <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
       <translation>Cette fonction nécessite la version 400 ou supérieure du micrologiciel. Contactez votre installateur pour mettre à jour votre Multi/Quattro.</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="139"/>
       <source>Charger not ready, equalization cannot be started</source>
+      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
       <translation>Le chargeur n'est pas prêt, l'égalisation ne peut pas être lancée</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="143"/>
       <source>Equalization cannot be triggered during bulk charge state</source>
+      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
       <translation>L'égalisation ne peut pas être déclenchée pendant l'étape de bluk</translation>
     </message>
     <message id="vebus_device_restart_vebus_system_restart_confirmation_description">
@@ -7693,78 +7001,20 @@ Voulez-vous continuer ?</translation>
       <source>Auto-started • %1</source>
       <translation>Démarrage automatique - %1</translation>
     </message>
-    <message id="common_words_battery">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery</source>
-      <translation type="unfinished">Batterie</translation>
-    </message>
-    <message id="common_words_boat_page">
-      <location filename="../../components/CommonWords.qml" line="111"/>
-      <source>Boat</source>
-      <extracomment>The 'Boat' page</extracomment>
-      <translation type="unfinished">Bateau</translation>
-    </message>
-    <message id="common_words_brief_page">
-      <location filename="../../components/CommonWords.qml" line="115"/>
-      <source>Brief</source>
-      <extracomment>The 'Brief' page</extracomment>
-      <translation type="unfinished">En bref</translation>
-    </message>
-    <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation type="unfinished">Fermé</translation>
-    </message>
-    <message id="common_words_color">
-      <location filename="../../components/CommonWords.qml" line="136"/>
-      <source>Color</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_connected">
-      <location filename="../../components/CommonWords.qml" line="139"/>
-      <source>Connected</source>
-      <translation type="unfinished">Connecté</translation>
-    </message>
     <message id="common_words_daily_history">
       <location filename="../../components/CommonWords.qml" line="152"/>
       <source>Daily history</source>
       <translation>Historique quotidien</translation>
-    </message>
-    <message id="common_words_disabled">
-      <location filename="../../components/CommonWords.qml" line="169"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Désactivé</translation>
-    </message>
-    <message id="common_words_disconnected">
-      <location filename="../../components/CommonWords.qml" line="175"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Déconnecté</translation>
-    </message>
-    <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="191"/>
-      <source>Error</source>
-      <translation type="unfinished">Erreur</translation>
     </message>
     <message id="common_words_error_not_a_number">
       <location filename="../../components/CommonWords.qml" line="200"/>
       <source>'%1' is not a number.</source>
       <translation>'%1' n'est pas un nombre.</translation>
     </message>
-    <message id="common_words_generator">
-      <location filename="../../components/CommonWords.qml" line="217"/>
-      <source>Generator</source>
-      <translation type="unfinished">Générateur</translation>
-    </message>
     <message id="common_words_input_current_limit">
       <location filename="../../components/CommonWords.qml" line="261"/>
       <source>Input current limit</source>
       <translation>Limite de courant d'entrée</translation>
-    </message>
-    <message id="common_words_inverter_charger">
-      <location filename="../../components/CommonWords.qml" line="264"/>
-      <source>Inverter / Charger</source>
-      <translation type="unfinished">Onduleur / Chargeur</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
       <location filename="../../components/CommonWords.qml" line="268"/>
@@ -7777,12 +7027,6 @@ Voulez-vous continuer ?</translation>
       <source>Manual stop</source>
       <translation>Arrêt manuel</translation>
     </message>
-    <message id="common_words_max">
-      <location filename="../../components/CommonWords.qml" line="315"/>
-      <source>Max</source>
-      <extracomment>Short for Maximum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_maximum_current">
       <location filename="../../components/CommonWords.qml" line="318"/>
       <source>Maximum current</source>
@@ -7793,62 +7037,10 @@ Voulez-vous continuer ?</translation>
       <source>Maximum power</source>
       <translation>Puissance maximale</translation>
     </message>
-    <message id="common_words_min">
-      <location filename="../../components/CommonWords.qml" line="331"/>
-      <source>Min</source>
-      <extracomment>Short for Minimum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_minimum_current">
       <location filename="../../components/CommonWords.qml" line="334"/>
       <source>Minimum current</source>
       <translation>Courant minimum</translation>
-    </message>
-    <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="433"/>
-      <source>No</source>
-      <translation type="unfinished">Non</translation>
-    </message>
-    <message id="common_words_none_option">
-      <location filename="../../components/CommonWords.qml" line="364"/>
-      <source>None</source>
-      <translation type="unfinished">Aucune</translation>
-    </message>
-    <message id="common_words_none_errors">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>None</source>
-      <extracomment>Indicates there are no errors</extracomment>
-      <translation type="unfinished">Aucune</translation>
-    </message>
-    <message id="common_words_not_available">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Not available</source>
-      <translation type="unfinished">Indisponible</translation>
-    </message>
-    <message id="common_words_off">
-      <location filename="../../components/CommonWords.qml" line="377"/>
-      <source>Off</source>
-      <translation type="unfinished">Off</translation>
-    </message>
-    <message id="common_words_ok">
-      <location filename="../../components/CommonWords.qml" line="383"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="41"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="45"/>
-      <source>OK</source>
-      <translation type="unfinished">OK</translation>
-    </message>
-    <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="386"/>
-      <source>On</source>
-      <translation type="unfinished">On</translation>
-    </message>
-    <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="393"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation type="unfinished">Ouvert</translation>
     </message>
     <message id="common_words_open_circuit">
       <location filename="../../components/CommonWords.qml" line="396"/>
@@ -7860,108 +7052,17 @@ Voulez-vous continuer ?</translation>
       <source>Overall history</source>
       <translation>Historique général</translation>
     </message>
-    <message id="common_words_press">
-      <location filename="../../components/CommonWords.qml" line="419"/>
-      <source>Press</source>
-      <translation type="unfinished">Presse</translation>
-    </message>
-    <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation type="unfinished">En marche</translation>
-    </message>
-    <message id="common_words_settings">
-      <location filename="../../components/CommonWords.qml" line="467"/>
-      <source>Settings</source>
-      <translation type="unfinished">Paramètres</translation>
-    </message>
-    <message id="common_words_silence_alarm">
-      <location filename="../../components/CommonWords.qml" line="476"/>
-      <source>Silence alarm</source>
-      <translation type="unfinished">Alarme en silencieux</translation>
-    </message>
     <message id="common_words_soc">
       <location filename="../../components/CommonWords.qml" line="480"/>
       <source>SOC %1</source>
       <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
       <translation>SOC %1%</translation>
     </message>
-    <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation type="unfinished">Vitesse</translation>
-    </message>
-    <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="487"/>
-      <source>Standby</source>
-      <translation type="unfinished">Standby</translation>
-    </message>
-    <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="502"/>
-      <source>State</source>
-      <translation type="unfinished">État</translation>
-    </message>
-    <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="512"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation type="unfinished">Démarrer (%1)</translation>
-    </message>
-    <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>Stopped</source>
-      <translation type="unfinished">Arrêté</translation>
-    </message>
-    <message id="common_words_total_power">
-      <location filename="../../components/CommonWords.qml" line="540"/>
-      <source>Total power</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="547"/>
-      <source>Type</source>
-      <translation type="unfinished">Type</translation>
-    </message>
-    <message id="common_words_unknown_status">
-      <location filename="../../components/CommonWords.qml" line="554"/>
-      <source>Unknown</source>
-      <extracomment>Status = "unknown"</extracomment>
-      <translation type="unfinished">Inconnu</translation>
-    </message>
-    <message id="common_words_value_must_be_greater_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="557"/>
-      <source>Value must be greater than start value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_value_must_be_greater_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="560"/>
-      <source>Value must be greater than stop value</source>
-      <translation type="unfinished">La valeur doit être supérieure à la valeur d'arrêt</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="563"/>
-      <source>Value must be lower than start value</source>
-      <translation type="unfinished">La valeur doit être inf. à la valeur de démarrage</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="566"/>
-      <source>Value must be lower than stop value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="581"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="431"/>
-      <source>Yes</source>
-      <translation type="unfinished">Oui</translation>
-    </message>
     <message id="common_words_yield_today">
       <location filename="../../components/CommonWords.qml" line="592"/>
       <source>Yield Today</source>
       <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+      <oldsource>Yield today</oldsource>
       <translation>Production aujourd'hui</translation>
     </message>
     <message id="common_words_format_error">
@@ -7988,10 +7089,11 @@ Voulez-vous continuer ?</translation>
     <message id="settings_firmware_installed_rebooting">
       <location filename="../../components/FirmwareUpdate.qml" line="79"/>
       <source>Firmware installed, device rebooting</source>
+      <oldsource>Firmware installed, rebooting.</oldsource>
       <translation>Firmware installé, appareil redémarré</translation>
     </message>
-    <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/RadioButtonListPage.qml" line="121"/>
+    <message id="modaldialog_confirm">
+      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
       <source>Confirm</source>
       <extracomment>Confirm password, and verify it if possible</extracomment>
       <translation>Confirmer</translation>
@@ -8009,11 +7111,13 @@ Voulez-vous continuer ?</translation>
     <message id="cgwacs_battery_schedule_duration">
       <location filename="../../components/listitems/ListChargeSchedule.qml" line="144"/>
       <source>Duration</source>
+      <oldsource>Duration (hh:mm)</oldsource>
       <translation>Durée</translation>
     </message>
     <message id="settings_relay_deactivation_value">
       <location filename="../../components/TemperatureRelaySettings.qml" line="86"/>
       <source>Deactivation value</source>
+      <oldsource>Deativation value</oldsource>
       <translation>Valeur de désactivation</translation>
     </message>
     <message id="splash_view_device_disconnected">
@@ -8061,29 +7165,6 @@ Voulez-vous continuer ?</translation>
       <source>Temperature warning</source>
       <translation>Avertissement de température</translation>
     </message>
-    <message id="battery_mode_idle">
-      <location filename="../../src/enums.cpp" line="26"/>
-      <source>Idle</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">En attente</translation>
-    </message>
-    <message id="battery_mode_charging">
-      <location filename="../../src/enums.cpp" line="30"/>
-      <source>Charging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Chargement</translation>
-    </message>
-    <message id="battery_mode_discharging">
-      <location filename="../../src/enums.cpp" line="34"/>
-      <source>Discharging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Déchargement</translation>
-    </message>
-    <message id="dcMeter_bilge_pump">
-      <location filename="../../src/enums.cpp" line="115"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">Pompe de cale</translation>
-    </message>
     <message id="switch_state_channel_fault">
       <location filename="../../src/enums.cpp" line="372"/>
       <source>Channel Fault</source>
@@ -8114,26 +7195,6 @@ Voulez-vous continuer ?</translation>
       <source>Slave of %1</source>
       <translation>Esclave de %1</translation>
     </message>
-    <message id="switchable_output_numeric_input">
-      <location filename="../../src/enums.cpp" line="418"/>
-      <source>Numeric input</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bilge_pump">
-      <location filename="../../src/enums.cpp" line="424"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">Pompe de cale</translation>
-    </message>
-    <message id="switchable_output_not_running">
-      <location filename="../../src/enums.cpp" line="448"/>
-      <source>Not running</source>
-      <translation type="unfinished">Pas en cours d'exécution</translation>
-    </message>
-    <message id="switchable_output_off">
-      <location filename="../../src/enums.cpp" line="451"/>
-      <source>Off</source>
-      <translation type="unfinished">Off</translation>
-    </message>
     <message id="switchable_output_powered">
       <location filename="../../src/enums.cpp" line="455"/>
       <source>Powered</source>
@@ -8162,16 +7223,19 @@ Voulez-vous continuer ?</translation>
     <message id="evchargers_status_welded_contacts_error">
       <location filename="../../data/EvChargers.qml" line="76"/>
       <source>Welded contacts test error (shorted)</source>
+      <oldsource>Welded contacts error</oldsource>
       <translation>Erreur de test des contacts soudés (court-circuit)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
       <location filename="../../data/EvChargers.qml" line="100"/>
       <source>Switching to 3 phase</source>
+      <oldsource>Switching to 3-phase</oldsource>
       <translation>Passage au triphasé</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
       <location filename="../../data/EvChargers.qml" line="103"/>
       <source>Switching to 1 phase</source>
+      <oldsource>Switching to single phase</oldsource>
       <translation>Passage à une phase</translation>
     </message>
     <message id="evchargers_status_stop_charging">
@@ -8324,17 +7388,6 @@ Si le générateur est en cours de fonctionnement en raison d'une condition de d
       <source>Open link</source>
       <translation>Ouvrir le lien</translation>
     </message>
-    <message id="listlink_show_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="43"/>
-      <source>Show QR code</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="listlink_scan_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="52"/>
-      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
-      <extracomment>%1 = url text</extracomment>
-      <translation type="unfinished">Scannez le code QR avec votre appareil portable.&lt;br /&gt;Ou insérez le lien : %1</translation>
-    </message>
     <message id="settings_services_mqtt_access">
       <location filename="../../components/listitems/ListMqttAccessSwitch.qml" line="11"/>
       <source>MQTT Access</source>
@@ -8406,12 +7459,6 @@ Si le générateur est en cours de fonctionnement en raison d'une condition de d
       <extracomment>The 'Brief' page, with the side panel opened</extracomment>
       <translation>Slip (panneau latéral ouvert)</translation>
     </message>
-    <message id="startpage_option_overview">
-      <location filename="../../data/StartPageConfiguration.qml" line="37"/>
-      <source>Overview</source>
-      <extracomment>The 'Overview' page</extracomment>
-      <translation type="unfinished">Vue d'ensemble</translation>
-    </message>
     <message id="startpage_option_levels_tanks">
       <location filename="../../data/StartPageConfiguration.qml" line="43"/>
       <source>Levels (Tanks)</source>
@@ -8430,12 +7477,12 @@ Si le générateur est en cours de fonctionnement en raison d'une condition de d
       <translation>Liste des piles</translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
+      <location filename="../../pages/DialogLayer.qml" line="56"/>
       <source>GX device has been updated</source>
       <translation>Le dispositif GX a été mis à jour</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
+      <location filename="../../pages/DialogLayer.qml" line="58"/>
       <source>Page will automatically reload in ten seconds to load the latest version.</source>
       <translation>La page sera automatiquement rechargée dans dix secondes pour afficher la dernière version.</translation>
     </message>
@@ -8528,6 +7575,7 @@ Notez que ce menu n'affiche que les compteurs Carlo Gavazzi connectés par RS485
       <translation>
         <numerusform>Après %n minute</numerusform>
         <numerusform>Après %n minute(s)</numerusform>
+        <numerusform>Après %n minute</numerusform>
       </translation>
     </message>
     <message id="settings_startpage_description">
@@ -8605,8 +7653,8 @@ Notez que ce menu n'affiche que les compteurs Carlo Gavazzi connectés par RS485
       <source>Unit</source>
       <translation>Unité</translation>
     </message>
-    <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="61"/>
+    <message id="page_settings_fronius_unitid_invalid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
       <source>%1 is not a valid unit number. Use a number between 1-247.</source>
       <translation>%1 n'est pas un numéro d'unité valide. Utilisez un nombre compris entre 1 et 247.</translation>
     </message>
@@ -8721,11 +7769,6 @@ Notez que ce menu n'affiche que les compteurs Carlo Gavazzi connectés par RS485
       <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="66"/>
       <source>Controller Temperature</source>
       <translation>Contrôleur température</translation>
-    </message>
-    <message id="devicelist_motordrive_motordirectioninverted">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
-      <source>Motor Direction Inverted</source>
-      <translation type="unfinished"/>
     </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
@@ -8917,11 +7960,6 @@ Avec une navigation simplifiée et un nouveau look, tout ce que vous aimez est m
     <message id="welcome_done">
       <location filename="../../pages/welcome/WelcomeView.qml" line="136"/>
       <source>Done</source>
-      <translation type="unfinished">Effectué</translation>
-    </message>
-    <message id="mk2vsc_state_done">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="20"/>
-      <source>Done</source>
       <translation>Effectué</translation>
     </message>
     <message id="welcome_next">
@@ -8979,6 +8017,7 @@ Le dispositif GX ne peut contrôler qu'un seul groupe électrogène connecté et
     <message id="settings_tz_etc">
       <location filename="../../pages/settings/PageTzInfo.qml" line="280"/>
       <source>Other</source>
+      <oldsource>Etc</oldsource>
       <translation>Autre</translation>
     </message>
     <message id="ac-in-modeldefault_energy_reverse_x">
@@ -8996,6 +8035,11 @@ Le dispositif GX ne peut contrôler qu'un seul groupe électrogène connecté et
       <location filename="../../src/enums.cpp" line="438"/>
       <source>Unsupported type: %1</source>
       <translation>Type non pris en charge : %1</translation>
+    </message>
+    <message id="common_words_press">
+      <location filename="../../components/CommonWords.qml" line="419"/>
+      <source>Press</source>
+      <translation>Presse</translation>
     </message>
     <message id="output_aux_battery_service_changed_dcdc">
       <location filename="../../components/listitems/ListOutputBatteryRadioButtonGroup.qml" line="27"/>
@@ -9136,13 +8180,6 @@ Le dispositif GX ne peut contrôler qu'un seul groupe électrogène connecté et
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="38"/>
       <source>Resetting VE.Bus products</source>
       <translation>Réinitialisation des produits VE.Bus</translation>
-    </message>
-    <message id="Unknown">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Inconnu</translation>
     </message>
     <message id="mk2vsc_error_mk2_mk3_comm">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="47"/>
@@ -9448,11 +8485,6 @@ Le dispositif GX ne peut contrôler qu'un seul groupe électrogène connecté et
       <source>Changing the GX Password</source>
       <translation>Changement du mot de passe GX</translation>
     </message>
-    <message id="modaldialog_confirm">
-      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
-      <source>Confirm</source>
-      <translation type="unfinished">Confirmer</translation>
-    </message>
     <message id="settings_security_profile_change_password_description">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="83"/>
       <source>Please enter a new GX password:</source>
@@ -9518,7 +8550,7 @@ Le dispositif GX ne peut contrôler qu'un seul groupe électrogène connecté et
     <message id="page_settings_no_cellular_modem_connected">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="55"/>
       <source>No cellular modem connected</source>
-      <translation>Pas de modem cellulaire conencté</translation>
+      <translation>Pas de modem cellulaire connecté</translation>
     </message>
     <message id="ess_active_soc_limit">
       <location filename="../../pages/controlcards/ESSCard.qml" line="87"/>
@@ -9544,21 +8576,6 @@ Le dispositif GX ne peut contrôler qu'un seul groupe électrogène connecté et
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="23"/>
       <source>Modifications installed</source>
       <translation>Modifications installées</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_modbus">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="28"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">Serveur Modbus TCP</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_signalk">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="32"/>
-      <source>Signal K</source>
-      <translation type="unfinished">Signal K</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_nodered">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="36"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">Node-RED</translation>
     </message>
     <message id="pagesettingsgeneral_modificationchecks_running_integrations">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="43"/>
@@ -9635,16 +8652,6 @@ Le dispositif GX ne peut contrôler qu'un seul groupe électrogène connecté et
       <source>Installed and enabled, disables at next boot</source>
       <translation>Installé et activé, se désactive au prochain démarrage</translation>
     </message>
-    <message id="pagesettingssupportstate_firmware_checking">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
-      <source>Checking...</source>
-      <translation type="unfinished">Vérification en cours...</translation>
-    </message>
-    <message id="pagesettingssupportstate_firmware_unknown">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="166"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Inconnu</translation>
-    </message>
     <message id="pagesettingssupportstate_support_status">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="228"/>
       <source>Support status</source>
@@ -9666,11 +8673,6 @@ Le dispositif GX ne peut contrôler qu'un seul groupe électrogène connecté et
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="288"/>
       <source>Press 'OK' to disable custom startup scripts and reboot</source>
       <translation>Appuyez sur « OK » pour désactiver les scripts de démarrage personnalisés et redémarrer</translation>
-    </message>
-    <message id="pagesettingssupportstate_re_enable_custom_startup_scripts">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="309"/>
-      <source>Re-enable custom startup scripts</source>
-      <translation type="unfinished">Réactiver les scripts de démarrage personnalisés</translation>
     </message>
     <message id="pagesettingssupportstate_reenable_and_reboot_now">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="322"/>
@@ -9697,11 +8699,6 @@ Le dispositif GX ne peut contrôler qu'un seul groupe électrogène connecté et
       <source>Disable also custom startup scripts?</source>
       <translation>Désactiver également les scripts de démarrage personnalisés ?</translation>
     </message>
-    <message id="pagesettingssupportstate_integrations">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
-      <source>Integrations</source>
-      <translation type="unfinished">Intégrations</translation>
-    </message>
     <message id="pagesettingssupportstate_orange_items_description">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="494"/>
       <source>Items colored orange are supported and provided by Victron Energy, but using them incorrectly can affect system stability. In case of troubleshooting, disable those first.</source>
@@ -9713,7 +8710,7 @@ Le dispositif GX ne peut contrôler qu'un seul groupe électrogène connecté et
       <translation>Connectez une clé USB Bluetooth compatible pour activer la connectivité Bluetooth.</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="140"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="142"/>
       <source>BatteryLife state</source>
       <translation>État BatteryLife</translation>
     </message>
@@ -9721,23 +8718,6 @@ Le dispositif GX ne peut contrôler qu'un seul groupe électrogène connecté et
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="33"/>
       <source>Device Integrations</source>
       <translation>Intégrations d'appareils</translation>
-    </message>
-    <message id="pagesettingsintegrations_modbus_tcp_server">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="201"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">Serveur Modbus TCP</translation>
-    </message>
-    <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="226"/>
-      <location filename="../../pages/settings/PageSettingsSignalK.qml" line="18"/>
-      <source>Signal K</source>
-      <translation type="unfinished">Signal K</translation>
-    </message>
-    <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="241"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">Node-RED</translation>
     </message>
     <message id="settings_venusos_large_documentation">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="267"/>
@@ -9747,6 +8727,7 @@ Le dispositif GX ne peut contrôler qu'un seul groupe électrogène connecté et
     <message id="settings_modbus_enable_modbus_tcp">
       <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
       <source>Enable Modbus TCP Server</source>
+      <oldsource>Enable Modbus/TCP</oldsource>
       <translation>Activer le serveur Modbus TCP</translation>
     </message>
     <message id="pagesettingsconnectivity_bluetooth_for_victronconnect_app">
@@ -9840,11 +8821,13 @@ Le dispositif GX ne peut contrôler qu'un seul groupe électrogène connecté et
     <message id="settings_gps_format_kmh">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="93"/>
       <source>Kilometres per hour</source>
+      <oldsource>Kilometers per hour</oldsource>
       <translation>Kilomètres par heure</translation>
     </message>
     <message id="settings_gps_format_ms">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="95"/>
       <source>Metres per second</source>
+      <oldsource>Meters per second</oldsource>
       <translation>Mètres par seconde</translation>
     </message>
     <message id="components_volumeunit_cubic_metres">
@@ -9872,8 +8855,8 @@ Le dispositif GX ne peut contrôler qu'un seul groupe électrogène connecté et
       <source>The Relay can now be found in the devices list</source>
       <translation>Le relais se trouve désormais dans la liste des appareils</translation>
     </message>
-    <message id="common_words_gx_device_relays">
-      <location filename="../../components/CommonWords.qml" line="223"/>
+    <message id="gx_device_relays">
+      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
       <source>GX device relays</source>
       <translation>Relais de l'appareil GX</translation>
     </message>
@@ -9927,12 +8910,6 @@ Le dispositif GX ne peut contrôler qu'un seul groupe électrogène connecté et
       <extracomment>Forced by app to %1</extracomment>
       <translation>auto</translation>
     </message>
-    <message id="settings_remote_console_forced_by_vrm">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="94"/>
-      <source>VRM</source>
-      <extracomment>Forced by %2 to dark</extracomment>
-      <translation type="unfinished">VRM</translation>
-    </message>
     <message id="settings_remote_console_forced_by_app">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="97"/>
       <source>app</source>
@@ -9982,6 +8959,7 @@ Le dispositif GX ne peut contrôler qu'un seul groupe électrogène connecté et
     <message id="settings_large_access_signal_k">
       <location filename="../../pages/settings/PageSettingsSignalK.qml" line="24"/>
       <source>Access Signal K</source>
+      <oldsource>Access Signal K (local network)</oldsource>
       <translation>Accéder à Signal K</translation>
     </message>
     <message id="pagesettingsintegrations_shelly_devices">
@@ -9992,6 +8970,7 @@ Le dispositif GX ne peut contrôler qu'un seul groupe électrogène connecté et
     <message id="settings_large_access_node_red">
       <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
       <source>Access Node-RED</source>
+      <oldsource>Access Node-RED (local network)</oldsource>
       <translation>Accéder à Node-RED</translation>
     </message>
     <message id="settings_wifi_access_point_password">
@@ -10059,57 +9038,6 @@ Le dispositif GX ne peut contrôler qu'un seul groupe électrogène connecté et
       <source>Wind charger</source>
       <translation>Chargeur éolien</translation>
     </message>
-    <message id="digitalinputs_type_disabled">
-      <location filename="../../src/enums.cpp" line="192"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Désactivé</translation>
-    </message>
-    <message id="digitalinputs_state_off">
-      <location filename="../../src/enums.cpp" line="242"/>
-      <source>Off</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Off</translation>
-    </message>
-    <message id="digitalinputs_state_on">
-      <location filename="../../src/enums.cpp" line="246"/>
-      <source>On</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">On</translation>
-    </message>
-    <message id="digitalinputs_state_ok">
-      <location filename="../../src/enums.cpp" line="266"/>
-      <source>OK</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">OK</translation>
-    </message>
-    <message id="digitalinputs_state_alarm">
-      <location filename="../../src/enums.cpp" line="270"/>
-      <source>Alarm</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Alarme</translation>
-    </message>
-    <message id="digitalinputs_state_running">
-      <location filename="../../src/enums.cpp" line="274"/>
-      <source>Running</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">En marche</translation>
-    </message>
-    <message id="pvinverter_statusCode_running">
-      <location filename="../../src/enums.cpp" line="300"/>
-      <source>Running</source>
-      <extracomment>PV inverter status code</extracomment>
-      <translation type="unfinished">En marche</translation>
-    </message>
-    <message id="solarchargers_state_external control">
-      <location filename="../../src/enums.cpp" line="352"/>
-      <source>External control</source>
-      <translation type="unfinished">Contrôle externe</translation>
-    </message>
-    <message id="switch_state_over_temperature">
-      <location filename="../../src/enums.cpp" line="366"/>
-      <source>Over temperature</source>
-      <translation type="unfinished">Surchauffe</translation>
-    </message>
     <message id="switchable_output_temperature_setpoint">
       <location filename="../../src/enums.cpp" line="398"/>
       <source>Temperature setpoint</source>
@@ -10119,11 +9047,6 @@ Le dispositif GX ne peut contrôler qu'un seul groupe électrogène connecté et
       <location filename="../../src/enums.cpp" line="401"/>
       <source>Stepped switch</source>
       <translation>Commutateur à gradins</translation>
-    </message>
-    <message id="switchable_output_slave">
-      <location filename="../../src/enums.cpp" line="408"/>
-      <source>Slave</source>
-      <translation type="unfinished">Esclave</translation>
     </message>
     <message id="switchable_output_dropdown">
       <location filename="../../src/enums.cpp" line="412"/>
@@ -10135,122 +9058,10 @@ Le dispositif GX ne peut contrôler qu'un seul groupe électrogène connecté et
       <source>Basic slider</source>
       <translation>Curseur de base</translation>
     </message>
-    <message id="switchable_output_rgb_color_wheel">
-      <location filename="../../src/enums.cpp" line="427"/>
-      <source>RGB color wheel</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_cct_color_wheel">
-      <location filename="../../src/enums.cpp" line="431"/>
-      <source>CCT color wheel</source>
-      <extracomment>Correlated Color Temperature color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_rgbw_color_wheel">
-      <location filename="../../src/enums.cpp" line="435"/>
-      <source>RGB + W color wheel</source>
-      <extracomment>RGB + white color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bypassed">
-      <location filename="../../src/enums.cpp" line="484"/>
-      <source>Bypassed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="tank_type_fuel">
-      <location filename="../../src/enums.cpp" line="495"/>
-      <source>Fuel</source>
-      <translation type="unfinished">Carburant</translation>
-    </message>
-    <message id="tank_type_fresh_water">
-      <location filename="../../src/enums.cpp" line="498"/>
-      <source>Fresh water</source>
-      <translation type="unfinished">Eau douce</translation>
-    </message>
-    <message id="tank_type_waste_water">
-      <location filename="../../src/enums.cpp" line="501"/>
-      <source>Waste water</source>
-      <translation type="unfinished">Eaux usées</translation>
-    </message>
-    <message id="tank_type_live_well">
-      <location filename="../../src/enums.cpp" line="504"/>
-      <source>Live well</source>
-      <translation type="unfinished">Vivier</translation>
-    </message>
-    <message id="tank_type_oil">
-      <location filename="../../src/enums.cpp" line="507"/>
-      <source>Oil</source>
-      <translation type="unfinished">Huile</translation>
-    </message>
-    <message id="tank_type_black_water">
-      <location filename="../../src/enums.cpp" line="510"/>
-      <source>Black water</source>
-      <translation type="unfinished">Eaux Noires</translation>
-    </message>
-    <message id="tank_type_gasoline">
-      <location filename="../../src/enums.cpp" line="513"/>
-      <source>Gasoline</source>
-      <translation type="unfinished">Essence</translation>
-    </message>
-    <message id="tank_type_diesel">
-      <location filename="../../src/enums.cpp" line="516"/>
-      <source>Diesel</source>
-      <translation type="unfinished">Diesel</translation>
-    </message>
-    <message id="tank_type_lpg">
-      <location filename="../../src/enums.cpp" line="519"/>
-      <source>LPG</source>
-      <translation type="unfinished">GPL</translation>
-    </message>
-    <message id="tank_type_lng">
-      <location filename="../../src/enums.cpp" line="522"/>
-      <source>LNG</source>
-      <translation type="unfinished">GNL</translation>
-    </message>
-    <message id="tank_type_hydraulic_oil">
-      <location filename="../../src/enums.cpp" line="525"/>
-      <source>Hydraulic oil</source>
-      <translation type="unfinished">Huile hydraulique</translation>
-    </message>
-    <message id="tank_type_raw_water">
-      <location filename="../../src/enums.cpp" line="528"/>
-      <source>Raw water</source>
-      <translation type="unfinished">Eau non traitée</translation>
-    </message>
-    <message id="microgrid_mode_hybrid_droop">
-      <location filename="../../src/enums.cpp" line="539"/>
-      <source>Hybrid droop</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_following">
-      <location filename="../../src/enums.cpp" line="542"/>
-      <source>Grid-following</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_forming">
-      <location filename="../../src/enums.cpp" line="545"/>
-      <source>Grid-forming</source>
-      <translation type="unfinished"/>
-    </message>
     <message id="switchable_output_three_state_switch">
       <location filename="../../src/enums.cpp" line="421"/>
       <source>Three-state switch</source>
       <translation>Commutateur à trois états</translation>
-    </message>
-    <message id="switchable_output_fault">
-      <location filename="../../src/enums.cpp" line="464"/>
-      <source>Fault</source>
-      <translation type="unfinished">Défaillance</translation>
-    </message>
-    <message id="switchable_output_running">
-      <location filename="../../src/enums.cpp" line="468"/>
-      <source>Running</source>
-      <translation type="unfinished">En marche</translation>
-    </message>
-    <message id="switchable_output_trip_low_voltage">
-      <location filename="../../src/enums.cpp" line="481"/>
-      <source>Trip low voltage</source>
-      <translation type="unfinished">Désactivé</translation>
     </message>
     <message id="settings_modbus_tcp_unit_id_note">
       <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="41"/>
@@ -10272,281 +9083,1152 @@ Le dispositif GX ne peut contrôler qu'un seul groupe électrogène connecté et
       <source>Press to refresh</source>
       <translation>Appuyer pour actualiser</translation>
     </message>
-    <message id="temperature_type_unknown">
-      <location filename="../../data/EnvironmentInputs.qml" line="65"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Inconnu</translation>
-    </message>
-    <message id="brief_solar_yield">
-      <location filename="../../pages/BriefSidePanel.qml" line="24"/>
-      <source>Solar yield</source>
-      <translation type="unfinished">Production solaire</translation>
-    </message>
-    <message id="brief_dc_input">
-      <location filename="../../pages/BriefSidePanel.qml" line="214"/>
-      <source>DC input</source>
-      <translation type="unfinished">Entrée DC</translation>
-    </message>
-    <message id="brief_ac_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="257"/>
-      <source>AC Loads</source>
-      <translation type="unfinished">Charges CA</translation>
-    </message>
-    <message id="brief_dc_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="284"/>
-      <source>DC Loads</source>
-      <translation type="unfinished">Charges DC</translation>
-    </message>
-    <message id="nav_overview">
-      <location filename="../../pages/OverviewPage.qml" line="450"/>
-      <source>Overview</source>
-      <translation type="unfinished">Vue d'ensemble</translation>
-    </message>
-    <message id="settings_state">
-      <location filename="../../pages/settings/PageCanbusStatus.qml" line="116"/>
-      <source>State</source>
-      <translation type="unfinished">État</translation>
-    </message>
-    <message id="inverter_pv">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="56"/>
-      <source>PV</source>
-      <translation type="unfinished">PV</translation>
-    </message>
-    <message id="inverter_total_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="76"/>
-      <source>Total yield</source>
-      <translation type="unfinished">Production totale</translation>
-    </message>
-    <message id="inverter_system_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="84"/>
-      <source>System yield</source>
-      <translation type="unfinished">Champ système</translation>
-    </message>
-    <message id="charger_total_pv_power">
-      <location filename="../../pages/solar/SolarDevicePage.qml" line="61"/>
-      <source>Total PV Power</source>
-      <translation type="unfinished">Puissance PV totale</translation>
-    </message>
-    <message id="vebus_device_alarm_only">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
-      <source>Alarm only</source>
-      <translation type="unfinished">Alarme uniquement</translation>
-    </message>
-    <message id="vebus_device_alarms_and_warnings">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
-      <source>Alarms &amp; warnings</source>
-      <translation type="unfinished">Alarmes &amp; Avertissements</translation>
-    </message>
-    <message id="vebus_device_alarm_group_warning">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
-      <source>Warning</source>
-      <translation type="unfinished">Avertissement</translation>
-    </message>
-    <message id="load_delegate_status">
-      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
-      <source>Status: %1</source>
-      <translation type="unfinished"/>
+    <message id="common_words_total_power">
+      <location filename="../../components/CommonWords.qml" line="540"/>
+      <source>Total power</source>
+      <translation>Puissance totale</translation>
     </message>
     <message id="venus_os_gui">
       <location filename="../../Main.qml" line="17"/>
       <source>Venus OS GUI</source>
       <extracomment>Application title</extracomment>
-      <translation type="unfinished"/>
       <extra-Context>only shown on desktop systems</extra-Context>
+      <translation>Interface graphique Venus OS</translation>
+    </message>
+    <message id="load_delegate_status">
+      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
+      <source>Status: %1</source>
+      <translation>État : %1</translation>
+    </message>
+    <message id="settings_relay_polarity_relay1">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
+      <source>Polarity (Relay 1)</source>
+      <translation>Polarité (Relais 1)</translation>
+    </message>
+    <message id="settings_relay_polarity">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
+      <source>Polarity</source>
+      <translation>Polarité</translation>
+    </message>
+    <message id="settings_relay_polarity_relay2">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
+      <source>Polarity (Relay 2)</source>
+      <translation>Polarité (Relais 2)</translation>
+    </message>
+    <message id="page_settings_wifi_invalid_password">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
+      <source>Password length must be either 0 or between 10 and 63 characters long</source>
+      <translation>La longueur du mot de passe doit être soit 0, soit comprise entre 10 et 63 caractères</translation>
+    </message>
+    <message id="page_settings_wifi_password_updated">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
+      <source>Password updated</source>
+      <translation>Mot de passe mis à jour</translation>
+    </message>
+    <message id="common_words_max">
+      <location filename="../../components/CommonWords.qml" line="315"/>
+      <source>Max</source>
+      <extracomment>Short for Maximum</extracomment>
+      <translation>Max.</translation>
+    </message>
+    <message id="common_words_min">
+      <location filename="../../components/CommonWords.qml" line="331"/>
+      <source>Min</source>
+      <extracomment>Short for Minimum</extracomment>
+      <translation>Min.</translation>
+    </message>
+    <message id="settings_ess_deprecated">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="321"/>
+      <source>Deprecated settings</source>
+      <translation>Paramètres obsolètes</translation>
+    </message>
+    <message id="settings_ess_max_charge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="328"/>
+      <source>Battery charge limit (% of CCL)</source>
+      <translation>Limite de charge de la batterie (% de CCL)</translation>
+    </message>
+    <message id="settings_ess_max_discharge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="339"/>
+      <source>Battery discharge limit (% of DCL)</source>
+      <translation>Limite de décharge de la batterie (% de DCL)</translation>
+    </message>
+    <message id="vebus_device_bms_message">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
+      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
+      <oldsource>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</oldsource>
+      <translation>Un VE.Bus BMS éteint automatiquement le système lorsque cela est nécessaire pour protéger la batterie. Il n'est donc pas possible de contrôler le système depuis l'appareil GX.</translation>
+    </message>
+    <message id="switchable_output_numeric_input">
+      <location filename="../../src/enums.cpp" line="418"/>
+      <source>Numeric input</source>
+      <translation>Saisie numérique</translation>
     </message>
     <message id="autotoggleswitch_disable_auto_mode_info">
       <location filename="../../components/controls/AutoToggleButton.qml" line="34"/>
       <source>Disable Auto mode first</source>
-      <translation type="unfinished"/>
+      <translation>Désactivez d'abord le mode Auto</translation>
+    </message>
+    <message id="pagesettingsintegrations_venus_os_enable_large_features">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
+      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
+      <translation>Activer le firmware Venus OS Large pour utiliser Node-RED ou Signal-K</translation>
+    </message>
+    <message id="settings_relays_sensors_tanks">
+      <location filename="../../pages/SettingsPage.qml" line="75"/>
+      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
+      <oldsource>Relays, Sensors, Tanks, PV Inverters, Modbus, MQTT…</oldsource>
+      <translation>Relais, capteurs, onduleurs PV, Modbus, Node-RED</translation>
+    </message>
+    <message id="vebus_device_page_microgrid_parameters">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
+      <source>Microgrid parameters</source>
+      <translation>Paramètres du micro-réseau</translation>
+    </message>
+    <message id="microgrid_mode_hybrid_droop">
+      <location filename="../../src/enums.cpp" line="539"/>
+      <source>Hybrid droop</source>
+      <translation>Affaissement hybride</translation>
+    </message>
+    <message id="microgrid_mode_grid_following">
+      <location filename="../../src/enums.cpp" line="542"/>
+      <source>Grid-following</source>
+      <translation>Suivi du réseau</translation>
+    </message>
+    <message id="microgrid_mode_grid_forming">
+      <location filename="../../src/enums.cpp" line="545"/>
+      <source>Grid-forming</source>
+      <translation>Formation de réseau</translation>
+    </message>
+    <message id="switchable_output_trip_low_voltage">
+      <location filename="../../src/enums.cpp" line="481"/>
+      <source>Trip low voltage</source>
+      <oldsource>Disabled</oldsource>
+      <translation>Déclenchement basse tension</translation>
     </message>
     <message id="microgrid">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="15"/>
       <source>Microgrid</source>
-      <translation type="unfinished"/>
+      <translation>Micro-réseau</translation>
     </message>
     <message id="page_microgrid_active_mode">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="19"/>
       <source>Active mode</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_microgrid_from_p1_to_p2">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="34"/>
-      <source>%1 %2 to %3 %4</source>
-      <extracomment>Describes a range from one quantity to another, e.g. "30 W to 60 W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
-      <translation type="unfinished"/>
+      <translation>Mode actif</translation>
     </message>
     <message id="page_microgrid_hybrid_droop_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="92"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
       <source>Hybrid droop parameters</source>
-      <translation type="unfinished"/>
+      <translation>Paramètres d'affaissement hybride</translation>
     </message>
     <message id="page_microgrid_reference_active_power_p0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="105"/>
       <source>Reference active power (P&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Puissance active de référence (P&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_frequency_f0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="108"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="112"/>
       <source>Reference frequency (f&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Fréquence de référence (f&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_frequency_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="117"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="119"/>
       <source>Frequency droop slope (droop&lt;sub&gt;fP&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Pente d'affaissement de fréquence (droop&lt;sub&gt;fP&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_reactive_power">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="126"/>
       <source>Reference reactive power (Q&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Puissance réactive de référence (Q&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_voltage">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="135"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="133"/>
       <source>Reference Voltage (U&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Tension de référence (U&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_voltage_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="144"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="140"/>
       <source>Voltage droop slope (droop&lt;sub&gt;UQ&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Pente d'affaissement de tension (droop&lt;sub&gt;UQ&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_minimum_and_maximum_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="146"/>
       <source>Minimum and maximum parameters</source>
-      <translation type="unfinished"/>
+      <translation>Paramètres minimum et maximum</translation>
     </message>
     <message id="page_microgrid_allowed_active_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="156"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
       <source>Allowed active power range</source>
-      <translation type="unfinished"/>
+      <translation>Plage de puissance active autorisée</translation>
     </message>
     <message id="page_microgrid_allowed_reactive_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="164"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="159"/>
       <source>Allowed reactive power range</source>
-      <translation type="unfinished"/>
+      <translation>Plage de puissance réactive autorisée</translation>
     </message>
     <message id="page_microgrid_p_q_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="176"/>
       <source>P-Q direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>Paramètres d'entraînement direct P-Q</translation>
     </message>
     <message id="page_microgrid_active_power_setpoint_p">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="186"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
       <source>Active power setpoint (P)</source>
-      <translation type="unfinished"/>
+      <translation>Consigne de puissance active (P)</translation>
     </message>
     <message id="page_microgrid_reactive_power_setpoint_q">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="194"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="188"/>
       <source>Reactive power setpoint (Q)</source>
-      <translation type="unfinished"/>
+      <translation>Consigne de puissance réactive (Q)</translation>
     </message>
     <message id="page_microgrid_allowed_frequency_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="202"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="195"/>
       <source>Allowed frequency range</source>
-      <translation type="unfinished"/>
+      <translation>Plage de fréquences autorisée</translation>
     </message>
     <message id="page_microgrid_allowed_voltage_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="210"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="203"/>
       <source>Allowed voltage range</source>
-      <translation type="unfinished"/>
+      <translation>Plage de tensions autorisée</translation>
     </message>
     <message id="page_microgrid_v_f_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="227"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="220"/>
       <source>V-f direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>Paramètres d'entraînement direct V-f</translation>
     </message>
     <message id="page_microgrid_voltage_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="225"/>
       <source>Voltage setpoint (U)</source>
-      <translation type="unfinished"/>
+      <translation>Consigne de tension (U)</translation>
     </message>
     <message id="page_microgrid_frequency_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="240"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
       <source>Frequency setpoint (f)</source>
-      <translation type="unfinished"/>
+      <translation>Consigne de fréquence (f)</translation>
     </message>
-    <message id="temperature_slider_current">
-      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
-      <source>Current</source>
-      <extracomment>The current temperature measurement</extracomment>
-      <translation type="unfinished">Courant</translation>
+    <message id="pagesettingsintegrations_canopenmotordrive">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
+      <source>CANopen motor drives</source>
+      <translation>Entraînements de moteur CANopen</translation>
+    </message>
+    <message id="pagesettingsintegrations_ui_plugins">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
+      <source>UI Plugins</source>
+      <translation>Plugins de l'interface utilisateur</translation>
+    </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
+      <source>Motor Direction Inverted</source>
+      <translation>Direction du moteur inversée</translation>
     </message>
     <message id="page_settings_canopenmotordrive_scan_for_motor_drives">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="31"/>
       <source>Scan for motor drives</source>
-      <translation type="unfinished"/>
+      <translation>Rechercher les entraînements de moteur</translation>
     </message>
     <message id="page_settings_canopenmotordrive_discovered_motor_drive_ids">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="39"/>
       <source>Discovered motor drive IDs</source>
-      <translation type="unfinished"/>
+      <translation>ID des entraînements de moteur découverts</translation>
     </message>
-    <message id="switchableoutput_gx_device_relays">
-      <location filename="../../src/switchableoutput.cpp" line="388"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">Relais de l'appareil GX</translation>
+    <message id="temperature_pm25">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
+      <source>PM2.5</source>
+      <translation>PM2.5</translation>
     </message>
-    <message id="gx_device_relays">
-      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">Relais de l'appareil GX</translation>
+    <message id="temperature_co2">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+      <source>CO₂</source>
+      <translation>CO₂</translation>
     </message>
-    <message id="color_preset">
-      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
-      <source>Preset</source>
-      <translation type="unfinished"/>
+    <message id="temperature_voc">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
+      <source>VOC index</source>
+      <translation>Indice COV</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_location">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
-      <source>Add Modbus port and unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_nox">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
+      <source>NOx index</source>
+      <translation>Indice NOx</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_unitid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
-      <source>Unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_luminosity">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
+      <source>Luminosity</source>
+      <translation>Luminosité</translation>
     </message>
-    <message id="page_settings_fronius_unitid_invalid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation type="unfinished">%1 n'est pas un numéro d'unité valide. Utilisez un nombre compris entre 1 et 247.</translation>
-    </message>
-    <message id="page_settings_fronius_add_modbus_location_button">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
-      <source>Add</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_locations_note">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
-      <source>The default modbus port is 502 and the default unit ID is 126.
-Here you can add additional ports and unit IDs to scan for PV inverters.</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_location_number">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
-      <source>Port/Unit ID %1</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location_description">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
-      <source>Port: %1 (Unit %2)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
-      <source>Remove Modbus port and unit ID?</source>
-      <translation type="unfinished"/>
+    <message id="switchable_output_bypassed">
+      <location filename="../../src/enums.cpp" line="484"/>
+      <source>Bypassed</source>
+      <translation>Contourné</translation>
     </message>
     <message id="switchableoutput_list_delegate_auto_status">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="84"/>
       <source>Auto (%1)</source>
       <extracomment>%1 = 'On' or 'Off'</extracomment>
-      <translation type="unfinished"/>
+      <translation>Auto (%1)</translation>
     </message>
     <message id="switchableoutput_list_delegate_state_forced">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="100"/>
       <source>Forced</source>
-      <translation type="unfinished"/>
+      <translation>Forcé</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_settings">
+      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
+      <source>Modbus port and unit ID settings</source>
+      <translation>Paramètres du port Modbus et de l'ID d'unité</translation>
+    </message>
+    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
+      <source>Integrates with the device list</source>
+      <translation>S'intègre à la liste des appareils</translation>
+    </message>
+    <message id="common_words_color">
+      <location filename="../../components/CommonWords.qml" line="136"/>
+      <source>Color</source>
+      <translation>Couleur</translation>
+    </message>
+    <message id="common_words_value_must_be_greater_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="557"/>
+      <source>Value must be greater than start value</source>
+      <translation>La valeur doit être supérieure à la valeur de début</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="566"/>
+      <source>Value must be lower than stop value</source>
+      <translation>La valeur doit être inférieure à la valeur de fin</translation>
+    </message>
+    <message id="notifications_page_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="43"/>
+      <source>Active Notifications</source>
+      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
+      <translation>Notifications actives</translation>
+    </message>
+    <message id="notifications_page_inactive_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="47"/>
+      <source>Inactive Notifications</source>
+      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
+      <translation>Notifications inactives</translation>
+    </message>
+    <message id="notifications_no_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="106"/>
+      <source>No active notifications</source>
+      <translation>Aucune notification active</translation>
+    </message>
+    <message id="switchable_output_rgb_color_wheel">
+      <location filename="../../src/enums.cpp" line="427"/>
+      <source>RGB color wheel</source>
+      <translation>Roue chromatique RVB</translation>
+    </message>
+    <message id="switchable_output_cct_color_wheel">
+      <location filename="../../src/enums.cpp" line="431"/>
+      <source>CCT color wheel</source>
+      <extracomment>Correlated Color Temperature color wheel</extracomment>
+      <translation>Roue chromatique CCT</translation>
+    </message>
+    <message id="switchable_output_rgbw_color_wheel">
+      <location filename="../../src/enums.cpp" line="435"/>
+      <source>RGB + W color wheel</source>
+      <extracomment>RGB + white color wheel</extracomment>
+      <translation>Roue chromatique RVB + B</translation>
+    </message>
+    <message id="listlink_show_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="43"/>
+      <source>Show QR code</source>
+      <translation>Afficher le code QR</translation>
+    </message>
+    <message id="listlink_scan_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="52"/>
+      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
+      <extracomment>%1 = url text</extracomment>
+      <oldsource>Scan the QR code with your portable device.&lt;br /&gt;Or insert the link: %1</oldsource>
+      <translation>Ouvrez le code QR pour le scanner avec votre appareil portable.&lt;br /&gt;Ou insérez le lien : %1</translation>
+    </message>
+    <message id="color_preset">
+      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
+      <source>Preset</source>
+      <translation>Préréglage</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
+      <source>Add Modbus port and unit ID</source>
+      <translation>Ajouter un port Modbus et un ID d'unité</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_unitid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
+      <source>Unit ID</source>
+      <translation>ID d'unité</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location_button">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
+      <source>Add</source>
+      <translation>Ajouter</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_locations_note">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
+      <source>The default modbus port is 502 and the default unit ID is 126.
+Here you can add additional ports and unit IDs to scan for PV inverters.</source>
+      <translation>Le port Modbus par défaut est 502 et l'ID d'unité par défaut est 126.
+Ici, vous pouvez ajouter des ports et des ID d'unité supplémentaires pour rechercher les onduleurs PV.</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_location_number">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
+      <source>Port/Unit ID %1</source>
+      <translation>Port/ID d'unité %1</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location_description">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
+      <source>Port: %1 (Unit %2)</source>
+      <translation>Port : %1 (Unité %2)</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
+      <source>Remove Modbus port and unit ID?</source>
+      <translation>Supprimer le port Modbus et l'ID d'unité ?</translation>
+    </message>
+    <message id="devicelist_tankshape_edit_point">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="182"/>
+      <source>Edit point %1</source>
+      <extracomment>%1 = which point is being edited, a number like "1" or "2"</extracomment>
+      <translation></translation>
+    </message>
+    <message id="settings_canbus_vecan">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
+      <source>VE.Can (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_250">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <source>VE.Can &amp; CANopen E-drive (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_500">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
+      <source>CANopen E-drive (500 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="page_microgrid_from_p1_to_p2">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="39"/>
+      <source>%1%2 to %3%4</source>
+      <extracomment>Describes a range from one quantity to another, e.g. "30W to 60W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
+      <translation></translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAfricaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
+      <source>Morocco Standard Time</source>
+      <translation>Heure standard Maroc</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
+      <source>W. Central Africa Standard Time</source>
+      <translation>Heure standard Afrique centrale ouest</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
+      <source>South Africa Standard Time</source>
+      <translation>Heure standard Afrique du sud</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
+      <source>Namibia Standard Time</source>
+      <translation>Heure standard Namibie</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
+      <source>Egypt Standard Time</source>
+      <translation>Heure standard Égypte</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
+      <source>E. Africa Standard Time</source>
+      <translation>Heure standard Afrique de l'est</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAmericaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
+      <source>Argentina Standard Time</source>
+      <translation>Heure standard Argentine</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
+      <source>E. South America Standard Time</source>
+      <translation>Heure standard Est Amérique du  sud</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
+      <source>Greenland Standard Time</source>
+      <translation>Heure standard Groenland</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
+      <source>Montevideo Standard Time</source>
+      <translation>Heure standard Montevideo</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
+      <source>Newfoundland Standard Time</source>
+      <translation>Heure standard Terre-Neuve-et-Labrador</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
+      <source>SA Eastern Standard Time</source>
+      <translation>Heure standard AS de l'est</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
+      <source>Atlantic Standard Time</source>
+      <translation>Heure standard Atlantique</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
+      <source>Central Brazilian Standard Time</source>
+      <translation>Heure standard Brésil centre</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>Heure standard Pacifique Asie du sud</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
+      <source>Paraguay Standard Time</source>
+      <translation>Heure standard Paraguay</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
+      <source>SA Western Standard Time</source>
+      <translation>Heure standard AS de l'ouest</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
+      <source>Venezuela Standard Time</source>
+      <translation>Heure standard Venezuela</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
+      <source>Eastern Standard Time</source>
+      <translation>Heure standard de l'est</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
+      <source>SA Pacific Standard Time</source>
+      <translation>Heure standard Pacifique AS</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
+      <source>US Eastern Standard Time</source>
+      <translation>Heure standard É-U de l'est</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
+      <source>Canada Central Standard Time</source>
+      <translation>Heure standard Canada centre</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
+      <source>Central America Standard Time</source>
+      <translation>Heure standard Amérique centrale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
+      <source>Central Standard Time (Mexico)</source>
+      <translation>Heure standard du Centre (Mexique)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
+      <source>Central Standard Time</source>
+      <translation>Heure standard du Centre</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
+      <source>Mountain Standard Time (Mexico)</source>
+      <translation>Heure standard des Rocheuses (Mexique)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
+      <source>Mountain Standard Time</source>
+      <translation>Heure standard des Rocheuses</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
+      <source>US Mountain Standard Time</source>
+      <translation>Heure standard montagne É-U</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
+      <source>Pacific Standard Time (Mexico)</source>
+      <translation>Heure standard Pacifique (Mexique)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
+      <source>Pacific Standard Time</source>
+      <translation>Heure standard Pacifique</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
+      <source>Alaskan Standard Time</source>
+      <translation>Heure standard Alaska</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
+      <source>Hawaii-Aleutian</source>
+      <translation>Hawaii-Aléoutien</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
+      <source>Atlantic Daylight Time</source>
+      <translation>Heure d'été de l'Atlantique</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAntarcticaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+      <source>New Zealand Standard Time</source>
+      <translation>Heure standard Nouvelle Zélande</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>Heure standard Pacifique centre</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+      <source>West Pacific Standard Time</source>
+      <translation>Heure standard Pacifique de l'ouest</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+      <source>W. Australia Standard Time</source>
+      <translation>Heure standard Australie de l'ouest</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+      <source>SE Asia Standard Time</source>
+      <translation>Heure standard Asie S-E</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+      <source>Central Asia Standard Time</source>
+      <translation>Heure standard Asie centrale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+      <source>West Asia Standard Time</source>
+      <translation>Heure standard Asie de l'ouest</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+      <source>E. Africa Standard Time</source>
+      <translation>Heure standard Afrique de l'est</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>Heure standard Pacifique Asie du sud</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+      <source>SA Western Standard Time</source>
+      <translation>Heure standard AS de l'ouest</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzArcticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
+      <source>W. Europe Standard Time</source>
+      <translation>Heure standard Europe de l'ouest</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAsiaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
+      <source>Kamchatka Standard Time</source>
+      <translation>Heure standard Kamchatka</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
+      <source>Magadan Standard Time</source>
+      <translation>Heure standard Magadan</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
+      <source>Vladivostok Standard Time</source>
+      <translation>Heure standard Vladivostok</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
+      <source>Yakutsk Standard Time</source>
+      <translation>Heure standaard Yakoutsk</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
+      <source>Tokyo Standard Time</source>
+      <translation>Heure standard Tokyo</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
+      <source>Korea Standard Time</source>
+      <translation>Heure standard Corée</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
+      <source>Singapore Standard Time</source>
+      <translation>Heure standard Singapour</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
+      <source>Ulaanbaatar Standard Time</source>
+      <translation>Heure standard Oulanbator</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
+      <source>Taipei Standard Time</source>
+      <translation>Heure standard Taïpei</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
+      <source>North Asia East Standard Time</source>
+      <translation>Heure standard Nord Asie de l'Est</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
+      <source>China Standard Time</source>
+      <translation>Heure standard Chine</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
+      <source>SE Asia Standard Time</source>
+      <translation>Heure standard Asie S-E</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
+      <source>North Asia Standard Time</source>
+      <translation>Heure standard Asie du nord</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
+      <source>Myanmar Standard Time</source>
+      <translation>Heure standard Myanmar</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
+      <source>N. Central Asia Standard Time</source>
+      <translation>Heure standard Asie centrale du N</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
+      <source>Central Asia Standard Time</source>
+      <translation>Heure standard Asie centrale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
+      <source>Bangladesh Standard Time</source>
+      <translation>Heure standard Bangladesh</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
+      <source>Nepal Standard Time</source>
+      <translation>Heure standard Népal</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
+      <source>Sri Lanka Standard Time</source>
+      <translation>Heure standard Sri Lanka</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
+      <source>India Standard Time</source>
+      <translation>Heure standar Inde</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
+      <source>West Asia Standard Time</source>
+      <translation>Heure standard Asie de l'ouest</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
+      <source>Pakistan Standard Time</source>
+      <translation>Heure standard Pakistan</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
+      <source>Ekaterinburg Standard Time</source>
+      <translation>Heure standard Ekaterinbourg</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
+      <source>Georgian Standard Time</source>
+      <translation>Heure standard Géorgie</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
+      <source>Caucasus Standard Time</source>
+      <translation>Heure standard Caucase</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
+      <source>Azerbaijan Standard Time</source>
+      <translation>Heure standard Azerbaïdjan</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
+      <source>Arabian Standard Time</source>
+      <translation>Heure standard d'Arabie</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
+      <source>Afghanistan Standard Time</source>
+      <translation>Heure standard Afghanistan</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
+      <source>Iran Standard Time</source>
+      <translation>Heure standard Iran</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
+      <source>Arabic Standard Time</source>
+      <translation>Heure standard arabe</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
+      <source>Arab Standard Time</source>
+      <translation>Heure standard arabe</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
+      <source>Syria Standard Time</source>
+      <translation>Heure standard Syrie</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
+      <source>Middle East Standard Time</source>
+      <translation>Heure standard Moyen-Orient</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
+      <source>Jordan Standard Time</source>
+      <translation>Heure standard Jordanie</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
+      <source>Israel Standard Time</source>
+      <translation>Heure standard Israël</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAtlanticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+      <source>Greenwich Standard Time</source>
+      <translation>Heure standard Greenwich</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+      <source>Azores Standard Time</source>
+      <translation>Heure standard Açores</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+      <source>Cape Verde Standard Time</source>
+      <translation>Heure standard Cap vert</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
+      <source>Mid-Atlantic Standard Time</source>
+      <translation>Heure standard Mid-Atlantic</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAustraliaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+      <source>Tasmania Standard Time</source>
+      <translation>Heure standard Tasmanie</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+      <source>E. Australia Standard Time</source>
+      <translation>Heure standard Australie de l'est</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+      <source>AUS Eastern Standard Time</source>
+      <translation>Heure standard AUS  de l'est</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+      <source>Cen. Australia Standard Time</source>
+      <translation>Heure standard Australie centrale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+      <source>AUS Central Standard Time</source>
+      <translation>Heure standard AUS  centrale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+      <source>W. Australia Standard Time</source>
+      <translation>Heure standard Australie de l'ouest</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEtcData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
+      <source>GMT +12</source>
+      <translation>GMT +12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
+      <source>GMT -02</source>
+      <translation>GMT -02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
+      <source>GMT -11</source>
+      <translation>GMT -11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
+      <source>GMT -13</source>
+      <translation>GMT -13</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
+      <source>GMT -12</source>
+      <translation>GMT -12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
+      <source>GMT -10</source>
+      <translation>GMT -10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
+      <source>GMT -09</source>
+      <translation>GMT -09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
+      <source>GMT -08</source>
+      <translation>GMT -08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
+      <source>GMT -07</source>
+      <translation>GMT -07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
+      <source>GMT -06</source>
+      <translation>GMT -06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
+      <source>GMT -05</source>
+      <translation>GMT -05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
+      <source>GMT -04</source>
+      <translation>GMT -04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
+      <source>GMT -03</source>
+      <translation>GMT -03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
+      <source>GMT -01</source>
+      <translation>GMT -01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
+      <source>GMT</source>
+      <translation>GMT</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
+      <source>GMT +01</source>
+      <translation>GMT +01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
+      <source>GMT +02</source>
+      <translation>GMT +02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
+      <source>GMT +03</source>
+      <translation>GMT +03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
+      <source>GMT +04</source>
+      <translation>GMT +04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
+      <source>GMT +05</source>
+      <translation>GMT +05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
+      <source>GMT +06</source>
+      <translation>GMT +06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
+      <source>GMT +07</source>
+      <translation>GMT +07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
+      <source>GMT +08</source>
+      <translation>GMT +08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
+      <source>GMT +09</source>
+      <translation>GMT +09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
+      <source>GMT +10</source>
+      <translation>GMT +10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
+      <source>GMT +11</source>
+      <translation>GMT +11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
+      <source>UTC</source>
+      <translation>UTC</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEuropeData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
+      <source>GMT Standard Time</source>
+      <translation>Temps standard GMT</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
+      <source>Central Europe Standard Time</source>
+      <translation>Temps standard Europe centrale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
+      <source>Central European Standard Time</source>
+      <translation>Temps standard européen central</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
+      <source>Romance Standard Time</source>
+      <translation>Temps standard europe centrale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
+      <source>W. Europe Standard Time</source>
+      <translation>Heure standard Europe de l'ouest</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
+      <source>E. Europe Standard Time</source>
+      <translation>Temps standard europe de l'est</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
+      <source>FLE Standard Time</source>
+      <translation>Temps standard FLE</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
+      <source>GTB Standard Time</source>
+      <translation>Temps standard GTB</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
+      <source>Belarus Standard Time</source>
+      <translation>Heure standard Biélorussie</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
+      <source>Russian Standard Time</source>
+      <translation>Heure standard Russie</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
+      <source>Turkey Standard Time</source>
+      <translation>Heure standard Turquie</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzIndianData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
+      <source>Mauritius Standard Time</source>
+      <translation>Heure standard Ile Maurice</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
+      <source>Christmas Island Standard Time</source>
+      <translation>Temps standard Ile Christmas</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzPacificData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
+      <source>Tonga Standard Time</source>
+      <translation>Heure standard Tonga</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
+      <source>Fiji Standard Time</source>
+      <translation>Heure standard Fidji</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
+      <source>New Zealand Standard Time</source>
+      <translation>Heure standard Nouvelle Zélande</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>Heure standard Pacifique centre</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
+      <source>West Pacific Standard Time</source>
+      <translation>Heure standard Pacifique de l'ouest</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
+      <source>Samoa Standard Time</source>
+      <translation>Heure standard Samoa</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
+      <source>Hawaiian Standard Time</source>
+      <translation>Heure standard Hawaï</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
+      <source>Easter Island Standard Time</source>
+      <translation>Temps standard Ile de Paques</translation>
     </message>
   </context>
   <context>
@@ -10995,7 +10677,7 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
     <message>
       <location filename="../../src/veutil/src/qt/charger_error.cpp" line="65"/>
       <source>BMS connection lost</source>
-      <translation>Connexion BLS perdue</translation>
+      <translation>Connexion BMS perdue</translation>
     </message>
     <message>
       <location filename="../../src/veutil/src/qt/charger_error.cpp" line="66"/>
@@ -12175,838 +11857,6 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
     </message>
   </context>
   <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>Heure standard Maroc</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>Heure standard Afrique centrale ouest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>Heure standard Afrique du sud</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>Heure standard Namibie</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>Heure standard Égypte</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Heure standard Afrique de l'est</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>Heure standard Argentine</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>Heure standard Est Amérique du  sud</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>Heure standard Groenland</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>Heure standard Montevideo</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>Heure standard Terre-Neuve-et-Labrador</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>Heure standard AS de l'est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Atlantic Standard Time</source>
-      <translation>Heure standard Atlantique</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>Heure standard Brésil centre</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Heure standard Pacifique Asie du sud</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>Paraguay Standard Time</source>
-      <translation>Heure standard Paraguay</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>SA Western Standard Time</source>
-      <translation>Heure standard AS de l'ouest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Venezuela Standard Time</source>
-      <translation>Heure standard Venezuela</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>Eastern Standard Time</source>
-      <translation>Heure standard de l'est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>Heure standard Pacifique AS</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>US Eastern Standard Time</source>
-      <translation>Heure standard É-U de l'est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Canada Central Standard Time</source>
-      <translation>Heure standard Canada centre</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central America Standard Time</source>
-      <translation>Heure standard Amérique centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>Heure standard du Centre (Mexique)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Central Standard Time</source>
-      <translation>Heure standard du Centre</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>Heure standard des Rocheuses (Mexique)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>Mountain Standard Time</source>
-      <translation>Heure standard des Rocheuses</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>US Mountain Standard Time</source>
-      <translation>Heure standard montagne É-U</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>Heure standard Pacifique (Mexique)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Pacific Standard Time</source>
-      <translation>Heure standard Pacifique</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Alaskan Standard Time</source>
-      <translation>Heure standard Alaska</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>Hawaii-Aléoutien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Daylight Time</source>
-      <translation>Heure d'été de l'Atlantique</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Heure standard Nouvelle Zélande</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Heure standard Pacifique centre</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Heure standard Pacifique de l'ouest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Heure standard Australie de l'ouest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Heure standard Asie S-E</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Heure standard Asie centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>Heure standard Asie de l'ouest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Heure standard Afrique de l'est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Heure standard Pacifique Asie du sud</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>Heure standard AS de l'ouest</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Heure standard Europe de l'ouest</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>Heure standard Kamchatka</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>Heure standard Magadan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>Heure standard Vladivostok</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>Heure standaard Yakoutsk</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>Heure standard Tokyo</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>Heure standard Corée</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>Heure standard Singapour</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>Heure standard Oulanbator</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>Heure standard Taïpei</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>Heure standard Nord Asie de l'Est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>Heure standard Chine</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Heure standard Asie S-E</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>Heure standard Asie du nord</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>Heure standard Myanmar</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>Heure standard Asie centrale du N</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Heure standard Asie centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>Heure standard Bangladesh</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>Heure standard Népal</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>Heure standard Sri Lanka</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>Heure standar Inde</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>Heure standard Asie de l'ouest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>Heure standard Pakistan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>Heure standard Ekaterinbourg</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>Heure standard Géorgie</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>Heure standard Caucase</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>Heure standard Azerbaïdjan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>Heure standard d'Arabie</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>Heure standard Afghanistan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>Heure standard Iran</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>Heure standard arabe</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>Heure standard arabe</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>Heure standard Syrie</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>Heure standard Moyen-Orient</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>Heure standard Jordanie</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>Heure standard Israël</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>Heure standard Greenwich</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>Heure standard Açores</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>Heure standard Cap vert</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>Heure standard Mid-Atlantic</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>Heure standard Tasmanie</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>Heure standard Australie de l'est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>Heure standard AUS  de l'est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>Heure standard Australie centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>Heure standard AUS  centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Heure standard Australie de l'ouest</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
-      <source>GMT +12</source>
-      <translation>GMT +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
-      <source>GMT -02</source>
-      <translation>GMT -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT -13</source>
-      <translation>GMT -13</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT -12</source>
-      <translation>GMT -12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -10</source>
-      <translation>GMT -10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -09</source>
-      <translation>GMT -09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>GMT -08</source>
-      <translation>GMT -08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
-      <source>GMT -07</source>
-      <translation>GMT -07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
-      <source>GMT -06</source>
-      <translation>GMT -06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
-      <source>GMT -05</source>
-      <translation>GMT -05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
-      <source>GMT -04</source>
-      <translation>GMT -04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
-      <source>GMT -03</source>
-      <translation>GMT -03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
-      <source>GMT -01</source>
-      <translation>GMT -01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
-      <source>GMT</source>
-      <translation>GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
-      <source>GMT +01</source>
-      <translation>GMT +01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
-      <source>GMT +02</source>
-      <translation>GMT +02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
-      <source>GMT +03</source>
-      <translation>GMT +03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
-      <source>GMT +04</source>
-      <translation>GMT +04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
-      <source>GMT +05</source>
-      <translation>GMT +05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
-      <source>GMT +06</source>
-      <translation>GMT +06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
-      <source>GMT +07</source>
-      <translation>GMT +07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
-      <source>GMT +08</source>
-      <translation>GMT +08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
-      <source>GMT +09</source>
-      <translation>GMT +09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
-      <source>GMT +10</source>
-      <translation>GMT +10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
-      <source>GMT +11</source>
-      <translation>GMT +11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
-      <source>UTC</source>
-      <translation>UTC</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>Temps standard GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>Temps standard Europe centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>Temps standard européen central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>Temps standard europe centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Heure standard Europe de l'ouest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>Temps standard europe de l'est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>Temps standard FLE</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>Temps standard GTB</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>Heure standard Biélorussie</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>Heure standard Russie</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>Heure standard Turquie</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>Heure standard Ile Maurice</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>Temps standard Ile Christmas</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>Heure standard Tonga</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>Heure standard Fidji</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Heure standard Nouvelle Zélande</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Heure standard Pacifique centre</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Heure standard Pacifique de l'ouest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>Heure standard Samoa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>Heure standard Hawaï</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>Temps standard Ile de Paques</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation type="unfinished">Erreur interne</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation type="unfinished"/>
-    </message>
-  </context>
-  <context>
     <name>Wakespeed</name>
     <message>
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
@@ -13142,7 +11992,7 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
     <message>
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="229"/>
       <source>BMS connection lost</source>
-      <translation>Connexion BLS perdue</translation>
+      <translation>Connexion BMS perdue</translation>
     </message>
     <message>
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="232"/>
@@ -13183,6 +12033,119 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
       <source>DC/DC misconfiguration</source>
       <translation>mauvaise configuration DC/DC</translation>
+    </message>
+  </context>
+  <context>
+    <name>VebusError</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+      <source>Device switched off</source>
+      <translation>Appareil éteint</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+      <source>Mixed old/new MK2</source>
+      <translation>Ancien/nouveau MK2 mélangés</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+      <source>Expected devices error</source>
+      <translation>Erreur d'appareils attendus</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+      <source>No other device detected</source>
+      <translation>Aucun autre appareil détecté</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+      <source>Overvoltage on AC-out</source>
+      <translation>Surtension sur la sortie CA</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+      <source>DDC program error</source>
+      <translation>Erreur du programme DDC</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+      <source>VE.Bus BMS without assistant</source>
+      <translation>VE.Bus BMS sans assistant</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+      <source>Ground relay test failed</source>
+      <translation>Test du relais de terre échoué</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+      <source>System time sync error</source>
+      <translation>Erreur de synchronisation de l'heure système</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+      <source>Grid relay test fault</source>
+      <translation>Défaut du test du relais de réseau</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+      <source>Config mismatch with 2nd mcu</source>
+      <translation>Incompatibilité de configuration avec le 2ème microcontrôleur</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+      <source>Device transmit error</source>
+      <translation>Erreur de transmission de l'appareil</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+      <source>Awaiting configuration or dongle missing</source>
+      <translation>En attente de configuration ou dongle manquant</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+      <source>Phase master missing</source>
+      <translation>Phase maître manquante</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+      <source>Overvoltage has occurred</source>
+      <translation>Une surtension s'est produite</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+      <source>Slave does not have AC input!</source>
+      <translation>L'esclave n'a pas d'entrée CA !</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+      <source>Device can't be slave</source>
+      <translation>L'appareil ne peut pas être esclave</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+      <source>System protection initiated</source>
+      <translation>Protection du système initiée</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+      <source>Firmware incompatibiltiy</source>
+      <translation>Incompatibilité du micrologiciel</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+      <source>Internal error</source>
+      <translation>Erreur interne</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+      <source>Failing relay test prevents connection</source>
+      <translation>L'échec du test du relais empêche la connexion</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+      <source>VE.Bus error</source>
+      <translation>Erreur VE.Bus</translation>
     </message>
   </context>
 </TS>

--- a/i18n/venus-gui-v2_it.ts
+++ b/i18n/venus-gui-v2_it.ts
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="it">
   <context>
-    <name/>
+    <name></name>
     <message id="switchable_output_disabled">
       <location filename="../../src/enums.cpp" line="478"/>
       <source>Disabled</source>
@@ -22,6 +22,7 @@
     <message id="solarchargers_state_off">
       <location filename="../../src/enums.cpp" line="331"/>
       <source>Off</source>
+      <extracomment>Digital input state</extracomment>
       <translation>Spento</translation>
     </message>
     <message id="common_words_auto">
@@ -52,18 +53,25 @@
     <message id="settings_startpage_none">
       <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
       <source>None</source>
+      <extracomment>Indicates no phase</extracomment>
       <translation>Nessuno</translation>
     </message>
     <message id="common_words_position_ac">
       <location filename="../../components/CommonWords.qml" line="416"/>
       <source>Position</source>
-      <extracomment>AC input or output position</extracomment>
+      <extracomment>EVCS AC input/output position</extracomment>
       <translation>Posizione</translation>
     </message>
     <message id="settings_minmax_speed">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="193"/>
       <source>Speed</source>
+      <extracomment>A speed measurement value</extracomment>
       <translation>Velocità</translation>
+    </message>
+    <message id="common_words_state">
+      <location filename="../../components/CommonWords.qml" line="502"/>
+      <source>State</source>
+      <translation>Stato</translation>
     </message>
     <message id="settings_firmware_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="67"/>
@@ -101,8 +109,8 @@
       <source>Solar yield</source>
       <translation>Rendimento solare</translation>
     </message>
-    <message id="ess_state_external_control">
-      <location filename="../../data/Ess.qml" line="41"/>
+    <message id="inverters_state_externalccontrol">
+      <location filename="../../data/System.qml" line="183"/>
       <source>External control</source>
       <translation>Controllo esterno</translation>
     </message>
@@ -140,6 +148,11 @@
       <location filename="../../components/CommonWords.qml" line="203"/>
       <source>ESS</source>
       <translation>ESS</translation>
+    </message>
+    <message id="pagesettingsconnectivity_ethernet">
+      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
+      <source>Ethernet</source>
+      <translation>Ethernet</translation>
     </message>
     <message id="pagesettingsconnectivity_wifi">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="28"/>
@@ -262,11 +275,6 @@
       <source>Name</source>
       <translation>Nome</translation>
     </message>
-    <message id="settings_deviceinfo_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="38"/>
-      <source>Name</source>
-      <translation type="unfinished">Nome</translation>
-    </message>
     <message id="settings_deviceinfo_product_id">
       <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
       <source>Product ID</source>
@@ -327,15 +335,20 @@
       <source>Daily run time</source>
       <translation>Tempo di funzionamento giornaliero</translation>
     </message>
+    <message id="common_words_value_must_be_greater_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="560"/>
+      <source>Value must be greater than stop value</source>
+      <translation>Il valore deve essere maggiore di quello di arresto</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="563"/>
+      <source>Value must be lower than start value</source>
+      <translation>Il valore deve essere inferiore a quello di avvio</translation>
+    </message>
     <message id="settings_minmax_acout_max_power">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="124"/>
       <source>AC output</source>
       <translation>Uscita CA</translation>
-    </message>
-    <message id="ac_output">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="15"/>
-      <source>AC output</source>
-      <translation type="unfinished">Uscita CA</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
       <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="25"/>
@@ -382,16 +395,6 @@
       <source>Unavailable monitor, set another</source>
       <translation>Monitor non disponibile, impostarne un altro</translation>
     </message>
-    <message id="page_generator_conditions_battery_monitor">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="42"/>
-      <source>Battery monitor</source>
-      <translation type="unfinished">Monitor batteria</translation>
-    </message>
-    <message id="page_generator_conditions_unavailable_monitor_set_another">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="44"/>
-      <source>Unavailable monitor, set another</source>
-      <translation type="unfinished">Monitor non disponibile, impostarne un altro</translation>
-    </message>
     <message id="page_generator_conditions_on_loss_of_communication">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="68"/>
       <source>On loss of communication</source>
@@ -416,11 +419,6 @@
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="105"/>
       <source>Battery SOC</source>
       <translation>SoC Batteria</translation>
-    </message>
-    <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="173"/>
-      <source>Periodic run</source>
-      <translation type="unfinished">Funzionamento periodico</translation>
     </message>
     <message id="settings_inverter_high_temperature">
       <location filename="../../data/Generators.qml" line="83"/>
@@ -505,7 +503,7 @@
     <message id="settings_gps_speed_kmh">
       <location filename="../../pages/settings/PageGps.qml" line="83"/>
       <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometres per hour</extracomment>
+      <extracomment>GPS speed data, in kilometers per hour</extracomment>
       <translation>%1 km/h</translation>
     </message>
     <message id="settings_gps_speed_mph">
@@ -523,7 +521,7 @@
     <message id="settings_gps_speed_ms">
       <location filename="../../pages/settings/PageGps.qml" line="95"/>
       <source>%1 m/s</source>
-      <extracomment>GPS speed data, in metres per second</extracomment>
+      <extracomment>GPS speed data, in meters per second</extracomment>
       <translation>%1 m/s</translation>
     </message>
     <message id="settings_gps_course">
@@ -580,21 +578,6 @@
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="64"/>
       <source>%1 (Output %2)</source>
       <translation>%1 (Uscita %2)</translation>
-    </message>
-    <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">Monitoraggio attivo batteria</translation>
-    </message>
-    <message id="settings_batteries_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="101"/>
-      <source>Name</source>
-      <translation type="unfinished">Nome</translation>
-    </message>
-    <message id="settings_batteries_enter_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="103"/>
-      <source>Enter name</source>
-      <translation type="unfinished">Inserire nome</translation>
     </message>
     <message id="settings_briefview_center_active_battery_monitor">
       <location filename="../../components/listitems/ListBriefCenterDetails.qml" line="27"/>
@@ -656,45 +639,25 @@
       <source>CAN-bus profile</source>
       <translation>Profilo CAN-bus</translation>
     </message>
-    <message id="settings_disabled">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="31"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Disattivato</translation>
-    </message>
-    <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can e Lynx Ion BMS (250 kbit/s)</translation>
-    </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
       <location filename="../../pages/settings/CanbusProfile.qml" line="42"/>
       <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
       <translation>VE.Can e CAN-bus BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
       <source>Oceanvolt (250 kbit/s)</source>
       <translation>Oceanvolt (250 kbit/s)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
       <source>RV-C (250 kbit/s)</source>
       <translation>RV-C (250 kbit/s)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
       <source>Up, but no services (250 kbit/s)</source>
       <translation>Attivo, ma senza servizi (250 kbit/s)</translation>
-    </message>
-    <message id="settings_canopen_motordrive_250">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
-      <source>CANopen Motor drive (250 kbit/s)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_canopen_motordrive_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
-      <source>CANopen Motor drive (500 kbit/s)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_devices">
       <location filename="../../components/CommonWords.qml" line="166"/>
@@ -731,11 +694,6 @@
       <source>Check Unique id numbers</source>
       <translation>Controlla numeri ID unici</translation>
     </message>
-    <message id="settings_canbus_unique_id_press_to_check">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Press to check</source>
-      <translation type="unfinished">Premere per verificare</translation>
-    </message>
     <message id="settings_canbus_unique_id_conflict">
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="125"/>
       <source>There is another device connected with this unique number, please select a new number.</source>
@@ -745,11 +703,6 @@
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="133"/>
       <source>OK: No other device is connected with this unique number.</source>
       <translation>OK: Non ci sono altri dispositivi collegati con questo numero unico.</translation>
-    </message>
-    <message id="pagesettingsintegrations_canopenmotordrive">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
-      <source>CANopen motor drives</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_network_status">
       <location filename="../../components/CommonWords.qml" line="349"/>
@@ -884,11 +837,6 @@
       <source>Unavailable sensor, set another</source>
       <translation>Sensore non disponibile, impostarne un altro</translation>
     </message>
-    <message id="settings_system_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="81"/>
-      <source>Unavailable sensor, set another</source>
-      <translation type="unfinished">Sensore non disponibile, impostarne un altro</translation>
-    </message>
     <message id="settings_dvcc_used_sensor">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="120"/>
       <source>Used sensor</source>
@@ -945,12 +893,6 @@
       <source>Auto selected</source>
       <translation>Auto-selezionato</translation>
     </message>
-    <message id="settings_dvcc_auto_selected_none">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="208"/>
-      <source>None</source>
-      <extracomment>Indicates no option is selected</extracomment>
-      <translation type="unfinished">Nessuno</translation>
-    </message>
     <message id="settings_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
       <source>Build date/time</source>
@@ -986,12 +928,6 @@
       <source>Installing %1</source>
       <extracomment>%1 = firmware version</extracomment>
       <translation>Installazione in corso %1</translation>
-    </message>
-    <message id="settings_firmware_offline_press_to_install">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">Premere per aggiornare a %1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="90"/>
@@ -1062,12 +998,6 @@
       <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
       <translation>Installazione in corso %1 %2%</translation>
     </message>
-    <message id="settings_firmware_online_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="86"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">Installazione in corso %1...</translation>
-    </message>
     <message id="settings_firmware_update_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="109"/>
       <source>Update build date/time</source>
@@ -1097,11 +1027,6 @@
       <location filename="../../pages/settings/PageSettingsFronius.qml" line="56"/>
       <source>TCP port</source>
       <translation>Porta TCP</translation>
-    </message>
-    <message id="page_settings_fronius_modbus_settings">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
-      <source>Modbus port and unit ID settings</source>
-      <translation type="unfinished"/>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
       <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
@@ -1153,16 +1078,6 @@
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="64"/>
       <source>AC-Out MP</source>
       <translation>AC-Out MP</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="52"/>
-      <source>AC-In1 L%1</source>
-      <translation type="unfinished">AC-In1 L%1</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="56"/>
-      <source>AC-In1 --</source>
-      <translation type="unfinished">AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="70"/>
@@ -1330,12 +1245,6 @@
       <source>Reset service timer</source>
       <translation>Ripristino timer di servizio</translation>
     </message>
-    <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
-      <source>Volume</source>
-      <extracomment>Title for a list of units of volume (e.g. cubic metres, litres, gallons)</extracomment>
-      <translation type="unfinished">Volume</translation>
-    </message>
     <message id="settings_gps_format">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="69"/>
       <source>Format</source>
@@ -1438,42 +1347,6 @@ Se ciò non funziona, verificare la sim-card del cellulare, per assicurarsi di a
       <source>Wrong PIN</source>
       <translation>PIN errato</translation>
     </message>
-    <message id="page_settings_gsm_ok">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>OK</source>
-      <translation type="unfinished">Ok</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="128"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">Errore sconosciuto</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_state">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="153"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Sconosciuto</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_value">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="182"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Sconosciuto</translation>
-    </message>
-    <message id="page_settings_gsm_offline">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="173"/>
-      <source>Offline</source>
-      <translation type="unfinished">Offline</translation>
-    </message>
-    <message id="page_settings_gsm_connecting">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="176"/>
-      <source>Connecting</source>
-      <translation type="unfinished">Collegamento in corso</translation>
-    </message>
-    <message id="page_settings_gsm_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="179"/>
-      <source>Connected</source>
-      <translation type="unfinished">Connesso</translation>
-    </message>
     <message id="page_settings_gsm_pin">
       <location filename="../../pages/settings/PageSettingsGsm.qml" line="191"/>
       <source>PIN</source>
@@ -1530,32 +1403,32 @@ Se ciò non funziona, verificare la sim-card del cellulare, per assicurarsi di a
       <translation>Misurazioni di rete</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
       <source>External meter</source>
       <translation>Contatore esterno</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="67"/>
       <source>Inverter/Charger</source>
       <translation>Inverter/Caricabatterie</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
       <source>Multiphase regulation</source>
       <translation>Regolazione multifase</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="91"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
       <source>Total of all phases</source>
       <translation>Totale di tutte le fasi</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="95"/>
       <source>Individual phase</source>
       <translation>Fase singola</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="99"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="101"/>
       <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
@@ -1564,68 +1437,13 @@ CAUTION: Use only if required by the utility provider.</source>
 ATTENZIONE: Utilizzare solo se richiesto dal fornitore di servizi.</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="104"/>
       <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
       <translation>Il totale di tutte le fasi è regolato in modo intelligente per raggiungere il valore di riferimento della rete (l'efficienza del sistema è ottimizzata).
 
 Utilizzare se non è vietato dal gestore della rete</translation>
-    </message>
-    <message id="settings_ess_min_soc">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation type="unfinished">SOC minima di scarico (a meno fallimento griglia)</translation>
-    </message>
-    <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="129"/>
-      <source>Active SOC limit</source>
-      <translation type="unfinished">Limite SoC attivo</translation>
-    </message>
-    <message id="settings_ess_battery_life_sustain">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
-      <source>Sustain</source>
-      <translation type="unfinished">Supporto</translation>
-    </message>
-    <message id="settings_ess_battery_life_recharge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="157"/>
-      <source>Recharge</source>
-      <translation type="unfinished">Caricamento</translation>
-    </message>
-    <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <source>Scheduled charge levels</source>
-      <translation type="unfinished">Livelli di carica programmati</translation>
-    </message>
-    <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="257"/>
-      <source>Active (%1)</source>
-      <translation type="unfinished">Attivo (%1)</translation>
-    </message>
-    <message id="settings_ess_inactive">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="259"/>
-      <source>Inactive</source>
-      <translation type="unfinished">Inattivo</translation>
-    </message>
-    <message id="settings_ess_dynamic">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="293"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">ESS dinamico</translation>
-    </message>
-    <message id="settings_ess_deprecated">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="319"/>
-      <source>Deprecated settings</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_charge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="326"/>
-      <source>Battery charge limit (% of CCL)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_discharge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="337"/>
-      <source>Battery discharge limit (% of DCL)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_rs_ess_min_soc">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="40"/>
@@ -1637,13 +1455,8 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <source>Active SOC limit</source>
       <translation>Limite SoC attivo</translation>
     </message>
-    <message id="scheduled_charge_inactive">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
-      <source>Inactive</source>
-      <translation type="unfinished">Inattivo</translation>
-    </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="245"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="247"/>
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
       <source>Peak shaving</source>
       <translation>Riduzione dei picchi</translation>
@@ -1659,12 +1472,12 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <translation>Sempre</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="151"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
       <source>Discharge disabled</source>
       <translation>Scarica disattivata</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
       <source>Slow charge</source>
       <translation>Carica lenta</translation>
     </message>
@@ -1679,32 +1492,32 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <translation>Caricamento</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="165"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="167"/>
       <source>Limit charge power</source>
       <translation>Limite potenza di carica</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="183"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="185"/>
       <source>Maximum charge power</source>
       <translation>Potenza di carica massima</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="196"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="198"/>
       <source>Limit inverter power</source>
       <translation>Limite potenza inverter</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="214"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="216"/>
       <source>Maximum inverter power</source>
       <translation>Massima potenza inverter</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="225"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="227"/>
       <source>Grid setpoint</source>
       <translation>Impostazione rete</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="236"/>
       <source>Grid feed-in</source>
       <translation>Iniezione a rete</translation>
     </message>
@@ -1743,8 +1556,8 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <source>Door alarm</source>
       <translation>Allarme porta</translation>
     </message>
-    <message id="digitalinputs_type_bilgepump">
-      <location filename="../../src/enums.cpp" line="201"/>
+    <message id="switchable_output_bilge_pump">
+      <location filename="../../src/enums.cpp" line="424"/>
       <source>Bilge pump</source>
       <translation>Pompa di sentina</translation>
     </message>
@@ -1796,11 +1609,6 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <source>Deferred by %1s</source>
       <extracomment>%1 = number of seconds</extracomment>
       <translation>Posticipato da %1s</translation>
-    </message>
-    <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="75"/>
-      <source>Are you sure?</source>
-      <translation type="unfinished">Siete sicuri?</translation>
     </message>
     <message id="settings_vrm_portal_id">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="87"/>
@@ -1939,11 +1747,6 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <source>External storage</source>
       <translation>Memoria esterna</translation>
     </message>
-    <message id="settings_vrm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="308"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">Errore sconosciuto</translation>
-    </message>
     <message id="settings_vrm_no_error">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="311"/>
       <source>No Error</source>
@@ -2029,37 +1832,10 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <source>Function</source>
       <translation>Funzione</translation>
     </message>
-    <message id="settings_relay_disabled">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="54"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="98"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Disattivato</translation>
-    </message>
     <message id="settings_relay_alarm_relay">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="56"/>
       <source>Alarm relay</source>
       <translation>Relè allarme</translation>
-    </message>
-    <message id="settings_relay_tank_pump">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="62"/>
-      <source>Tank pump</source>
-      <translation type="unfinished">Pompa del serbatoio</translation>
-    </message>
-    <message id="settings_relay_manual">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="64"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="100"/>
-      <source>Manual</source>
-      <translation type="unfinished">Manuale</translation>
-    </message>
-    <message id="settings_relay_polarity_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
-      <source>Polarity (Relay 1)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_relay_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
-      <source>Polarity</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_normally_open">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="83"/>
@@ -2075,11 +1851,6 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="93"/>
       <source>Function (Relay 2)</source>
       <translation>Funzione (Relè 2)</translation>
-    </message>
-    <message id="settings_relay_polarity_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
-      <source>Polarity (Relay 2)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_temp_control_rules">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="119"/>
@@ -2111,12 +1882,6 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
       <source>Press to boot</source>
       <translation>Premere per riavviare</translation>
-    </message>
-    <message id="settings_firmware_backup_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
-      <translation type="unfinished">Firmware %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
@@ -2152,6 +1917,7 @@ Utilizzare se non è vietato dal gestore della rete</translation>
     <message id="nav_boat">
       <location filename="../../pages/boat/BoatPage.qml" line="14"/>
       <source>Boat</source>
+      <extracomment>The 'Boat' page</extracomment>
       <translation>Imbarcazione</translation>
     </message>
     <message id="settings_system_name">
@@ -2219,11 +1985,6 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <source>Solar charger current control</source>
       <translation>Controllo corrente caricabatterie solare</translation>
     </message>
-    <message id="settings_system_status_bms_params">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
-      <source>BMS control</source>
-      <translation type="unfinished">Controllo BMS</translation>
-    </message>
     <message id="common_words_bms_control">
       <location filename="../../components/CommonWords.qml" line="101"/>
       <source>BMS control</source>
@@ -2238,11 +1999,6 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
       <source>Pump state</source>
       <translation>Stato pompa</translation>
-    </message>
-    <message id="settings_pump_auto">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="56"/>
-      <source>Auto</source>
-      <translation type="unfinished">Automatico</translation>
     </message>
     <message id="settings_tank_sensor">
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
@@ -2271,11 +2027,6 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="35"/>
       <source>Unplugged</source>
       <translation>Scollegato</translation>
-    </message>
-    <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="16"/>
-      <source>Name</source>
-      <translation type="unfinished">Nome</translation>
     </message>
     <message id="settings_tcpip_hidden">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="21"/>
@@ -2317,16 +2068,6 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="99"/>
       <source>IP configuration</source>
       <translation>Configurazione IP</translation>
-    </message>
-    <message id="settings_tcpip_manual">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="105"/>
-      <source>Manual</source>
-      <translation type="unfinished">Manuale</translation>
-    </message>
-    <message id="settings_tcpip_off">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="107"/>
-      <source>Off</source>
-      <translation type="unfinished">Spento</translation>
     </message>
     <message id="settings_tcpip_fixed">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="109"/>
@@ -2382,21 +2123,6 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="30"/>
       <source>Create access point</source>
       <translation>Crea punto di accesso</translation>
-    </message>
-    <message id="settings_wifi_access_point_enter_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="68"/>
-      <source>Enter password</source>
-      <translation type="unfinished">Inserire password</translation>
-    </message>
-    <message id="page_settings_wifi_invalid_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
-      <source>Password length must be either 0 or between 10 and 63 characters long</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_wifi_password_updated">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
-      <source>Password updated</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_wifi_networks">
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="86"/>
@@ -2539,20 +2265,10 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <extracomment>Network status: Standalone</extracomment>
       <translation>Indipendente</translation>
     </message>
-    <message id="charger_standalone">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="45"/>
-      <source>Standalone</source>
-      <translation type="unfinished">Indipendente</translation>
-    </message>
     <message id="charger_charge">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="48"/>
       <source>Charge</source>
       <translation>Carico</translation>
-    </message>
-    <message id="charger_external_control">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="51"/>
-      <source>External control</source>
-      <translation type="unfinished">Controllo esterno</translation>
     </message>
     <message id="charger_charge_hub_1">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="54"/>
@@ -2584,16 +2300,6 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <source>Master setting</source>
       <translation>Impostazioni master</translation>
     </message>
-    <message id="charger_slave">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="85"/>
-      <source>Slave</source>
-      <translation type="unfinished">Slave</translation>
-    </message>
-    <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation type="unfinished">Tensione di carica</translation>
-    </message>
     <message id="systemsettings_networkstatus_slave">
       <location filename="../../data/SystemSettings.qml" line="148"/>
       <source>Slave</source>
@@ -2615,14 +2321,15 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <source>Group &amp; Charge master</source>
       <translation>Gruppo e Carica master</translation>
     </message>
-    <message id="genset_charge_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="365"/>
+    <message id="charger_charge_voltage">
+      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
       <source>Charge voltage</source>
       <translation>Tensione di carica</translation>
     </message>
     <message id="common_words_reset">
       <location filename="../../components/CommonWords.qml" line="448"/>
       <source>Reset</source>
+      <extracomment>Reset the BMS control</extracomment>
       <translation>Ripristina</translation>
     </message>
     <message id="solarcharger_load">
@@ -2651,14 +2358,14 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <extracomment>Voltage alarm is at "Warning" level</extracomment>
       <translation>Avvertimento</translation>
     </message>
-    <message id="listitems_alarm_level_alarm">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="25"/>
+    <message id="digitalinputs_state_alarm">
+      <location filename="../../src/enums.cpp" line="270"/>
       <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
+      <extracomment>Relay function is 'alarm'</extracomment>
       <translation>Allarme</translation>
     </message>
-    <message id="devicelist_tankshape_volume">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="190"/>
+    <message id="components_volumeunit_volume">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
       <source>Volume</source>
       <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
       <translation>Volume</translation>
@@ -2808,26 +2515,10 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <source>Relay function</source>
       <translation>Funzione relè</translation>
     </message>
-    <message id="batterysettingrelay_alarm">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation type="unfinished">Allarme</translation>
-    </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
       <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
       <source>Charger or generator start/stop</source>
       <translation>Avvio/arresto caricatore o generatore</translation>
-    </message>
-    <message id="batterysettingrelay_manual_control">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
-      <source>Manual control</source>
-      <translation type="unfinished">Controllo manuale</translation>
-    </message>
-    <message id="batterysettingrelay_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">Fusibile bruciato</translation>
     </message>
     <message id="common_words_manual_control">
       <location filename="../../components/CommonWords.qml" line="302"/>
@@ -2853,12 +2544,6 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
       <source>Status LEDs</source>
       <translation>Stato LED</translation>
-    </message>
-    <message id="batterydiagnostics_none">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
-      <source>None</source>
-      <extracomment>Indicates no alarm is set</extracomment>
-      <translation type="unfinished">Nessuno</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
@@ -2888,7 +2573,7 @@ Utilizzare se non è vietato dal gestore della rete</translation>
     <message id="common_words_switch">
       <location filename="../../components/CommonWords.qml" line="525"/>
       <source>Switch</source>
-      <extracomment>Change the mode value</extracomment>
+      <extracomment>Change the battery mode</extracomment>
       <translation>Interruttore</translation>
     </message>
     <message id="devicelist_battery_initializing">
@@ -2956,21 +2641,6 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <source>Top section voltage</source>
       <translation>Tensione sezione superiore</translation>
     </message>
-    <message id="battery_bank_error_communication">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="96"/>
-      <source>Communication error</source>
-      <translation type="unfinished">Errore di comunicazione</translation>
-    </message>
-    <message id="battery_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="182"/>
-      <source>State of health</source>
-      <translation type="unfinished">Stato di salute</translation>
-    </message>
-    <message id="battery_bus_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="212"/>
-      <source>Bus voltage</source>
-      <translation type="unfinished">Tensione Bus</translation>
-    </message>
     <message id="battery_bottom_section_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="228"/>
       <source>Bottom section voltage</source>
@@ -3016,16 +2686,6 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <source>IO</source>
       <translation>IO</translation>
     </message>
-    <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="391"/>
-      <source>System</source>
-      <translation type="unfinished">Sistema</translation>
-    </message>
-    <message id="battery_press_to_redetect">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="433"/>
-      <source>Press to redetect</source>
-      <translation type="unfinished">Premere per rilevare nuovamente</translation>
-    </message>
     <message id="pagesettingsgeneral_system">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="107"/>
       <source>System</source>
@@ -3066,16 +2726,6 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <source>Low SOC</source>
       <translation>SOC basso</translation>
     </message>
-    <message id="batteryalarms_high_battery_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
-      <source>High battery voltage</source>
-      <translation type="unfinished">Alta tensione batteria</translation>
-    </message>
-    <message id="batteryalarms_low_soc">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low SOC</source>
-      <translation type="unfinished">SOC basso</translation>
-    </message>
     <message id="batteryalarms_low_starter_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="73"/>
       <source>Low starter voltage</source>
@@ -3095,11 +2745,6 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
       <source>Mid-point voltage</source>
       <translation>Tensione del punto medio</translation>
-    </message>
-    <message id="batteryalarms_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">Fusibile bruciato</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
@@ -3293,11 +2938,6 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <source>Restore factory defaults</source>
       <translation>Ripristina impostazioni di fabbrica</translation>
     </message>
-    <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation type="unfinished">Premere per ripristinare</translation>
-    </message>
     <message id="vebus_backup_press_to_restore">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="362"/>
       <source>Press to restore</source>
@@ -3337,11 +2977,6 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="18"/>
       <source>Capacity</source>
       <translation>Capacità</translation>
-    </message>
-    <message id="batterysettingsbattery_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
-      <source>Capacity</source>
-      <translation type="unfinished">Capacità</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
@@ -3418,11 +3053,6 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <source>No power on busbar</source>
       <translation>Nessuna alimentazione sulla busbar</translation>
     </message>
-    <message id="lynxdistributor_connection_lost">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
-      <source>Connection lost</source>
-      <translation type="unfinished">Connessione persa</translation>
-    </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
       <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
       <source>%n fuse(s) blown</source>
@@ -3458,26 +3088,6 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <source>Shutdowns due error</source>
       <translation>Arresti dovuti a errore</translation>
     </message>
-    <message id="lynxiondiagnostics_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
-      <source>Last error</source>
-      <translation type="unfinished">Ultimo errore</translation>
-    </message>
-    <message id="lynxiondiagnostics_2nd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
-      <source>2nd last error</source>
-      <translation type="unfinished">Penultimo errore</translation>
-    </message>
-    <message id="lynxiondiagnostics_3rd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
-      <source>3rd last error</source>
-      <translation type="unfinished">Terzultimo errore</translation>
-    </message>
-    <message id="lynxiondiagnostics_4th_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
-      <source>4th last error</source>
-      <translation type="unfinished">Quartultimo errore</translation>
-    </message>
     <message id="lynxionio_system_switch">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
       <source>System Switch</source>
@@ -3497,11 +3107,6 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <location filename="../../components/CommonWords.qml" line="54"/>
       <source>Batteries</source>
       <translation>Batterie</translation>
-    </message>
-    <message id="lynxionsystem_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
-      <source>Capacity</source>
-      <translation type="unfinished">Capacità</translation>
     </message>
     <message id="lynxionsystem_parallel">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="30"/>
@@ -3523,20 +3128,10 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <source>Min/max cell temperature</source>
       <translation>Temperatura min/max cella</translation>
     </message>
-    <message id="lynxionsystem_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="92"/>
-      <source>Balancing</source>
-      <translation type="unfinished">Bilanciamento</translation>
-    </message>
     <message id="lynxionsystem_balancer_balancing">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
       <source>Balancing</source>
       <translation>Bilanciamento</translation>
-    </message>
-    <message id="lynxionsystem_balancer_unknown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="117"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Sconosciuto</translation>
     </message>
     <message id="dc_output">
       <location filename="../../components/listitems/ListDcOutputQuantityGroup.qml" line="16"/>
@@ -3644,11 +3239,6 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <source>Remaining</source>
       <translation>Rimanente</translation>
     </message>
-    <message id="devicelist_tanksensor_sensor_battery">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="51"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">Batteria sensore</translation>
-    </message>
     <message id="temperature_sensor_battery">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="112"/>
       <source>Sensor battery</source>
@@ -3677,7 +3267,7 @@ Utilizzare se non è vietato dal gestore della rete</translation>
     <message id="devicelist_tanksetup_custom">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="53"/>
       <source>Custom</source>
-      <translation type="unfinished">Personalizza</translation>
+      <translation>Personalizza</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="59"/>
@@ -3710,34 +3300,34 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <translation>Valore sensore</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="75"/>
       <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
       <translation>Non sono state definite forme personalizzate. È possibile definirne una con un massimo di dieci punti. Si noti che 0 % e 100 % sono impliciti.</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="91"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="89"/>
       <source>Point %1</source>
       <extracomment>%1 = the point number</extracomment>
       <translation>Punto %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="133"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="179"/>
       <source>Add point</source>
       <translation>Aggiungi punto</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="156"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="205"/>
       <source>Sensor level</source>
       <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
       <translation>Livello Sensore</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="256"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="311"/>
       <source>Duplicate sensor level values are not allowed.</source>
       <translation>Non sono consentiti valori di livello del sensore duplicati.</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="262"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="317"/>
       <source>Volume values must be increasing.</source>
       <translation>I valori volume devono essere crescenti.</translation>
     </message>
@@ -3777,11 +3367,6 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <source>Switch position</source>
       <translation>Cambia posizione</translation>
     </message>
-    <message id="ac-in-setup_single_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="142"/>
-      <source>Single phase</source>
-      <translation type="unfinished">Monofase</translation>
-    </message>
     <message id="ac-in-setup_two_phase">
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="144"/>
       <source>2-phase</source>
@@ -3791,11 +3376,6 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="146"/>
       <source>3-phase</source>
       <translation>Trifase</translation>
-    </message>
-    <message id="ac-in-setup_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="161"/>
-      <source>Devices</source>
-      <translation type="unfinished">Dispositivi</translation>
     </message>
     <message id="ac-in-genset_ac">
       <location filename="../../components/PageGensetModel.qml" line="194"/>
@@ -3889,12 +3469,6 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <extracomment>%1 = CT device number</extracomment>
       <translation>CT %1</translation>
     </message>
-    <message id="smappeect_phase_none">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation type="unfinished">Nessuno</translation>
-    </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
       <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
       <source>Flashing LED indicates this CT</source>
@@ -3908,11 +3482,13 @@ Utilizzare se non è vietato dal gestore della rete</translation>
     <message id="common_words_setting_disabled_when_dmc_connected">
       <location filename="../../components/CommonWords.qml" line="355"/>
       <source>This setting is disabled when a Digital Multi Control is connected.</source>
+      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>Questa impostazione viene disattivata quando e collegato un Digital Multi Control.</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
       <location filename="../../components/CommonWords.qml" line="358"/>
       <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>Questa impostazione viene disattivata quando è collegato un VE.Bus BMS.</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
@@ -3930,16 +3506,6 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="21"/>
       <source>Inverted</source>
       <translation>Invertito</translation>
-    </message>
-    <message id="digitalinput_enable_alarm">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="48"/>
-      <source>Enable alarm</source>
-      <translation type="unfinished">Attiva allarme</translation>
-    </message>
-    <message id="digitalinput_inverted">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="54"/>
-      <source>Inverted</source>
-      <translation type="unfinished">Invertito</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
       <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="60"/>
@@ -3976,16 +3542,6 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <source>Wind speed</source>
       <translation>Velocità del vento</translation>
     </message>
-    <message id="page_meteo_battery_voltage">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="99"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">Batteria sensore</translation>
-    </message>
-    <message id="meteo_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="120"/>
-      <source>Low</source>
-      <translation type="unfinished">Basso</translation>
-    </message>
     <message id="page_meteo_settings_auto_detect">
       <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
       <source>Auto-detect</source>
@@ -4016,16 +3572,6 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <source>Reset counter</source>
       <translation>Ripristino contatore</translation>
     </message>
-    <message id="temperature_short_circuited">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="32"/>
-      <source>Short circuited</source>
-      <translation type="unfinished">In corto circuito</translation>
-    </message>
-    <message id="temperature_reverse_polarity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="35"/>
-      <source>Reverse polarity</source>
-      <translation type="unfinished">Polarità inversa</translation>
-    </message>
     <message id="temperature_sensor_battery_low">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
       <source>Sensor battery low</source>
@@ -4040,36 +3586,6 @@ Utilizzare se non è vietato dal gestore della rete</translation>
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="62"/>
       <source>Pressure</source>
       <translation>Pressione</translation>
-    </message>
-    <message id="temperature_pm25">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
-      <source>PM2.5</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_co2">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>CO₂</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_voc">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
-      <source>VOC index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_nox">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
-      <source>NOx index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_luminosity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
-      <source>Luminosity</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="133"/>
-      <source>Low</source>
-      <translation type="unfinished">Basso</translation>
     </message>
     <message id="temperature_offset">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
@@ -4123,25 +3639,10 @@ NOTE: L'aggiornamento potrebbe arrestare temporaneamente il sistema.</translatio
       <source>Updating the MK3, values will reappear after the update is complete</source>
       <translation>Aggiornamento dell’MK3 in corso: i valori riappariranno al termine dell'aggiornamento</translation>
     </message>
-    <message id="vebus_device_charging_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="78"/>
-      <source>Charging the battery to 100%</source>
-      <translation type="unfinished">Carica della batteria al 100 %</translation>
-    </message>
     <message id="vebus_device_charging_the_battery_to_100">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="93"/>
       <source>Charging the battery to 100%</source>
       <translation>Carica della batteria al 100 %</translation>
-    </message>
-    <message id="vebus_device_page_microgrid_parameters">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
-      <source>Microgrid parameters</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="vebus_device_page_advanced">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
-      <source>Advanced</source>
-      <translation type="unfinished">Avanzate</translation>
     </message>
     <message id="vebus_device_in_progress">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="80"/>
@@ -4195,15 +3696,15 @@ Si desidera continuare?</translation>
       <source>DC Current</source>
       <translation>Corrente CC</translation>
     </message>
+    <message id="vebus_device_page_advanced">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
+      <source>Advanced</source>
+      <translation>Avanzate</translation>
+    </message>
     <message id="common_words_alarm_setup">
       <location filename="../../components/CommonWords.qml" line="65"/>
       <source>Alarm setup</source>
       <translation>Configurazione allarme</translation>
-    </message>
-    <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
-      <translation type="unfinished">Un VE.Bus BMS spegne automaticamente il sistema quando necessario per proteggere la batteria. Controllare il sistema dal Color Control non è pertanto possibile.</translation>
     </message>
     <message id="vebus_device_bms_not_found">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="240"/>
@@ -4244,7 +3745,7 @@ Si desidera continuare?</translation>
     <message id="vebus_device_starting">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="117"/>
       <source>Starting...</source>
-      <translation type="unfinished">Avvio in corso...</translation>
+      <translation>Avvio in corso...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="120"/>
@@ -4310,16 +3811,6 @@ Si desidera continuare?</translation>
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="260"/>
       <source>ESS Relay test</source>
       <translation>Test Relè ESS</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_completed">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="266"/>
-      <source>Completed</source>
-      <translation type="unfinished">Completo</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_pending">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="268"/>
-      <source>Pending</source>
-      <translation type="unfinished">In attesa</translation>
     </message>
     <message id="cycle_history_completed">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
@@ -4506,6 +3997,7 @@ Si desidera continuare?</translation>
     <message id="rssystemalarms_overload">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
       <source>Overload</source>
+      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
       <translation>Sovraccarico</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
@@ -4518,11 +4010,6 @@ Si desidera continuare?</translation>
       <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
       <source>Voltage Sensor</source>
       <translation>Sensore di tensione</translation>
-    </message>
-    <message id="vebus_device_phase_rotation">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
-      <source>Phase rotation</source>
-      <translation type="unfinished">Rotazione fase</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
@@ -4554,12 +4041,6 @@ Si desidera continuare?</translation>
       <source>VE.Bus BMS version</source>
       <translation>Versione VE.Bus BMS</translation>
     </message>
-    <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="15"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="52"/>
-      <source>Minimum SOC</source>
-      <translation type="unfinished">SOC minimo</translation>
-    </message>
     <message id="ess_unless_grid_fails">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="32"/>
       <source>Unless grid fails</source>
@@ -4579,7 +4060,7 @@ Si desidera continuare?</translation>
     <message id="common_words_ac_input_role">
       <location filename="../../components/CommonWords.qml" line="24"/>
       <source>Role</source>
-      <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
       <translation>Ruolo</translation>
     </message>
     <message id="common_words_ac_load">
@@ -4618,18 +4099,6 @@ Si desidera continuare?</translation>
       <source>Active</source>
       <extracomment>Status is 'active'</extracomment>
       <translation>Attivo</translation>
-    </message>
-    <message id="common_words_alarm">
-      <location filename="../../components/CommonWords.qml" line="51"/>
-      <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
-      <translation type="unfinished">Allarme</translation>
-    </message>
-    <message id="common_words_alarm_setting_overload">
-      <location filename="../../components/CommonWords.qml" line="58"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation type="unfinished">Sovraccarico</translation>
     </message>
     <message id="common_words_alarm_status">
       <location filename="../../components/CommonWords.qml" line="68"/>
@@ -4676,8 +4145,8 @@ Si desidera continuare?</translation>
       <source>Charge current</source>
       <translation>Corrente di carica</translation>
     </message>
-    <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="125"/>
+    <message id="battery_mode_charging">
+      <location filename="../../src/enums.cpp" line="30"/>
       <source>Charging</source>
       <extracomment>"Charging" state</extracomment>
       <translation>Carica in corso</translation>
@@ -4691,7 +4160,7 @@ Si desidera continuare?</translation>
     <message id="digitalinputs_state_closed">
       <location filename="../../src/enums.cpp" line="262"/>
       <source>Closed</source>
-      <extracomment>Digital input state</extracomment>
+      <extracomment>Status is 'closed'</extracomment>
       <translation>Chiuso</translation>
     </message>
     <message id="evchargers_status_connected">
@@ -4699,8 +4168,8 @@ Si desidera continuare?</translation>
       <source>Connected</source>
       <translation>Connesso</translation>
     </message>
-    <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="143"/>
+    <message id="temperature_slider_current">
+      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
       <source>Current</source>
       <extracomment>Electric current, as measured in Amps</extracomment>
       <translation>Corrente</translation>
@@ -4727,9 +4196,10 @@ Si desidera continuare?</translation>
       <extracomment>Title for device information</extracomment>
       <translation>Dispositivo</translation>
     </message>
-    <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="172"/>
+    <message id="battery_mode_discharging">
+      <location filename="../../src/enums.cpp" line="34"/>
       <source>Discharging</source>
+      <extracomment>Battery mode</extracomment>
       <translation>Scarica in corso</translation>
     </message>
     <message id="wifimodel_disconnected">
@@ -4815,13 +4285,14 @@ Si desidera continuare?</translation>
       <source>%1 Hour(s)</source>
       <translation>%1 Ora/e</translation>
     </message>
-    <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="251"/>
+    <message id="battery_mode_idle">
+      <location filename="../../src/enums.cpp" line="26"/>
       <source>Idle</source>
+      <extracomment>Battery mode</extracomment>
       <translation>Inattivo</translation>
     </message>
-    <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="258"/>
+    <message id="scheduled_charge_inactive">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
       <source>Inactive</source>
       <extracomment>Status is 'inactive'</extracomment>
       <translation>Inattivo</translation>
@@ -4923,8 +4394,8 @@ Si desidera continuare?</translation>
       <source>Offline</source>
       <translation>Offline</translation>
     </message>
-    <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="17"/>
+    <message id="digitalinputs_state_ok">
+      <location filename="../../src/enums.cpp" line="266"/>
       <source>OK</source>
       <extracomment>Voltage alarm is at "OK" level</extracomment>
       <translation>Ok</translation>
@@ -4932,6 +4403,7 @@ Si desidera continuare?</translation>
     <message id="switchable_output_on">
       <location filename="../../src/enums.cpp" line="471"/>
       <source>On</source>
+      <extracomment>Digital input state</extracomment>
       <translation>Acceso</translation>
     </message>
     <message id="common_words_online">
@@ -4942,7 +4414,7 @@ Si desidera continuare?</translation>
     <message id="digitalinputs_state_open">
       <location filename="../../src/enums.cpp" line="258"/>
       <source>Open</source>
-      <extracomment>Digital input open</extracomment>
+      <extracomment>Status is 'open'</extracomment>
       <translation>Aperto</translation>
     </message>
     <message id="common_words_password">
@@ -5002,9 +4474,10 @@ Si desidera continuare?</translation>
       <source>Remove</source>
       <translation>Rimuovi</translation>
     </message>
-    <message id="switch_state_running">
-      <location filename="../../src/enums.cpp" line="363"/>
+    <message id="switchable_output_running">
+      <location filename="../../src/enums.cpp" line="468"/>
       <source>Running</source>
+      <extracomment>Status = "running"</extracomment>
       <translation>In funzionamento</translation>
     </message>
     <message id="common_words_scanning">
@@ -5071,7 +4544,7 @@ Si desidera continuare?</translation>
     <message id="pvinverter_statusCode_startup">
       <location filename="../../src/enums.cpp" line="296"/>
       <source>Startup (%1)</source>
-      <extracomment>PV inverter status code. %1 = the startup status number</extracomment>
+      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
       <translation>Avvio (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
@@ -5126,8 +4599,10 @@ Si desidera continuare?</translation>
       <source>Unique Identity Number</source>
       <translation>Numero Identificativo Univoco</translation>
     </message>
-    <message id="settings_radio_button_group_unknown">
-      <location filename="../../components/listitems/core/ListRadioButtonGroup.qml" line="44"/>
+    <message id="Unknown">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
       <source>Unknown</source>
       <translation>Sconosciuto</translation>
     </message>
@@ -5282,11 +4757,6 @@ Si desidera continuare?</translation>
       <source>Error while checking for firmware updates</source>
       <translation>Errore durante la verifica degli aggiornamenti del firmware</translation>
     </message>
-    <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation type="unfinished">Errore durante la verifica degli aggiornamenti del firmware</translation>
-    </message>
     <message id="settings_firmware_downloading_and_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="63"/>
       <source>Downloading and installing firmware %1...</source>
@@ -5313,6 +4783,66 @@ Si desidera continuare?</translation>
       <source>No firmware found</source>
       <translation>Non sono stati trovati firmware</translation>
     </message>
+    <message id="tank_type_fuel">
+      <location filename="../../src/enums.cpp" line="495"/>
+      <source>Fuel</source>
+      <translation>Carburante</translation>
+    </message>
+    <message id="tank_type_fresh_water">
+      <location filename="../../src/enums.cpp" line="498"/>
+      <source>Fresh water</source>
+      <translation>Acqua dolce</translation>
+    </message>
+    <message id="tank_type_waste_water">
+      <location filename="../../src/enums.cpp" line="501"/>
+      <source>Waste water</source>
+      <translation>Acque reflue</translation>
+    </message>
+    <message id="tank_type_live_well">
+      <location filename="../../src/enums.cpp" line="504"/>
+      <source>Live well</source>
+      <translation>Serbatoio</translation>
+    </message>
+    <message id="tank_type_oil">
+      <location filename="../../src/enums.cpp" line="507"/>
+      <source>Oil</source>
+      <translation>Olio</translation>
+    </message>
+    <message id="tank_type_black_water">
+      <location filename="../../src/enums.cpp" line="510"/>
+      <source>Black water</source>
+      <translation>ACQUE NERE</translation>
+    </message>
+    <message id="tank_type_gasoline">
+      <location filename="../../src/enums.cpp" line="513"/>
+      <source>Gasoline</source>
+      <translation>Benzina</translation>
+    </message>
+    <message id="tank_type_diesel">
+      <location filename="../../src/enums.cpp" line="516"/>
+      <source>Diesel</source>
+      <translation>Diesel</translation>
+    </message>
+    <message id="tank_type_lpg">
+      <location filename="../../src/enums.cpp" line="519"/>
+      <source>LPG</source>
+      <translation>LPG</translation>
+    </message>
+    <message id="tank_type_lng">
+      <location filename="../../src/enums.cpp" line="522"/>
+      <source>LNG</source>
+      <translation>LNG</translation>
+    </message>
+    <message id="tank_type_hydraulic_oil">
+      <location filename="../../src/enums.cpp" line="525"/>
+      <source>Hydraulic oil</source>
+      <translation>Olio idraulico</translation>
+    </message>
+    <message id="tank_type_raw_water">
+      <location filename="../../src/enums.cpp" line="528"/>
+      <source>Raw water</source>
+      <translation>Acqua grezza</translation>
+    </message>
     <message id="listItem_no_access">
       <location filename="../../components/listitems/core/ListItem.qml" line="102"/>
       <source>Setting locked for access level</source>
@@ -5326,6 +4856,7 @@ Si desidera continuare?</translation>
     <message id="welcome_brief_title">
       <location filename="../../pages/welcome/WelcomeView.qml" line="81"/>
       <source>Brief</source>
+      <extracomment>The 'Brief' page</extracomment>
       <translation>Ragguagli</translation>
     </message>
     <message id="welcome_overview_title">
@@ -5342,23 +4873,6 @@ Si desidera continuare?</translation>
       <location filename="../../pages/NotificationsPage.qml" line="13"/>
       <source>Notifications</source>
       <translation>Notifiche</translation>
-    </message>
-    <message id="notifications_page_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="43"/>
-      <source>Active Notifications</source>
-      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_page_inactive_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="47"/>
-      <source>Inactive Notifications</source>
-      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_no_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="106"/>
-      <source>No active notifications</source>
-      <translation type="unfinished"/>
     </message>
     <message id="utils_formatTimestamp_now">
       <location filename="../../components/Utils.js" line="258"/>
@@ -5463,11 +4977,6 @@ Si desidera continuare?</translation>
       <source>Self-consumption above limit</source>
       <translation>Autoconsumo oltre il limite</translation>
     </message>
-    <message id="cgwacs_battery_schedule_pv">
-      <location filename="../../components/listitems/ListChargeSchedule.qml" line="171"/>
-      <source>PV</source>
-      <translation type="unfinished">FV</translation>
-    </message>
     <message id="settings_multirs_pv">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="185"/>
       <source>PV</source>
@@ -5478,8 +4987,8 @@ Si desidera continuare?</translation>
       <source>PV &amp; Battery</source>
       <translation>FV e Batteria</translation>
     </message>
-    <message id="settings_firmware_checking">
-      <location filename="../../components/listitems/ListFirmwareCheckButton.qml" line="16"/>
+    <message id="pagesettingssupportstate_firmware_checking">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
       <source>Checking...</source>
       <translation>Verifica in corso...</translation>
     </message>
@@ -5487,12 +4996,6 @@ Si desidera continuare?</translation>
       <location filename="../../components/listitems/ListAlarmState.qml" line="11"/>
       <source>Alarm state</source>
       <translation>Stato allarme</translation>
-    </message>
-    <message id="devicelist_battery_alarm_state">
-      <location filename="../../components/listitems/ListAlarmState.qml" line="19"/>
-      <source>Alarm</source>
-      <extracomment>Alarm state is active</extracomment>
-      <translation type="unfinished">Allarme</translation>
     </message>
     <message id="clear_history_button_clear_history">
       <location filename="../../components/listitems/ListClearHistoryButton.qml" line="15"/>
@@ -5644,11 +5147,6 @@ Si desidera continuare?</translation>
       <source>Max Voltage</source>
       <translation>Tensione massima</translation>
     </message>
-    <message id="charger_history_box_max_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="64"/>
-      <source>Max Voltage</source>
-      <translation type="unfinished">Tensione massima</translation>
-    </message>
     <message id="charger_history_box_max_current">
       <location filename="../../components/SolarDetailBox.qml" line="70"/>
       <source>Max Current</source>
@@ -5659,24 +5157,6 @@ Si desidera continuare?</translation>
       <source>Charge time</source>
       <extracomment>Statistics for battery charging time</extracomment>
       <translation>Tempo di carica</translation>
-    </message>
-    <message id="charger_history_box_bulk">
-      <location filename="../../components/SolarDetailBox.qml" line="136"/>
-      <source>Bulk</source>
-      <extracomment>Battery: time spent in 'Bulk' mode</extracomment>
-      <translation type="unfinished">Prima fase</translation>
-    </message>
-    <message id="charger_history_box_float">
-      <location filename="../../components/SolarDetailBox.qml" line="148"/>
-      <source>Float</source>
-      <extracomment>Battery: time spent in 'Float' mode</extracomment>
-      <translation type="unfinished">Mantenimento</translation>
-    </message>
-    <message id="charger_history_hr">
-      <location filename="../../components/SolarDetailBox.qml" line="174"/>
-      <source>hr</source>
-      <extracomment>Abbreviation of "hour"</extracomment>
-      <translation type="unfinished">h</translation>
     </message>
     <message id="solarchargers_state_bulk">
       <location filename="../../src/enums.cpp" line="337"/>
@@ -5748,11 +5228,6 @@ Si desidera continuare?</translation>
       <source>Connecting</source>
       <translation>Collegamento in corso</translation>
     </message>
-    <message id="splash_view_connecting">
-      <location filename="../../components/SplashView.qml" line="288"/>
-      <source>Connecting</source>
-      <translation type="unfinished">Collegamento in corso</translation>
-    </message>
     <message id="splash_view_connected">
       <location filename="../../components/SplashView.qml" line="290"/>
       <source>Connected, awaiting broker messages</source>
@@ -5808,6 +5283,11 @@ Si desidera continuare?</translation>
       <source>MQTT protocol level 5 error</source>
       <translation>Errore di livello 5 del protocollo MQTT</translation>
     </message>
+    <message id="common_words_silence_alarm">
+      <location filename="../../components/CommonWords.qml" line="476"/>
+      <source>Silence alarm</source>
+      <translation>Silenziamento allarme</translation>
+    </message>
     <message id="vebus_device_page_total_power">
       <location filename="../../components/ThreePhaseQuantityTable.qml" line="47"/>
       <source>Total Power</source>
@@ -5858,20 +5338,10 @@ Si desidera continuare?</translation>
       <source>Retrieving IP address</source>
       <translation>Recupero dell'indirizzo IP in corso</translation>
     </message>
-    <message id="utils_connman_connected">
-      <location filename="../../components/Utils.js" line="292"/>
-      <source>Connected</source>
-      <translation type="unfinished">Connesso</translation>
-    </message>
     <message id="utils_connman_disconnect">
       <location filename="../../components/Utils.js" line="295"/>
       <source>Disconnect</source>
       <translation>Disconnettere</translation>
-    </message>
-    <message id="utils_connman_disconnected">
-      <location filename="../../components/Utils.js" line="299"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Disconnesso</translation>
     </message>
     <message id="overview_widget_acloads_title">
       <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
@@ -5909,11 +5379,6 @@ Si desidera continuare?</translation>
       <source>Shore current limit</source>
       <translation>Limite di corrente da banchina</translation>
     </message>
-    <message id="acInputs_statusCode_stopping">
-      <location filename="../../data/AcInputs.qml" line="170"/>
-      <source>Stopping</source>
-      <translation type="unfinished">In interruzione</translation>
-    </message>
     <message id="page_generator_stopping">
       <location filename="../../data/Generators.qml" line="44"/>
       <source>Stopping</source>
@@ -5929,7 +5394,7 @@ Si desidera continuare?</translation>
       <location filename="../../data/common/TankDescription.qml" line="24"/>
       <location filename="../../src/device.cpp" line="133"/>
       <source>%1 tank (%2)</source>
-      <extracomment>Tank description. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
       <translation>%1 Serbatoio (%2)</translation>
     </message>
     <message id="dcMeter_ac_charger">
@@ -5978,11 +5443,6 @@ Si desidera continuare?</translation>
       <location filename="../../data/Ess.qml" line="20"/>
       <source>Keep batteries charged</source>
       <translation>Conservare batterie cariche</translation>
-    </message>
-    <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="50"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Disconnesso</translation>
     </message>
     <message id="evchargers_status_charged">
       <location filename="../../data/EvChargers.qml" line="58"/>
@@ -6043,16 +5503,6 @@ Si desidera continuare?</translation>
       <location filename="../../data/EvChargers.qml" line="97"/>
       <source>Start charging</source>
       <translation>Avvio della carica</translation>
-    </message>
-    <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="113"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Sconosciuto</translation>
-    </message>
-    <message id="evchargers_mode_scheduled">
-      <location filename="../../data/EvChargers.qml" line="126"/>
-      <source>Scheduled</source>
-      <translation type="unfinished">Programmato</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
       <location filename="../../data/System.qml" line="195"/>
@@ -6177,11 +5627,6 @@ Si desidera continuare?</translation>
       <source>Power supply mode</source>
       <translation>Modalità alimentazione</translation>
     </message>
-    <message id="inverters_state_sustain">
-      <location filename="../../data/System.qml" line="158"/>
-      <source>Sustain</source>
-      <translation type="unfinished">Supporto</translation>
-    </message>
     <message id="inverters_state_wakeup">
       <location filename="../../data/System.qml" line="162"/>
       <source>Wake up</source>
@@ -6216,16 +5661,6 @@ Si desidera continuare?</translation>
       <location filename="../../data/System.qml" line="180"/>
       <source>Test</source>
       <translation>Test</translation>
-    </message>
-    <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="183"/>
-      <source>External control</source>
-      <translation type="unfinished">Controllo esterno</translation>
-    </message>
-    <message id="inverters_state_dynamic_ess">
-      <location filename="../../data/System.qml" line="198"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">ESS dinamico</translation>
     </message>
     <message id="settings_rs_ess_dess">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="97"/>
@@ -6304,16 +5739,13 @@ Si desidera continuare?</translation>
     <message id="ess_recommended">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="73"/>
       <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
       <translation>Per le batterie al litio, si sconsiglia di scendere sotto il 10 % della carica. Per altri tipi di batterie, consultare nella scheda tecnica il livello minimo raccomandato dal produttore.</translation>
-    </message>
-    <message id="controlcard_generator_label_autostart">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="63"/>
-      <source>Autostart</source>
-      <translation type="unfinished">Avvio automatico</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
       <location filename="../../pages/controlcards/GeneratorCard.qml" line="70"/>
       <source>Start and stop the generator based on the configured autostart conditions.</source>
+      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
       <translation>Avviare e arrestare il generatore in base alle condizioni di avvio automatico configurate.</translation>
     </message>
     <message id="generator_dialog_disabled">
@@ -6336,11 +5768,13 @@ Si desidera continuare?</translation>
       <location filename="../../pages/controlcards/InverterChargerCard.qml" line="26"/>
       <source>Inverter / Charger (%1)</source>
       <extracomment>%1 = the inverter/charger name</extracomment>
+      <oldsource>Inverter / Charger</oldsource>
       <translation>Inverter / Caricabatterie (%1)</translation>
     </message>
     <message id="settings_page_debug_quit_application">
       <location filename="../../pages/settings/debug/PageDebug.qml" line="36"/>
       <source>Quit application</source>
+      <oldsource>Quit Application</oldsource>
       <translation>Esci dall’applicazione</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
@@ -6351,12 +5785,8 @@ Si desidera continuare?</translation>
     <message id="settings_page_relay_generator_run_time">
       <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
       <source>Current run time</source>
+      <oldsource>Run time</oldsource>
       <translation>Tempo di funzionamento attuale</translation>
-    </message>
-    <message id="settings_page_genset_generator_run_time">
-      <location filename="../../components/PageGensetModel.qml" line="102"/>
-      <source>Current run time</source>
-      <translation type="unfinished">Tempo di funzionamento attuale</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
       <location filename="../../components/PageGensetModel.qml" line="110"/>
@@ -6383,19 +5813,10 @@ Si desidera continuare?</translation>
       <source>Remote start mode</source>
       <translation>Modalità avvio remoto</translation>
     </message>
-    <message id="ac-in-genset_speed">
-      <location filename="../../components/PageGensetModel.qml" line="245"/>
-      <source>Speed</source>
-      <translation type="unfinished">Velocità</translation>
-    </message>
-    <message id="ac-in-genset_load">
-      <location filename="../../components/PageGensetModel.qml" line="252"/>
-      <source>Load</source>
-      <translation type="unfinished">Carico</translation>
-    </message>
     <message id="ac-in-genset_oil_pressure">
       <location filename="../../components/PageGensetModel.qml" line="260"/>
       <source>Oil pressure</source>
+      <oldsource>Oil Pressure</oldsource>
       <translation>Pressione dell'olio</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
@@ -6491,11 +5912,13 @@ Si desidera continuare?</translation>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
       <source>High starter battery voltage alarms</source>
+      <oldsource>High starter batttery voltage alarms</oldsource>
       <translation>Allarmi di alta tensione batteria di avviamento</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
       <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
       <translation>Tenere presente che cambiando l’impostazione "Soglia di scarica tempo restante" cambia anche l'impostazione "Basso livello di carica" nel menù relè.</translation>
     </message>
     <message id="lynxionsystem_cells_per_battery">
@@ -6572,6 +5995,7 @@ Si desidera continuare?</translation>
       <location filename="../../pages/settings/devicelist/delegates/DeviceListDelegate_solarcharger.qml" line="34"/>
       <source>Error: #%1</source>
       <extracomment>%1 = error number</extracomment>
+      <oldsource>Error: %1</oldsource>
       <translation>Errore: #%1</translation>
     </message>
     <message id="devicelistpage_genset">
@@ -6628,17 +6052,14 @@ Si desidera continuare?</translation>
     <message id="settings_page_relay_generator_auto_start_enabled">
       <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
       <source>Autostart functionality</source>
+      <oldsource>Auto start functionality</oldsource>
       <translation>Funzionalità di avvio automatico</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="97"/>
       <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
       <translation>Assicurarsi che il generatore non sia collegato all'ingresso CA %1 quando si utilizza questa opzione.</translation>
-    </message>
-    <message id="page_generator_conditions_inverter_high_temperature">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="139"/>
-      <source>Inverter high temperature</source>
-      <translation type="unfinished">Alta temperatura inverter</translation>
     </message>
     <message id="page_generator_conditions_tank_level">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="159"/>
@@ -6668,30 +6089,34 @@ Si desidera continuare?</translation>
     <message id="settings_generator_function_not_enabled">
       <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
       <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
+      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
       <translation>Funzione avvio/arresto generatore non attivata, vai alle impostazioni relè e imposta la funzione "Avvio/arresto generatore"</translation>
     </message>
     <message id="settings_batteries_intro">
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="45"/>
       <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
       <translation>Utilizzare questo menu per definire i dati della batteria visualizzati quando si fa clic sull'icona Batteria nella pagina Panoramica. La stessa selezione è visibile anche sul portale VRM.</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
       <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
       <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
       <translation>La scansione continua può interferire con il funzionamento del WiFi.</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
       <source>CAN-bus BMS LV (500 kbit/s)</source>
+      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
       <translation>CAN-bus BMS LV (500 kbit/s)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
       <source>CAN-bus BMS HV (500 kbit/s)</source>
       <translation>CAN-bus BMS HV (500 kbit/s)</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
       <source>Up, but no services (500 kbit/s)</source>
       <translation>Attivo, ma senza servizi (500 kbit/s)</translation>
     </message>
@@ -6704,41 +6129,6 @@ Si desidera continuare?</translation>
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="127"/>
       <source>Brief page</source>
       <translation>Pagina breve</translation>
-    </message>
-    <message id="settings_displayoff_1min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="46"/>
-      <source>1 min</source>
-      <translation type="unfinished">1 min</translation>
-    </message>
-    <message id="settings_displayoff_10min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="48"/>
-      <source>10 min</source>
-      <translation type="unfinished">10 min</translation>
-    </message>
-    <message id="settings_displayoff_30min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="50"/>
-      <source>30 min</source>
-      <translation type="unfinished">30 min</translation>
-    </message>
-    <message id="settings_displayoff_never">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="52"/>
-      <source>Never</source>
-      <translation type="unfinished">Mai</translation>
-    </message>
-    <message id="settings_remote_console_appearance_auto">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="112"/>
-      <source>Auto</source>
-      <translation type="unfinished">Automatico</translation>
-    </message>
-    <message id="settings_brief_view_start_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="119"/>
-      <source>Start page</source>
-      <translation type="unfinished">Pagina d’inizio</translation>
-    </message>
-    <message id="settings_display_boat_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="135"/>
-      <source>Boat page</source>
-      <translation type="unfinished">Pagina della barca</translation>
     </message>
     <message id="settings_display_minmax">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="148"/>
@@ -6793,21 +6183,6 @@ Si desidera continuare?</translation>
       <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
       <translation>%1 è impostato su %2</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_unsupported_device">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="50"/>
-      <source>Unsupported GX device</source>
-      <translation type="unfinished">Dispositivo GX non supportato</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_clean">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="55"/>
-      <source>Clean</source>
-      <translation type="unfinished">Pulito</translation>
-    </message>
-    <message id="pagesettingsgeneral_firmware">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="112"/>
-      <source>Firmware</source>
-      <translation type="unfinished">Firmware</translation>
-    </message>
     <message id="pagesettingsgeneral_access_and_security">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
       <source>Access &amp; Security</source>
@@ -6841,6 +6216,7 @@ Si desidera continuare?</translation>
     <message id="settings_language_please_wait">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="209"/>
       <source>Please wait while the language is changed.</source>
+      <oldsource>Please wait while the language is changed</oldsource>
       <translation>Si prega di attendere mentre si modifica la lingua.</translation>
     </message>
     <message id="settings_briefview_totals">
@@ -6857,11 +6233,6 @@ Si desidera continuare?</translation>
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="71"/>
       <source>Tank is not connected.</source>
       <translation>Il serbatoio non è collegato.</translation>
-    </message>
-    <message id="settings_briefview_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="83"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">Monitoraggio attivo batteria</translation>
     </message>
     <message id="settings_briefview_individual_batteries">
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="86"/>
@@ -6912,6 +6283,7 @@ Si desidera continuare?</translation>
     <message id="settings_dvcc_charge_current_limits">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="30"/>
       <source>Charge current limits</source>
+      <oldsource>Charge Current limits</oldsource>
       <translation>Limiti corrente di carica</translation>
     </message>
     <message id="settings_firmware_official_release">
@@ -6991,11 +6363,6 @@ Si desidera continuare?</translation>
       <source>No password and the network communication is not encrypted</source>
       <translation>Nessuna password e la comunicazione di rete non è crittografata</translation>
     </message>
-    <message id="settings_logout_now">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
-      <source>Log out now</source>
-      <translation type="unfinished">Esci ora</translation>
-    </message>
     <message id="settings_security_profile_password_incorrect_length">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="28"/>
       <source>Password needs to be at least 8 characters long</source>
@@ -7045,25 +6412,10 @@ Si desidera continuare?</translation>
       <source>Page will automatically reload in 5 seconds</source>
       <translation>La pagina si ricaricherà automaticamente tra 5 secondi</translation>
     </message>
-    <message id="settings_security_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="159"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">La password deve avere una lunghezza di almeno 8 caratteri</translation>
-    </message>
     <message id="settings_root_password">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="269"/>
       <source>Root password</source>
       <translation>Password di root</translation>
-    </message>
-    <message id="settings_root_enter_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="272"/>
-      <source>Enter password</source>
-      <translation type="unfinished">Inserire password</translation>
-    </message>
-    <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="277"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">La password deve avere una lunghezza di almeno 8 caratteri</translation>
     </message>
     <message id="settings_root_password_changed_to">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="283"/>
@@ -7079,6 +6431,11 @@ Si desidera continuare?</translation>
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="321"/>
       <source>Logout</source>
       <translation>Esci</translation>
+    </message>
+    <message id="settings_logout_now">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
+      <source>Log out now</source>
+      <translation>Esci ora</translation>
     </message>
     <message id="settings_logout_dialog_title">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="335"/>
@@ -7138,11 +6495,13 @@ Si desidera continuare?</translation>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="141"/>
       <source>Alarm when generator is not in autostart mode</source>
+      <oldsource>Alarm when generator is not in auto start mode</oldsource>
       <translation>Allarme se il generatore non si trova in modalità di avvio automatico</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="147"/>
       <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
       <translation>Quando la funzione di avvio automatico rimane disattivata per più di 10 minuti, scatta un allarme</translation>
     </message>
     <message id="settings_units_amps_exceptions">
@@ -7158,6 +6517,11 @@ Si desidera continuare?</translation>
     <message id="settings_ess_use_this_option_for_peak_shaving">
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
       <source>Use this option for peak shaving.</source>
+      <oldsource>Use this option for peak shaving.
+
+The peak shaving threshold is set using the AC input current limit setting.
+
+See documentation for further information.</oldsource>
       <translation>Utilizzare questa opzione per la riduzione dei picchi.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
@@ -7201,17 +6565,17 @@ Si desidera continuare?</translation>
       <translation>Massima corrente di esportazione del sistema (per fase)</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="71"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="73"/>
       <source>Self-consumption from battery</source>
       <translation>Autoconsumo da batteria</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="76"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
       <source>All system loads</source>
       <translation>Tutti i carichi del sistema</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="80"/>
       <source>Only critical loads</source>
       <translation>Solo carichi critici</translation>
     </message>
@@ -7269,26 +6633,6 @@ Si desidera continuare?</translation>
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="194"/>
       <source>Server Applications</source>
       <translation>Applicazioni server</translation>
-    </message>
-    <message id="pagesettingsintegrations_venus_os_enable_large_features">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
-      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_large_victron_community">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="274"/>
-      <source>Victron Community</source>
-      <translation type="unfinished">Comunità Victron</translation>
-    </message>
-    <message id="pagesettingsintegrations_ui_plugins">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
-      <source>UI Plugins</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
-      <source>Integrates with the device list</source>
-      <translation type="unfinished"/>
     </message>
     <message id="pagesettingssupportstate_modbus_tcp_server">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="453"/>
@@ -7391,25 +6735,10 @@ Si desidera continuare?</translation>
       <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
       <translation>La commutazione della versione del firmware non è possibile se non è selezionato "Profilo di sicurezza della rete" in "Impostazioni / Generali".</translation>
     </message>
-    <message id="pagesettingsconnectivity_ethernet">
-      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
-      <source>Ethernet</source>
-      <translation type="unfinished">Ethernet</translation>
-    </message>
     <message id="pagesettingsconnectivity_mobile_network">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="53"/>
       <source>Mobile Network</source>
       <translation>Rete mobile</translation>
-    </message>
-    <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Boat</source>
-      <translation type="unfinished">Imbarcazione</translation>
-    </message>
-    <message id="settings_system_name_auto">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="32"/>
-      <source>Automatic</source>
-      <translation type="unfinished">Automatico</translation>
     </message>
     <message id="pagesettingssystem_ac_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
@@ -7440,11 +6769,6 @@ Si desidera continuare?</translation>
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="89"/>
       <source>Distributed Voltage and Current Control (DVCC)</source>
       <translation>Tensione Distribuita e Controllo Corrente (DVCC)</translation>
-    </message>
-    <message id="settings_system_grid">
-      <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="18"/>
-      <source>Grid</source>
-      <translation type="unfinished">Rete</translation>
     </message>
     <message id="settings_system_ac_position">
       <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="58"/>
@@ -7484,16 +6808,19 @@ Si desidera continuare?</translation>
     <message id="settings_system_has_dc_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="97"/>
       <source>Display DC Loads</source>
+      <oldsource>Has DC system</oldsource>
       <translation>Visualizza Carichi CC</translation>
     </message>
     <message id="settings_system_battery_measurements">
       <location filename="../../pages/settings/PageSettingsBatteries.qml" line="65"/>
       <source>Battery measurements</source>
+      <oldsource>Battery Measurements</oldsource>
       <translation>Misurazioni batteria</translation>
     </message>
     <message id="settings_system_system_status">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
       <source>System status</source>
+      <oldsource>System Status</oldsource>
       <translation>Stato del sistema</translation>
     </message>
     <message id="settings_tcpip_wired">
@@ -7504,11 +6831,13 @@ Si desidera continuare?</translation>
     <message id="settings_vecan_device_instance">
       <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
       <source>VE.Can Device Instance</source>
+      <oldsource>Device Instance</oldsource>
       <translation>Istanza dispositivo VE.Can</translation>
     </message>
     <message id="settings_vecan_device_number">
       <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="32"/>
       <source>VE.Can Instance# %1</source>
+      <oldsource>Device# %1</oldsource>
       <translation>Istanza# VE.Can %1</translation>
     </message>
     <message id="settings_tz_antarctica">
@@ -7539,6 +6868,7 @@ Si desidera continuare?</translation>
     <message id="settings_vrm">
       <location filename="../../pages/SettingsPage.qml" line="59"/>
       <source>VRM</source>
+      <extracomment>Forced by %2 to dark</extracomment>
       <translation>VRM</translation>
     </message>
     <message id="settings_remote_monitoring_portal">
@@ -7546,20 +6876,10 @@ Si desidera continuare?</translation>
       <source>Remote monitoring portal</source>
       <translation>Portale di monitoraggio remoto</translation>
     </message>
-    <message id="settings_advanced">
-      <location filename="../../pages/SettingsPage.qml" line="68"/>
-      <source>Advanced</source>
-      <translation type="unfinished">Avanzate</translation>
-    </message>
-    <message id="settings_integrations">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
+    <message id="pagesettingssupportstate_integrations">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
       <source>Integrations</source>
       <translation>Integrazioni</translation>
-    </message>
-    <message id="settings_relays_sensors_tanks">
-      <location filename="../../pages/SettingsPage.qml" line="75"/>
-      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
-      <translation type="unfinished">Relè, Sensori, Serbatoi, Inverter FV, Modbus, MQTT...</translation>
     </message>
     <message id="settings_acdcsystem_ess_dvcc_battery">
       <location filename="../../pages/SettingsPage.qml" line="84"/>
@@ -7579,11 +6899,13 @@ Si desidera continuare?</translation>
     <message id="settings_system_setup">
       <location filename="../../pages/SettingsPage.qml" line="82"/>
       <source>System Setup</source>
+      <oldsource>System setup</oldsource>
       <translation>Configurazione sistema</translation>
     </message>
     <message id="settings_vrm_device_instances">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
       <source>VRM device instances</source>
+      <oldsource>VRM Device Instances</oldsource>
       <translation>Istanze dispositivo VRM</translation>
     </message>
     <message id="solarcharger_not_supported">
@@ -7601,28 +6923,10 @@ Si desidera continuare?</translation>
       <source>The firmware version in the MPPT Solar Charger must be v1.09 or later. Contact Victron Service for update instructions and files.</source>
       <translation>La versione del firmware del caricabatterie solare MPPT deve essere la v1.09 o successiva. Contattare Victron Service per ottenere istruzioni e file di aggiornamento.</translation>
     </message>
-    <message id="solarcharger_pv">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="102"/>
-      <source>PV</source>
-      <extracomment>PV power for solar charger</extracomment>
-      <translation type="unfinished">FV</translation>
-    </message>
     <message id="solarcharger_total_power">
       <location filename="../../pages/solar/PageSolarCharger.qml" line="127"/>
       <source>Total PV power</source>
       <translation>Potenza FV totale</translation>
-    </message>
-    <message id="solarcharger_total_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="211"/>
-      <source>Total yield</source>
-      <extracomment>Solar charger total yield</extracomment>
-      <translation type="unfinished">Rendimento totale</translation>
-    </message>
-    <message id="solarcharger_system_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="220"/>
-      <source>System yield</source>
-      <extracomment>Solar charger system yield</extracomment>
-      <translation type="unfinished">Rendimento sistema</translation>
     </message>
     <message id="settings_multirs_total_yield">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="63"/>
@@ -7658,16 +6962,19 @@ Si desidera continuare?</translation>
     <message id="vebus_device_update_firmware">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="133"/>
       <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
       <translation>Questa funzione richiede la versione 400 o successiva del firmware. Contattare l'installatore per aggiornare il Multi/Quattro.</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="139"/>
       <source>Charger not ready, equalization cannot be started</source>
+      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
       <translation>Caricabatterie non pronto, l'equalizzazione non può iniziare</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="143"/>
       <source>Equalization cannot be triggered during bulk charge state</source>
+      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
       <translation>Non si può attivare l'equalizzazione durante la fase di carica di massa.</translation>
     </message>
     <message id="vebus_device_restart_vebus_system_restart_confirmation_description">
@@ -7690,78 +6997,20 @@ Si desidera continuare?</translation>
       <source>Auto-started • %1</source>
       <translation>Avviato automaticamente • %1</translation>
     </message>
-    <message id="common_words_battery">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery</source>
-      <translation type="unfinished">Batteria</translation>
-    </message>
-    <message id="common_words_boat_page">
-      <location filename="../../components/CommonWords.qml" line="111"/>
-      <source>Boat</source>
-      <extracomment>The 'Boat' page</extracomment>
-      <translation type="unfinished">Imbarcazione</translation>
-    </message>
-    <message id="common_words_brief_page">
-      <location filename="../../components/CommonWords.qml" line="115"/>
-      <source>Brief</source>
-      <extracomment>The 'Brief' page</extracomment>
-      <translation type="unfinished">Ragguagli</translation>
-    </message>
-    <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation type="unfinished">Chiuso</translation>
-    </message>
-    <message id="common_words_color">
-      <location filename="../../components/CommonWords.qml" line="136"/>
-      <source>Color</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_connected">
-      <location filename="../../components/CommonWords.qml" line="139"/>
-      <source>Connected</source>
-      <translation type="unfinished">Connesso</translation>
-    </message>
     <message id="common_words_daily_history">
       <location filename="../../components/CommonWords.qml" line="152"/>
       <source>Daily history</source>
       <translation>Cronologia giornaliera</translation>
-    </message>
-    <message id="common_words_disabled">
-      <location filename="../../components/CommonWords.qml" line="169"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Disattivato</translation>
-    </message>
-    <message id="common_words_disconnected">
-      <location filename="../../components/CommonWords.qml" line="175"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Disconnesso</translation>
-    </message>
-    <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="191"/>
-      <source>Error</source>
-      <translation type="unfinished">Errore</translation>
     </message>
     <message id="common_words_error_not_a_number">
       <location filename="../../components/CommonWords.qml" line="200"/>
       <source>'%1' is not a number.</source>
       <translation>'%1' non è un numero.</translation>
     </message>
-    <message id="common_words_generator">
-      <location filename="../../components/CommonWords.qml" line="217"/>
-      <source>Generator</source>
-      <translation type="unfinished">Generatore</translation>
-    </message>
     <message id="common_words_input_current_limit">
       <location filename="../../components/CommonWords.qml" line="261"/>
       <source>Input current limit</source>
       <translation>Limite corrente in ingresso</translation>
-    </message>
-    <message id="common_words_inverter_charger">
-      <location filename="../../components/CommonWords.qml" line="264"/>
-      <source>Inverter / Charger</source>
-      <translation type="unfinished">Inverter / Caricabatterie</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
       <location filename="../../components/CommonWords.qml" line="268"/>
@@ -7774,12 +7023,6 @@ Si desidera continuare?</translation>
       <source>Manual stop</source>
       <translation>Arresto manuale</translation>
     </message>
-    <message id="common_words_max">
-      <location filename="../../components/CommonWords.qml" line="315"/>
-      <source>Max</source>
-      <extracomment>Short for Maximum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_maximum_current">
       <location filename="../../components/CommonWords.qml" line="318"/>
       <source>Maximum current</source>
@@ -7790,62 +7033,10 @@ Si desidera continuare?</translation>
       <source>Maximum power</source>
       <translation>Potenza massima</translation>
     </message>
-    <message id="common_words_min">
-      <location filename="../../components/CommonWords.qml" line="331"/>
-      <source>Min</source>
-      <extracomment>Short for Minimum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_minimum_current">
       <location filename="../../components/CommonWords.qml" line="334"/>
       <source>Minimum current</source>
       <translation>Corrente minima</translation>
-    </message>
-    <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="433"/>
-      <source>No</source>
-      <translation type="unfinished">No</translation>
-    </message>
-    <message id="common_words_none_option">
-      <location filename="../../components/CommonWords.qml" line="364"/>
-      <source>None</source>
-      <translation type="unfinished">Nessuno</translation>
-    </message>
-    <message id="common_words_none_errors">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>None</source>
-      <extracomment>Indicates there are no errors</extracomment>
-      <translation type="unfinished">Nessuno</translation>
-    </message>
-    <message id="common_words_not_available">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Not available</source>
-      <translation type="unfinished">Non disponibile</translation>
-    </message>
-    <message id="common_words_off">
-      <location filename="../../components/CommonWords.qml" line="377"/>
-      <source>Off</source>
-      <translation type="unfinished">Spento</translation>
-    </message>
-    <message id="common_words_ok">
-      <location filename="../../components/CommonWords.qml" line="383"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="41"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="45"/>
-      <source>OK</source>
-      <translation type="unfinished">Ok</translation>
-    </message>
-    <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="386"/>
-      <source>On</source>
-      <translation type="unfinished">Acceso</translation>
-    </message>
-    <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="393"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation type="unfinished">Aperto</translation>
     </message>
     <message id="common_words_open_circuit">
       <location filename="../../components/CommonWords.qml" line="396"/>
@@ -7857,108 +7048,17 @@ Si desidera continuare?</translation>
       <source>Overall history</source>
       <translation>Cronologia complessiva</translation>
     </message>
-    <message id="common_words_press">
-      <location filename="../../components/CommonWords.qml" line="419"/>
-      <source>Press</source>
-      <translation type="unfinished">Premere</translation>
-    </message>
-    <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation type="unfinished">In funzionamento</translation>
-    </message>
-    <message id="common_words_settings">
-      <location filename="../../components/CommonWords.qml" line="467"/>
-      <source>Settings</source>
-      <translation type="unfinished">Impostazioni</translation>
-    </message>
-    <message id="common_words_silence_alarm">
-      <location filename="../../components/CommonWords.qml" line="476"/>
-      <source>Silence alarm</source>
-      <translation type="unfinished">Silenziamento allarme</translation>
-    </message>
     <message id="common_words_soc">
       <location filename="../../components/CommonWords.qml" line="480"/>
       <source>SOC %1</source>
       <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
       <translation>SoC %1%</translation>
     </message>
-    <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation type="unfinished">Velocità</translation>
-    </message>
-    <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="487"/>
-      <source>Standby</source>
-      <translation type="unfinished">Standby</translation>
-    </message>
-    <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="502"/>
-      <source>State</source>
-      <translation type="unfinished">Stato</translation>
-    </message>
-    <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="512"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation type="unfinished">Avvio (%1)</translation>
-    </message>
-    <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>Stopped</source>
-      <translation type="unfinished">Arrestato</translation>
-    </message>
-    <message id="common_words_total_power">
-      <location filename="../../components/CommonWords.qml" line="540"/>
-      <source>Total power</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="547"/>
-      <source>Type</source>
-      <translation type="unfinished">Tipo</translation>
-    </message>
-    <message id="common_words_unknown_status">
-      <location filename="../../components/CommonWords.qml" line="554"/>
-      <source>Unknown</source>
-      <extracomment>Status = "unknown"</extracomment>
-      <translation type="unfinished">Sconosciuto</translation>
-    </message>
-    <message id="common_words_value_must_be_greater_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="557"/>
-      <source>Value must be greater than start value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_value_must_be_greater_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="560"/>
-      <source>Value must be greater than stop value</source>
-      <translation type="unfinished">Il valore deve essere maggiore di quello di arresto</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="563"/>
-      <source>Value must be lower than start value</source>
-      <translation type="unfinished">Il valore deve essere inferiore a quello di avvio</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="566"/>
-      <source>Value must be lower than stop value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="581"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="431"/>
-      <source>Yes</source>
-      <translation type="unfinished">Sì</translation>
-    </message>
     <message id="common_words_yield_today">
       <location filename="../../components/CommonWords.qml" line="592"/>
       <source>Yield Today</source>
       <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+      <oldsource>Yield today</oldsource>
       <translation>Rendimento odierno</translation>
     </message>
     <message id="common_words_format_error">
@@ -7985,10 +7085,11 @@ Si desidera continuare?</translation>
     <message id="settings_firmware_installed_rebooting">
       <location filename="../../components/FirmwareUpdate.qml" line="79"/>
       <source>Firmware installed, device rebooting</source>
+      <oldsource>Firmware installed, rebooting.</oldsource>
       <translation>Firmware installato, riavvio del dispositivo in corso</translation>
     </message>
-    <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/RadioButtonListPage.qml" line="121"/>
+    <message id="modaldialog_confirm">
+      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
       <source>Confirm</source>
       <extracomment>Confirm password, and verify it if possible</extracomment>
       <translation>Conferma</translation>
@@ -8006,11 +7107,13 @@ Si desidera continuare?</translation>
     <message id="cgwacs_battery_schedule_duration">
       <location filename="../../components/listitems/ListChargeSchedule.qml" line="144"/>
       <source>Duration</source>
+      <oldsource>Duration (hh:mm)</oldsource>
       <translation>Durata</translation>
     </message>
     <message id="settings_relay_deactivation_value">
       <location filename="../../components/TemperatureRelaySettings.qml" line="86"/>
       <source>Deactivation value</source>
+      <oldsource>Deativation value</oldsource>
       <translation>Valore disattivazione</translation>
     </message>
     <message id="splash_view_device_disconnected">
@@ -8058,29 +7161,6 @@ Si desidera continuare?</translation>
       <source>Temperature warning</source>
       <translation>Avviso di temperatura</translation>
     </message>
-    <message id="battery_mode_idle">
-      <location filename="../../src/enums.cpp" line="26"/>
-      <source>Idle</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Inattivo</translation>
-    </message>
-    <message id="battery_mode_charging">
-      <location filename="../../src/enums.cpp" line="30"/>
-      <source>Charging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Carica in corso</translation>
-    </message>
-    <message id="battery_mode_discharging">
-      <location filename="../../src/enums.cpp" line="34"/>
-      <source>Discharging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Scarica in corso</translation>
-    </message>
-    <message id="dcMeter_bilge_pump">
-      <location filename="../../src/enums.cpp" line="115"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">Pompa di sentina</translation>
-    </message>
     <message id="switch_state_channel_fault">
       <location filename="../../src/enums.cpp" line="372"/>
       <source>Channel Fault</source>
@@ -8111,26 +7191,6 @@ Si desidera continuare?</translation>
       <source>Slave of %1</source>
       <translation>Slave di %1</translation>
     </message>
-    <message id="switchable_output_numeric_input">
-      <location filename="../../src/enums.cpp" line="418"/>
-      <source>Numeric input</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bilge_pump">
-      <location filename="../../src/enums.cpp" line="424"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">Pompa di sentina</translation>
-    </message>
-    <message id="switchable_output_not_running">
-      <location filename="../../src/enums.cpp" line="448"/>
-      <source>Not running</source>
-      <translation type="unfinished">Non in esecuzione</translation>
-    </message>
-    <message id="switchable_output_off">
-      <location filename="../../src/enums.cpp" line="451"/>
-      <source>Off</source>
-      <translation type="unfinished">Spento</translation>
-    </message>
     <message id="switchable_output_powered">
       <location filename="../../src/enums.cpp" line="455"/>
       <source>Powered</source>
@@ -8159,16 +7219,19 @@ Si desidera continuare?</translation>
     <message id="evchargers_status_welded_contacts_error">
       <location filename="../../data/EvChargers.qml" line="76"/>
       <source>Welded contacts test error (shorted)</source>
+      <oldsource>Welded contacts error</oldsource>
       <translation>Errore del test dei contatti saldati (in cortocircuito)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
       <location filename="../../data/EvChargers.qml" line="100"/>
       <source>Switching to 3 phase</source>
+      <oldsource>Switching to 3-phase</oldsource>
       <translation>Commutazione a trifase in corso</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
       <location filename="../../data/EvChargers.qml" line="103"/>
       <source>Switching to 1 phase</source>
+      <oldsource>Switching to single phase</oldsource>
       <translation>Commutazione a monofase in corso</translation>
     </message>
     <message id="evchargers_status_stop_charging">
@@ -8321,17 +7384,6 @@ Se il generatore è in funzione in seguito a una condizione di avvio automatico,
       <source>Open link</source>
       <translation>Apri link</translation>
     </message>
-    <message id="listlink_show_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="43"/>
-      <source>Show QR code</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="listlink_scan_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="52"/>
-      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
-      <extracomment>%1 = url text</extracomment>
-      <translation type="unfinished">Scansionare il codice QR con il proprio dispositivo portatile.&lt;br /&gt;Oppure inserire il link: %1</translation>
-    </message>
     <message id="settings_services_mqtt_access">
       <location filename="../../components/listitems/ListMqttAccessSwitch.qml" line="11"/>
       <source>MQTT Access</source>
@@ -8403,12 +7455,6 @@ Se il generatore è in funzione in seguito a una condizione di avvio automatico,
       <extracomment>The 'Brief' page, with the side panel opened</extracomment>
       <translation>Sintesi (pannello laterale aperto)</translation>
     </message>
-    <message id="startpage_option_overview">
-      <location filename="../../data/StartPageConfiguration.qml" line="37"/>
-      <source>Overview</source>
-      <extracomment>The 'Overview' page</extracomment>
-      <translation type="unfinished">Panoramica</translation>
-    </message>
     <message id="startpage_option_levels_tanks">
       <location filename="../../data/StartPageConfiguration.qml" line="43"/>
       <source>Levels (Tanks)</source>
@@ -8427,12 +7473,12 @@ Se il generatore è in funzione in seguito a una condizione di avvio automatico,
       <translation>Elenco delle batterie</translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
+      <location filename="../../pages/DialogLayer.qml" line="56"/>
       <source>GX device has been updated</source>
       <translation>Il dispositivo GX è stato aggiornato</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
+      <location filename="../../pages/DialogLayer.qml" line="58"/>
       <source>Page will automatically reload in ten seconds to load the latest version.</source>
       <translation>La pagina si ricaricherà automaticamente dopo dieci secondi per caricare la versione più recente.</translation>
     </message>
@@ -8602,8 +7648,8 @@ Notare che questo menu mostra solo i contatori Carlo Gavazzi collegati tramite R
       <source>Unit</source>
       <translation>Unità</translation>
     </message>
-    <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="61"/>
+    <message id="page_settings_fronius_unitid_invalid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
       <source>%1 is not a valid unit number. Use a number between 1-247.</source>
       <translation>%1 non è un numero di unità valido. Utilizzare un numero compreso tra 1-247.</translation>
     </message>
@@ -8718,11 +7764,6 @@ Notare che questo menu mostra solo i contatori Carlo Gavazzi collegati tramite R
       <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="66"/>
       <source>Controller Temperature</source>
       <translation>Temperatura regolatore</translation>
-    </message>
-    <message id="devicelist_motordrive_motordirectioninverted">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
-      <source>Motor Direction Inverted</source>
-      <translation type="unfinished"/>
     </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
@@ -8912,11 +7953,6 @@ With streamlined navigation and a fresh look, everything you love is now even ea
     <message id="welcome_done">
       <location filename="../../pages/welcome/WelcomeView.qml" line="136"/>
       <source>Done</source>
-      <translation type="unfinished">Fatto</translation>
-    </message>
-    <message id="mk2vsc_state_done">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="20"/>
-      <source>Done</source>
       <translation>Fatto</translation>
     </message>
     <message id="welcome_next">
@@ -8974,6 +8010,7 @@ Il dispositivo GX può controllare un solo generatore collegato e considera quel
     <message id="settings_tz_etc">
       <location filename="../../pages/settings/PageTzInfo.qml" line="280"/>
       <source>Other</source>
+      <oldsource>Etc</oldsource>
       <translation>Altro</translation>
     </message>
     <message id="ac-in-modeldefault_energy_reverse_x">
@@ -8991,6 +8028,11 @@ Il dispositivo GX può controllare un solo generatore collegato e considera quel
       <location filename="../../src/enums.cpp" line="438"/>
       <source>Unsupported type: %1</source>
       <translation>Tipo non supportato: %1</translation>
+    </message>
+    <message id="common_words_press">
+      <location filename="../../components/CommonWords.qml" line="419"/>
+      <source>Press</source>
+      <translation>Premere</translation>
     </message>
     <message id="output_aux_battery_service_changed_dcdc">
       <location filename="../../components/listitems/ListOutputBatteryRadioButtonGroup.qml" line="27"/>
@@ -9131,13 +8173,6 @@ Il dispositivo GX può controllare un solo generatore collegato e considera quel
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="38"/>
       <source>Resetting VE.Bus products</source>
       <translation>Ripristino dei prodotti VE.Bus in corso</translation>
-    </message>
-    <message id="Unknown">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Sconosciuto</translation>
     </message>
     <message id="mk2vsc_error_mk2_mk3_comm">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="47"/>
@@ -9443,11 +8478,6 @@ Il dispositivo GX può controllare un solo generatore collegato e considera quel
       <source>Changing the GX Password</source>
       <translation>Modifica della password del GX in corso</translation>
     </message>
-    <message id="modaldialog_confirm">
-      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
-      <source>Confirm</source>
-      <translation type="unfinished">Conferma</translation>
-    </message>
     <message id="settings_security_profile_change_password_description">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="83"/>
       <source>Please enter a new GX password:</source>
@@ -9540,21 +8570,6 @@ Il dispositivo GX può controllare un solo generatore collegato e considera quel
       <source>Modifications installed</source>
       <translation>Modifiche installate</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_modbus">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="28"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">Server Modbus TCP</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_signalk">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="32"/>
-      <source>Signal K</source>
-      <translation type="unfinished">Segnale K</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_nodered">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="36"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">Node-RED</translation>
-    </message>
     <message id="pagesettingsgeneral_modificationchecks_running_integrations">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="43"/>
       <source>%1 running integrations</source>
@@ -9630,16 +8645,6 @@ Il dispositivo GX può controllare un solo generatore collegato e considera quel
       <source>Installed and enabled, disables at next boot</source>
       <translation>Installato e abilitato, si disabilita al prossimo avvio</translation>
     </message>
-    <message id="pagesettingssupportstate_firmware_checking">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
-      <source>Checking...</source>
-      <translation type="unfinished">Verifica in corso...</translation>
-    </message>
-    <message id="pagesettingssupportstate_firmware_unknown">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="166"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Sconosciuto</translation>
-    </message>
     <message id="pagesettingssupportstate_support_status">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="228"/>
       <source>Support status</source>
@@ -9662,11 +8667,6 @@ Il dispositivo GX può controllare un solo generatore collegato e considera quel
       <source>Press 'OK' to disable custom startup scripts and reboot</source>
       <translation>Premere 'OK' per disabilitare gli script di avvio personalizzati e riavviare</translation>
     </message>
-    <message id="pagesettingssupportstate_re_enable_custom_startup_scripts">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="309"/>
-      <source>Re-enable custom startup scripts</source>
-      <translation type="unfinished">Riabilita script di avvio personalizzati</translation>
-    </message>
     <message id="pagesettingssupportstate_reenable_and_reboot_now">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="322"/>
       <source>Re-enable custom startup scripts</source>
@@ -9685,17 +8685,12 @@ Il dispositivo GX può controllare un solo generatore collegato e considera quel
     <message id="pagesettingssupportstate_latest_official_firmware_installed">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="368"/>
       <source>Latest official firmware version installed?</source>
-      <translation>È installata l'ultima versione ufficiale del firmware?</translation>
+      <translation>Questa è l'ultima versione installata?</translation>
     </message>
     <message id="pagesettingssupportstate_disable_also_custom_startup_scripts">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="428"/>
       <source>Disable also custom startup scripts?</source>
       <translation>Disabilitare anche gli script di avvio personalizzati?</translation>
-    </message>
-    <message id="pagesettingssupportstate_integrations">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
-      <source>Integrations</source>
-      <translation type="unfinished">Integrazioni</translation>
     </message>
     <message id="pagesettingssupportstate_orange_items_description">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="494"/>
@@ -9708,7 +8703,7 @@ Il dispositivo GX può controllare un solo generatore collegato e considera quel
       <translation>Collegare un dongle USB Bluetooth compatibile per abilitare la connettività Bluetooth.</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="140"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="142"/>
       <source>BatteryLife state</source>
       <translation>Stato BatteryLife</translation>
     </message>
@@ -9716,23 +8711,6 @@ Il dispositivo GX può controllare un solo generatore collegato e considera quel
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="33"/>
       <source>Device Integrations</source>
       <translation>Integrazioni del dispositivo</translation>
-    </message>
-    <message id="pagesettingsintegrations_modbus_tcp_server">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="201"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">Server Modbus TCP</translation>
-    </message>
-    <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="226"/>
-      <location filename="../../pages/settings/PageSettingsSignalK.qml" line="18"/>
-      <source>Signal K</source>
-      <translation type="unfinished">Segnale K</translation>
-    </message>
-    <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="241"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">Node-RED</translation>
     </message>
     <message id="settings_venusos_large_documentation">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="267"/>
@@ -9742,6 +8720,7 @@ Il dispositivo GX può controllare un solo generatore collegato e considera quel
     <message id="settings_modbus_enable_modbus_tcp">
       <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
       <source>Enable Modbus TCP Server</source>
+      <oldsource>Enable Modbus/TCP</oldsource>
       <translation>Abilita server Modbus TCP</translation>
     </message>
     <message id="pagesettingsconnectivity_bluetooth_for_victronconnect_app">
@@ -9835,11 +8814,13 @@ Il dispositivo GX può controllare un solo generatore collegato e considera quel
     <message id="settings_gps_format_kmh">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="93"/>
       <source>Kilometres per hour</source>
+      <oldsource>Kilometers per hour</oldsource>
       <translation>Chilometri orari</translation>
     </message>
     <message id="settings_gps_format_ms">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="95"/>
       <source>Metres per second</source>
+      <oldsource>Meters per second</oldsource>
       <translation>Metri al secondo</translation>
     </message>
     <message id="components_volumeunit_cubic_metres">
@@ -9867,8 +8848,8 @@ Il dispositivo GX può controllare un solo generatore collegato e considera quel
       <source>The Relay can now be found in the devices list</source>
       <translation>Il relè è ora disponibile nell'elenco dei dispositivi</translation>
     </message>
-    <message id="common_words_gx_device_relays">
-      <location filename="../../components/CommonWords.qml" line="223"/>
+    <message id="gx_device_relays">
+      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
       <source>GX device relays</source>
       <translation>Relè del dispositivo GX</translation>
     </message>
@@ -9922,12 +8903,6 @@ Il dispositivo GX può controllare un solo generatore collegato e considera quel
       <extracomment>Forced by app to %1</extracomment>
       <translation>auto</translation>
     </message>
-    <message id="settings_remote_console_forced_by_vrm">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="94"/>
-      <source>VRM</source>
-      <extracomment>Forced by %2 to dark</extracomment>
-      <translation type="unfinished">VRM</translation>
-    </message>
     <message id="settings_remote_console_forced_by_app">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="97"/>
       <source>app</source>
@@ -9977,6 +8952,7 @@ Il dispositivo GX può controllare un solo generatore collegato e considera quel
     <message id="settings_large_access_signal_k">
       <location filename="../../pages/settings/PageSettingsSignalK.qml" line="24"/>
       <source>Access Signal K</source>
+      <oldsource>Access Signal K (local network)</oldsource>
       <translation>Accedi a Signal K</translation>
     </message>
     <message id="pagesettingsintegrations_shelly_devices">
@@ -9987,6 +8963,7 @@ Il dispositivo GX può controllare un solo generatore collegato e considera quel
     <message id="settings_large_access_node_red">
       <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
       <source>Access Node-RED</source>
+      <oldsource>Access Node-RED (local network)</oldsource>
       <translation>Accedi a Node-RED</translation>
     </message>
     <message id="settings_wifi_access_point_password">
@@ -10054,57 +9031,6 @@ Il dispositivo GX può controllare un solo generatore collegato e considera quel
       <source>Wind charger</source>
       <translation>Caricabatterie eolico</translation>
     </message>
-    <message id="digitalinputs_type_disabled">
-      <location filename="../../src/enums.cpp" line="192"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Disattivato</translation>
-    </message>
-    <message id="digitalinputs_state_off">
-      <location filename="../../src/enums.cpp" line="242"/>
-      <source>Off</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Spento</translation>
-    </message>
-    <message id="digitalinputs_state_on">
-      <location filename="../../src/enums.cpp" line="246"/>
-      <source>On</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Acceso</translation>
-    </message>
-    <message id="digitalinputs_state_ok">
-      <location filename="../../src/enums.cpp" line="266"/>
-      <source>OK</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Ok</translation>
-    </message>
-    <message id="digitalinputs_state_alarm">
-      <location filename="../../src/enums.cpp" line="270"/>
-      <source>Alarm</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Allarme</translation>
-    </message>
-    <message id="digitalinputs_state_running">
-      <location filename="../../src/enums.cpp" line="274"/>
-      <source>Running</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">In funzionamento</translation>
-    </message>
-    <message id="pvinverter_statusCode_running">
-      <location filename="../../src/enums.cpp" line="300"/>
-      <source>Running</source>
-      <extracomment>PV inverter status code</extracomment>
-      <translation type="unfinished">In funzionamento</translation>
-    </message>
-    <message id="solarchargers_state_external control">
-      <location filename="../../src/enums.cpp" line="352"/>
-      <source>External control</source>
-      <translation type="unfinished">Controllo esterno</translation>
-    </message>
-    <message id="switch_state_over_temperature">
-      <location filename="../../src/enums.cpp" line="366"/>
-      <source>Over temperature</source>
-      <translation type="unfinished">Sovratemperatura</translation>
-    </message>
     <message id="switchable_output_temperature_setpoint">
       <location filename="../../src/enums.cpp" line="398"/>
       <source>Temperature setpoint</source>
@@ -10114,11 +9040,6 @@ Il dispositivo GX può controllare un solo generatore collegato e considera quel
       <location filename="../../src/enums.cpp" line="401"/>
       <source>Stepped switch</source>
       <translation>Interruttore a gradini</translation>
-    </message>
-    <message id="switchable_output_slave">
-      <location filename="../../src/enums.cpp" line="408"/>
-      <source>Slave</source>
-      <translation type="unfinished">Slave</translation>
     </message>
     <message id="switchable_output_dropdown">
       <location filename="../../src/enums.cpp" line="412"/>
@@ -10130,122 +9051,10 @@ Il dispositivo GX può controllare un solo generatore collegato e considera quel
       <source>Basic slider</source>
       <translation>Cursore base</translation>
     </message>
-    <message id="switchable_output_rgb_color_wheel">
-      <location filename="../../src/enums.cpp" line="427"/>
-      <source>RGB color wheel</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_cct_color_wheel">
-      <location filename="../../src/enums.cpp" line="431"/>
-      <source>CCT color wheel</source>
-      <extracomment>Correlated Color Temperature color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_rgbw_color_wheel">
-      <location filename="../../src/enums.cpp" line="435"/>
-      <source>RGB + W color wheel</source>
-      <extracomment>RGB + white color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bypassed">
-      <location filename="../../src/enums.cpp" line="484"/>
-      <source>Bypassed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="tank_type_fuel">
-      <location filename="../../src/enums.cpp" line="495"/>
-      <source>Fuel</source>
-      <translation type="unfinished">Carburante</translation>
-    </message>
-    <message id="tank_type_fresh_water">
-      <location filename="../../src/enums.cpp" line="498"/>
-      <source>Fresh water</source>
-      <translation type="unfinished">Acqua dolce</translation>
-    </message>
-    <message id="tank_type_waste_water">
-      <location filename="../../src/enums.cpp" line="501"/>
-      <source>Waste water</source>
-      <translation type="unfinished">Acque reflue</translation>
-    </message>
-    <message id="tank_type_live_well">
-      <location filename="../../src/enums.cpp" line="504"/>
-      <source>Live well</source>
-      <translation type="unfinished">Serbatoio</translation>
-    </message>
-    <message id="tank_type_oil">
-      <location filename="../../src/enums.cpp" line="507"/>
-      <source>Oil</source>
-      <translation type="unfinished">Olio</translation>
-    </message>
-    <message id="tank_type_black_water">
-      <location filename="../../src/enums.cpp" line="510"/>
-      <source>Black water</source>
-      <translation type="unfinished">ACQUE NERE</translation>
-    </message>
-    <message id="tank_type_gasoline">
-      <location filename="../../src/enums.cpp" line="513"/>
-      <source>Gasoline</source>
-      <translation type="unfinished">Benzina</translation>
-    </message>
-    <message id="tank_type_diesel">
-      <location filename="../../src/enums.cpp" line="516"/>
-      <source>Diesel</source>
-      <translation type="unfinished">Diesel</translation>
-    </message>
-    <message id="tank_type_lpg">
-      <location filename="../../src/enums.cpp" line="519"/>
-      <source>LPG</source>
-      <translation type="unfinished">LPG</translation>
-    </message>
-    <message id="tank_type_lng">
-      <location filename="../../src/enums.cpp" line="522"/>
-      <source>LNG</source>
-      <translation type="unfinished">LNG</translation>
-    </message>
-    <message id="tank_type_hydraulic_oil">
-      <location filename="../../src/enums.cpp" line="525"/>
-      <source>Hydraulic oil</source>
-      <translation type="unfinished">Olio idraulico</translation>
-    </message>
-    <message id="tank_type_raw_water">
-      <location filename="../../src/enums.cpp" line="528"/>
-      <source>Raw water</source>
-      <translation type="unfinished">Acqua grezza</translation>
-    </message>
-    <message id="microgrid_mode_hybrid_droop">
-      <location filename="../../src/enums.cpp" line="539"/>
-      <source>Hybrid droop</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_following">
-      <location filename="../../src/enums.cpp" line="542"/>
-      <source>Grid-following</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_forming">
-      <location filename="../../src/enums.cpp" line="545"/>
-      <source>Grid-forming</source>
-      <translation type="unfinished"/>
-    </message>
     <message id="switchable_output_three_state_switch">
       <location filename="../../src/enums.cpp" line="421"/>
       <source>Three-state switch</source>
       <translation>Interruttore a tre posizioni</translation>
-    </message>
-    <message id="switchable_output_fault">
-      <location filename="../../src/enums.cpp" line="464"/>
-      <source>Fault</source>
-      <translation type="unfinished">Errore</translation>
-    </message>
-    <message id="switchable_output_running">
-      <location filename="../../src/enums.cpp" line="468"/>
-      <source>Running</source>
-      <translation type="unfinished">In funzionamento</translation>
-    </message>
-    <message id="switchable_output_trip_low_voltage">
-      <location filename="../../src/enums.cpp" line="481"/>
-      <source>Trip low voltage</source>
-      <translation type="unfinished">Disattivato</translation>
     </message>
     <message id="settings_modbus_tcp_unit_id_note">
       <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="41"/>
@@ -10267,281 +9076,1152 @@ Il dispositivo GX può controllare un solo generatore collegato e considera quel
       <source>Press to refresh</source>
       <translation>Premere per aggiornare</translation>
     </message>
-    <message id="temperature_type_unknown">
-      <location filename="../../data/EnvironmentInputs.qml" line="65"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Sconosciuto</translation>
-    </message>
-    <message id="brief_solar_yield">
-      <location filename="../../pages/BriefSidePanel.qml" line="24"/>
-      <source>Solar yield</source>
-      <translation type="unfinished">Rendimento solare</translation>
-    </message>
-    <message id="brief_dc_input">
-      <location filename="../../pages/BriefSidePanel.qml" line="214"/>
-      <source>DC input</source>
-      <translation type="unfinished">Ingresso CC</translation>
-    </message>
-    <message id="brief_ac_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="257"/>
-      <source>AC Loads</source>
-      <translation type="unfinished">Carichi CA</translation>
-    </message>
-    <message id="brief_dc_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="284"/>
-      <source>DC Loads</source>
-      <translation type="unfinished">Carichi CC</translation>
-    </message>
-    <message id="nav_overview">
-      <location filename="../../pages/OverviewPage.qml" line="450"/>
-      <source>Overview</source>
-      <translation type="unfinished">Panoramica</translation>
-    </message>
-    <message id="settings_state">
-      <location filename="../../pages/settings/PageCanbusStatus.qml" line="116"/>
-      <source>State</source>
-      <translation type="unfinished">Stato</translation>
-    </message>
-    <message id="inverter_pv">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="56"/>
-      <source>PV</source>
-      <translation type="unfinished">FV</translation>
-    </message>
-    <message id="inverter_total_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="76"/>
-      <source>Total yield</source>
-      <translation type="unfinished">Rendimento totale</translation>
-    </message>
-    <message id="inverter_system_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="84"/>
-      <source>System yield</source>
-      <translation type="unfinished">Rendimento sistema</translation>
-    </message>
-    <message id="charger_total_pv_power">
-      <location filename="../../pages/solar/SolarDevicePage.qml" line="61"/>
-      <source>Total PV Power</source>
-      <translation type="unfinished">Potenza totale</translation>
-    </message>
-    <message id="vebus_device_alarm_only">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
-      <source>Alarm only</source>
-      <translation type="unfinished">Solo allarme</translation>
-    </message>
-    <message id="vebus_device_alarms_and_warnings">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
-      <source>Alarms &amp; warnings</source>
-      <translation type="unfinished">Allarmi &amp; avvertenze</translation>
-    </message>
-    <message id="vebus_device_alarm_group_warning">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
-      <source>Warning</source>
-      <translation type="unfinished">Avvertimento</translation>
-    </message>
-    <message id="load_delegate_status">
-      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
-      <source>Status: %1</source>
-      <translation type="unfinished"/>
+    <message id="common_words_total_power">
+      <location filename="../../components/CommonWords.qml" line="540"/>
+      <source>Total power</source>
+      <translation>Potenza totale</translation>
     </message>
     <message id="venus_os_gui">
       <location filename="../../Main.qml" line="17"/>
       <source>Venus OS GUI</source>
       <extracomment>Application title</extracomment>
-      <translation type="unfinished"/>
       <extra-Context>only shown on desktop systems</extra-Context>
+      <translation>GUI di Venus OS</translation>
+    </message>
+    <message id="load_delegate_status">
+      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
+      <source>Status: %1</source>
+      <translation>Stato: %1</translation>
+    </message>
+    <message id="settings_relay_polarity_relay1">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
+      <source>Polarity (Relay 1)</source>
+      <translation>Polarità (Relè 1)</translation>
+    </message>
+    <message id="settings_relay_polarity">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
+      <source>Polarity</source>
+      <translation>Polarità</translation>
+    </message>
+    <message id="settings_relay_polarity_relay2">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
+      <source>Polarity (Relay 2)</source>
+      <translation>Polarità (Relè 2)</translation>
+    </message>
+    <message id="page_settings_wifi_invalid_password">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
+      <source>Password length must be either 0 or between 10 and 63 characters long</source>
+      <translation>La lunghezza della password deve essere 0 oppure compresa tra 10 e 63 caratteri</translation>
+    </message>
+    <message id="page_settings_wifi_password_updated">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
+      <source>Password updated</source>
+      <translation>Password aggiornata</translation>
+    </message>
+    <message id="common_words_max">
+      <location filename="../../components/CommonWords.qml" line="315"/>
+      <source>Max</source>
+      <extracomment>Short for Maximum</extracomment>
+      <translation>Max</translation>
+    </message>
+    <message id="common_words_min">
+      <location filename="../../components/CommonWords.qml" line="331"/>
+      <source>Min</source>
+      <extracomment>Short for Minimum</extracomment>
+      <translation>Min</translation>
+    </message>
+    <message id="settings_ess_deprecated">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="321"/>
+      <source>Deprecated settings</source>
+      <translation>Impostazioni obsolete</translation>
+    </message>
+    <message id="settings_ess_max_charge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="328"/>
+      <source>Battery charge limit (% of CCL)</source>
+      <translation>Limite di carica della batteria (% del CCL)</translation>
+    </message>
+    <message id="settings_ess_max_discharge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="339"/>
+      <source>Battery discharge limit (% of DCL)</source>
+      <translation>Limite di scarica della batteria (% del DCL)</translation>
+    </message>
+    <message id="vebus_device_bms_message">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
+      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
+      <oldsource>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</oldsource>
+      <translation>Un BMS VE.Bus spegne automaticamente il sistema quando necessario per proteggere la batteria. Pertanto, non è possibile controllare il sistema dal dispositivo GX.</translation>
+    </message>
+    <message id="switchable_output_numeric_input">
+      <location filename="../../src/enums.cpp" line="418"/>
+      <source>Numeric input</source>
+      <translation>Inserimento numerico</translation>
     </message>
     <message id="autotoggleswitch_disable_auto_mode_info">
       <location filename="../../components/controls/AutoToggleButton.qml" line="34"/>
       <source>Disable Auto mode first</source>
-      <translation type="unfinished"/>
+      <translation>Disattivare prima la modalità Auto</translation>
+    </message>
+    <message id="pagesettingsintegrations_venus_os_enable_large_features">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
+      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
+      <translation>Abilita il firmware Venus OS Large per utilizzare Node-RED o Signal-K</translation>
+    </message>
+    <message id="settings_relays_sensors_tanks">
+      <location filename="../../pages/SettingsPage.qml" line="75"/>
+      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
+      <oldsource>Relays, Sensors, Tanks, PV Inverters, Modbus, MQTT…</oldsource>
+      <translation>Relè, sensori, inverter fotovoltaici, Modbus, Node-RED</translation>
+    </message>
+    <message id="vebus_device_page_microgrid_parameters">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
+      <source>Microgrid parameters</source>
+      <translation>Parametri della microrete</translation>
+    </message>
+    <message id="microgrid_mode_hybrid_droop">
+      <location filename="../../src/enums.cpp" line="539"/>
+      <source>Hybrid droop</source>
+      <translation>Droop ibrido</translation>
+    </message>
+    <message id="microgrid_mode_grid_following">
+      <location filename="../../src/enums.cpp" line="542"/>
+      <source>Grid-following</source>
+      <translation>Grid-following</translation>
+    </message>
+    <message id="microgrid_mode_grid_forming">
+      <location filename="../../src/enums.cpp" line="545"/>
+      <source>Grid-forming</source>
+      <translation>Grid-forming</translation>
+    </message>
+    <message id="switchable_output_trip_low_voltage">
+      <location filename="../../src/enums.cpp" line="481"/>
+      <source>Trip low voltage</source>
+      <oldsource>Disabled</oldsource>
+      <translation>Interruzione per bassa tensione</translation>
     </message>
     <message id="microgrid">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="15"/>
       <source>Microgrid</source>
-      <translation type="unfinished"/>
+      <translation>Microrrete</translation>
     </message>
     <message id="page_microgrid_active_mode">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="19"/>
       <source>Active mode</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_microgrid_from_p1_to_p2">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="34"/>
-      <source>%1 %2 to %3 %4</source>
-      <extracomment>Describes a range from one quantity to another, e.g. "30 W to 60 W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
-      <translation type="unfinished"/>
+      <translation>Modalità attiva</translation>
     </message>
     <message id="page_microgrid_hybrid_droop_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="92"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
       <source>Hybrid droop parameters</source>
-      <translation type="unfinished"/>
+      <translation>Parametri droop ibrido</translation>
     </message>
     <message id="page_microgrid_reference_active_power_p0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="105"/>
       <source>Reference active power (P&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Potenza attiva di riferimento (P&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_frequency_f0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="108"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="112"/>
       <source>Reference frequency (f&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Frequenza di riferimento (f&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_frequency_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="117"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="119"/>
       <source>Frequency droop slope (droop&lt;sub&gt;fP&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Pendenza di droop della frequenza (droop&lt;sub&gt;fP&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_reactive_power">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="126"/>
       <source>Reference reactive power (Q&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Potenza reattiva di riferimento (Q&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_voltage">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="135"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="133"/>
       <source>Reference Voltage (U&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Tensione di riferimento (U&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_voltage_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="144"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="140"/>
       <source>Voltage droop slope (droop&lt;sub&gt;UQ&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Pendenza di droop della tensione (droop&lt;sub&gt;UQ&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_minimum_and_maximum_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="146"/>
       <source>Minimum and maximum parameters</source>
-      <translation type="unfinished"/>
+      <translation>Parametri minimi e massimi</translation>
     </message>
     <message id="page_microgrid_allowed_active_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="156"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
       <source>Allowed active power range</source>
-      <translation type="unfinished"/>
+      <translation>Intervallo di potenza attiva consentito</translation>
     </message>
     <message id="page_microgrid_allowed_reactive_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="164"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="159"/>
       <source>Allowed reactive power range</source>
-      <translation type="unfinished"/>
+      <translation>Intervallo di potenza reattiva consentito</translation>
     </message>
     <message id="page_microgrid_p_q_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="176"/>
       <source>P-Q direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>Impostazioni di trasmissione diretta P-Q</translation>
     </message>
     <message id="page_microgrid_active_power_setpoint_p">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="186"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
       <source>Active power setpoint (P)</source>
-      <translation type="unfinished"/>
+      <translation>Setpoint di potenza attiva (P)</translation>
     </message>
     <message id="page_microgrid_reactive_power_setpoint_q">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="194"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="188"/>
       <source>Reactive power setpoint (Q)</source>
-      <translation type="unfinished"/>
+      <translation>Setpoint di potenza reattiva (Q)</translation>
     </message>
     <message id="page_microgrid_allowed_frequency_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="202"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="195"/>
       <source>Allowed frequency range</source>
-      <translation type="unfinished"/>
+      <translation>Intervallo di frequenza consentito</translation>
     </message>
     <message id="page_microgrid_allowed_voltage_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="210"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="203"/>
       <source>Allowed voltage range</source>
-      <translation type="unfinished"/>
+      <translation>Intervallo di tensione consentito</translation>
     </message>
     <message id="page_microgrid_v_f_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="227"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="220"/>
       <source>V-f direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>Impostazioni di trasmissione diretta V-f</translation>
     </message>
     <message id="page_microgrid_voltage_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="225"/>
       <source>Voltage setpoint (U)</source>
-      <translation type="unfinished"/>
+      <translation>Setpoint di tensione (U)</translation>
     </message>
     <message id="page_microgrid_frequency_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="240"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
       <source>Frequency setpoint (f)</source>
-      <translation type="unfinished"/>
+      <translation>Setpoint di frequenza (f)</translation>
     </message>
-    <message id="temperature_slider_current">
-      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
-      <source>Current</source>
-      <extracomment>The current temperature measurement</extracomment>
-      <translation type="unfinished">Corrente</translation>
+    <message id="pagesettingsintegrations_canopenmotordrive">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
+      <source>CANopen motor drives</source>
+      <translation>Azionamenti motore CANopen</translation>
+    </message>
+    <message id="pagesettingsintegrations_ui_plugins">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
+      <source>UI Plugins</source>
+      <translation>Plugin UI</translation>
+    </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
+      <source>Motor Direction Inverted</source>
+      <translation>Direzione motore invertita</translation>
     </message>
     <message id="page_settings_canopenmotordrive_scan_for_motor_drives">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="31"/>
       <source>Scan for motor drives</source>
-      <translation type="unfinished"/>
+      <translation>Ricerca azionamenti motore</translation>
     </message>
     <message id="page_settings_canopenmotordrive_discovered_motor_drive_ids">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="39"/>
       <source>Discovered motor drive IDs</source>
-      <translation type="unfinished"/>
+      <translation>ID azionamenti motore rilevati</translation>
     </message>
-    <message id="switchableoutput_gx_device_relays">
-      <location filename="../../src/switchableoutput.cpp" line="388"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">Relè del dispositivo GX</translation>
+    <message id="temperature_pm25">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
+      <source>PM2.5</source>
+      <translation>PM2.5</translation>
     </message>
-    <message id="gx_device_relays">
-      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">Relè del dispositivo GX</translation>
+    <message id="temperature_co2">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+      <source>CO₂</source>
+      <translation>CO₂</translation>
     </message>
-    <message id="color_preset">
-      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
-      <source>Preset</source>
-      <translation type="unfinished"/>
+    <message id="temperature_voc">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
+      <source>VOC index</source>
+      <translation>Indice VOC</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_location">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
-      <source>Add Modbus port and unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_nox">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
+      <source>NOx index</source>
+      <translation>Indice NOx</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_unitid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
-      <source>Unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_luminosity">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
+      <source>Luminosity</source>
+      <translation>Luminosità</translation>
     </message>
-    <message id="page_settings_fronius_unitid_invalid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation type="unfinished">%1 non è un numero di unità valido. Utilizzare un numero compreso tra 1-247.</translation>
-    </message>
-    <message id="page_settings_fronius_add_modbus_location_button">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
-      <source>Add</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_locations_note">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
-      <source>The default modbus port is 502 and the default unit ID is 126.
-Here you can add additional ports and unit IDs to scan for PV inverters.</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_location_number">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
-      <source>Port/Unit ID %1</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location_description">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
-      <source>Port: %1 (Unit %2)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
-      <source>Remove Modbus port and unit ID?</source>
-      <translation type="unfinished"/>
+    <message id="switchable_output_bypassed">
+      <location filename="../../src/enums.cpp" line="484"/>
+      <source>Bypassed</source>
+      <translation>Escluso</translation>
     </message>
     <message id="switchableoutput_list_delegate_auto_status">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="84"/>
       <source>Auto (%1)</source>
       <extracomment>%1 = 'On' or 'Off'</extracomment>
-      <translation type="unfinished"/>
+      <translation>Auto (%1)</translation>
     </message>
     <message id="switchableoutput_list_delegate_state_forced">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="100"/>
       <source>Forced</source>
-      <translation type="unfinished"/>
+      <translation>Forzato</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_settings">
+      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
+      <source>Modbus port and unit ID settings</source>
+      <translation>Impostazioni porta Modbus e ID unità</translation>
+    </message>
+    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
+      <source>Integrates with the device list</source>
+      <translation>Si integra con l'elenco dei dispositivi</translation>
+    </message>
+    <message id="common_words_color">
+      <location filename="../../components/CommonWords.qml" line="136"/>
+      <source>Color</source>
+      <translation>Colore</translation>
+    </message>
+    <message id="common_words_value_must_be_greater_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="557"/>
+      <source>Value must be greater than start value</source>
+      <translation>Il valore deve essere maggiore del valore iniziale</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="566"/>
+      <source>Value must be lower than stop value</source>
+      <translation>Il valore deve essere inferiore al valore di arresto</translation>
+    </message>
+    <message id="notifications_page_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="43"/>
+      <source>Active Notifications</source>
+      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
+      <translation>Notifiche attive</translation>
+    </message>
+    <message id="notifications_page_inactive_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="47"/>
+      <source>Inactive Notifications</source>
+      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
+      <translation>Notifiche inattive</translation>
+    </message>
+    <message id="notifications_no_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="106"/>
+      <source>No active notifications</source>
+      <translation>Nessuna notifica attiva</translation>
+    </message>
+    <message id="switchable_output_rgb_color_wheel">
+      <location filename="../../src/enums.cpp" line="427"/>
+      <source>RGB color wheel</source>
+      <translation>Ruota colori RGB</translation>
+    </message>
+    <message id="switchable_output_cct_color_wheel">
+      <location filename="../../src/enums.cpp" line="431"/>
+      <source>CCT color wheel</source>
+      <extracomment>Correlated Color Temperature color wheel</extracomment>
+      <translation>Ruota colori CCT</translation>
+    </message>
+    <message id="switchable_output_rgbw_color_wheel">
+      <location filename="../../src/enums.cpp" line="435"/>
+      <source>RGB + W color wheel</source>
+      <extracomment>RGB + white color wheel</extracomment>
+      <translation>Ruota colori RGB + W</translation>
+    </message>
+    <message id="listlink_show_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="43"/>
+      <source>Show QR code</source>
+      <translation>Mostra codice QR</translation>
+    </message>
+    <message id="listlink_scan_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="52"/>
+      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
+      <extracomment>%1 = url text</extracomment>
+      <oldsource>Scan the QR code with your portable device.&lt;br /&gt;Or insert the link: %1</oldsource>
+      <translation>Apri il codice QR per scansionarlo con il tuo dispositivo portatile.&lt;br /&gt;Oppure inserisci il link: %1</translation>
+    </message>
+    <message id="color_preset">
+      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
+      <source>Preset</source>
+      <translation>Preimpostato</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
+      <source>Add Modbus port and unit ID</source>
+      <translation>Aggiungi porta Modbus e ID unità</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_unitid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
+      <source>Unit ID</source>
+      <translation>ID unità</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location_button">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
+      <source>Add</source>
+      <translation>Aggiungi</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_locations_note">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
+      <source>The default modbus port is 502 and the default unit ID is 126.
+Here you can add additional ports and unit IDs to scan for PV inverters.</source>
+      <translation>La porta Modbus predefinita è la 502 e l'ID unità predefinito è 126.
+Qui puoi aggiungere ulteriori porte e ID unità da scansionare per gli inverter FV.</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_location_number">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
+      <source>Port/Unit ID %1</source>
+      <translation>Porta/ID unità %1</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location_description">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
+      <source>Port: %1 (Unit %2)</source>
+      <translation>Porta: %1 (Unità %2)</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
+      <source>Remove Modbus port and unit ID?</source>
+      <translation>Rimuovere la porta Modbus e l'ID unità?</translation>
+    </message>
+    <message id="devicelist_tankshape_edit_point">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="182"/>
+      <source>Edit point %1</source>
+      <extracomment>%1 = which point is being edited, a number like "1" or "2"</extracomment>
+      <translation></translation>
+    </message>
+    <message id="settings_canbus_vecan">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
+      <source>VE.Can (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_250">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <source>VE.Can &amp; CANopen E-drive (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_500">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
+      <source>CANopen E-drive (500 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="page_microgrid_from_p1_to_p2">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="39"/>
+      <source>%1%2 to %3%4</source>
+      <extracomment>Describes a range from one quantity to another, e.g. "30W to 60W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
+      <translation></translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAfricaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
+      <source>Morocco Standard Time</source>
+      <translation>Fuso Orario del Marocco</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
+      <source>W. Central Africa Standard Time</source>
+      <translation>Fuso Orario dell'Africa Centrale Occidentale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
+      <source>South Africa Standard Time</source>
+      <translation>Fuso Orario del Sud Africa</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
+      <source>Namibia Standard Time</source>
+      <translation>Fuso Orario della Namibia</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
+      <source>Egypt Standard Time</source>
+      <translation>Fuso Orario dell'Egitto</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
+      <source>E. Africa Standard Time</source>
+      <translation>Fuso Orario dell'Africa Orientale</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAmericaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
+      <source>Argentina Standard Time</source>
+      <translation>Fuso Orario dell'Argentina</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
+      <source>E. South America Standard Time</source>
+      <translation>Fuso Orario del Sud America Orientale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
+      <source>Greenland Standard Time</source>
+      <translation>Fuso Orario della Groenlandia</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
+      <source>Montevideo Standard Time</source>
+      <translation>Fuso Orario di Montevideo</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
+      <source>Newfoundland Standard Time</source>
+      <translation>Fuso Orario di Terranova</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
+      <source>SA Eastern Standard Time</source>
+      <translation>Fuso Orario del SA Orientale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
+      <source>Atlantic Standard Time</source>
+      <translation>Fuso Orario dell'Atlantico</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
+      <source>Central Brazilian Standard Time</source>
+      <translation>Fuso Orario del Brasile Centrale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>Fuso Orario del Pacifico Sudamericano</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
+      <source>Paraguay Standard Time</source>
+      <translation>Fuso Orario del Paraguay</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
+      <source>SA Western Standard Time</source>
+      <translation>Fuso Orario del Sud America Occidentale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
+      <source>Venezuela Standard Time</source>
+      <translation>Fuso Orario del Venezuela</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
+      <source>Eastern Standard Time</source>
+      <translation>Fuso Orario Orientale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
+      <source>SA Pacific Standard Time</source>
+      <translation>Fuso Orario del Pacifico Sudamericano</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
+      <source>US Eastern Standard Time</source>
+      <translation>Fuso Orario degli USA Orientali</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
+      <source>Canada Central Standard Time</source>
+      <translation>Fuso Orario del Canada Centrale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
+      <source>Central America Standard Time</source>
+      <translation>Fuso Orario dell'America Centrale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
+      <source>Central Standard Time (Mexico)</source>
+      <translation>Fuso Orario Centrale (Messico)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
+      <source>Central Standard Time</source>
+      <translation>Fuso Orario Centrale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
+      <source>Mountain Standard Time (Mexico)</source>
+      <translation>Fuso Orario zona Montagne (Messico)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
+      <source>Mountain Standard Time</source>
+      <translation>Fuso Orario zona Montagne</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
+      <source>US Mountain Standard Time</source>
+      <translation>Fuso Orario zona Montagne degli USA</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
+      <source>Pacific Standard Time (Mexico)</source>
+      <translation>Fuso Orario del Pacifico (Messico)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
+      <source>Pacific Standard Time</source>
+      <translation>Fuso Orario del Pacifico</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
+      <source>Alaskan Standard Time</source>
+      <translation>Fuso Orario dell'Alaska</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
+      <source>Hawaii-Aleutian</source>
+      <translation>Hawaii-Aleutine</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
+      <source>Atlantic Daylight Time</source>
+      <translation>Ora Legale dell'Atlantico</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAntarcticaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+      <source>New Zealand Standard Time</source>
+      <translation>Fuso Orario della Nuova Zelanda</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>Fuso Orario del Pacifico Centrale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+      <source>West Pacific Standard Time</source>
+      <translation>Fuso Orario del Pacifico Occidentale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+      <source>W. Australia Standard Time</source>
+      <translation>Fuso Orario dell'Australia Occidentale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+      <source>SE Asia Standard Time</source>
+      <translation>Fuso Orario del Sud Est Asiatico</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+      <source>Central Asia Standard Time</source>
+      <translation>Fuso Orario dell'Asia Centrale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+      <source>West Asia Standard Time</source>
+      <translation>Fuso Orario dell'Asia Occidentale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+      <source>E. Africa Standard Time</source>
+      <translation>Fuso Orario dell'Africa Orientale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>Fuso Orario del Pacifico Sudamericano</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+      <source>SA Western Standard Time</source>
+      <translation>Fuso Orario del Sud America Occidentale</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzArcticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
+      <source>W. Europe Standard Time</source>
+      <translation>Fuso Orario dell'Europa Occidentale</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAsiaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
+      <source>Kamchatka Standard Time</source>
+      <translation>Fuso Orario della Kamchatka</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
+      <source>Magadan Standard Time</source>
+      <translation>Fuso Orario di Magadan</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
+      <source>Vladivostok Standard Time</source>
+      <translation>Fuso Orario di Vladivostok</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
+      <source>Yakutsk Standard Time</source>
+      <translation>Fuso Orario di Jakutsk</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
+      <source>Tokyo Standard Time</source>
+      <translation>Fuso Orario di Tokio</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
+      <source>Korea Standard Time</source>
+      <translation>Fuso Orario della Corea</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
+      <source>Singapore Standard Time</source>
+      <translation>Fuso Orario di Singapore</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
+      <source>Ulaanbaatar Standard Time</source>
+      <translation>Fuso Orario di Ulan Bator</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
+      <source>Taipei Standard Time</source>
+      <translation>Fuso Orario di Taipei</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
+      <source>North Asia East Standard Time</source>
+      <translation>Fuso Orario del Nord Est Asiatico</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
+      <source>China Standard Time</source>
+      <translation>Fuso Orario della Cina</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
+      <source>SE Asia Standard Time</source>
+      <translation>Fuso Orario del Sud Est Asiatico</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
+      <source>North Asia Standard Time</source>
+      <translation>Fuso Orario del Nord Asia</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
+      <source>Myanmar Standard Time</source>
+      <translation>Fuso Orario di Myanmar</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
+      <source>N. Central Asia Standard Time</source>
+      <translation>Fuso Orario del Centro Nord Asiatico</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
+      <source>Central Asia Standard Time</source>
+      <translation>Fuso Orario dell'Asia Centrale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
+      <source>Bangladesh Standard Time</source>
+      <translation>Fuso Orario del Bangladesh</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
+      <source>Nepal Standard Time</source>
+      <translation>Fuso Orario del Nepal</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
+      <source>Sri Lanka Standard Time</source>
+      <translation>Fuso Orario dello Sri Lanka</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
+      <source>India Standard Time</source>
+      <translation>Fuso Orario dell'India</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
+      <source>West Asia Standard Time</source>
+      <translation>Fuso Orario dell'Asia Occidentale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
+      <source>Pakistan Standard Time</source>
+      <translation>Fuso Orario del Pakistan</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
+      <source>Ekaterinburg Standard Time</source>
+      <translation>Fuso Orario di Ekaterinburg</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
+      <source>Georgian Standard Time</source>
+      <translation>Fuso Orario della Georgia</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
+      <source>Caucasus Standard Time</source>
+      <translation>Fuso Orario del Caucaso</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
+      <source>Azerbaijan Standard Time</source>
+      <translation>Fuso Orario dell'Azerbaigian</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
+      <source>Arabian Standard Time</source>
+      <translation>Fuso Orario dell'Arabia</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
+      <source>Afghanistan Standard Time</source>
+      <translation>Fuso Orario dell'Afganistan</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
+      <source>Iran Standard Time</source>
+      <translation>Fuso Orario dell'Iran</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
+      <source>Arabic Standard Time</source>
+      <translation>Fuso Orario Arabo</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
+      <source>Arab Standard Time</source>
+      <translation>Fuso Orario Arab</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
+      <source>Syria Standard Time</source>
+      <translation>Fuso Orario della Siria</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
+      <source>Middle East Standard Time</source>
+      <translation>Fuso Orario del Medio Oriente</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
+      <source>Jordan Standard Time</source>
+      <translation>Fuso Orario della Giordania</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
+      <source>Israel Standard Time</source>
+      <translation>Fuso Orario di Israele</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAtlanticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+      <source>Greenwich Standard Time</source>
+      <translation>Tempo Medio di Greenwich</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+      <source>Azores Standard Time</source>
+      <translation>Fuso Orario delle Azzorre</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+      <source>Cape Verde Standard Time</source>
+      <translation>Fuso Orario di Capo Verde</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
+      <source>Mid-Atlantic Standard Time</source>
+      <translation>Fuso Orario dell'Atlantico</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAustraliaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+      <source>Tasmania Standard Time</source>
+      <translation>Fuso Orario della Tasmania</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+      <source>E. Australia Standard Time</source>
+      <translation>Fuso Orario dell'Australia Orientale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+      <source>AUS Eastern Standard Time</source>
+      <translation>Fuso Orario dell'AUS Orientale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+      <source>Cen. Australia Standard Time</source>
+      <translation>Fuso Orario dell'Australia Centrale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+      <source>AUS Central Standard Time</source>
+      <translation>Fuso Orario dell'AUS Centrale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+      <source>W. Australia Standard Time</source>
+      <translation>Fuso Orario dell'Australia Occidentale</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEtcData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
+      <source>GMT +12</source>
+      <translation>GMT +12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
+      <source>GMT -02</source>
+      <translation>GMT -02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
+      <source>GMT -11</source>
+      <translation>GMT -11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
+      <source>GMT -13</source>
+      <translation>GMT -13</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
+      <source>GMT -12</source>
+      <translation>GMT -12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
+      <source>GMT -10</source>
+      <translation>GMT -10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
+      <source>GMT -09</source>
+      <translation>GMT -09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
+      <source>GMT -08</source>
+      <translation>GMT -08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
+      <source>GMT -07</source>
+      <translation>GMT -07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
+      <source>GMT -06</source>
+      <translation>GMT -06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
+      <source>GMT -05</source>
+      <translation>GMT -05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
+      <source>GMT -04</source>
+      <translation>GMT -04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
+      <source>GMT -03</source>
+      <translation>GMT -03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
+      <source>GMT -01</source>
+      <translation>GMT -01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
+      <source>GMT</source>
+      <translation>GMT</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
+      <source>GMT +01</source>
+      <translation>GMT +01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
+      <source>GMT +02</source>
+      <translation>GMT +02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
+      <source>GMT +03</source>
+      <translation>GMT +03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
+      <source>GMT +04</source>
+      <translation>GMT +04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
+      <source>GMT +05</source>
+      <translation>GMT +05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
+      <source>GMT +06</source>
+      <translation>GMT +06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
+      <source>GMT +07</source>
+      <translation>GMT +07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
+      <source>GMT +08</source>
+      <translation>GMT +08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
+      <source>GMT +09</source>
+      <translation>GMT +09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
+      <source>GMT +10</source>
+      <translation>GMT +10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
+      <source>GMT +11</source>
+      <translation>GMT +11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
+      <source>UTC</source>
+      <translation>UTC</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEuropeData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
+      <source>GMT Standard Time</source>
+      <translation>Tempo Medio GMT</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
+      <source>Central Europe Standard Time</source>
+      <translation>Fuso Orario dell'Europa Centrale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
+      <source>Central European Standard Time</source>
+      <translation>Fuso Orario dell'Europa Centrale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
+      <source>Romance Standard Time</source>
+      <translation>Romance Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
+      <source>W. Europe Standard Time</source>
+      <translation>Fuso Orario dell'Europa Occidentale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
+      <source>E. Europe Standard Time</source>
+      <translation>Fuso Orario dell'Europa Orientale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
+      <source>FLE Standard Time</source>
+      <translation>Fuso Orario FLE</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
+      <source>GTB Standard Time</source>
+      <translation>Fuso Orario GTB</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
+      <source>Belarus Standard Time</source>
+      <translation>Fuso Orario della Bielorussia</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
+      <source>Russian Standard Time</source>
+      <translation>Fuso Orario della Russia</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
+      <source>Turkey Standard Time</source>
+      <translation>Fuso Orario della Turchia</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzIndianData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
+      <source>Mauritius Standard Time</source>
+      <translation>Fuso Orario delle Mauritius</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
+      <source>Christmas Island Standard Time</source>
+      <translation>Fuso Orario dell’Isola di Natale</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzPacificData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
+      <source>Tonga Standard Time</source>
+      <translation>Fuso Orario di Tonga</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
+      <source>Fiji Standard Time</source>
+      <translation>Fuso Orario delle Fiji</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
+      <source>New Zealand Standard Time</source>
+      <translation>Fuso Orario della Nuova Zelanda</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>Fuso Orario del Pacifico Centrale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
+      <source>West Pacific Standard Time</source>
+      <translation>Fuso Orario del Pacifico Occidentale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
+      <source>Samoa Standard Time</source>
+      <translation>Fuso Orario di Samoa</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
+      <source>Hawaiian Standard Time</source>
+      <translation>Fuso Orario delle Hawaii</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
+      <source>Easter Island Standard Time</source>
+      <translation>Fuso Orario dell’Isola di Pasqua</translation>
     </message>
   </context>
   <context>
@@ -12170,838 +11850,6 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
     </message>
   </context>
   <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>Fuso Orario del Marocco</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>Fuso Orario dell'Africa Centrale Occidentale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>Fuso Orario del Sud Africa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>Fuso Orario della Namibia</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>Fuso Orario dell'Egitto</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Fuso Orario dell'Africa Orientale</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>Fuso Orario dell'Argentina</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>Fuso Orario del Sud America Orientale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>Fuso Orario della Groenlandia</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>Fuso Orario di Montevideo</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>Fuso Orario di Terranova</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>Fuso Orario del SA Orientale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Atlantic Standard Time</source>
-      <translation>Fuso Orario dell'Atlantico</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>Fuso Orario del Brasile Centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Fuso Orario del Pacifico Sudamericano</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>Paraguay Standard Time</source>
-      <translation>Fuso Orario del Paraguay</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>SA Western Standard Time</source>
-      <translation>Fuso Orario del Sud America Occidentale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Venezuela Standard Time</source>
-      <translation>Fuso Orario del Venezuela</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>Eastern Standard Time</source>
-      <translation>Fuso Orario Orientale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>Fuso Orario del Pacifico Sudamericano</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>US Eastern Standard Time</source>
-      <translation>Fuso Orario degli USA Orientali</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Canada Central Standard Time</source>
-      <translation>Fuso Orario del Canada Centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central America Standard Time</source>
-      <translation>Fuso Orario dell'America Centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>Fuso Orario Centrale (Messico)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Central Standard Time</source>
-      <translation>Fuso Orario Centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>Fuso Orario zona Montagne (Messico)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>Mountain Standard Time</source>
-      <translation>Fuso Orario zona Montagne</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>US Mountain Standard Time</source>
-      <translation>Fuso Orario zona Montagne degli USA</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>Fuso Orario del Pacifico (Messico)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Pacific Standard Time</source>
-      <translation>Fuso Orario del Pacifico</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Alaskan Standard Time</source>
-      <translation>Fuso Orario dell'Alaska</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>Hawaii-Aleutine</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Daylight Time</source>
-      <translation>Ora Legale dell'Atlantico</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Fuso Orario della Nuova Zelanda</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Fuso Orario del Pacifico Centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Fuso Orario del Pacifico Occidentale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Fuso Orario dell'Australia Occidentale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Fuso Orario del Sud Est Asiatico</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Fuso Orario dell'Asia Centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>Fuso Orario dell'Asia Occidentale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Fuso Orario dell'Africa Orientale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Fuso Orario del Pacifico Sudamericano</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>Fuso Orario del Sud America Occidentale</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Fuso Orario dell'Europa Occidentale</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>Fuso Orario della Kamchatka</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>Fuso Orario di Magadan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>Fuso Orario di Vladivostok</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>Fuso Orario di Jakutsk</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>Fuso Orario di Tokio</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>Fuso Orario della Corea</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>Fuso Orario di Singapore</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>Fuso Orario di Ulan Bator</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>Fuso Orario di Taipei</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>Fuso Orario del Nord Est Asiatico</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>Fuso Orario della Cina</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Fuso Orario del Sud Est Asiatico</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>Fuso Orario del Nord Asia</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>Fuso Orario di Myanmar</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>Fuso Orario del Centro Nord Asiatico</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Fuso Orario dell'Asia Centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>Fuso Orario del Bangladesh</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>Fuso Orario del Nepal</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>Fuso Orario dello Sri Lanka</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>Fuso Orario dell'India</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>Fuso Orario dell'Asia Occidentale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>Fuso Orario del Pakistan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>Fuso Orario di Ekaterinburg</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>Fuso Orario della Georgia</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>Fuso Orario del Caucaso</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>Fuso Orario dell'Azerbaigian</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>Fuso Orario dell'Arabia</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>Fuso Orario dell'Afganistan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>Fuso Orario dell'Iran</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>Fuso Orario Arabo</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>Fuso Orario Arab</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>Fuso Orario della Siria</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>Fuso Orario del Medio Oriente</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>Fuso Orario della Giordania</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>Fuso Orario di Israele</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>Tempo Medio di Greenwich</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>Fuso Orario delle Azzorre</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>Fuso Orario di Capo Verde</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>Fuso Orario dell'Atlantico</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>Fuso Orario della Tasmania</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>Fuso Orario dell'Australia Orientale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>Fuso Orario dell'AUS Orientale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>Fuso Orario dell'Australia Centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>Fuso Orario dell'AUS Centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Fuso Orario dell'Australia Occidentale</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
-      <source>GMT +12</source>
-      <translation>GMT +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
-      <source>GMT -02</source>
-      <translation>GMT -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT -13</source>
-      <translation>GMT -13</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT -12</source>
-      <translation>GMT -12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -10</source>
-      <translation>GMT -10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -09</source>
-      <translation>GMT -09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>GMT -08</source>
-      <translation>GMT -08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
-      <source>GMT -07</source>
-      <translation>GMT -07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
-      <source>GMT -06</source>
-      <translation>GMT -06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
-      <source>GMT -05</source>
-      <translation>GMT -05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
-      <source>GMT -04</source>
-      <translation>GMT -04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
-      <source>GMT -03</source>
-      <translation>GMT -03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
-      <source>GMT -01</source>
-      <translation>GMT -01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
-      <source>GMT</source>
-      <translation>GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
-      <source>GMT +01</source>
-      <translation>GMT +01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
-      <source>GMT +02</source>
-      <translation>GMT +02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
-      <source>GMT +03</source>
-      <translation>GMT +03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
-      <source>GMT +04</source>
-      <translation>GMT +04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
-      <source>GMT +05</source>
-      <translation>GMT +05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
-      <source>GMT +06</source>
-      <translation>GMT +06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
-      <source>GMT +07</source>
-      <translation>GMT +07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
-      <source>GMT +08</source>
-      <translation>GMT +08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
-      <source>GMT +09</source>
-      <translation>GMT +09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
-      <source>GMT +10</source>
-      <translation>GMT +10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
-      <source>GMT +11</source>
-      <translation>GMT +11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
-      <source>UTC</source>
-      <translation>UTC</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>Tempo Medio GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>Fuso Orario dell'Europa Centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>Fuso Orario dell'Europa Centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>Romance Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Fuso Orario dell'Europa Occidentale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>Fuso Orario dell'Europa Orientale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>Fuso Orario FLE</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>Fuso Orario GTB</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>Fuso Orario della Bielorussia</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>Fuso Orario della Russia</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>Fuso Orario della Turchia</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>Fuso Orario delle Mauritius</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>Fuso Orario dell’Isola di Natale</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>Fuso Orario di Tonga</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>Fuso Orario delle Fiji</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Fuso Orario della Nuova Zelanda</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Fuso Orario del Pacifico Centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Fuso Orario del Pacifico Occidentale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>Fuso Orario di Samoa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>Fuso Orario delle Hawaii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>Fuso Orario dell’Isola di Pasqua</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation type="unfinished">Errore interno</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation type="unfinished"/>
-    </message>
-  </context>
-  <context>
     <name>Wakespeed</name>
     <message>
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
@@ -13178,6 +12026,119 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
       <source>DC/DC misconfiguration</source>
       <translation>Configurazione errata CC/CC</translation>
+    </message>
+  </context>
+  <context>
+    <name>VebusError</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+      <source>Device switched off</source>
+      <translation>Dispositivo spento</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+      <source>Mixed old/new MK2</source>
+      <translation>MK2 vecchio/nuovo misto</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+      <source>Expected devices error</source>
+      <translation>Errore dispositivi previsti</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+      <source>No other device detected</source>
+      <translation>Nessun altro dispositivo rilevato</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+      <source>Overvoltage on AC-out</source>
+      <translation>Sovratensione su AC-out</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+      <source>DDC program error</source>
+      <translation>Errore programma DDC</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+      <source>VE.Bus BMS without assistant</source>
+      <translation>VE.Bus BMS senza assistente</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+      <source>Ground relay test failed</source>
+      <translation>Test relè di terra fallito</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+      <source>System time sync error</source>
+      <translation>Errore di sincronizzazione dell'ora di sistema</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+      <source>Grid relay test fault</source>
+      <translation>Errore test relè di rete</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+      <source>Config mismatch with 2nd mcu</source>
+      <translation>Mancata corrispondenza della configurazione con la seconda MCU</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+      <source>Device transmit error</source>
+      <translation>Errore di trasmissione del dispositivo</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+      <source>Awaiting configuration or dongle missing</source>
+      <translation>In attesa di configurazione o dongle mancante</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+      <source>Phase master missing</source>
+      <translation>Fase master mancante</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+      <source>Overvoltage has occurred</source>
+      <translation>Si è verificata una sovratensione</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+      <source>Slave does not have AC input!</source>
+      <translation>Lo slave non ha ingresso AC!</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+      <source>Device can't be slave</source>
+      <translation>Il dispositivo non può essere slave</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+      <source>System protection initiated</source>
+      <translation>Protezione di sistema avviata</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+      <source>Firmware incompatibiltiy</source>
+      <translation>Incompatibilità del firmware</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+      <source>Internal error</source>
+      <translation>Errore interno</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+      <source>Failing relay test prevents connection</source>
+      <translation>Il test del relè non riuscito impedisce la connessione</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+      <source>VE.Bus error</source>
+      <translation>Errore VE.Bus</translation>
     </message>
   </context>
 </TS>

--- a/i18n/venus-gui-v2_nl.ts
+++ b/i18n/venus-gui-v2_nl.ts
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="nl">
   <context>
-    <name/>
+    <name></name>
     <message id="switchable_output_disabled">
       <location filename="../../src/enums.cpp" line="478"/>
       <source>Disabled</source>
@@ -22,6 +22,7 @@
     <message id="solarchargers_state_off">
       <location filename="../../src/enums.cpp" line="331"/>
       <source>Off</source>
+      <extracomment>Digital input state</extracomment>
       <translation>Uit</translation>
     </message>
     <message id="common_words_auto">
@@ -52,18 +53,25 @@
     <message id="settings_startpage_none">
       <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
       <source>None</source>
+      <extracomment>Indicates no phase</extracomment>
       <translation>Geen</translation>
     </message>
     <message id="common_words_position_ac">
       <location filename="../../components/CommonWords.qml" line="416"/>
       <source>Position</source>
-      <extracomment>AC input or output position</extracomment>
+      <extracomment>EVCS AC input/output position</extracomment>
       <translation>Positie</translation>
     </message>
     <message id="settings_minmax_speed">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="193"/>
       <source>Speed</source>
+      <extracomment>A speed measurement value</extracomment>
       <translation>Snelheid</translation>
+    </message>
+    <message id="common_words_state">
+      <location filename="../../components/CommonWords.qml" line="502"/>
+      <source>State</source>
+      <translation>Status</translation>
     </message>
     <message id="settings_firmware_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="67"/>
@@ -101,8 +109,8 @@
       <source>Solar yield</source>
       <translation>Zon opbrengst</translation>
     </message>
-    <message id="ess_state_external_control">
-      <location filename="../../data/Ess.qml" line="41"/>
+    <message id="inverters_state_externalccontrol">
+      <location filename="../../data/System.qml" line="183"/>
       <source>External control</source>
       <translation>Externe besturing</translation>
     </message>
@@ -140,6 +148,11 @@
       <location filename="../../components/CommonWords.qml" line="203"/>
       <source>ESS</source>
       <translation>ESS</translation>
+    </message>
+    <message id="pagesettingsconnectivity_ethernet">
+      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
+      <source>Ethernet</source>
+      <translation>Ethernet</translation>
     </message>
     <message id="pagesettingsconnectivity_wifi">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="28"/>
@@ -262,11 +275,6 @@
       <source>Name</source>
       <translation>Naam</translation>
     </message>
-    <message id="settings_deviceinfo_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="38"/>
-      <source>Name</source>
-      <translation type="unfinished">Naam</translation>
-    </message>
     <message id="settings_deviceinfo_product_id">
       <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
       <source>Product ID</source>
@@ -327,15 +335,20 @@
       <source>Daily run time</source>
       <translation>Dagelijkse bedrijfstijd</translation>
     </message>
+    <message id="common_words_value_must_be_greater_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="560"/>
+      <source>Value must be greater than stop value</source>
+      <translation>Waarde moet hoger zijn dan stopwaarde</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="563"/>
+      <source>Value must be lower than start value</source>
+      <translation>Waarde moet lager zijn dan startwaarde</translation>
+    </message>
     <message id="settings_minmax_acout_max_power">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="124"/>
       <source>AC output</source>
       <translation>AC uitgang</translation>
-    </message>
-    <message id="ac_output">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="15"/>
-      <source>AC output</source>
-      <translation type="unfinished">AC uitgang</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
       <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="25"/>
@@ -382,16 +395,6 @@
       <source>Unavailable monitor, set another</source>
       <translation>Onbeschikbare monitor, stel een andere in</translation>
     </message>
-    <message id="page_generator_conditions_battery_monitor">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="42"/>
-      <source>Battery monitor</source>
-      <translation type="unfinished">Accumonitor</translation>
-    </message>
-    <message id="page_generator_conditions_unavailable_monitor_set_another">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="44"/>
-      <source>Unavailable monitor, set another</source>
-      <translation type="unfinished">Onbeschikbare monitor, stel een andere in</translation>
-    </message>
     <message id="page_generator_conditions_on_loss_of_communication">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="68"/>
       <source>On loss of communication</source>
@@ -416,11 +419,6 @@
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="105"/>
       <source>Battery SOC</source>
       <translation>Accu laadtoestand</translation>
-    </message>
-    <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="173"/>
-      <source>Periodic run</source>
-      <translation type="unfinished">Periodiek in bedrijf</translation>
     </message>
     <message id="settings_inverter_high_temperature">
       <location filename="../../data/Generators.qml" line="83"/>
@@ -505,7 +503,7 @@
     <message id="settings_gps_speed_kmh">
       <location filename="../../pages/settings/PageGps.qml" line="83"/>
       <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometres per hour</extracomment>
+      <extracomment>GPS speed data, in kilometers per hour</extracomment>
       <translation>%1 km/u</translation>
     </message>
     <message id="settings_gps_speed_mph">
@@ -523,7 +521,7 @@
     <message id="settings_gps_speed_ms">
       <location filename="../../pages/settings/PageGps.qml" line="95"/>
       <source>%1 m/s</source>
-      <extracomment>GPS speed data, in metres per second</extracomment>
+      <extracomment>GPS speed data, in meters per second</extracomment>
       <translation>%1 m/s</translation>
     </message>
     <message id="settings_gps_course">
@@ -580,21 +578,6 @@
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="64"/>
       <source>%1 (Output %2)</source>
       <translation>%1 (Uitgang %2)</translation>
-    </message>
-    <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">Actieve accumonitor</translation>
-    </message>
-    <message id="settings_batteries_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="101"/>
-      <source>Name</source>
-      <translation type="unfinished">Naam</translation>
-    </message>
-    <message id="settings_batteries_enter_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="103"/>
-      <source>Enter name</source>
-      <translation type="unfinished">Naam invoeren</translation>
     </message>
     <message id="settings_briefview_center_active_battery_monitor">
       <location filename="../../components/listitems/ListBriefCenterDetails.qml" line="27"/>
@@ -656,45 +639,25 @@
       <source>CAN-bus profile</source>
       <translation>CAN-bus profiel</translation>
     </message>
-    <message id="settings_disabled">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="31"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Uitgeschakeld</translation>
-    </message>
-    <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</translation>
-    </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
       <location filename="../../pages/settings/CanbusProfile.qml" line="42"/>
       <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
       <translation>VE.Can &amp; CAN-bus BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
       <source>Oceanvolt (250 kbit/s)</source>
       <translation>Oceanvolt (250 kbit/s)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
       <source>RV-C (250 kbit/s)</source>
       <translation>RV-C (250 kbit/s)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
       <source>Up, but no services (250 kbit/s)</source>
       <translation>Beschikbaar, maar geen diensten (250 kbit/s)</translation>
-    </message>
-    <message id="settings_canopen_motordrive_250">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
-      <source>CANopen Motor drive (250 kbit/s)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_canopen_motordrive_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
-      <source>CANopen Motor drive (500 kbit/s)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_devices">
       <location filename="../../components/CommonWords.qml" line="166"/>
@@ -731,11 +694,6 @@
       <source>Check Unique id numbers</source>
       <translation>Controleer unieke ID-nummers</translation>
     </message>
-    <message id="settings_canbus_unique_id_press_to_check">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Press to check</source>
-      <translation type="unfinished">Drukken om te controleren</translation>
-    </message>
     <message id="settings_canbus_unique_id_conflict">
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="125"/>
       <source>There is another device connected with this unique number, please select a new number.</source>
@@ -745,11 +703,6 @@
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="133"/>
       <source>OK: No other device is connected with this unique number.</source>
       <translation>OK: Geen ander apparaat met dit unieke nummer is verbonden.</translation>
-    </message>
-    <message id="pagesettingsintegrations_canopenmotordrive">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
-      <source>CANopen motor drives</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_network_status">
       <location filename="../../components/CommonWords.qml" line="349"/>
@@ -884,11 +837,6 @@
       <source>Unavailable sensor, set another</source>
       <translation>Onbeschikbare sensor, stel een andere in</translation>
     </message>
-    <message id="settings_system_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="81"/>
-      <source>Unavailable sensor, set another</source>
-      <translation type="unfinished">Onbeschikbare sensor, stel een andere in</translation>
-    </message>
     <message id="settings_dvcc_used_sensor">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="120"/>
       <source>Used sensor</source>
@@ -945,12 +893,6 @@
       <source>Auto selected</source>
       <translation>Automatisch geselecteerd</translation>
     </message>
-    <message id="settings_dvcc_auto_selected_none">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="208"/>
-      <source>None</source>
-      <extracomment>Indicates no option is selected</extracomment>
-      <translation type="unfinished">Geen</translation>
-    </message>
     <message id="settings_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
       <source>Build date/time</source>
@@ -986,12 +928,6 @@
       <source>Installing %1</source>
       <extracomment>%1 = firmware version</extracomment>
       <translation>Installeren %1</translation>
-    </message>
-    <message id="settings_firmware_offline_press_to_install">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">Druk voor bijwerken naar %1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="90"/>
@@ -1062,12 +998,6 @@
       <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
       <translation>Installeren %1 %2%</translation>
     </message>
-    <message id="settings_firmware_online_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="86"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">%1 wordt geïnstalleerd...</translation>
-    </message>
     <message id="settings_firmware_update_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="109"/>
       <source>Update build date/time</source>
@@ -1097,11 +1027,6 @@
       <location filename="../../pages/settings/PageSettingsFronius.qml" line="56"/>
       <source>TCP port</source>
       <translation>TCP poort</translation>
-    </message>
-    <message id="page_settings_fronius_modbus_settings">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
-      <source>Modbus port and unit ID settings</source>
-      <translation type="unfinished"/>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
       <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
@@ -1153,16 +1078,6 @@
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="64"/>
       <source>AC-Out MP</source>
       <translation>AC uit MP</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="52"/>
-      <source>AC-In1 L%1</source>
-      <translation type="unfinished">AC In1 L%1</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="56"/>
-      <source>AC-In1 --</source>
-      <translation type="unfinished">AC In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="70"/>
@@ -1330,12 +1245,6 @@
       <source>Reset service timer</source>
       <translation>Onderhoudstimer herstarten</translation>
     </message>
-    <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
-      <source>Volume</source>
-      <extracomment>Title for a list of units of volume (e.g. cubic metres, litres, gallons)</extracomment>
-      <translation type="unfinished">Volume</translation>
-    </message>
     <message id="settings_gps_format">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="69"/>
       <source>Format</source>
@@ -1438,42 +1347,6 @@ Als dit niet werkt, controleer dan de SIM kaart in een telefoon om er zeker van 
       <source>Wrong PIN</source>
       <translation>Verkeerde PIN code</translation>
     </message>
-    <message id="page_settings_gsm_ok">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>OK</source>
-      <translation type="unfinished">OK</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="128"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">Onbekende fout</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_state">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="153"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Onbekend</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_value">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="182"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Onbekend</translation>
-    </message>
-    <message id="page_settings_gsm_offline">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="173"/>
-      <source>Offline</source>
-      <translation type="unfinished">Offline</translation>
-    </message>
-    <message id="page_settings_gsm_connecting">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="176"/>
-      <source>Connecting</source>
-      <translation type="unfinished">Verbinding wordt gemaakt</translation>
-    </message>
-    <message id="page_settings_gsm_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="179"/>
-      <source>Connected</source>
-      <translation type="unfinished">Verbonden</translation>
-    </message>
     <message id="page_settings_gsm_pin">
       <location filename="../../pages/settings/PageSettingsGsm.qml" line="191"/>
       <source>PIN</source>
@@ -1530,32 +1403,32 @@ Als dit niet werkt, controleer dan de SIM kaart in een telefoon om er zeker van 
       <translation>Net meting</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
       <source>External meter</source>
       <translation>Externe meter</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="67"/>
       <source>Inverter/Charger</source>
       <translation>Omvormer/Acculader</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
       <source>Multiphase regulation</source>
       <translation>Meer fasen regeling</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="91"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
       <source>Total of all phases</source>
       <translation>Totaal van alle fasen</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="95"/>
       <source>Individual phase</source>
       <translation>Individuele fase</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="99"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="101"/>
       <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
@@ -1564,68 +1437,13 @@ CAUTION: Use only if required by the utility provider.</source>
 LET OP: Alleen gebruiken indien vereist door de energieleverancier.</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="104"/>
       <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
       <translation>Het totaal van alle fasen wordt intelligent geregeld om het setpoint van het stroomnet te bereiken (systeemrendement wordt geoptimaliseerd).
 
 Gebruik tenzij verboden door de energieleverancier.</translation>
-    </message>
-    <message id="settings_ess_min_soc">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation type="unfinished">Minimale laadtoestand (tenzij net uitvalt)</translation>
-    </message>
-    <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="129"/>
-      <source>Active SOC limit</source>
-      <translation type="unfinished">Huidige laadtoestand limiet</translation>
-    </message>
-    <message id="settings_ess_battery_life_sustain">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
-      <source>Sustain</source>
-      <translation type="unfinished">Onderhouden</translation>
-    </message>
-    <message id="settings_ess_battery_life_recharge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="157"/>
-      <source>Recharge</source>
-      <translation type="unfinished">Opnieuw laden</translation>
-    </message>
-    <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <source>Scheduled charge levels</source>
-      <translation type="unfinished">Geplande laad niveau's</translation>
-    </message>
-    <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="257"/>
-      <source>Active (%1)</source>
-      <translation type="unfinished">Actief (%1)</translation>
-    </message>
-    <message id="settings_ess_inactive">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="259"/>
-      <source>Inactive</source>
-      <translation type="unfinished">Inactief</translation>
-    </message>
-    <message id="settings_ess_dynamic">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="293"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">Dynamic ESS</translation>
-    </message>
-    <message id="settings_ess_deprecated">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="319"/>
-      <source>Deprecated settings</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_charge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="326"/>
-      <source>Battery charge limit (% of CCL)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_discharge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="337"/>
-      <source>Battery discharge limit (% of DCL)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_rs_ess_min_soc">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="40"/>
@@ -1637,13 +1455,8 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <source>Active SOC limit</source>
       <translation>Huidige laadtoestand limiet</translation>
     </message>
-    <message id="scheduled_charge_inactive">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
-      <source>Inactive</source>
-      <translation type="unfinished">Inactief</translation>
-    </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="245"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="247"/>
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
       <source>Peak shaving</source>
       <translation>Peak shaving</translation>
@@ -1659,12 +1472,12 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <translation>Altijd</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="151"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
       <source>Discharge disabled</source>
       <translation>Ontlading uitgeschakeld</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
       <source>Slow charge</source>
       <translation>Langzaam laden</translation>
     </message>
@@ -1679,32 +1492,32 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <translation>Opnieuw laden</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="165"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="167"/>
       <source>Limit charge power</source>
       <translation>Limiet laadvermogen</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="183"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="185"/>
       <source>Maximum charge power</source>
       <translation>Maximaal laadvermogen</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="196"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="198"/>
       <source>Limit inverter power</source>
       <translation>Vermogen omvormer beperken</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="214"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="216"/>
       <source>Maximum inverter power</source>
       <translation>Maximaal vermogen omvormer</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="225"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="227"/>
       <source>Grid setpoint</source>
       <translation>Instelwaarde stroomnet</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="236"/>
       <source>Grid feed-in</source>
       <translation>Net teruglevering</translation>
     </message>
@@ -1743,8 +1556,8 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <source>Door alarm</source>
       <translation>Deuralarm</translation>
     </message>
-    <message id="digitalinputs_type_bilgepump">
-      <location filename="../../src/enums.cpp" line="201"/>
+    <message id="switchable_output_bilge_pump">
+      <location filename="../../src/enums.cpp" line="424"/>
       <source>Bilge pump</source>
       <translation>Lenspomp</translation>
     </message>
@@ -1796,11 +1609,6 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <source>Deferred by %1s</source>
       <extracomment>%1 = number of seconds</extracomment>
       <translation>%1s uitgesteld</translation>
-    </message>
-    <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="75"/>
-      <source>Are you sure?</source>
-      <translation type="unfinished">Weet je het zeker?</translation>
     </message>
     <message id="settings_vrm_portal_id">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="87"/>
@@ -1939,11 +1747,6 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <source>External storage</source>
       <translation>Externe opslag</translation>
     </message>
-    <message id="settings_vrm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="308"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">Onbekende fout</translation>
-    </message>
     <message id="settings_vrm_no_error">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="311"/>
       <source>No Error</source>
@@ -2029,37 +1832,10 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <source>Function</source>
       <translation>Functie</translation>
     </message>
-    <message id="settings_relay_disabled">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="54"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="98"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Uitgeschakeld</translation>
-    </message>
     <message id="settings_relay_alarm_relay">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="56"/>
       <source>Alarm relay</source>
       <translation>Alarm relais</translation>
-    </message>
-    <message id="settings_relay_tank_pump">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="62"/>
-      <source>Tank pump</source>
-      <translation type="unfinished">Tankpomp</translation>
-    </message>
-    <message id="settings_relay_manual">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="64"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="100"/>
-      <source>Manual</source>
-      <translation type="unfinished">Handmatig</translation>
-    </message>
-    <message id="settings_relay_polarity_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
-      <source>Polarity (Relay 1)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_relay_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
-      <source>Polarity</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_normally_open">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="83"/>
@@ -2075,11 +1851,6 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="93"/>
       <source>Function (Relay 2)</source>
       <translation>Functie (Relais 2)</translation>
-    </message>
-    <message id="settings_relay_polarity_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
-      <source>Polarity (Relay 2)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_temp_control_rules">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="119"/>
@@ -2111,12 +1882,6 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
       <source>Press to boot</source>
       <translation>Drukken om op te starten</translation>
-    </message>
-    <message id="settings_firmware_backup_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
-      <translation type="unfinished">Firmware %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
@@ -2152,6 +1917,7 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
     <message id="nav_boat">
       <location filename="../../pages/boat/BoatPage.qml" line="14"/>
       <source>Boat</source>
+      <extracomment>The 'Boat' page</extracomment>
       <translation>Boot</translation>
     </message>
     <message id="settings_system_name">
@@ -2219,11 +1985,6 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <source>Solar charger current control</source>
       <translation>PV lader stroomregeling</translation>
     </message>
-    <message id="settings_system_status_bms_params">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
-      <source>BMS control</source>
-      <translation type="unfinished">BMS-besturing</translation>
-    </message>
     <message id="common_words_bms_control">
       <location filename="../../components/CommonWords.qml" line="101"/>
       <source>BMS control</source>
@@ -2238,11 +1999,6 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
       <source>Pump state</source>
       <translation>Pompstatus</translation>
-    </message>
-    <message id="settings_pump_auto">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="56"/>
-      <source>Auto</source>
-      <translation type="unfinished">Automatisch</translation>
     </message>
     <message id="settings_tank_sensor">
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
@@ -2271,11 +2027,6 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="35"/>
       <source>Unplugged</source>
       <translation>Losgekoppeld</translation>
-    </message>
-    <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="16"/>
-      <source>Name</source>
-      <translation type="unfinished">Naam</translation>
     </message>
     <message id="settings_tcpip_hidden">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="21"/>
@@ -2317,16 +2068,6 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="99"/>
       <source>IP configuration</source>
       <translation>IP instellingen</translation>
-    </message>
-    <message id="settings_tcpip_manual">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="105"/>
-      <source>Manual</source>
-      <translation type="unfinished">Handmatig</translation>
-    </message>
-    <message id="settings_tcpip_off">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="107"/>
-      <source>Off</source>
-      <translation type="unfinished">Uit</translation>
     </message>
     <message id="settings_tcpip_fixed">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="109"/>
@@ -2382,21 +2123,6 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="30"/>
       <source>Create access point</source>
       <translation>Access point maken</translation>
-    </message>
-    <message id="settings_wifi_access_point_enter_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="68"/>
-      <source>Enter password</source>
-      <translation type="unfinished">Geef wachtwoord</translation>
-    </message>
-    <message id="page_settings_wifi_invalid_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
-      <source>Password length must be either 0 or between 10 and 63 characters long</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_wifi_password_updated">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
-      <source>Password updated</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_wifi_networks">
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="86"/>
@@ -2539,20 +2265,10 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <extracomment>Network status: Standalone</extracomment>
       <translation>Stand-alone</translation>
     </message>
-    <message id="charger_standalone">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="45"/>
-      <source>Standalone</source>
-      <translation type="unfinished">Stand-alone</translation>
-    </message>
     <message id="charger_charge">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="48"/>
       <source>Charge</source>
       <translation>Laden</translation>
-    </message>
-    <message id="charger_external_control">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="51"/>
-      <source>External control</source>
-      <translation type="unfinished">Externe besturing</translation>
     </message>
     <message id="charger_charge_hub_1">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="54"/>
@@ -2584,16 +2300,6 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <source>Master setting</source>
       <translation>Master instelling</translation>
     </message>
-    <message id="charger_slave">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="85"/>
-      <source>Slave</source>
-      <translation type="unfinished">Slave</translation>
-    </message>
-    <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation type="unfinished">Laadspanning</translation>
-    </message>
     <message id="systemsettings_networkstatus_slave">
       <location filename="../../data/SystemSettings.qml" line="148"/>
       <source>Slave</source>
@@ -2615,14 +2321,15 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <source>Group &amp; Charge master</source>
       <translation>Groeps- &amp; laadmaster</translation>
     </message>
-    <message id="genset_charge_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="365"/>
+    <message id="charger_charge_voltage">
+      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
       <source>Charge voltage</source>
       <translation>Laadspanning</translation>
     </message>
     <message id="common_words_reset">
       <location filename="../../components/CommonWords.qml" line="448"/>
       <source>Reset</source>
+      <extracomment>Reset the BMS control</extracomment>
       <translation>Reset</translation>
     </message>
     <message id="solarcharger_load">
@@ -2651,14 +2358,14 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <extracomment>Voltage alarm is at "Warning" level</extracomment>
       <translation>Waarschuwing</translation>
     </message>
-    <message id="listitems_alarm_level_alarm">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="25"/>
+    <message id="digitalinputs_state_alarm">
+      <location filename="../../src/enums.cpp" line="270"/>
       <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
+      <extracomment>Relay function is 'alarm'</extracomment>
       <translation>Alarm</translation>
     </message>
-    <message id="devicelist_tankshape_volume">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="190"/>
+    <message id="components_volumeunit_volume">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
       <source>Volume</source>
       <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
       <translation>Volume</translation>
@@ -2808,26 +2515,10 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <source>Relay function</source>
       <translation>Relaisfunctie</translation>
     </message>
-    <message id="batterysettingrelay_alarm">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation type="unfinished">Alarm</translation>
-    </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
       <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
       <source>Charger or generator start/stop</source>
       <translation>Start/stop lader of aggregaat</translation>
-    </message>
-    <message id="batterysettingrelay_manual_control">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
-      <source>Manual control</source>
-      <translation type="unfinished">Handmatige bediening</translation>
-    </message>
-    <message id="batterysettingrelay_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">Zekering doorgebrand</translation>
     </message>
     <message id="common_words_manual_control">
       <location filename="../../components/CommonWords.qml" line="302"/>
@@ -2853,12 +2544,6 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
       <source>Status LEDs</source>
       <translation>Status LED's</translation>
-    </message>
-    <message id="batterydiagnostics_none">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
-      <source>None</source>
-      <extracomment>Indicates no alarm is set</extracomment>
-      <translation type="unfinished">Geen</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
@@ -2888,7 +2573,7 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
     <message id="common_words_switch">
       <location filename="../../components/CommonWords.qml" line="525"/>
       <source>Switch</source>
-      <extracomment>Change the mode value</extracomment>
+      <extracomment>Change the battery mode</extracomment>
       <translation>Schakelaar</translation>
     </message>
     <message id="devicelist_battery_initializing">
@@ -2956,21 +2641,6 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <source>Top section voltage</source>
       <translation>Spanning bovenste deel</translation>
     </message>
-    <message id="battery_bank_error_communication">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="96"/>
-      <source>Communication error</source>
-      <translation type="unfinished">Communicatiefout</translation>
-    </message>
-    <message id="battery_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="182"/>
-      <source>State of health</source>
-      <translation type="unfinished">Gezondheidstoestand</translation>
-    </message>
-    <message id="battery_bus_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="212"/>
-      <source>Bus voltage</source>
-      <translation type="unfinished">Busspanning</translation>
-    </message>
     <message id="battery_bottom_section_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="228"/>
       <source>Bottom section voltage</source>
@@ -3016,16 +2686,6 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <source>IO</source>
       <translation>IO</translation>
     </message>
-    <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="391"/>
-      <source>System</source>
-      <translation type="unfinished">Systeem</translation>
-    </message>
-    <message id="battery_press_to_redetect">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="433"/>
-      <source>Press to redetect</source>
-      <translation type="unfinished">Drukken om te detecteren</translation>
-    </message>
     <message id="pagesettingsgeneral_system">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="107"/>
       <source>System</source>
@@ -3066,16 +2726,6 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <source>Low SOC</source>
       <translation>Lage laadstatus</translation>
     </message>
-    <message id="batteryalarms_high_battery_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
-      <source>High battery voltage</source>
-      <translation type="unfinished">Hoge accuspanning</translation>
-    </message>
-    <message id="batteryalarms_low_soc">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low SOC</source>
-      <translation type="unfinished">Lage laadstatus</translation>
-    </message>
     <message id="batteryalarms_low_starter_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="73"/>
       <source>Low starter voltage</source>
@@ -3095,11 +2745,6 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
       <source>Mid-point voltage</source>
       <translation>Middelpuntspanning</translation>
-    </message>
-    <message id="batteryalarms_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">Zekering doorgebrand</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
@@ -3293,11 +2938,6 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <source>Restore factory defaults</source>
       <translation>Fabrieksinstellingen herstellen</translation>
     </message>
-    <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation type="unfinished">Klik om te herstellen</translation>
-    </message>
     <message id="vebus_backup_press_to_restore">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="362"/>
       <source>Press to restore</source>
@@ -3337,11 +2977,6 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="18"/>
       <source>Capacity</source>
       <translation>Capaciteit</translation>
-    </message>
-    <message id="batterysettingsbattery_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
-      <source>Capacity</source>
-      <translation type="unfinished">Capaciteit</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
@@ -3418,11 +3053,6 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <source>No power on busbar</source>
       <translation>Geen spanning op verdeelrail</translation>
     </message>
-    <message id="lynxdistributor_connection_lost">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
-      <source>Connection lost</source>
-      <translation type="unfinished">Verbinding onderbroken</translation>
-    </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
       <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
       <source>%n fuse(s) blown</source>
@@ -3458,26 +3088,6 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <source>Shutdowns due error</source>
       <translation>Stopgezet door storing</translation>
     </message>
-    <message id="lynxiondiagnostics_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
-      <source>Last error</source>
-      <translation type="unfinished">Laatste fout</translation>
-    </message>
-    <message id="lynxiondiagnostics_2nd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
-      <source>2nd last error</source>
-      <translation type="unfinished">1 na laatste fout</translation>
-    </message>
-    <message id="lynxiondiagnostics_3rd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
-      <source>3rd last error</source>
-      <translation type="unfinished">2 na laatste fout</translation>
-    </message>
-    <message id="lynxiondiagnostics_4th_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
-      <source>4th last error</source>
-      <translation type="unfinished">3 na laatste fout</translation>
-    </message>
     <message id="lynxionio_system_switch">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
       <source>System Switch</source>
@@ -3497,11 +3107,6 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <location filename="../../components/CommonWords.qml" line="54"/>
       <source>Batteries</source>
       <translation>Accu's</translation>
-    </message>
-    <message id="lynxionsystem_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
-      <source>Capacity</source>
-      <translation type="unfinished">Capaciteit</translation>
     </message>
     <message id="lynxionsystem_parallel">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="30"/>
@@ -3523,20 +3128,10 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <source>Min/max cell temperature</source>
       <translation>Min/max. celtemperatuur</translation>
     </message>
-    <message id="lynxionsystem_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="92"/>
-      <source>Balancing</source>
-      <translation type="unfinished">Balanceren</translation>
-    </message>
     <message id="lynxionsystem_balancer_balancing">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
       <source>Balancing</source>
       <translation>Balanceren</translation>
-    </message>
-    <message id="lynxionsystem_balancer_unknown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="117"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Onbekend</translation>
     </message>
     <message id="dc_output">
       <location filename="../../components/listitems/ListDcOutputQuantityGroup.qml" line="16"/>
@@ -3644,11 +3239,6 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <source>Remaining</source>
       <translation>Resterend</translation>
     </message>
-    <message id="devicelist_tanksensor_sensor_battery">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="51"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">Accu sensor</translation>
-    </message>
     <message id="temperature_sensor_battery">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="112"/>
       <source>Sensor battery</source>
@@ -3677,7 +3267,7 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
     <message id="devicelist_tanksetup_custom">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="53"/>
       <source>Custom</source>
-      <translation type="unfinished">Aangepast</translation>
+      <translation>Aangepast</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="59"/>
@@ -3710,34 +3300,34 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <translation>Sensor waarde</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="75"/>
       <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
       <translation>Geen aangepaste vorm gedefinieerd. Er kan een gedefinieerd worden met maximaal tien punten. Let op dat 0% en 100% geïmpliceerd zijn.</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="91"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="89"/>
       <source>Point %1</source>
       <extracomment>%1 = the point number</extracomment>
       <translation>Punt %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="133"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="179"/>
       <source>Add point</source>
       <translation>Punt toevoegen</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="156"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="205"/>
       <source>Sensor level</source>
       <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
       <translation>Sensorniveau</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="256"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="311"/>
       <source>Duplicate sensor level values are not allowed.</source>
       <translation>Dubbele sensor niveau waarden zijn niet toegestaan.</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="262"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="317"/>
       <source>Volume values must be increasing.</source>
       <translation>Volume waarden moeten oplopend zijn.</translation>
     </message>
@@ -3777,11 +3367,6 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <source>Switch position</source>
       <translation>Stand schakelaar</translation>
     </message>
-    <message id="ac-in-setup_single_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="142"/>
-      <source>Single phase</source>
-      <translation type="unfinished">1-Fase</translation>
-    </message>
     <message id="ac-in-setup_two_phase">
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="144"/>
       <source>2-phase</source>
@@ -3791,11 +3376,6 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="146"/>
       <source>3-phase</source>
       <translation>3-Fasen</translation>
-    </message>
-    <message id="ac-in-setup_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="161"/>
-      <source>Devices</source>
-      <translation type="unfinished">Apparaten</translation>
     </message>
     <message id="ac-in-genset_ac">
       <location filename="../../components/PageGensetModel.qml" line="194"/>
@@ -3889,12 +3469,6 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <extracomment>%1 = CT device number</extracomment>
       <translation>CT %1</translation>
     </message>
-    <message id="smappeect_phase_none">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation type="unfinished">Geen</translation>
-    </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
       <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
       <source>Flashing LED indicates this CT</source>
@@ -3908,11 +3482,13 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
     <message id="common_words_setting_disabled_when_dmc_connected">
       <location filename="../../components/CommonWords.qml" line="355"/>
       <source>This setting is disabled when a Digital Multi Control is connected.</source>
+      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>Deze instelling is uitgeschakeld als een Digital Multi Control is aangesloten.</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
       <location filename="../../components/CommonWords.qml" line="358"/>
       <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>Deze instelling is uitgeschakeld als een VE.Bus BMS is aangesloten.</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
@@ -3930,16 +3506,6 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="21"/>
       <source>Inverted</source>
       <translation>Omgekeerd</translation>
-    </message>
-    <message id="digitalinput_enable_alarm">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="48"/>
-      <source>Enable alarm</source>
-      <translation type="unfinished">Alarm inschakelen</translation>
-    </message>
-    <message id="digitalinput_inverted">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="54"/>
-      <source>Inverted</source>
-      <translation type="unfinished">Omgekeerd</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
       <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="60"/>
@@ -3976,16 +3542,6 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <source>Wind speed</source>
       <translation>Windsnelheid</translation>
     </message>
-    <message id="page_meteo_battery_voltage">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="99"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">Accu sensor</translation>
-    </message>
-    <message id="meteo_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="120"/>
-      <source>Low</source>
-      <translation type="unfinished">Laag</translation>
-    </message>
     <message id="page_meteo_settings_auto_detect">
       <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
       <source>Auto-detect</source>
@@ -4016,16 +3572,6 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <source>Reset counter</source>
       <translation>Teller resetten</translation>
     </message>
-    <message id="temperature_short_circuited">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="32"/>
-      <source>Short circuited</source>
-      <translation type="unfinished">Kortsluiting</translation>
-    </message>
-    <message id="temperature_reverse_polarity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="35"/>
-      <source>Reverse polarity</source>
-      <translation type="unfinished">Omgekeerde polariteit</translation>
-    </message>
     <message id="temperature_sensor_battery_low">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
       <source>Sensor battery low</source>
@@ -4040,36 +3586,6 @@ Gebruik tenzij verboden door de energieleverancier.</translation>
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="62"/>
       <source>Pressure</source>
       <translation>Druk</translation>
-    </message>
-    <message id="temperature_pm25">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
-      <source>PM2.5</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_co2">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>CO₂</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_voc">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
-      <source>VOC index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_nox">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
-      <source>NOx index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_luminosity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
-      <source>Luminosity</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="133"/>
-      <source>Low</source>
-      <translation type="unfinished">Laag</translation>
     </message>
     <message id="temperature_offset">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
@@ -4123,25 +3639,10 @@ OPMERKING: Het bijwerken kan het systeem tijdelijk stoppen.</translation>
       <source>Updating the MK3, values will reappear after the update is complete</source>
       <translation>MK3 bijwerken, de waarden zullen na het bijwerken terug komen.</translation>
     </message>
-    <message id="vebus_device_charging_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="78"/>
-      <source>Charging the battery to 100%</source>
-      <translation type="unfinished">De accu opladen tot 100%</translation>
-    </message>
     <message id="vebus_device_charging_the_battery_to_100">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="93"/>
       <source>Charging the battery to 100%</source>
       <translation>De accu opladen tot 100%</translation>
-    </message>
-    <message id="vebus_device_page_microgrid_parameters">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
-      <source>Microgrid parameters</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="vebus_device_page_advanced">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
-      <source>Advanced</source>
-      <translation type="unfinished">Geavanceerd</translation>
     </message>
     <message id="vebus_device_in_progress">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="80"/>
@@ -4194,15 +3695,15 @@ Do you want to continue?</source>
       <source>DC Current</source>
       <translation>DC stroom</translation>
     </message>
+    <message id="vebus_device_page_advanced">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
+      <source>Advanced</source>
+      <translation>Geavanceerd</translation>
+    </message>
     <message id="common_words_alarm_setup">
       <location filename="../../components/CommonWords.qml" line="65"/>
       <source>Alarm setup</source>
       <translation>Alarm instellingen</translation>
-    </message>
-    <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
-      <translation type="unfinished">Een VE.Bus BMS schakelt indien nodig automatisch het systeem uit om de accu te beschermen. Besturing van het systeem vanuit de Color Control is daarom niet mogelijk.</translation>
     </message>
     <message id="vebus_device_bms_not_found">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="240"/>
@@ -4243,7 +3744,7 @@ Do you want to continue?</source>
     <message id="vebus_device_starting">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="117"/>
       <source>Starting...</source>
-      <translation type="unfinished">Starten...</translation>
+      <translation>Starten...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="120"/>
@@ -4309,16 +3810,6 @@ Do you want to continue?</source>
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="260"/>
       <source>ESS Relay test</source>
       <translation>ESS relais test</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_completed">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="266"/>
-      <source>Completed</source>
-      <translation type="unfinished">Voltooid</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_pending">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="268"/>
-      <source>Pending</source>
-      <translation type="unfinished">In behandeling...</translation>
     </message>
     <message id="cycle_history_completed">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
@@ -4505,6 +3996,7 @@ Do you want to continue?</source>
     <message id="rssystemalarms_overload">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
       <source>Overload</source>
+      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
       <translation>Overbelasting</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
@@ -4517,11 +4009,6 @@ Do you want to continue?</source>
       <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
       <source>Voltage Sensor</source>
       <translation>Spanningssensor</translation>
-    </message>
-    <message id="vebus_device_phase_rotation">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
-      <source>Phase rotation</source>
-      <translation type="unfinished">Faserotatie</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
@@ -4553,12 +4040,6 @@ Do you want to continue?</source>
       <source>VE.Bus BMS version</source>
       <translation>VE.Bus BMS versie</translation>
     </message>
-    <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="15"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="52"/>
-      <source>Minimum SOC</source>
-      <translation type="unfinished">Minimum laadtoestand</translation>
-    </message>
     <message id="ess_unless_grid_fails">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="32"/>
       <source>Unless grid fails</source>
@@ -4578,7 +4059,7 @@ Do you want to continue?</source>
     <message id="common_words_ac_input_role">
       <location filename="../../components/CommonWords.qml" line="24"/>
       <source>Role</source>
-      <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
       <translation>Rol</translation>
     </message>
     <message id="common_words_ac_load">
@@ -4617,18 +4098,6 @@ Do you want to continue?</source>
       <source>Active</source>
       <extracomment>Status is 'active'</extracomment>
       <translation>Actief</translation>
-    </message>
-    <message id="common_words_alarm">
-      <location filename="../../components/CommonWords.qml" line="51"/>
-      <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
-      <translation type="unfinished">Alarm</translation>
-    </message>
-    <message id="common_words_alarm_setting_overload">
-      <location filename="../../components/CommonWords.qml" line="58"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation type="unfinished">Overbelasting</translation>
     </message>
     <message id="common_words_alarm_status">
       <location filename="../../components/CommonWords.qml" line="68"/>
@@ -4675,8 +4144,8 @@ Do you want to continue?</source>
       <source>Charge current</source>
       <translation>Laadstroom</translation>
     </message>
-    <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="125"/>
+    <message id="battery_mode_charging">
+      <location filename="../../src/enums.cpp" line="30"/>
       <source>Charging</source>
       <extracomment>"Charging" state</extracomment>
       <translation>Opladen</translation>
@@ -4690,7 +4159,7 @@ Do you want to continue?</source>
     <message id="digitalinputs_state_closed">
       <location filename="../../src/enums.cpp" line="262"/>
       <source>Closed</source>
-      <extracomment>Digital input state</extracomment>
+      <extracomment>Status is 'closed'</extracomment>
       <translation>Gesloten</translation>
     </message>
     <message id="evchargers_status_connected">
@@ -4698,8 +4167,8 @@ Do you want to continue?</source>
       <source>Connected</source>
       <translation>Verbonden</translation>
     </message>
-    <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="143"/>
+    <message id="temperature_slider_current">
+      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
       <source>Current</source>
       <extracomment>Electric current, as measured in Amps</extracomment>
       <translation>Stroom</translation>
@@ -4726,9 +4195,10 @@ Do you want to continue?</source>
       <extracomment>Title for device information</extracomment>
       <translation>Apparaat</translation>
     </message>
-    <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="172"/>
+    <message id="battery_mode_discharging">
+      <location filename="../../src/enums.cpp" line="34"/>
       <source>Discharging</source>
+      <extracomment>Battery mode</extracomment>
       <translation>Ontladen</translation>
     </message>
     <message id="wifimodel_disconnected">
@@ -4814,13 +4284,14 @@ Do you want to continue?</source>
       <source>%1 Hour(s)</source>
       <translation>%1 Uur/uren</translation>
     </message>
-    <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="251"/>
+    <message id="battery_mode_idle">
+      <location filename="../../src/enums.cpp" line="26"/>
       <source>Idle</source>
+      <extracomment>Battery mode</extracomment>
       <translation>Inactief</translation>
     </message>
-    <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="258"/>
+    <message id="scheduled_charge_inactive">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
       <source>Inactive</source>
       <extracomment>Status is 'inactive'</extracomment>
       <translation>Inactief</translation>
@@ -4922,8 +4393,8 @@ Do you want to continue?</source>
       <source>Offline</source>
       <translation>Offline</translation>
     </message>
-    <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="17"/>
+    <message id="digitalinputs_state_ok">
+      <location filename="../../src/enums.cpp" line="266"/>
       <source>OK</source>
       <extracomment>Voltage alarm is at "OK" level</extracomment>
       <translation>OK</translation>
@@ -4931,6 +4402,7 @@ Do you want to continue?</source>
     <message id="switchable_output_on">
       <location filename="../../src/enums.cpp" line="471"/>
       <source>On</source>
+      <extracomment>Digital input state</extracomment>
       <translation>Aan</translation>
     </message>
     <message id="common_words_online">
@@ -4941,7 +4413,7 @@ Do you want to continue?</source>
     <message id="digitalinputs_state_open">
       <location filename="../../src/enums.cpp" line="258"/>
       <source>Open</source>
-      <extracomment>Digital input open</extracomment>
+      <extracomment>Status is 'open'</extracomment>
       <translation>Geopend</translation>
     </message>
     <message id="common_words_password">
@@ -5001,9 +4473,10 @@ Do you want to continue?</source>
       <source>Remove</source>
       <translation>Verwijderen</translation>
     </message>
-    <message id="switch_state_running">
-      <location filename="../../src/enums.cpp" line="363"/>
+    <message id="switchable_output_running">
+      <location filename="../../src/enums.cpp" line="468"/>
       <source>Running</source>
+      <extracomment>Status = "running"</extracomment>
       <translation>Loopt</translation>
     </message>
     <message id="common_words_scanning">
@@ -5070,7 +4543,7 @@ Do you want to continue?</source>
     <message id="pvinverter_statusCode_startup">
       <location filename="../../src/enums.cpp" line="296"/>
       <source>Startup (%1)</source>
-      <extracomment>PV inverter status code. %1 = the startup status number</extracomment>
+      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
       <translation>Opstarten (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
@@ -5125,8 +4598,10 @@ Do you want to continue?</source>
       <source>Unique Identity Number</source>
       <translation>Uniek Identity nummer</translation>
     </message>
-    <message id="settings_radio_button_group_unknown">
-      <location filename="../../components/listitems/core/ListRadioButtonGroup.qml" line="44"/>
+    <message id="Unknown">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
       <source>Unknown</source>
       <translation>Onbekend</translation>
     </message>
@@ -5281,11 +4756,6 @@ Do you want to continue?</source>
       <source>Error while checking for firmware updates</source>
       <translation>Fout tijdens het controleren op firmware-updates</translation>
     </message>
-    <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation type="unfinished">Fout tijdens het controleren op firmware-updates</translation>
-    </message>
     <message id="settings_firmware_downloading_and_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="63"/>
       <source>Downloading and installing firmware %1...</source>
@@ -5312,6 +4782,66 @@ Do you want to continue?</source>
       <source>No firmware found</source>
       <translation>Geen firmware gevonden</translation>
     </message>
+    <message id="tank_type_fuel">
+      <location filename="../../src/enums.cpp" line="495"/>
+      <source>Fuel</source>
+      <translation>Brandstof</translation>
+    </message>
+    <message id="tank_type_fresh_water">
+      <location filename="../../src/enums.cpp" line="498"/>
+      <source>Fresh water</source>
+      <translation>Vers water</translation>
+    </message>
+    <message id="tank_type_waste_water">
+      <location filename="../../src/enums.cpp" line="501"/>
+      <source>Waste water</source>
+      <translation>Afvalwater</translation>
+    </message>
+    <message id="tank_type_live_well">
+      <location filename="../../src/enums.cpp" line="504"/>
+      <source>Live well</source>
+      <translation>Bronwater</translation>
+    </message>
+    <message id="tank_type_oil">
+      <location filename="../../src/enums.cpp" line="507"/>
+      <source>Oil</source>
+      <translation>Olie</translation>
+    </message>
+    <message id="tank_type_black_water">
+      <location filename="../../src/enums.cpp" line="510"/>
+      <source>Black water</source>
+      <translation>Vuilwater</translation>
+    </message>
+    <message id="tank_type_gasoline">
+      <location filename="../../src/enums.cpp" line="513"/>
+      <source>Gasoline</source>
+      <translation>Benzine</translation>
+    </message>
+    <message id="tank_type_diesel">
+      <location filename="../../src/enums.cpp" line="516"/>
+      <source>Diesel</source>
+      <translation>Diesel</translation>
+    </message>
+    <message id="tank_type_lpg">
+      <location filename="../../src/enums.cpp" line="519"/>
+      <source>LPG</source>
+      <translation>LPG</translation>
+    </message>
+    <message id="tank_type_lng">
+      <location filename="../../src/enums.cpp" line="522"/>
+      <source>LNG</source>
+      <translation>LNG</translation>
+    </message>
+    <message id="tank_type_hydraulic_oil">
+      <location filename="../../src/enums.cpp" line="525"/>
+      <source>Hydraulic oil</source>
+      <translation>Hydraulische olie</translation>
+    </message>
+    <message id="tank_type_raw_water">
+      <location filename="../../src/enums.cpp" line="528"/>
+      <source>Raw water</source>
+      <translation>Vuil water</translation>
+    </message>
     <message id="listItem_no_access">
       <location filename="../../components/listitems/core/ListItem.qml" line="102"/>
       <source>Setting locked for access level</source>
@@ -5325,6 +4855,7 @@ Do you want to continue?</source>
     <message id="welcome_brief_title">
       <location filename="../../pages/welcome/WelcomeView.qml" line="81"/>
       <source>Brief</source>
+      <extracomment>The 'Brief' page</extracomment>
       <translation>Kort</translation>
     </message>
     <message id="welcome_overview_title">
@@ -5341,23 +4872,6 @@ Do you want to continue?</source>
       <location filename="../../pages/NotificationsPage.qml" line="13"/>
       <source>Notifications</source>
       <translation>Berichten</translation>
-    </message>
-    <message id="notifications_page_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="43"/>
-      <source>Active Notifications</source>
-      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_page_inactive_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="47"/>
-      <source>Inactive Notifications</source>
-      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_no_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="106"/>
-      <source>No active notifications</source>
-      <translation type="unfinished"/>
     </message>
     <message id="utils_formatTimestamp_now">
       <location filename="../../components/Utils.js" line="258"/>
@@ -5462,11 +4976,6 @@ Do you want to continue?</source>
       <source>Self-consumption above limit</source>
       <translation>Eigen verbruik boven limiet</translation>
     </message>
-    <message id="cgwacs_battery_schedule_pv">
-      <location filename="../../components/listitems/ListChargeSchedule.qml" line="171"/>
-      <source>PV</source>
-      <translation type="unfinished">Zonnepaneel</translation>
-    </message>
     <message id="settings_multirs_pv">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="185"/>
       <source>PV</source>
@@ -5477,8 +4986,8 @@ Do you want to continue?</source>
       <source>PV &amp; Battery</source>
       <translation>Zonnepaneel &amp; Accu</translation>
     </message>
-    <message id="settings_firmware_checking">
-      <location filename="../../components/listitems/ListFirmwareCheckButton.qml" line="16"/>
+    <message id="pagesettingssupportstate_firmware_checking">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
       <source>Checking...</source>
       <translation>Controleren...</translation>
     </message>
@@ -5486,12 +4995,6 @@ Do you want to continue?</source>
       <location filename="../../components/listitems/ListAlarmState.qml" line="11"/>
       <source>Alarm state</source>
       <translation>Alarmtoestand</translation>
-    </message>
-    <message id="devicelist_battery_alarm_state">
-      <location filename="../../components/listitems/ListAlarmState.qml" line="19"/>
-      <source>Alarm</source>
-      <extracomment>Alarm state is active</extracomment>
-      <translation type="unfinished">Alarm</translation>
     </message>
     <message id="clear_history_button_clear_history">
       <location filename="../../components/listitems/ListClearHistoryButton.qml" line="15"/>
@@ -5643,11 +5146,6 @@ Do you want to continue?</source>
       <source>Max Voltage</source>
       <translation>Max. Spanning</translation>
     </message>
-    <message id="charger_history_box_max_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="64"/>
-      <source>Max Voltage</source>
-      <translation type="unfinished">Max. Spanning</translation>
-    </message>
     <message id="charger_history_box_max_current">
       <location filename="../../components/SolarDetailBox.qml" line="70"/>
       <source>Max Current</source>
@@ -5658,24 +5156,6 @@ Do you want to continue?</source>
       <source>Charge time</source>
       <extracomment>Statistics for battery charging time</extracomment>
       <translation>Laadtijd</translation>
-    </message>
-    <message id="charger_history_box_bulk">
-      <location filename="../../components/SolarDetailBox.qml" line="136"/>
-      <source>Bulk</source>
-      <extracomment>Battery: time spent in 'Bulk' mode</extracomment>
-      <translation type="unfinished">Bulk</translation>
-    </message>
-    <message id="charger_history_box_float">
-      <location filename="../../components/SolarDetailBox.qml" line="148"/>
-      <source>Float</source>
-      <extracomment>Battery: time spent in 'Float' mode</extracomment>
-      <translation type="unfinished">Druppellading</translation>
-    </message>
-    <message id="charger_history_hr">
-      <location filename="../../components/SolarDetailBox.qml" line="174"/>
-      <source>hr</source>
-      <extracomment>Abbreviation of "hour"</extracomment>
-      <translation type="unfinished">uur</translation>
     </message>
     <message id="solarchargers_state_bulk">
       <location filename="../../src/enums.cpp" line="337"/>
@@ -5747,11 +5227,6 @@ Do you want to continue?</source>
       <source>Connecting</source>
       <translation>Verbinding wordt gemaakt</translation>
     </message>
-    <message id="splash_view_connecting">
-      <location filename="../../components/SplashView.qml" line="288"/>
-      <source>Connecting</source>
-      <translation type="unfinished">Verbinding wordt gemaakt</translation>
-    </message>
     <message id="splash_view_connected">
       <location filename="../../components/SplashView.qml" line="290"/>
       <source>Connected, awaiting broker messages</source>
@@ -5807,6 +5282,11 @@ Do you want to continue?</source>
       <source>MQTT protocol level 5 error</source>
       <translation>MQTT protocol niveau 5 fout</translation>
     </message>
+    <message id="common_words_silence_alarm">
+      <location filename="../../components/CommonWords.qml" line="476"/>
+      <source>Silence alarm</source>
+      <translation>Alarm uitzetten</translation>
+    </message>
     <message id="vebus_device_page_total_power">
       <location filename="../../components/ThreePhaseQuantityTable.qml" line="47"/>
       <source>Total Power</source>
@@ -5857,20 +5337,10 @@ Do you want to continue?</source>
       <source>Retrieving IP address</source>
       <translation>Bezig IP adres te ontvangen</translation>
     </message>
-    <message id="utils_connman_connected">
-      <location filename="../../components/Utils.js" line="292"/>
-      <source>Connected</source>
-      <translation type="unfinished">Verbonden</translation>
-    </message>
     <message id="utils_connman_disconnect">
       <location filename="../../components/Utils.js" line="295"/>
       <source>Disconnect</source>
       <translation>Verbinding verbreken</translation>
-    </message>
-    <message id="utils_connman_disconnected">
-      <location filename="../../components/Utils.js" line="299"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Losgekoppeld</translation>
     </message>
     <message id="overview_widget_acloads_title">
       <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
@@ -5908,11 +5378,6 @@ Do you want to continue?</source>
       <source>Shore current limit</source>
       <translation>Walstroomlimiet</translation>
     </message>
-    <message id="acInputs_statusCode_stopping">
-      <location filename="../../data/AcInputs.qml" line="170"/>
-      <source>Stopping</source>
-      <translation type="unfinished">Stoppen</translation>
-    </message>
     <message id="page_generator_stopping">
       <location filename="../../data/Generators.qml" line="44"/>
       <source>Stopping</source>
@@ -5928,7 +5393,7 @@ Do you want to continue?</source>
       <location filename="../../data/common/TankDescription.qml" line="24"/>
       <location filename="../../src/device.cpp" line="133"/>
       <source>%1 tank (%2)</source>
-      <extracomment>Tank description. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
       <translation>%1 tank (%2)</translation>
     </message>
     <message id="dcMeter_ac_charger">
@@ -5977,11 +5442,6 @@ Do you want to continue?</source>
       <location filename="../../data/Ess.qml" line="20"/>
       <source>Keep batteries charged</source>
       <translation>Houd de accu's opgeladen</translation>
-    </message>
-    <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="50"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Losgekoppeld</translation>
     </message>
     <message id="evchargers_status_charged">
       <location filename="../../data/EvChargers.qml" line="58"/>
@@ -6042,16 +5502,6 @@ Do you want to continue?</source>
       <location filename="../../data/EvChargers.qml" line="97"/>
       <source>Start charging</source>
       <translation>Start laden</translation>
-    </message>
-    <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="113"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Onbekend</translation>
-    </message>
-    <message id="evchargers_mode_scheduled">
-      <location filename="../../data/EvChargers.qml" line="126"/>
-      <source>Scheduled</source>
-      <translation type="unfinished">Gepland</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
       <location filename="../../data/System.qml" line="195"/>
@@ -6176,11 +5626,6 @@ Do you want to continue?</source>
       <source>Power supply mode</source>
       <translation>Voeding modus</translation>
     </message>
-    <message id="inverters_state_sustain">
-      <location filename="../../data/System.qml" line="158"/>
-      <source>Sustain</source>
-      <translation type="unfinished">Onderhouden</translation>
-    </message>
     <message id="inverters_state_wakeup">
       <location filename="../../data/System.qml" line="162"/>
       <source>Wake up</source>
@@ -6215,16 +5660,6 @@ Do you want to continue?</source>
       <location filename="../../data/System.qml" line="180"/>
       <source>Test</source>
       <translation>Test</translation>
-    </message>
-    <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="183"/>
-      <source>External control</source>
-      <translation type="unfinished">Externe besturing</translation>
-    </message>
-    <message id="inverters_state_dynamic_ess">
-      <location filename="../../data/System.qml" line="198"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">Dynamic ESS</translation>
     </message>
     <message id="settings_rs_ess_dess">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="97"/>
@@ -6303,16 +5738,13 @@ Do you want to continue?</source>
     <message id="ess_recommended">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="73"/>
       <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
       <translation>Voor lithiumaccu's wordt een lading van minder dan 10% afgeraden. Raadpleeg voor andere accutypen het gegevensblad voor het minimumniveau dat door de fabrikant wordt aanbevolen.</translation>
-    </message>
-    <message id="controlcard_generator_label_autostart">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="63"/>
-      <source>Autostart</source>
-      <translation type="unfinished">Automatisch starten</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
       <location filename="../../pages/controlcards/GeneratorCard.qml" line="70"/>
       <source>Start and stop the generator based on the configured autostart conditions.</source>
+      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
       <translation>Het aggregaat starten en stoppen op basis van de ingestelde autostartvoorwaarden.</translation>
     </message>
     <message id="generator_dialog_disabled">
@@ -6335,11 +5767,13 @@ Do you want to continue?</source>
       <location filename="../../pages/controlcards/InverterChargerCard.qml" line="26"/>
       <source>Inverter / Charger (%1)</source>
       <extracomment>%1 = the inverter/charger name</extracomment>
+      <oldsource>Inverter / Charger</oldsource>
       <translation>Omvormer/lader (%1)</translation>
     </message>
     <message id="settings_page_debug_quit_application">
       <location filename="../../pages/settings/debug/PageDebug.qml" line="36"/>
       <source>Quit application</source>
+      <oldsource>Quit Application</oldsource>
       <translation>Toepassing beëindigen</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
@@ -6350,12 +5784,8 @@ Do you want to continue?</source>
     <message id="settings_page_relay_generator_run_time">
       <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
       <source>Current run time</source>
+      <oldsource>Run time</oldsource>
       <translation>Huidige looptijd</translation>
-    </message>
-    <message id="settings_page_genset_generator_run_time">
-      <location filename="../../components/PageGensetModel.qml" line="102"/>
-      <source>Current run time</source>
-      <translation type="unfinished">Huidige looptijd</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
       <location filename="../../components/PageGensetModel.qml" line="110"/>
@@ -6382,19 +5812,10 @@ Do you want to continue?</source>
       <source>Remote start mode</source>
       <translation>Modus starten op afstand</translation>
     </message>
-    <message id="ac-in-genset_speed">
-      <location filename="../../components/PageGensetModel.qml" line="245"/>
-      <source>Speed</source>
-      <translation type="unfinished">Snelheid</translation>
-    </message>
-    <message id="ac-in-genset_load">
-      <location filename="../../components/PageGensetModel.qml" line="252"/>
-      <source>Load</source>
-      <translation type="unfinished">Belasting</translation>
-    </message>
     <message id="ac-in-genset_oil_pressure">
       <location filename="../../components/PageGensetModel.qml" line="260"/>
       <source>Oil pressure</source>
+      <oldsource>Oil Pressure</oldsource>
       <translation>Oliedruk</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
@@ -6490,11 +5911,13 @@ Do you want to continue?</source>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
       <source>High starter battery voltage alarms</source>
+      <oldsource>High starter batttery voltage alarms</oldsource>
       <translation>Alarm bij hoge startaccuspanning</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
       <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
       <translation>Let op dat het wijzigen van de instelling voor de Tijd tot ontladingsvloer ook de instelling voor de Lage laadstatus in het relaismenu verandert.</translation>
     </message>
     <message id="lynxionsystem_cells_per_battery">
@@ -6571,6 +5994,7 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/devicelist/delegates/DeviceListDelegate_solarcharger.qml" line="34"/>
       <source>Error: #%1</source>
       <extracomment>%1 = error number</extracomment>
+      <oldsource>Error: %1</oldsource>
       <translation>Fout: #%1</translation>
     </message>
     <message id="devicelistpage_genset">
@@ -6627,17 +6051,14 @@ Do you want to continue?</source>
     <message id="settings_page_relay_generator_auto_start_enabled">
       <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
       <source>Autostart functionality</source>
+      <oldsource>Auto start functionality</oldsource>
       <translation>Autostart-functionaliteit</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="97"/>
       <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
       <translation>Zorg ervoor dat het aggregaat niet is aangesloten op AC-ingang %1 als deze optie wordt gebruikt.</translation>
-    </message>
-    <message id="page_generator_conditions_inverter_high_temperature">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="139"/>
-      <source>Inverter high temperature</source>
-      <translation type="unfinished">Hoge temperatuur omvormer</translation>
     </message>
     <message id="page_generator_conditions_tank_level">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="159"/>
@@ -6667,30 +6088,34 @@ Do you want to continue?</source>
     <message id="settings_generator_function_not_enabled">
       <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
       <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
+      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
       <translation>Aggregaat start/stop-functie is niet ingeschakeld, ga naar relaisinstellingen en stel functie in op "Aggregaat start/stop".</translation>
     </message>
     <message id="settings_batteries_intro">
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="45"/>
       <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
       <translation>Gebruik dit menu om de accugegevens te definiëren die worden weergegeven als op het pictogram Accu geklikt wordt op de pagina Overzicht. Dezelfde selectie is ook zichtbaar op het VRM Portal.</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
       <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
       <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
       <translation>Continu zoeken kan de WiFi functie verstoren.</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
       <source>CAN-bus BMS LV (500 kbit/s)</source>
+      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
       <translation>CAN-bus BMS LV (500 kbit/s)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
       <source>CAN-bus BMS HV (500 kbit/s)</source>
       <translation>CAN-bus BMS HV (500 kbit/s)</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
       <source>Up, but no services (500 kbit/s)</source>
       <translation>In bedrijf, maar geen diensten (500 kbit/s)</translation>
     </message>
@@ -6703,41 +6128,6 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="127"/>
       <source>Brief page</source>
       <translation>Korte pagina</translation>
-    </message>
-    <message id="settings_displayoff_1min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="46"/>
-      <source>1 min</source>
-      <translation type="unfinished">1 min</translation>
-    </message>
-    <message id="settings_displayoff_10min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="48"/>
-      <source>10 min</source>
-      <translation type="unfinished">10 min</translation>
-    </message>
-    <message id="settings_displayoff_30min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="50"/>
-      <source>30 min</source>
-      <translation type="unfinished">30 min</translation>
-    </message>
-    <message id="settings_displayoff_never">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="52"/>
-      <source>Never</source>
-      <translation type="unfinished">Nooit</translation>
-    </message>
-    <message id="settings_remote_console_appearance_auto">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="112"/>
-      <source>Auto</source>
-      <translation type="unfinished">Automatisch</translation>
-    </message>
-    <message id="settings_brief_view_start_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="119"/>
-      <source>Start page</source>
-      <translation type="unfinished">Startpagina</translation>
-    </message>
-    <message id="settings_display_boat_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="135"/>
-      <source>Boat page</source>
-      <translation type="unfinished">Bootpagina</translation>
     </message>
     <message id="settings_display_minmax">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="148"/>
@@ -6792,21 +6182,6 @@ Do you want to continue?</source>
       <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
       <translation>%1 is ingesteld op %2</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_unsupported_device">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="50"/>
-      <source>Unsupported GX device</source>
-      <translation type="unfinished">Niet ondersteund GX-apparaat</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_clean">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="55"/>
-      <source>Clean</source>
-      <translation type="unfinished">Schoon</translation>
-    </message>
-    <message id="pagesettingsgeneral_firmware">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="112"/>
-      <source>Firmware</source>
-      <translation type="unfinished">Firmware</translation>
-    </message>
     <message id="pagesettingsgeneral_access_and_security">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
       <source>Access &amp; Security</source>
@@ -6840,6 +6215,7 @@ Do you want to continue?</source>
     <message id="settings_language_please_wait">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="209"/>
       <source>Please wait while the language is changed.</source>
+      <oldsource>Please wait while the language is changed</oldsource>
       <translation>Even geduld terwijl de taal wordt gewijzigd.</translation>
     </message>
     <message id="settings_briefview_totals">
@@ -6856,11 +6232,6 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="71"/>
       <source>Tank is not connected.</source>
       <translation>De tank is niet aangesloten.</translation>
-    </message>
-    <message id="settings_briefview_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="83"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">Actieve accumonitor</translation>
     </message>
     <message id="settings_briefview_individual_batteries">
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="86"/>
@@ -6911,6 +6282,7 @@ Do you want to continue?</source>
     <message id="settings_dvcc_charge_current_limits">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="30"/>
       <source>Charge current limits</source>
+      <oldsource>Charge Current limits</oldsource>
       <translation>Laadstroomlimieten</translation>
     </message>
     <message id="settings_firmware_official_release">
@@ -6990,11 +6362,6 @@ Do you want to continue?</source>
       <source>No password and the network communication is not encrypted</source>
       <translation>Geen wachtwoord en de netwerkcommunicatie is niet versleuteld</translation>
     </message>
-    <message id="settings_logout_now">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
-      <source>Log out now</source>
-      <translation type="unfinished">Nu uitloggen</translation>
-    </message>
     <message id="settings_security_profile_password_incorrect_length">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="28"/>
       <source>Password needs to be at least 8 characters long</source>
@@ -7045,25 +6412,10 @@ Do you want to continue?</source>
       <source>Page will automatically reload in 5 seconds</source>
       <translation>Pagina wordt automatisch opnieuw geladen na 5 seconden</translation>
     </message>
-    <message id="settings_security_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="159"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">Wachtwoord moet minstens 8 tekens lang zijn</translation>
-    </message>
     <message id="settings_root_password">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="269"/>
       <source>Root password</source>
       <translation>Root wachtwoord</translation>
-    </message>
-    <message id="settings_root_enter_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="272"/>
-      <source>Enter password</source>
-      <translation type="unfinished">Geef wachtwoord</translation>
-    </message>
-    <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="277"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">Wachtwoord moet minstens 8 tekens lang zijn</translation>
     </message>
     <message id="settings_root_password_changed_to">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="283"/>
@@ -7079,6 +6431,11 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="321"/>
       <source>Logout</source>
       <translation>Uitloggen</translation>
+    </message>
+    <message id="settings_logout_now">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
+      <source>Log out now</source>
+      <translation>Nu uitloggen</translation>
     </message>
     <message id="settings_logout_dialog_title">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="335"/>
@@ -7138,11 +6495,13 @@ Do you want to continue?</source>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="141"/>
       <source>Alarm when generator is not in autostart mode</source>
+      <oldsource>Alarm when generator is not in auto start mode</oldsource>
       <translation>Alarm als hert aggregaat niet in autostartmodus staat</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="147"/>
       <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
       <translation>Er gaat een alarm af als de autostartfunctie meer dan 10 minuten uitgeschakeld blijft.</translation>
     </message>
     <message id="settings_units_amps_exceptions">
@@ -7158,6 +6517,11 @@ Do you want to continue?</source>
     <message id="settings_ess_use_this_option_for_peak_shaving">
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
       <source>Use this option for peak shaving.</source>
+      <oldsource>Use this option for peak shaving.
+
+The peak shaving threshold is set using the AC input current limit setting.
+
+See documentation for further information.</oldsource>
       <translation>Gebruik deze optie voor piekafvlakken.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
@@ -7201,17 +6565,17 @@ Do you want to continue?</source>
       <translation>Maximale systeemexportstroom (per fase)</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="71"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="73"/>
       <source>Self-consumption from battery</source>
       <translation>Eigen verbruik van accu</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="76"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
       <source>All system loads</source>
       <translation>Alle systeembelastingen</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="80"/>
       <source>Only critical loads</source>
       <translation>Alleen kritieke belastingen</translation>
     </message>
@@ -7269,26 +6633,6 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="194"/>
       <source>Server Applications</source>
       <translation>Servertoepassingen</translation>
-    </message>
-    <message id="pagesettingsintegrations_venus_os_enable_large_features">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
-      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_large_victron_community">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="274"/>
-      <source>Victron Community</source>
-      <translation type="unfinished">Victron Community</translation>
-    </message>
-    <message id="pagesettingsintegrations_ui_plugins">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
-      <source>UI Plugins</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
-      <source>Integrates with the device list</source>
-      <translation type="unfinished"/>
     </message>
     <message id="pagesettingssupportstate_modbus_tcp_server">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="453"/>
@@ -7391,25 +6735,10 @@ Do you want to continue?</source>
       <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
       <translation>De firmwareversie kan niet worden gewijzigd als "Netwerkbeveiligingsprofiel" in "Instellingen / Algemeen" niet is geselecteerd.</translation>
     </message>
-    <message id="pagesettingsconnectivity_ethernet">
-      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
-      <source>Ethernet</source>
-      <translation type="unfinished">Ethernet</translation>
-    </message>
     <message id="pagesettingsconnectivity_mobile_network">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="53"/>
       <source>Mobile Network</source>
       <translation>Mobiel netwerk</translation>
-    </message>
-    <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Boat</source>
-      <translation type="unfinished">Boot</translation>
-    </message>
-    <message id="settings_system_name_auto">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="32"/>
-      <source>Automatic</source>
-      <translation type="unfinished">Automatisch</translation>
     </message>
     <message id="pagesettingssystem_ac_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
@@ -7440,11 +6769,6 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="89"/>
       <source>Distributed Voltage and Current Control (DVCC)</source>
       <translation>Gedistribueerde spanning- en stroomregeling (DVCC)</translation>
-    </message>
-    <message id="settings_system_grid">
-      <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="18"/>
-      <source>Grid</source>
-      <translation type="unfinished">Net</translation>
     </message>
     <message id="settings_system_ac_position">
       <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="58"/>
@@ -7484,16 +6808,19 @@ Do you want to continue?</source>
     <message id="settings_system_has_dc_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="97"/>
       <source>Display DC Loads</source>
+      <oldsource>Has DC system</oldsource>
       <translation>DC belastingen weergeven</translation>
     </message>
     <message id="settings_system_battery_measurements">
       <location filename="../../pages/settings/PageSettingsBatteries.qml" line="65"/>
       <source>Battery measurements</source>
+      <oldsource>Battery Measurements</oldsource>
       <translation>Accu metingen</translation>
     </message>
     <message id="settings_system_system_status">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
       <source>System status</source>
+      <oldsource>System Status</oldsource>
       <translation>Systeemstatus</translation>
     </message>
     <message id="settings_tcpip_wired">
@@ -7504,11 +6831,13 @@ Do you want to continue?</source>
     <message id="settings_vecan_device_instance">
       <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
       <source>VE.Can Device Instance</source>
+      <oldsource>Device Instance</oldsource>
       <translation>VE.Can Device Instance</translation>
     </message>
     <message id="settings_vecan_device_number">
       <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="32"/>
       <source>VE.Can Instance# %1</source>
+      <oldsource>Device# %1</oldsource>
       <translation>VE.Can Instance# %1</translation>
     </message>
     <message id="settings_tz_antarctica">
@@ -7539,6 +6868,7 @@ Do you want to continue?</source>
     <message id="settings_vrm">
       <location filename="../../pages/SettingsPage.qml" line="59"/>
       <source>VRM</source>
+      <extracomment>Forced by %2 to dark</extracomment>
       <translation>VRM</translation>
     </message>
     <message id="settings_remote_monitoring_portal">
@@ -7546,20 +6876,10 @@ Do you want to continue?</source>
       <source>Remote monitoring portal</source>
       <translation>Portaal voor bewaking op afstand</translation>
     </message>
-    <message id="settings_advanced">
-      <location filename="../../pages/SettingsPage.qml" line="68"/>
-      <source>Advanced</source>
-      <translation type="unfinished">Geavanceerd</translation>
-    </message>
-    <message id="settings_integrations">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
+    <message id="pagesettingssupportstate_integrations">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
       <source>Integrations</source>
       <translation>Integraties</translation>
-    </message>
-    <message id="settings_relays_sensors_tanks">
-      <location filename="../../pages/SettingsPage.qml" line="75"/>
-      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
-      <translation type="unfinished">Relais, sensoren, tanks, PV-omvormers, Modbus, MQTT...</translation>
     </message>
     <message id="settings_acdcsystem_ess_dvcc_battery">
       <location filename="../../pages/SettingsPage.qml" line="84"/>
@@ -7579,11 +6899,13 @@ Do you want to continue?</source>
     <message id="settings_system_setup">
       <location filename="../../pages/SettingsPage.qml" line="82"/>
       <source>System Setup</source>
+      <oldsource>System setup</oldsource>
       <translation>Systeemconfiguratie</translation>
     </message>
     <message id="settings_vrm_device_instances">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
       <source>VRM device instances</source>
+      <oldsource>VRM Device Instances</oldsource>
       <translation>VRM apparaatinstanties</translation>
     </message>
     <message id="solarcharger_not_supported">
@@ -7601,28 +6923,10 @@ Do you want to continue?</source>
       <source>The firmware version in the MPPT Solar Charger must be v1.09 or later. Contact Victron Service for update instructions and files.</source>
       <translation>De firmwareversie in de MPPT Solar Charger moet v1.09 of later zijn. Neem contact op met Victron Service voor update-instructies en -bestanden.</translation>
     </message>
-    <message id="solarcharger_pv">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="102"/>
-      <source>PV</source>
-      <extracomment>PV power for solar charger</extracomment>
-      <translation type="unfinished">Zonnepaneel</translation>
-    </message>
     <message id="solarcharger_total_power">
       <location filename="../../pages/solar/PageSolarCharger.qml" line="127"/>
       <source>Total PV power</source>
       <translation>Totaal PV energie</translation>
-    </message>
-    <message id="solarcharger_total_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="211"/>
-      <source>Total yield</source>
-      <extracomment>Solar charger total yield</extracomment>
-      <translation type="unfinished">Totaal opbrengst</translation>
-    </message>
-    <message id="solarcharger_system_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="220"/>
-      <source>System yield</source>
-      <extracomment>Solar charger system yield</extracomment>
-      <translation type="unfinished">Systeem opbrengst</translation>
     </message>
     <message id="settings_multirs_total_yield">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="63"/>
@@ -7658,16 +6962,19 @@ Do you want to continue?</source>
     <message id="vebus_device_update_firmware">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="133"/>
       <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
       <translation>Voor deze functie is firmwareversie 400 of hoger vereist. Neem contact op met de installateur om de Multi/Quattro bij te werken.</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="139"/>
       <source>Charger not ready, equalization cannot be started</source>
+      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
       <translation>Lader niet gereed, egalisatie kan niet worden gestart</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="143"/>
       <source>Equalization cannot be triggered during bulk charge state</source>
+      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
       <translation>Egalisatie kan niet worden geactiveerd tijdens bulklaadstatus</translation>
     </message>
     <message id="vebus_device_restart_vebus_system_restart_confirmation_description">
@@ -7690,78 +6997,20 @@ Do you want to continue?</source>
       <source>Auto-started • %1</source>
       <translation>Automatisch gestart • %1</translation>
     </message>
-    <message id="common_words_battery">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery</source>
-      <translation type="unfinished">Accu</translation>
-    </message>
-    <message id="common_words_boat_page">
-      <location filename="../../components/CommonWords.qml" line="111"/>
-      <source>Boat</source>
-      <extracomment>The 'Boat' page</extracomment>
-      <translation type="unfinished">Boot</translation>
-    </message>
-    <message id="common_words_brief_page">
-      <location filename="../../components/CommonWords.qml" line="115"/>
-      <source>Brief</source>
-      <extracomment>The 'Brief' page</extracomment>
-      <translation type="unfinished">Kort</translation>
-    </message>
-    <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation type="unfinished">Gesloten</translation>
-    </message>
-    <message id="common_words_color">
-      <location filename="../../components/CommonWords.qml" line="136"/>
-      <source>Color</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_connected">
-      <location filename="../../components/CommonWords.qml" line="139"/>
-      <source>Connected</source>
-      <translation type="unfinished">Verbonden</translation>
-    </message>
     <message id="common_words_daily_history">
       <location filename="../../components/CommonWords.qml" line="152"/>
       <source>Daily history</source>
       <translation>Dagelijkse geschiedenis</translation>
-    </message>
-    <message id="common_words_disabled">
-      <location filename="../../components/CommonWords.qml" line="169"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Uitgeschakeld</translation>
-    </message>
-    <message id="common_words_disconnected">
-      <location filename="../../components/CommonWords.qml" line="175"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Losgekoppeld</translation>
-    </message>
-    <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="191"/>
-      <source>Error</source>
-      <translation type="unfinished">Fout</translation>
     </message>
     <message id="common_words_error_not_a_number">
       <location filename="../../components/CommonWords.qml" line="200"/>
       <source>'%1' is not a number.</source>
       <translation>'%1' is geen getal.</translation>
     </message>
-    <message id="common_words_generator">
-      <location filename="../../components/CommonWords.qml" line="217"/>
-      <source>Generator</source>
-      <translation type="unfinished">Aggregaat</translation>
-    </message>
     <message id="common_words_input_current_limit">
       <location filename="../../components/CommonWords.qml" line="261"/>
       <source>Input current limit</source>
       <translation>Ingangsstroomlimiet</translation>
-    </message>
-    <message id="common_words_inverter_charger">
-      <location filename="../../components/CommonWords.qml" line="264"/>
-      <source>Inverter / Charger</source>
-      <translation type="unfinished">Omvormer / Lader</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
       <location filename="../../components/CommonWords.qml" line="268"/>
@@ -7774,12 +7023,6 @@ Do you want to continue?</source>
       <source>Manual stop</source>
       <translation>Handmatig stoppen</translation>
     </message>
-    <message id="common_words_max">
-      <location filename="../../components/CommonWords.qml" line="315"/>
-      <source>Max</source>
-      <extracomment>Short for Maximum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_maximum_current">
       <location filename="../../components/CommonWords.qml" line="318"/>
       <source>Maximum current</source>
@@ -7790,62 +7033,10 @@ Do you want to continue?</source>
       <source>Maximum power</source>
       <translation>Maximaal vermogen</translation>
     </message>
-    <message id="common_words_min">
-      <location filename="../../components/CommonWords.qml" line="331"/>
-      <source>Min</source>
-      <extracomment>Short for Minimum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_minimum_current">
       <location filename="../../components/CommonWords.qml" line="334"/>
       <source>Minimum current</source>
       <translation>Minimale stroom</translation>
-    </message>
-    <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="433"/>
-      <source>No</source>
-      <translation type="unfinished">Nee</translation>
-    </message>
-    <message id="common_words_none_option">
-      <location filename="../../components/CommonWords.qml" line="364"/>
-      <source>None</source>
-      <translation type="unfinished">Geen</translation>
-    </message>
-    <message id="common_words_none_errors">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>None</source>
-      <extracomment>Indicates there are no errors</extracomment>
-      <translation type="unfinished">Geen</translation>
-    </message>
-    <message id="common_words_not_available">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Not available</source>
-      <translation type="unfinished">Niet beschikbaar</translation>
-    </message>
-    <message id="common_words_off">
-      <location filename="../../components/CommonWords.qml" line="377"/>
-      <source>Off</source>
-      <translation type="unfinished">Uit</translation>
-    </message>
-    <message id="common_words_ok">
-      <location filename="../../components/CommonWords.qml" line="383"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="41"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="45"/>
-      <source>OK</source>
-      <translation type="unfinished">OK</translation>
-    </message>
-    <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="386"/>
-      <source>On</source>
-      <translation type="unfinished">Aan</translation>
-    </message>
-    <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="393"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation type="unfinished">Geopend</translation>
     </message>
     <message id="common_words_open_circuit">
       <location filename="../../components/CommonWords.qml" line="396"/>
@@ -7857,108 +7048,17 @@ Do you want to continue?</source>
       <source>Overall history</source>
       <translation>Complete geschiedenis</translation>
     </message>
-    <message id="common_words_press">
-      <location filename="../../components/CommonWords.qml" line="419"/>
-      <source>Press</source>
-      <translation type="unfinished">Pers</translation>
-    </message>
-    <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation type="unfinished">Loopt</translation>
-    </message>
-    <message id="common_words_settings">
-      <location filename="../../components/CommonWords.qml" line="467"/>
-      <source>Settings</source>
-      <translation type="unfinished">Instellingen</translation>
-    </message>
-    <message id="common_words_silence_alarm">
-      <location filename="../../components/CommonWords.qml" line="476"/>
-      <source>Silence alarm</source>
-      <translation type="unfinished">Alarm uitzetten</translation>
-    </message>
     <message id="common_words_soc">
       <location filename="../../components/CommonWords.qml" line="480"/>
       <source>SOC %1</source>
       <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
       <translation>Laadtoestand %1%</translation>
     </message>
-    <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation type="unfinished">Snelheid</translation>
-    </message>
-    <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="487"/>
-      <source>Standby</source>
-      <translation type="unfinished">Stand-by</translation>
-    </message>
-    <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="502"/>
-      <source>State</source>
-      <translation type="unfinished">Status</translation>
-    </message>
-    <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="512"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation type="unfinished">Opstarten (%1)</translation>
-    </message>
-    <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>Stopped</source>
-      <translation type="unfinished">Gestopt</translation>
-    </message>
-    <message id="common_words_total_power">
-      <location filename="../../components/CommonWords.qml" line="540"/>
-      <source>Total power</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="547"/>
-      <source>Type</source>
-      <translation type="unfinished">Type</translation>
-    </message>
-    <message id="common_words_unknown_status">
-      <location filename="../../components/CommonWords.qml" line="554"/>
-      <source>Unknown</source>
-      <extracomment>Status = "unknown"</extracomment>
-      <translation type="unfinished">Onbekend</translation>
-    </message>
-    <message id="common_words_value_must_be_greater_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="557"/>
-      <source>Value must be greater than start value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_value_must_be_greater_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="560"/>
-      <source>Value must be greater than stop value</source>
-      <translation type="unfinished">Waarde moet hoger zijn dan stopwaarde</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="563"/>
-      <source>Value must be lower than start value</source>
-      <translation type="unfinished">Waarde moet lager zijn dan startwaarde</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="566"/>
-      <source>Value must be lower than stop value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="581"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="431"/>
-      <source>Yes</source>
-      <translation type="unfinished">Ja</translation>
-    </message>
     <message id="common_words_yield_today">
       <location filename="../../components/CommonWords.qml" line="592"/>
       <source>Yield Today</source>
       <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+      <oldsource>Yield today</oldsource>
       <translation>Opbrengst vandaag</translation>
     </message>
     <message id="common_words_format_error">
@@ -7985,10 +7085,11 @@ Do you want to continue?</source>
     <message id="settings_firmware_installed_rebooting">
       <location filename="../../components/FirmwareUpdate.qml" line="79"/>
       <source>Firmware installed, device rebooting</source>
+      <oldsource>Firmware installed, rebooting.</oldsource>
       <translation>Firmware geïnstalleerd, apparaat start opnieuw op</translation>
     </message>
-    <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/RadioButtonListPage.qml" line="121"/>
+    <message id="modaldialog_confirm">
+      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
       <source>Confirm</source>
       <extracomment>Confirm password, and verify it if possible</extracomment>
       <translation>Bevestigen</translation>
@@ -8006,11 +7107,13 @@ Do you want to continue?</source>
     <message id="cgwacs_battery_schedule_duration">
       <location filename="../../components/listitems/ListChargeSchedule.qml" line="144"/>
       <source>Duration</source>
+      <oldsource>Duration (hh:mm)</oldsource>
       <translation>Duur</translation>
     </message>
     <message id="settings_relay_deactivation_value">
       <location filename="../../components/TemperatureRelaySettings.qml" line="86"/>
       <source>Deactivation value</source>
+      <oldsource>Deativation value</oldsource>
       <translation>Uitschakel waarde</translation>
     </message>
     <message id="splash_view_device_disconnected">
@@ -8058,29 +7161,6 @@ Do you want to continue?</source>
       <source>Temperature warning</source>
       <translation>Temperatuurwaarschuwing</translation>
     </message>
-    <message id="battery_mode_idle">
-      <location filename="../../src/enums.cpp" line="26"/>
-      <source>Idle</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Inactief</translation>
-    </message>
-    <message id="battery_mode_charging">
-      <location filename="../../src/enums.cpp" line="30"/>
-      <source>Charging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Opladen</translation>
-    </message>
-    <message id="battery_mode_discharging">
-      <location filename="../../src/enums.cpp" line="34"/>
-      <source>Discharging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Ontladen</translation>
-    </message>
-    <message id="dcMeter_bilge_pump">
-      <location filename="../../src/enums.cpp" line="115"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">Lenspomp</translation>
-    </message>
     <message id="switch_state_channel_fault">
       <location filename="../../src/enums.cpp" line="372"/>
       <source>Channel Fault</source>
@@ -8111,26 +7191,6 @@ Do you want to continue?</source>
       <source>Slave of %1</source>
       <translation>Slaaf van %1</translation>
     </message>
-    <message id="switchable_output_numeric_input">
-      <location filename="../../src/enums.cpp" line="418"/>
-      <source>Numeric input</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bilge_pump">
-      <location filename="../../src/enums.cpp" line="424"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">Lenspomp</translation>
-    </message>
-    <message id="switchable_output_not_running">
-      <location filename="../../src/enums.cpp" line="448"/>
-      <source>Not running</source>
-      <translation type="unfinished">Niet actief</translation>
-    </message>
-    <message id="switchable_output_off">
-      <location filename="../../src/enums.cpp" line="451"/>
-      <source>Off</source>
-      <translation type="unfinished">Uit</translation>
-    </message>
     <message id="switchable_output_powered">
       <location filename="../../src/enums.cpp" line="455"/>
       <source>Powered</source>
@@ -8159,16 +7219,19 @@ Do you want to continue?</source>
     <message id="evchargers_status_welded_contacts_error">
       <location filename="../../data/EvChargers.qml" line="76"/>
       <source>Welded contacts test error (shorted)</source>
+      <oldsource>Welded contacts error</oldsource>
       <translation>Testfout vastgesmolten contacten (kortgesloten)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
       <location filename="../../data/EvChargers.qml" line="100"/>
       <source>Switching to 3 phase</source>
+      <oldsource>Switching to 3-phase</oldsource>
       <translation>Overschakelen naar 3 fasen</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
       <location filename="../../data/EvChargers.qml" line="103"/>
       <source>Switching to 1 phase</source>
+      <oldsource>Switching to single phase</oldsource>
       <translation>Overschakelen naar 1 fase</translation>
     </message>
     <message id="evchargers_status_stop_charging">
@@ -8321,17 +7384,6 @@ Als het aggregaat momenteel draait vanwege een autostartconditie, zal het uitsch
       <source>Open link</source>
       <translation>Open link</translation>
     </message>
-    <message id="listlink_show_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="43"/>
-      <source>Show QR code</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="listlink_scan_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="52"/>
-      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
-      <extracomment>%1 = url text</extracomment>
-      <translation type="unfinished">Scan de QR-code met een draagbaar apparaat.&lt;br /&gt;Of voeg de link in: %1</translation>
-    </message>
     <message id="settings_services_mqtt_access">
       <location filename="../../components/listitems/ListMqttAccessSwitch.qml" line="11"/>
       <source>MQTT Access</source>
@@ -8403,12 +7455,6 @@ Als het aggregaat momenteel draait vanwege een autostartconditie, zal het uitsch
       <extracomment>The 'Brief' page, with the side panel opened</extracomment>
       <translation>Kort (zijpaneel open)</translation>
     </message>
-    <message id="startpage_option_overview">
-      <location filename="../../data/StartPageConfiguration.qml" line="37"/>
-      <source>Overview</source>
-      <extracomment>The 'Overview' page</extracomment>
-      <translation type="unfinished">Overzicht</translation>
-    </message>
     <message id="startpage_option_levels_tanks">
       <location filename="../../data/StartPageConfiguration.qml" line="43"/>
       <source>Levels (Tanks)</source>
@@ -8427,12 +7473,12 @@ Als het aggregaat momenteel draait vanwege een autostartconditie, zal het uitsch
       <translation>Accu lijst</translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
+      <location filename="../../pages/DialogLayer.qml" line="56"/>
       <source>GX device has been updated</source>
       <translation>GX apparaat is bijgewerkt</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
+      <location filename="../../pages/DialogLayer.qml" line="58"/>
       <source>Page will automatically reload in ten seconds to load the latest version.</source>
       <translation>De pagina wordt na tien seconden automatisch opnieuw geladen om de nieuwste versie te laden.</translation>
     </message>
@@ -8602,8 +7648,8 @@ Let op: dit menu toont alleen Carlo Gavazzi-meters die zijn aangesloten via RS48
       <source>Unit</source>
       <translation>Eenheid</translation>
     </message>
-    <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="61"/>
+    <message id="page_settings_fronius_unitid_invalid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
       <source>%1 is not a valid unit number. Use a number between 1-247.</source>
       <translation>%1 is geen geldig eenheidsnummer. Gebruik een getal tussen 1-247.</translation>
     </message>
@@ -8718,11 +7764,6 @@ Let op: dit menu toont alleen Carlo Gavazzi-meters die zijn aangesloten via RS48
       <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="66"/>
       <source>Controller Temperature</source>
       <translation>Temperatuur besturing</translation>
-    </message>
-    <message id="devicelist_motordrive_motordirectioninverted">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
-      <source>Motor Direction Inverted</source>
-      <translation type="unfinished"/>
     </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
@@ -8914,11 +7955,6 @@ Met een gestroomlijnde navigatie en een frisse look is alles waar je van houdt n
     <message id="welcome_done">
       <location filename="../../pages/welcome/WelcomeView.qml" line="136"/>
       <source>Done</source>
-      <translation type="unfinished">Klaar</translation>
-    </message>
-    <message id="mk2vsc_state_done">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="20"/>
-      <source>Done</source>
       <translation>Klaar</translation>
     </message>
     <message id="welcome_next">
@@ -8976,6 +8012,7 @@ Het GX-apparaat kan slechts één aangesloten aggregaat besturen en neemt degene
     <message id="settings_tz_etc">
       <location filename="../../pages/settings/PageTzInfo.qml" line="280"/>
       <source>Other</source>
+      <oldsource>Etc</oldsource>
       <translation>Andere</translation>
     </message>
     <message id="ac-in-modeldefault_energy_reverse_x">
@@ -8993,6 +8030,11 @@ Het GX-apparaat kan slechts één aangesloten aggregaat besturen en neemt degene
       <location filename="../../src/enums.cpp" line="438"/>
       <source>Unsupported type: %1</source>
       <translation>Niet-ondersteund type: %1</translation>
+    </message>
+    <message id="common_words_press">
+      <location filename="../../components/CommonWords.qml" line="419"/>
+      <source>Press</source>
+      <translation>Pers</translation>
     </message>
     <message id="output_aux_battery_service_changed_dcdc">
       <location filename="../../components/listitems/ListOutputBatteryRadioButtonGroup.qml" line="27"/>
@@ -9133,13 +8175,6 @@ Het GX-apparaat kan slechts één aangesloten aggregaat besturen en neemt degene
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="38"/>
       <source>Resetting VE.Bus products</source>
       <translation>VE.Bus producten opnieuw instellen</translation>
-    </message>
-    <message id="Unknown">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Onbekend</translation>
     </message>
     <message id="mk2vsc_error_mk2_mk3_comm">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="47"/>
@@ -9445,11 +8480,6 @@ Het GX-apparaat kan slechts één aangesloten aggregaat besturen en neemt degene
       <source>Changing the GX Password</source>
       <translation>Het GX wachtwoord wijzigen</translation>
     </message>
-    <message id="modaldialog_confirm">
-      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
-      <source>Confirm</source>
-      <translation type="unfinished">Bevestigen</translation>
-    </message>
     <message id="settings_security_profile_change_password_description">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="83"/>
       <source>Please enter a new GX password:</source>
@@ -9542,21 +8572,6 @@ Het GX-apparaat kan slechts één aangesloten aggregaat besturen en neemt degene
       <source>Modifications installed</source>
       <translation>Wijzigingen geïnstalleerd</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_modbus">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="28"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">Modbus TCP-server</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_signalk">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="32"/>
-      <source>Signal K</source>
-      <translation type="unfinished">Signal K</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_nodered">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="36"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">Node-RED</translation>
-    </message>
     <message id="pagesettingsgeneral_modificationchecks_running_integrations">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="43"/>
       <source>%1 running integrations</source>
@@ -9634,16 +8649,6 @@ Geïnstalleerd maar uitgeschakeld (rc.local)
       <source>Installed and enabled, disables at next boot</source>
       <translation>Geïnstalleerd en ingeschakeld, wordt bij de volgende keer opstarten uitgeschakeld.</translation>
     </message>
-    <message id="pagesettingssupportstate_firmware_checking">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
-      <source>Checking...</source>
-      <translation type="unfinished">Controleren...</translation>
-    </message>
-    <message id="pagesettingssupportstate_firmware_unknown">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="166"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Onbekend</translation>
-    </message>
     <message id="pagesettingssupportstate_support_status">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="228"/>
       <source>Support status</source>
@@ -9665,11 +8670,6 @@ Geïnstalleerd maar uitgeschakeld (rc.local)
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="288"/>
       <source>Press 'OK' to disable custom startup scripts and reboot</source>
       <translation>Druk op ‘OK’ om aangepaste opstartscripts uit te schakelen en opnieuw op te starten.</translation>
-    </message>
-    <message id="pagesettingssupportstate_re_enable_custom_startup_scripts">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="309"/>
-      <source>Re-enable custom startup scripts</source>
-      <translation type="unfinished">Aangepaste opstartscripts opnieuw inschakelen</translation>
     </message>
     <message id="pagesettingssupportstate_reenable_and_reboot_now">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="322"/>
@@ -9696,11 +8696,6 @@ Geïnstalleerd maar uitgeschakeld (rc.local)
       <source>Disable also custom startup scripts?</source>
       <translation>Ook aangepaste opstartscripts uitschakelen?</translation>
     </message>
-    <message id="pagesettingssupportstate_integrations">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
-      <source>Integrations</source>
-      <translation type="unfinished">Integraties</translation>
-    </message>
     <message id="pagesettingssupportstate_orange_items_description">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="494"/>
       <source>Items colored orange are supported and provided by Victron Energy, but using them incorrectly can affect system stability. In case of troubleshooting, disable those first.</source>
@@ -9709,49 +8704,33 @@ Geïnstalleerd maar uitgeschakeld (rc.local)
     <message id="settings_bluetooth_unavailable_message">
       <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="26"/>
       <source>Connect a compatible Bluetooth USB dongle to enable Bluetooth connectivity.</source>
-      <translation>Sluit een compatibele Bluetooth USB-dongle aan om Bluetooth-connectiviteit mogelijk te maken.</translation>
+      <translation> Sluit een compatibele Bluetooth USB dongle aan om Bluetooth verbindingen mogelijk te maken.</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="140"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="142"/>
       <source>BatteryLife state</source>
-      <translation>BatteryLife-status</translation>
+      <translation>BatteryLife status</translation>
     </message>
     <message id="pagesettingsintegrations_device_integrations">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="33"/>
       <source>Device Integrations</source>
-      <translation>Apparaatintegraties</translation>
-    </message>
-    <message id="pagesettingsintegrations_modbus_tcp_server">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="201"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">Modbus TCP-server</translation>
-    </message>
-    <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="226"/>
-      <location filename="../../pages/settings/PageSettingsSignalK.qml" line="18"/>
-      <source>Signal K</source>
-      <translation type="unfinished">Signal K</translation>
-    </message>
-    <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="241"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">Node-RED</translation>
+      <translation>Apparaat integraties</translation>
     </message>
     <message id="settings_venusos_large_documentation">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="267"/>
       <source>Venus OS Large Documentation</source>
-      <translation>Venus OS Large-documentatie</translation>
+      <translation>Venus OS Large documentatie</translation>
     </message>
     <message id="settings_modbus_enable_modbus_tcp">
       <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
       <source>Enable Modbus TCP Server</source>
-      <translation>Modbus TCP-server inschakelen</translation>
+      <oldsource>Enable Modbus/TCP</oldsource>
+      <translation>Modbus TCP server inschakelen</translation>
     </message>
     <message id="pagesettingsconnectivity_bluetooth_for_victronconnect_app">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="38"/>
       <source>Bluetooth (for VictronConnect App)</source>
-      <translation>Bluetooth (voor VictronConnect-app)</translation>
+      <translation>Bluetooth (voor VictronConnect app)</translation>
     </message>
     <message id="pagesettingsconnectivity_bluetooth_not_available">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="42"/>
@@ -9829,21 +8808,23 @@ Geïnstalleerd maar uitgeschakeld (rc.local)
     <message id="pagesettingssupportstate_press_to_update">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="389"/>
       <source>Press to update to</source>
-      <translation>Druk om te updaten naar</translation>
+      <translation>Druk om bij te werken naar</translation>
     </message>
     <message id="pagesettingssupportstate_update_firmware_to_fix_modified_state_description">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="404"/>
       <source>This will download and update rootfs with the latest official firmware.&lt;br&gt;Internet connectivity is required.&lt;br&gt;Press 'OK' to continue.</source>
-      <translation>Dit zal rootfs downloaden en updaten met de laatste officiële firmware.&lt;br&gt;Een internetverbinding is vereist.&lt;br&gt;Druk op 'OK' om door te gaan.</translation>
+      <translation>Dit zal rootfs downloaden en bijwerken met de laatste officiële firmware.&lt;br&gt;Een internetverbinding is vereist.&lt;br&gt;Druk op 'OK' om door te gaan.</translation>
     </message>
     <message id="settings_gps_format_kmh">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="93"/>
       <source>Kilometres per hour</source>
+      <oldsource>Kilometers per hour</oldsource>
       <translation>Kilometers per uur</translation>
     </message>
     <message id="settings_gps_format_ms">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="95"/>
       <source>Metres per second</source>
+      <oldsource>Meters per second</oldsource>
       <translation>Meters per seconde</translation>
     </message>
     <message id="components_volumeunit_cubic_metres">
@@ -9859,27 +8840,27 @@ Geïnstalleerd maar uitgeschakeld (rc.local)
     <message id="settings_ui_animations">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="157"/>
       <source>UI Animations</source>
-      <translation>UI-animaties</translation>
+      <translation>UI animaties</translation>
     </message>
     <message id="settings_ui_animations_description">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="159"/>
       <source>Disable to reduce CPU usage</source>
-      <translation>Uitschakelen om CPU-gebruik te verminderen</translation>
+      <translation>Uitschakelen om CPU gebruik te verminderen</translation>
     </message>
     <message id="settings_relay_manual_can_now_be_found">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="24"/>
       <source>The Relay can now be found in the devices list</source>
       <translation>Het relais is nu te vinden in de apparatenlijst</translation>
     </message>
-    <message id="common_words_gx_device_relays">
-      <location filename="../../components/CommonWords.qml" line="223"/>
+    <message id="gx_device_relays">
+      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
       <source>GX device relays</source>
       <translation>GX apparaat relais</translation>
     </message>
     <message id="ess_active_soc_limit_info">
       <location filename="../../pages/controlcards/ESSCard.qml" line="96"/>
       <source>BatteryLife dynamically adjusts the minimum battery state of charge to prevent deep discharges and ensure regular full charges, helping to prolong battery life and maintain system reliability.</source>
-      <translation>BatteryLife past de minimale laadstatus van de batterij dynamisch aan om diepe ontladingen te voorkomen en regelmatige volledige laadbeurten te garanderen, waardoor de levensduur van de batterij wordt verlengd en de betrouwbaarheid van het systeem wordt behouden.</translation>
+      <translation>BatteryLife past de minimale laadstatus van de accu dynamisch aan om diepe ontladingen te voorkomen en regelmatige volledige laadbeurten te garanderen, waardoor de levensduur van de accu wordt verlengd en de betrouwbaarheid van het systeem wordt behouden.</translation>
     </message>
     <message id="settings_canbus_rvc_reverse_current_polarity">
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="69"/>
@@ -9894,7 +8875,7 @@ Geïnstalleerd maar uitgeschakeld (rc.local)
     <message id="settings_gx_display_appearance">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="59"/>
       <source>GX display appearance</source>
-      <translation>Weergave van het GX-scherm</translation>
+      <translation>Weergave van het GX scherm</translation>
     </message>
     <message id="settings_remote_console_appearance">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="74"/>
@@ -9926,12 +8907,6 @@ Geïnstalleerd maar uitgeschakeld (rc.local)
       <extracomment>Forced by app to %1</extracomment>
       <translation>auto</translation>
     </message>
-    <message id="settings_remote_console_forced_by_vrm">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="94"/>
-      <source>VRM</source>
-      <extracomment>Forced by %2 to dark</extracomment>
-      <translation type="unfinished">VRM</translation>
-    </message>
     <message id="settings_remote_console_forced_by_app">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="97"/>
       <source>app</source>
@@ -9941,12 +8916,12 @@ Geïnstalleerd maar uitgeschakeld (rc.local)
     <message id="settings_remote_console_appearance_same_as_gx_display">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="110"/>
       <source>Same as GX display</source>
-      <translation>Hetzelfde als GX-scherm</translation>
+      <translation>Hetzelfde als GX scherm</translation>
     </message>
     <message id="page_settings_gsm_registration_status">
       <location filename="../../pages/settings/PageSettingsGsm.qml" line="136"/>
       <source>Registration status</source>
-      <translation>Registratiestatus</translation>
+      <translation>Registratie status</translation>
     </message>
     <message id="page_settings_gsm_not_registered_not_searching">
       <location filename="../../pages/settings/PageSettingsGsm.qml" line="141"/>
@@ -9981,6 +8956,7 @@ Geïnstalleerd maar uitgeschakeld (rc.local)
     <message id="settings_large_access_signal_k">
       <location filename="../../pages/settings/PageSettingsSignalK.qml" line="24"/>
       <source>Access Signal K</source>
+      <oldsource>Access Signal K (local network)</oldsource>
       <translation>Toegang tot Signal K</translation>
     </message>
     <message id="pagesettingsintegrations_shelly_devices">
@@ -9991,6 +8967,7 @@ Geïnstalleerd maar uitgeschakeld (rc.local)
     <message id="settings_large_access_node_red">
       <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
       <source>Access Node-RED</source>
+      <oldsource>Access Node-RED (local network)</oldsource>
       <translation>Toegang tot Node-RED</translation>
     </message>
     <message id="settings_wifi_access_point_password">
@@ -10031,7 +9008,7 @@ Geïnstalleerd maar uitgeschakeld (rc.local)
     <message id="dcMeter_dc_genset">
       <location filename="../../src/enums.cpp" line="142"/>
       <source>DC genset</source>
-      <translation>DC-aggregaat</translation>
+      <translation>DC aggregaat</translation>
     </message>
     <message id="dcMeter_inverter">
       <location filename="../../src/enums.cpp" line="145"/>
@@ -10058,57 +9035,6 @@ Geïnstalleerd maar uitgeschakeld (rc.local)
       <source>Wind charger</source>
       <translation>Windgenerator</translation>
     </message>
-    <message id="digitalinputs_type_disabled">
-      <location filename="../../src/enums.cpp" line="192"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Uitgeschakeld</translation>
-    </message>
-    <message id="digitalinputs_state_off">
-      <location filename="../../src/enums.cpp" line="242"/>
-      <source>Off</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Uit</translation>
-    </message>
-    <message id="digitalinputs_state_on">
-      <location filename="../../src/enums.cpp" line="246"/>
-      <source>On</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Aan</translation>
-    </message>
-    <message id="digitalinputs_state_ok">
-      <location filename="../../src/enums.cpp" line="266"/>
-      <source>OK</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">OK</translation>
-    </message>
-    <message id="digitalinputs_state_alarm">
-      <location filename="../../src/enums.cpp" line="270"/>
-      <source>Alarm</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Alarm</translation>
-    </message>
-    <message id="digitalinputs_state_running">
-      <location filename="../../src/enums.cpp" line="274"/>
-      <source>Running</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Loopt</translation>
-    </message>
-    <message id="pvinverter_statusCode_running">
-      <location filename="../../src/enums.cpp" line="300"/>
-      <source>Running</source>
-      <extracomment>PV inverter status code</extracomment>
-      <translation type="unfinished">Loopt</translation>
-    </message>
-    <message id="solarchargers_state_external control">
-      <location filename="../../src/enums.cpp" line="352"/>
-      <source>External control</source>
-      <translation type="unfinished">Externe besturing</translation>
-    </message>
-    <message id="switch_state_over_temperature">
-      <location filename="../../src/enums.cpp" line="366"/>
-      <source>Over temperature</source>
-      <translation type="unfinished">Te hoge temperatuur</translation>
-    </message>
     <message id="switchable_output_temperature_setpoint">
       <location filename="../../src/enums.cpp" line="398"/>
       <source>Temperature setpoint</source>
@@ -10119,142 +9045,25 @@ Geïnstalleerd maar uitgeschakeld (rc.local)
       <source>Stepped switch</source>
       <translation>Gefaseerde schakelaar</translation>
     </message>
-    <message id="switchable_output_slave">
-      <location filename="../../src/enums.cpp" line="408"/>
-      <source>Slave</source>
-      <translation type="unfinished">Slave</translation>
-    </message>
     <message id="switchable_output_dropdown">
       <location filename="../../src/enums.cpp" line="412"/>
       <source>Dropdown</source>
-      <translation>Dropdown</translation>
+      <translation>Keuzemenu</translation>
     </message>
     <message id="switchable_output_basic_slider">
       <location filename="../../src/enums.cpp" line="415"/>
       <source>Basic slider</source>
       <translation>Basis schuifregelaar</translation>
     </message>
-    <message id="switchable_output_rgb_color_wheel">
-      <location filename="../../src/enums.cpp" line="427"/>
-      <source>RGB color wheel</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_cct_color_wheel">
-      <location filename="../../src/enums.cpp" line="431"/>
-      <source>CCT color wheel</source>
-      <extracomment>Correlated Color Temperature color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_rgbw_color_wheel">
-      <location filename="../../src/enums.cpp" line="435"/>
-      <source>RGB + W color wheel</source>
-      <extracomment>RGB + white color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bypassed">
-      <location filename="../../src/enums.cpp" line="484"/>
-      <source>Bypassed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="tank_type_fuel">
-      <location filename="../../src/enums.cpp" line="495"/>
-      <source>Fuel</source>
-      <translation type="unfinished">Brandstof</translation>
-    </message>
-    <message id="tank_type_fresh_water">
-      <location filename="../../src/enums.cpp" line="498"/>
-      <source>Fresh water</source>
-      <translation type="unfinished">Vers water</translation>
-    </message>
-    <message id="tank_type_waste_water">
-      <location filename="../../src/enums.cpp" line="501"/>
-      <source>Waste water</source>
-      <translation type="unfinished">Afvalwater</translation>
-    </message>
-    <message id="tank_type_live_well">
-      <location filename="../../src/enums.cpp" line="504"/>
-      <source>Live well</source>
-      <translation type="unfinished">Bronwater</translation>
-    </message>
-    <message id="tank_type_oil">
-      <location filename="../../src/enums.cpp" line="507"/>
-      <source>Oil</source>
-      <translation type="unfinished">Olie</translation>
-    </message>
-    <message id="tank_type_black_water">
-      <location filename="../../src/enums.cpp" line="510"/>
-      <source>Black water</source>
-      <translation type="unfinished">Vuilwater</translation>
-    </message>
-    <message id="tank_type_gasoline">
-      <location filename="../../src/enums.cpp" line="513"/>
-      <source>Gasoline</source>
-      <translation type="unfinished">Benzine</translation>
-    </message>
-    <message id="tank_type_diesel">
-      <location filename="../../src/enums.cpp" line="516"/>
-      <source>Diesel</source>
-      <translation type="unfinished">Diesel</translation>
-    </message>
-    <message id="tank_type_lpg">
-      <location filename="../../src/enums.cpp" line="519"/>
-      <source>LPG</source>
-      <translation type="unfinished">LPG</translation>
-    </message>
-    <message id="tank_type_lng">
-      <location filename="../../src/enums.cpp" line="522"/>
-      <source>LNG</source>
-      <translation type="unfinished">LNG</translation>
-    </message>
-    <message id="tank_type_hydraulic_oil">
-      <location filename="../../src/enums.cpp" line="525"/>
-      <source>Hydraulic oil</source>
-      <translation type="unfinished">Hydraulische olie</translation>
-    </message>
-    <message id="tank_type_raw_water">
-      <location filename="../../src/enums.cpp" line="528"/>
-      <source>Raw water</source>
-      <translation type="unfinished">Vuil water</translation>
-    </message>
-    <message id="microgrid_mode_hybrid_droop">
-      <location filename="../../src/enums.cpp" line="539"/>
-      <source>Hybrid droop</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_following">
-      <location filename="../../src/enums.cpp" line="542"/>
-      <source>Grid-following</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_forming">
-      <location filename="../../src/enums.cpp" line="545"/>
-      <source>Grid-forming</source>
-      <translation type="unfinished"/>
-    </message>
     <message id="switchable_output_three_state_switch">
       <location filename="../../src/enums.cpp" line="421"/>
       <source>Three-state switch</source>
       <translation>Driestanden schakelaar</translation>
     </message>
-    <message id="switchable_output_fault">
-      <location filename="../../src/enums.cpp" line="464"/>
-      <source>Fault</source>
-      <translation type="unfinished">Fout</translation>
-    </message>
-    <message id="switchable_output_running">
-      <location filename="../../src/enums.cpp" line="468"/>
-      <source>Running</source>
-      <translation type="unfinished">Loopt</translation>
-    </message>
-    <message id="switchable_output_trip_low_voltage">
-      <location filename="../../src/enums.cpp" line="481"/>
-      <source>Trip low voltage</source>
-      <translation type="unfinished">Uitgeschakeld</translation>
-    </message>
     <message id="settings_modbus_tcp_unit_id_note">
       <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="41"/>
       <source>See the Settings → VRM → VRM device instances menu to change the Modbus-TCP unit IDs.</source>
-      <translation>Ga naar Instellingen → VRM → VRM-apparaatinstanties om de Modbus-TCP-eenheid-ID's te wijzigen.</translation>
+      <translation>Ga naar Instellingen → VRM → VRM apparaatinstanties om de Modbus TCP eenheid ID's te wijzigen.</translation>
     </message>
     <message id="device_page_switches">
       <location filename="../../components/DevicePage.qml" line="49"/>
@@ -10271,281 +9080,1152 @@ Geïnstalleerd maar uitgeschakeld (rc.local)
       <source>Press to refresh</source>
       <translation>Druk om te vernieuwen</translation>
     </message>
-    <message id="temperature_type_unknown">
-      <location filename="../../data/EnvironmentInputs.qml" line="65"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Onbekend</translation>
-    </message>
-    <message id="brief_solar_yield">
-      <location filename="../../pages/BriefSidePanel.qml" line="24"/>
-      <source>Solar yield</source>
-      <translation type="unfinished">Zon opbrengst</translation>
-    </message>
-    <message id="brief_dc_input">
-      <location filename="../../pages/BriefSidePanel.qml" line="214"/>
-      <source>DC input</source>
-      <translation type="unfinished">DC ingang</translation>
-    </message>
-    <message id="brief_ac_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="257"/>
-      <source>AC Loads</source>
-      <translation type="unfinished">AC Belastingen</translation>
-    </message>
-    <message id="brief_dc_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="284"/>
-      <source>DC Loads</source>
-      <translation type="unfinished">DC Belastingen</translation>
-    </message>
-    <message id="nav_overview">
-      <location filename="../../pages/OverviewPage.qml" line="450"/>
-      <source>Overview</source>
-      <translation type="unfinished">Overzicht</translation>
-    </message>
-    <message id="settings_state">
-      <location filename="../../pages/settings/PageCanbusStatus.qml" line="116"/>
-      <source>State</source>
-      <translation type="unfinished">Status</translation>
-    </message>
-    <message id="inverter_pv">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="56"/>
-      <source>PV</source>
-      <translation type="unfinished">Zonnepaneel</translation>
-    </message>
-    <message id="inverter_total_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="76"/>
-      <source>Total yield</source>
-      <translation type="unfinished">Totaal opbrengst</translation>
-    </message>
-    <message id="inverter_system_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="84"/>
-      <source>System yield</source>
-      <translation type="unfinished">Systeem opbrengst</translation>
-    </message>
-    <message id="charger_total_pv_power">
-      <location filename="../../pages/solar/SolarDevicePage.qml" line="61"/>
-      <source>Total PV Power</source>
-      <translation type="unfinished">Totaal PV energie</translation>
-    </message>
-    <message id="vebus_device_alarm_only">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
-      <source>Alarm only</source>
-      <translation type="unfinished">Alleen alarm</translation>
-    </message>
-    <message id="vebus_device_alarms_and_warnings">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
-      <source>Alarms &amp; warnings</source>
-      <translation type="unfinished">Alarmen en meldingen</translation>
-    </message>
-    <message id="vebus_device_alarm_group_warning">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
-      <source>Warning</source>
-      <translation type="unfinished">Waarschuwing</translation>
-    </message>
-    <message id="load_delegate_status">
-      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
-      <source>Status: %1</source>
-      <translation type="unfinished"/>
+    <message id="common_words_total_power">
+      <location filename="../../components/CommonWords.qml" line="540"/>
+      <source>Total power</source>
+      <translation>Totaal vermogen</translation>
     </message>
     <message id="venus_os_gui">
       <location filename="../../Main.qml" line="17"/>
       <source>Venus OS GUI</source>
       <extracomment>Application title</extracomment>
-      <translation type="unfinished"/>
       <extra-Context>only shown on desktop systems</extra-Context>
+      <translation>Venus OS GUI</translation>
+    </message>
+    <message id="load_delegate_status">
+      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
+      <source>Status: %1</source>
+      <translation>Status: %1</translation>
+    </message>
+    <message id="settings_relay_polarity_relay1">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
+      <source>Polarity (Relay 1)</source>
+      <translation>Polariteit (Relais 1)</translation>
+    </message>
+    <message id="settings_relay_polarity">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
+      <source>Polarity</source>
+      <translation>Polariteit</translation>
+    </message>
+    <message id="settings_relay_polarity_relay2">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
+      <source>Polarity (Relay 2)</source>
+      <translation>Polariteit (Relais 2)</translation>
+    </message>
+    <message id="page_settings_wifi_invalid_password">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
+      <source>Password length must be either 0 or between 10 and 63 characters long</source>
+      <translation>Wachtwoord lengte moet 0 zijn of tussen de 10 en 63 tekens lang zijn</translation>
+    </message>
+    <message id="page_settings_wifi_password_updated">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
+      <source>Password updated</source>
+      <translation>Wachtwoord bijgewerkt</translation>
+    </message>
+    <message id="common_words_max">
+      <location filename="../../components/CommonWords.qml" line="315"/>
+      <source>Max</source>
+      <extracomment>Short for Maximum</extracomment>
+      <translation>Max</translation>
+    </message>
+    <message id="common_words_min">
+      <location filename="../../components/CommonWords.qml" line="331"/>
+      <source>Min</source>
+      <extracomment>Short for Minimum</extracomment>
+      <translation>Min</translation>
+    </message>
+    <message id="settings_ess_deprecated">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="321"/>
+      <source>Deprecated settings</source>
+      <translation>Verouderde instellingen</translation>
+    </message>
+    <message id="settings_ess_max_charge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="328"/>
+      <source>Battery charge limit (% of CCL)</source>
+      <translation>Accu laadlimiet (% van CCL)</translation>
+    </message>
+    <message id="settings_ess_max_discharge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="339"/>
+      <source>Battery discharge limit (% of DCL)</source>
+      <translation>Accu ontladingslimiet (% van DCL)</translation>
+    </message>
+    <message id="vebus_device_bms_message">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
+      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
+      <oldsource>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</oldsource>
+      <translation>Een VE.Bus BMS schakelt het systeem automatisch uit wanneer dat nodig is om de accu te beschermen. Het is daarom niet mogelijk om het systeem via het GX-apparaat te bedienen.</translation>
+    </message>
+    <message id="switchable_output_numeric_input">
+      <location filename="../../src/enums.cpp" line="418"/>
+      <source>Numeric input</source>
+      <translation>Numerieke invoer</translation>
     </message>
     <message id="autotoggleswitch_disable_auto_mode_info">
       <location filename="../../components/controls/AutoToggleButton.qml" line="34"/>
       <source>Disable Auto mode first</source>
-      <translation type="unfinished"/>
+      <translation>Schakel eerst de automatische modus uit</translation>
+    </message>
+    <message id="pagesettingsintegrations_venus_os_enable_large_features">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
+      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
+      <translation>Schakel de Venus OS Large firmware in om Node-RED of Signal-K te gebruiken</translation>
+    </message>
+    <message id="settings_relays_sensors_tanks">
+      <location filename="../../pages/SettingsPage.qml" line="75"/>
+      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
+      <oldsource>Relays, Sensors, Tanks, PV Inverters, Modbus, MQTT…</oldsource>
+      <translation>Relais, Sensoren, PV-omvormers, Modbus, Node-RED</translation>
+    </message>
+    <message id="vebus_device_page_microgrid_parameters">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
+      <source>Microgrid parameters</source>
+      <translation>Microgrid parameters</translation>
+    </message>
+    <message id="microgrid_mode_hybrid_droop">
+      <location filename="../../src/enums.cpp" line="539"/>
+      <source>Hybrid droop</source>
+      <translation>Hybride droop</translation>
+    </message>
+    <message id="microgrid_mode_grid_following">
+      <location filename="../../src/enums.cpp" line="542"/>
+      <source>Grid-following</source>
+      <translation>Netvolgend</translation>
+    </message>
+    <message id="microgrid_mode_grid_forming">
+      <location filename="../../src/enums.cpp" line="545"/>
+      <source>Grid-forming</source>
+      <translation>Netvormend</translation>
+    </message>
+    <message id="switchable_output_trip_low_voltage">
+      <location filename="../../src/enums.cpp" line="481"/>
+      <source>Trip low voltage</source>
+      <oldsource>Disabled</oldsource>
+      <translation>Onderspanning uitschakelen</translation>
     </message>
     <message id="microgrid">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="15"/>
       <source>Microgrid</source>
-      <translation type="unfinished"/>
+      <translation>Microgrid</translation>
     </message>
     <message id="page_microgrid_active_mode">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="19"/>
       <source>Active mode</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_microgrid_from_p1_to_p2">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="34"/>
-      <source>%1 %2 to %3 %4</source>
-      <extracomment>Describes a range from one quantity to another, e.g. "30 W to 60 W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
-      <translation type="unfinished"/>
+      <translation>Actieve modus</translation>
     </message>
     <message id="page_microgrid_hybrid_droop_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="92"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
       <source>Hybrid droop parameters</source>
-      <translation type="unfinished"/>
+      <translation>Hybride droop parameters</translation>
     </message>
     <message id="page_microgrid_reference_active_power_p0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="105"/>
       <source>Reference active power (P&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Referentie actief vermogen (P&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_frequency_f0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="108"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="112"/>
       <source>Reference frequency (f&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Referentie frequentie (f&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_frequency_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="117"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="119"/>
       <source>Frequency droop slope (droop&lt;sub&gt;fP&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Frequentie droop helling (droop&lt;sub&gt;fP&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_reactive_power">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="126"/>
       <source>Reference reactive power (Q&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Referentie reactief vermogen (Q&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_voltage">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="135"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="133"/>
       <source>Reference Voltage (U&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Referentie spanning (U&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_voltage_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="144"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="140"/>
       <source>Voltage droop slope (droop&lt;sub&gt;UQ&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Spanning droop helling (droop&lt;sub&gt;UQ&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_minimum_and_maximum_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="146"/>
       <source>Minimum and maximum parameters</source>
-      <translation type="unfinished"/>
+      <translation>Minimum en maximum parameters</translation>
     </message>
     <message id="page_microgrid_allowed_active_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="156"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
       <source>Allowed active power range</source>
-      <translation type="unfinished"/>
+      <translation>Toegestaan actief vermogensbereik</translation>
     </message>
     <message id="page_microgrid_allowed_reactive_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="164"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="159"/>
       <source>Allowed reactive power range</source>
-      <translation type="unfinished"/>
+      <translation>Toegestaan reactief vermogensbereik</translation>
     </message>
     <message id="page_microgrid_p_q_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="176"/>
       <source>P-Q direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>P-Q direct drive instellingen</translation>
     </message>
     <message id="page_microgrid_active_power_setpoint_p">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="186"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
       <source>Active power setpoint (P)</source>
-      <translation type="unfinished"/>
+      <translation>Actief vermogen setpoint (P)</translation>
     </message>
     <message id="page_microgrid_reactive_power_setpoint_q">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="194"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="188"/>
       <source>Reactive power setpoint (Q)</source>
-      <translation type="unfinished"/>
+      <translation>Reactief vermogen setpoint (Q)</translation>
     </message>
     <message id="page_microgrid_allowed_frequency_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="202"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="195"/>
       <source>Allowed frequency range</source>
-      <translation type="unfinished"/>
+      <translation>Toegestaan frequentiebereik</translation>
     </message>
     <message id="page_microgrid_allowed_voltage_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="210"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="203"/>
       <source>Allowed voltage range</source>
-      <translation type="unfinished"/>
+      <translation>Toegestaan spanningsbereik</translation>
     </message>
     <message id="page_microgrid_v_f_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="227"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="220"/>
       <source>V-f direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>V-f direct drive instellingen</translation>
     </message>
     <message id="page_microgrid_voltage_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="225"/>
       <source>Voltage setpoint (U)</source>
-      <translation type="unfinished"/>
+      <translation>Spanning setpoint (U)</translation>
     </message>
     <message id="page_microgrid_frequency_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="240"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
       <source>Frequency setpoint (f)</source>
-      <translation type="unfinished"/>
+      <translation>Frequentie setpoint (f)</translation>
     </message>
-    <message id="temperature_slider_current">
-      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
-      <source>Current</source>
-      <extracomment>The current temperature measurement</extracomment>
-      <translation type="unfinished">Stroom</translation>
+    <message id="pagesettingsintegrations_canopenmotordrive">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
+      <source>CANopen motor drives</source>
+      <translation>CANopen-motoraandrijvingen</translation>
+    </message>
+    <message id="pagesettingsintegrations_ui_plugins">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
+      <source>UI Plugins</source>
+      <translation>UI-plug-ins</translation>
+    </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
+      <source>Motor Direction Inverted</source>
+      <translation>Motorrichting omgekeerd</translation>
     </message>
     <message id="page_settings_canopenmotordrive_scan_for_motor_drives">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="31"/>
       <source>Scan for motor drives</source>
-      <translation type="unfinished"/>
+      <translation>Scannen naar motoraandrijvingen</translation>
     </message>
     <message id="page_settings_canopenmotordrive_discovered_motor_drive_ids">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="39"/>
       <source>Discovered motor drive IDs</source>
-      <translation type="unfinished"/>
+      <translation>Gevonden ID's van motoraandrijvingen</translation>
     </message>
-    <message id="switchableoutput_gx_device_relays">
-      <location filename="../../src/switchableoutput.cpp" line="388"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">GX apparaat relais</translation>
+    <message id="temperature_pm25">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
+      <source>PM2.5</source>
+      <translation>PM2.5</translation>
     </message>
-    <message id="gx_device_relays">
-      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">GX apparaat relais</translation>
+    <message id="temperature_co2">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+      <source>CO₂</source>
+      <translation>CO₂</translation>
     </message>
-    <message id="color_preset">
-      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
-      <source>Preset</source>
-      <translation type="unfinished"/>
+    <message id="temperature_voc">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
+      <source>VOC index</source>
+      <translation>VOC-index</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_location">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
-      <source>Add Modbus port and unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_nox">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
+      <source>NOx index</source>
+      <translation>NOx-index</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_unitid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
-      <source>Unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_luminosity">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
+      <source>Luminosity</source>
+      <translation>Luminositeit</translation>
     </message>
-    <message id="page_settings_fronius_unitid_invalid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation type="unfinished">%1 is geen geldig eenheidsnummer. Gebruik een getal tussen 1-247.</translation>
-    </message>
-    <message id="page_settings_fronius_add_modbus_location_button">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
-      <source>Add</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_locations_note">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
-      <source>The default modbus port is 502 and the default unit ID is 126.
-Here you can add additional ports and unit IDs to scan for PV inverters.</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_location_number">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
-      <source>Port/Unit ID %1</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location_description">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
-      <source>Port: %1 (Unit %2)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
-      <source>Remove Modbus port and unit ID?</source>
-      <translation type="unfinished"/>
+    <message id="switchable_output_bypassed">
+      <location filename="../../src/enums.cpp" line="484"/>
+      <source>Bypassed</source>
+      <translation>Omzeild</translation>
     </message>
     <message id="switchableoutput_list_delegate_auto_status">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="84"/>
       <source>Auto (%1)</source>
       <extracomment>%1 = 'On' or 'Off'</extracomment>
-      <translation type="unfinished"/>
+      <translation>Auto (%1)</translation>
     </message>
     <message id="switchableoutput_list_delegate_state_forced">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="100"/>
       <source>Forced</source>
-      <translation type="unfinished"/>
+      <translation>Geforceerd</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_settings">
+      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
+      <source>Modbus port and unit ID settings</source>
+      <translation>Modbus-poort- en unit ID-instellingen</translation>
+    </message>
+    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
+      <source>Integrates with the device list</source>
+      <translation>Integreert met de apparatenlijst</translation>
+    </message>
+    <message id="common_words_color">
+      <location filename="../../components/CommonWords.qml" line="136"/>
+      <source>Color</source>
+      <translation>Kleur</translation>
+    </message>
+    <message id="common_words_value_must_be_greater_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="557"/>
+      <source>Value must be greater than start value</source>
+      <translation>Waarde moet groter zijn dan de beginwaarde</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="566"/>
+      <source>Value must be lower than stop value</source>
+      <translation>Waarde moet lager zijn dan de eindwaarde</translation>
+    </message>
+    <message id="notifications_page_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="43"/>
+      <source>Active Notifications</source>
+      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
+      <translation>Actieve meldingen</translation>
+    </message>
+    <message id="notifications_page_inactive_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="47"/>
+      <source>Inactive Notifications</source>
+      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
+      <translation>Inactieve meldingen</translation>
+    </message>
+    <message id="notifications_no_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="106"/>
+      <source>No active notifications</source>
+      <translation>Geen actieve meldingen</translation>
+    </message>
+    <message id="switchable_output_rgb_color_wheel">
+      <location filename="../../src/enums.cpp" line="427"/>
+      <source>RGB color wheel</source>
+      <translation>RGB-kleurenwiel</translation>
+    </message>
+    <message id="switchable_output_cct_color_wheel">
+      <location filename="../../src/enums.cpp" line="431"/>
+      <source>CCT color wheel</source>
+      <extracomment>Correlated Color Temperature color wheel</extracomment>
+      <translation>CCT-kleurenwiel</translation>
+    </message>
+    <message id="switchable_output_rgbw_color_wheel">
+      <location filename="../../src/enums.cpp" line="435"/>
+      <source>RGB + W color wheel</source>
+      <extracomment>RGB + white color wheel</extracomment>
+      <translation>RGB + W kleurenwiel</translation>
+    </message>
+    <message id="listlink_show_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="43"/>
+      <source>Show QR code</source>
+      <translation>QR-code weergeven</translation>
+    </message>
+    <message id="listlink_scan_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="52"/>
+      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
+      <extracomment>%1 = url text</extracomment>
+      <oldsource>Scan the QR code with your portable device.&lt;br /&gt;Or insert the link: %1</oldsource>
+      <translation>Open de QR-code om deze met uw draagbare apparaat te scannen.&lt;br /&gt;Of voer de link in: %1</translation>
+    </message>
+    <message id="color_preset">
+      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
+      <source>Preset</source>
+      <translation>Voorinstelling</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
+      <source>Add Modbus port and unit ID</source>
+      <translation>Modbus-poort en unit ID toevoegen</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_unitid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
+      <source>Unit ID</source>
+      <translation>Unit ID</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location_button">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
+      <source>Add</source>
+      <translation>Toevoegen</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_locations_note">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
+      <source>The default modbus port is 502 and the default unit ID is 126.
+Here you can add additional ports and unit IDs to scan for PV inverters.</source>
+      <translation>De standaard Modbus-poort is 502 en de standaard unit ID is 126.
+Hier kunt u extra poorten en unit ID's toevoegen om naar PV-omvormers te scannen.</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_location_number">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
+      <source>Port/Unit ID %1</source>
+      <translation>Poort/Unit ID %1</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location_description">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
+      <source>Port: %1 (Unit %2)</source>
+      <translation>Poort: %1 (Unit %2)</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
+      <source>Remove Modbus port and unit ID?</source>
+      <translation>Modbus-poort en unit ID verwijderen?</translation>
+    </message>
+    <message id="devicelist_tankshape_edit_point">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="182"/>
+      <source>Edit point %1</source>
+      <extracomment>%1 = which point is being edited, a number like "1" or "2"</extracomment>
+      <translation></translation>
+    </message>
+    <message id="settings_canbus_vecan">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
+      <source>VE.Can (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_250">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <source>VE.Can &amp; CANopen E-drive (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_500">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
+      <source>CANopen E-drive (500 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="page_microgrid_from_p1_to_p2">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="39"/>
+      <source>%1%2 to %3%4</source>
+      <extracomment>Describes a range from one quantity to another, e.g. "30W to 60W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
+      <translation></translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAfricaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
+      <source>Morocco Standard Time</source>
+      <translation>Standaardtijd Marokko</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
+      <source>W. Central Africa Standard Time</source>
+      <translation>Standaardtijd West-Centraal-Afrika</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
+      <source>South Africa Standard Time</source>
+      <translation>Standaardtijd Zuid-Afrika</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
+      <source>Namibia Standard Time</source>
+      <translation>Standaardtijd Namibië</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
+      <source>Egypt Standard Time</source>
+      <translation>Standaardtijd Egypte</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
+      <source>E. Africa Standard Time</source>
+      <translation>Standaardtijd Oost-Afrika</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAmericaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
+      <source>Argentina Standard Time</source>
+      <translation>Standaardtijd Argentinië</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
+      <source>E. South America Standard Time</source>
+      <translation>Standaardtijd Zuidoost-Amerika</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
+      <source>Greenland Standard Time</source>
+      <translation>Standaardtijd Groenland</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
+      <source>Montevideo Standard Time</source>
+      <translation>Standaardtijd Montevideo</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
+      <source>Newfoundland Standard Time</source>
+      <translation>Standaardtijd Newfoundland</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
+      <source>SA Eastern Standard Time</source>
+      <translation>Standaardtijd Zuidoost-Amerika</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
+      <source>Atlantic Standard Time</source>
+      <translation>Atlantische standaardtijd</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
+      <source>Central Brazilian Standard Time</source>
+      <translation>Standaardtijd Centraal-Brazilië</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>Standaardtijd Pacific SA</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
+      <source>Paraguay Standard Time</source>
+      <translation>Standaardttijd Paraguay</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
+      <source>SA Western Standard Time</source>
+      <translation>Standaardtijd SA Western</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
+      <source>Venezuela Standard Time</source>
+      <translation>Standaardtijd Venezuela</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
+      <source>Eastern Standard Time</source>
+      <translation>Standaardtijd Eastern</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
+      <source>SA Pacific Standard Time</source>
+      <translation>Standaardtijd SA Pacific</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
+      <source>US Eastern Standard Time</source>
+      <translation>Standaardtijd US Eastern</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
+      <source>Canada Central Standard Time</source>
+      <translation>Standaardtijd Centraal-Canada</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
+      <source>Central America Standard Time</source>
+      <translation>Standaardtijd Centraal-Amerika</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
+      <source>Central Standard Time (Mexico)</source>
+      <translation>Standaardtijd Centraal-Mexico</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
+      <source>Central Standard Time</source>
+      <translation>Standaardtijd Central</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
+      <source>Mountain Standard Time (Mexico)</source>
+      <translation>Standaardtijd Mountain (Mexico)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
+      <source>Mountain Standard Time</source>
+      <translation>Standaardtijd Mountain</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
+      <source>US Mountain Standard Time</source>
+      <translation>Standaardtijd US Mountain</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
+      <source>Pacific Standard Time (Mexico)</source>
+      <translation>Standaardtijd Pacific (Mexico)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
+      <source>Pacific Standard Time</source>
+      <translation>Standaardtijd Stille Oceaan</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
+      <source>Alaskan Standard Time</source>
+      <translation>Standaardtijd Alaska</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
+      <source>Hawaii-Aleutian</source>
+      <translation>Standaardtijd Hawaii-Aleutian</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
+      <source>Atlantic Daylight Time</source>
+      <translation>Atlantische zomertijd</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAntarcticaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+      <source>New Zealand Standard Time</source>
+      <translation>Standaardtijd Nieuw-Zeeland</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>Standaardtijd Central Pacific</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+      <source>West Pacific Standard Time</source>
+      <translation>Standaardtijd West Pacific</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+      <source>W. Australia Standard Time</source>
+      <translation>Standaardtijd West-Australië</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+      <source>SE Asia Standard Time</source>
+      <translation>Standaardtijd Zuidoost-Azië</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+      <source>Central Asia Standard Time</source>
+      <translation>Standaardtijd Centraal-Azië</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+      <source>West Asia Standard Time</source>
+      <translation>Standaardtijd West-Azië</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+      <source>E. Africa Standard Time</source>
+      <translation>Standaardtijd Oost-Afrika</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>Standaardtijd Pacific SA</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+      <source>SA Western Standard Time</source>
+      <translation>Standaardtijd SA Western</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzArcticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
+      <source>W. Europe Standard Time</source>
+      <translation>Standaardtijd West Europa</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAsiaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
+      <source>Kamchatka Standard Time</source>
+      <translation>Standaardtijd Kamchatka</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
+      <source>Magadan Standard Time</source>
+      <translation>Standaardtijd Magadan</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
+      <source>Vladivostok Standard Time</source>
+      <translation>Standaardtijd Vladivostok</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
+      <source>Yakutsk Standard Time</source>
+      <translation>Standaardtijd Yakutsk</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
+      <source>Tokyo Standard Time</source>
+      <translation>Standaardtijd Tokio</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
+      <source>Korea Standard Time</source>
+      <translation>Standaardtijd Korea</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
+      <source>Singapore Standard Time</source>
+      <translation>Standaardtijd Singapur</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
+      <source>Ulaanbaatar Standard Time</source>
+      <translation>Standaardtijd Ulaanbaatar</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
+      <source>Taipei Standard Time</source>
+      <translation>Standaardtijd Taipei</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
+      <source>North Asia East Standard Time</source>
+      <translation>Standaardtijd Noordoost-Azië</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
+      <source>China Standard Time</source>
+      <translation>Standaardtijd China</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
+      <source>SE Asia Standard Time</source>
+      <translation>Standaardtijd Zuidoost-Azië</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
+      <source>North Asia Standard Time</source>
+      <translation>Standaardtijd Noord-Azië</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
+      <source>Myanmar Standard Time</source>
+      <translation>Standaardtijd Myanmar</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
+      <source>N. Central Asia Standard Time</source>
+      <translation>Standaardtijd Noord-Centraal-Azië</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
+      <source>Central Asia Standard Time</source>
+      <translation>Standaardtijd Centraal-Azië</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
+      <source>Bangladesh Standard Time</source>
+      <translation>Standaardtijd Bangladesh</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
+      <source>Nepal Standard Time</source>
+      <translation>Standaardtijd Nepal</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
+      <source>Sri Lanka Standard Time</source>
+      <translation>Standaardtijd Sri Lanka</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
+      <source>India Standard Time</source>
+      <translation>Standaardtijd India</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
+      <source>West Asia Standard Time</source>
+      <translation>Standaardtijd West-Azië</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
+      <source>Pakistan Standard Time</source>
+      <translation>Standaardtijd Pakistan</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
+      <source>Ekaterinburg Standard Time</source>
+      <translation>Standaardtijd Jekaterinaburg</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
+      <source>Georgian Standard Time</source>
+      <translation>Standaardtijd Georgië</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
+      <source>Caucasus Standard Time</source>
+      <translation>Standaardtijd Kaukasus</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
+      <source>Azerbaijan Standard Time</source>
+      <translation>Standaardtijd Azerbeidzjan</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
+      <source>Arabian Standard Time</source>
+      <translation>Standaardtijd Arabië</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
+      <source>Afghanistan Standard Time</source>
+      <translation>Standaardtijd Afghanistan</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
+      <source>Iran Standard Time</source>
+      <translation>Standaardtijd Iran</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
+      <source>Arabic Standard Time</source>
+      <translation>Standaardtijd Arabië</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
+      <source>Arab Standard Time</source>
+      <translation>Standaardtijd Arabië</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
+      <source>Syria Standard Time</source>
+      <translation>Standaardtijd Syrië</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
+      <source>Middle East Standard Time</source>
+      <translation>Standaardtijd Midden-Oosten</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
+      <source>Jordan Standard Time</source>
+      <translation>Standaardtijd Jordanië</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
+      <source>Israel Standard Time</source>
+      <translation>Standaardtijd Israël</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAtlanticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+      <source>Greenwich Standard Time</source>
+      <translation>Standaardtijd Greenwich</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+      <source>Azores Standard Time</source>
+      <translation>Standaardtijd Azoren</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+      <source>Cape Verde Standard Time</source>
+      <translation>Standaardtijd Kaapverdië</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
+      <source>Mid-Atlantic Standard Time</source>
+      <translation>Mid Atlantische standaardtijd</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAustraliaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+      <source>Tasmania Standard Time</source>
+      <translation>Standaardtijd Tasmanië</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+      <source>E. Australia Standard Time</source>
+      <translation>Standaardtijd Oost-Australië</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+      <source>AUS Eastern Standard Time</source>
+      <translation>Standaardtijd AUS Oost</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+      <source>Cen. Australia Standard Time</source>
+      <translation>Standaardtijd Centraal-Australië</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+      <source>AUS Central Standard Time</source>
+      <translation>Standaardtijd AUS Centraal</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+      <source>W. Australia Standard Time</source>
+      <translation>Standaardtijd West-Australië</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEtcData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
+      <source>GMT +12</source>
+      <translation>GMT +12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
+      <source>GMT -02</source>
+      <translation>GMT -02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
+      <source>GMT -11</source>
+      <translation>GMT -11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
+      <source>GMT -13</source>
+      <translation>GMT -13</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
+      <source>GMT -12</source>
+      <translation>GMT -12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
+      <source>GMT -10</source>
+      <translation>GMT -10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
+      <source>GMT -09</source>
+      <translation>GMT -09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
+      <source>GMT -08</source>
+      <translation>GMT -08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
+      <source>GMT -07</source>
+      <translation>GMT -07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
+      <source>GMT -06</source>
+      <translation>GMT -06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
+      <source>GMT -05</source>
+      <translation>GMT -05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
+      <source>GMT -04</source>
+      <translation>GMT -04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
+      <source>GMT -03</source>
+      <translation>GMT -03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
+      <source>GMT -01</source>
+      <translation>GMT -01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
+      <source>GMT</source>
+      <translation>GMT</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
+      <source>GMT +01</source>
+      <translation>GMT +01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
+      <source>GMT +02</source>
+      <translation>GMT +02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
+      <source>GMT +03</source>
+      <translation>GMT +03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
+      <source>GMT +04</source>
+      <translation>GMT +04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
+      <source>GMT +05</source>
+      <translation>GMT +05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
+      <source>GMT +06</source>
+      <translation>GMT +06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
+      <source>GMT +07</source>
+      <translation>GMT +07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
+      <source>GMT +08</source>
+      <translation>GMT +08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
+      <source>GMT +09</source>
+      <translation>GMT +09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
+      <source>GMT +10</source>
+      <translation>GMT +10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
+      <source>GMT +11</source>
+      <translation>GMT +11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
+      <source>UTC</source>
+      <translation>UTC</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEuropeData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
+      <source>GMT Standard Time</source>
+      <translation>Standaardtijd GMT</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
+      <source>Central Europe Standard Time</source>
+      <translation>Standaardtijd Centraal-Europa</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
+      <source>Central European Standard Time</source>
+      <translation>Standaardtijd Midden-Europa</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
+      <source>Romance Standard Time</source>
+      <translation>Standaardtijd Midden-Europa</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
+      <source>W. Europe Standard Time</source>
+      <translation>Standaardtijd West-Europa</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
+      <source>E. Europe Standard Time</source>
+      <translation>Standaardtijd Oost-Europa</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
+      <source>FLE Standard Time</source>
+      <translation>Standaardtijd FLE</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
+      <source>GTB Standard Time</source>
+      <translation>Standaardtijd GTB</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
+      <source>Belarus Standard Time</source>
+      <translation>Standaardtijd Wit-Rusland</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
+      <source>Russian Standard Time</source>
+      <translation>Standaardtijd Rusland</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
+      <source>Turkey Standard Time</source>
+      <translation>Standaardtijd Turkije</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzIndianData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
+      <source>Mauritius Standard Time</source>
+      <translation>Standaardtijd Mauritius</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
+      <source>Christmas Island Standard Time</source>
+      <translation>Standaardtijd Christmas Island</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzPacificData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
+      <source>Tonga Standard Time</source>
+      <translation>Standaardtijd Tonga</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
+      <source>Fiji Standard Time</source>
+      <translation>Standaardtijd Fiji</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
+      <source>New Zealand Standard Time</source>
+      <translation>Standaardtijd Nieuw-Zeeland</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>Standaardtijd Central Pacific</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
+      <source>West Pacific Standard Time</source>
+      <translation>Standaardtijd West Pacific</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
+      <source>Samoa Standard Time</source>
+      <translation>Standaardtijd Samoa</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
+      <source>Hawaiian Standard Time</source>
+      <translation>Standaardtijd Hawaii</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
+      <source>Easter Island Standard Time</source>
+      <translation>Standaardtijd Paaseiland</translation>
     </message>
   </context>
   <context>
@@ -12126,7 +11806,7 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
     <message>
       <location filename="../../src/main.cpp" line="184"/>
       <source>Name of mock configuration</source>
-      <translation>Naam van de mock-configuratie</translation>
+      <translation>Naam van de proefconfiguratie</translation>
     </message>
     <message>
       <location filename="../../src/main.cpp" line="185"/>
@@ -12153,7 +11833,7 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
     <message>
       <location filename="../../src/main.cpp" line="202"/>
       <source>Signal K URL</source>
-      <translation>Signal K-URL</translation>
+      <translation>Signal K URL</translation>
     </message>
     <message>
       <location filename="../../src/main.cpp" line="203"/>
@@ -12170,839 +11850,7 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
       <location filename="../../src/main.cpp" line="209"/>
       <source>scheme</source>
       <comment>Color scheme value</comment>
-      <translation>scheme</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>Standaardtijd Marokko</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>Standaardtijd West-Centraal-Afrika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>Standaardtijd Zuid-Afrika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>Standaardtijd Namibië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>Standaardtijd Egypte</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Standaardtijd Oost-Afrika</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>Standaardtijd Argentinië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>Standaardtijd Zuidoost-Amerika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>Standaardtijd Groenland</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>Standaardtijd Montevideo</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>Standaardtijd Newfoundland</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>Standaardtijd Zuidoost-Amerika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Atlantic Standard Time</source>
-      <translation>Atlantische standaardtijd</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>Standaardtijd Centraal-Brazilië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Standaardtijd Pacific SA</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>Paraguay Standard Time</source>
-      <translation>Standaardttijd Paraguay</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>SA Western Standard Time</source>
-      <translation>Standaardtijd SA Western</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Venezuela Standard Time</source>
-      <translation>Standaardtijd Venezuela</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>Eastern Standard Time</source>
-      <translation>Standaardtijd Eastern</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>Standaardtijd SA Pacific</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>US Eastern Standard Time</source>
-      <translation>Standaardtijd US Eastern</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Canada Central Standard Time</source>
-      <translation>Standaardtijd Centraal-Canada</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central America Standard Time</source>
-      <translation>Standaardtijd Centraal-Amerika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>Standaardtijd Centraal-Mexico</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Central Standard Time</source>
-      <translation>Standaardtijd Central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>Standaardtijd Mountain (Mexico)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>Mountain Standard Time</source>
-      <translation>Standaardtijd Mountain</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>US Mountain Standard Time</source>
-      <translation>Standaardtijd US Mountain</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>Standaardtijd Pacific (Mexico)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Pacific Standard Time</source>
-      <translation>Standaardtijd Stille Oceaan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Alaskan Standard Time</source>
-      <translation>Standaardtijd Alaska</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>Standaardtijd Hawaii-Aleutian</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Daylight Time</source>
-      <translation>Atlantische zomertijd</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Standaardtijd Nieuw-Zeeland</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Standaardtijd Central Pacific</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Standaardtijd West Pacific</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Standaardtijd West-Australië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Standaardtijd Zuidoost-Azië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Standaardtijd Centraal-Azië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>Standaardtijd West-Azië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Standaardtijd Oost-Afrika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Standaardtijd Pacific SA</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>Standaardtijd SA Western</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Standaardtijd West Europa</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>Standaardtijd Kamchatka</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>Standaardtijd Magadan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>Standaardtijd Vladivostok</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>Standaardtijd Yakutsk</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>Standaardtijd Tokio</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>Standaardtijd Korea</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>Standaardtijd Singapur</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>Standaardtijd Ulaanbaatar</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>Standaardtijd Taipei</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>Standaardtijd Noordoost-Azië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>Standaardtijd China</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Standaardtijd Zuidoost-Azië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>Standaardtijd Noord-Azië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>Standaardtijd Myanmar</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>Standaardtijd Noord-Centraal-Azië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Standaardtijd Centraal-Azië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>Standaardtijd Bangladesh</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>Standaardtijd Nepal</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>Standaardtijd Sri Lanka</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>Standaardtijd India</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>Standaardtijd West-Azië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>Standaardtijd Pakistan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>Standaardtijd Jekaterinaburg</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>Standaardtijd Georgië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>Standaardtijd Kaukasus</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>Standaardtijd Azerbeidzjan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>Standaardtijd Arabië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>Standaardtijd Afghanistan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>Standaardtijd Iran</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>Standaardtijd Arabië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>Standaardtijd Arabië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>Standaardtijd Syrië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>Standaardtijd Midden-Oosten</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>Standaardtijd Jordanië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>Standaardtijd Israël</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>Standaardtijd Greenwich</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>Standaardtijd Azoren</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>Standaardtijd Kaapverdië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>Mid Atlantische standaardtijd</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>Standaardtijd Tasmanië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>Standaardtijd Oost-Australië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>Standaardtijd AUS Oost</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>Standaardtijd Centraal-Australië</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>Standaardtijd AUS Centraal</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Standaardtijd West-Australië</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
-      <source>GMT +12</source>
-      <translation>GMT +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
-      <source>GMT -02</source>
-      <translation>GMT -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT -13</source>
-      <translation>GMT -13</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT -12</source>
-      <translation>GMT -12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -10</source>
-      <translation>GMT -10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -09</source>
-      <translation>GMT -09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>GMT -08</source>
-      <translation>GMT -08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
-      <source>GMT -07</source>
-      <translation>GMT -07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
-      <source>GMT -06</source>
-      <translation>GMT -06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
-      <source>GMT -05</source>
-      <translation>GMT -05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
-      <source>GMT -04</source>
-      <translation>GMT -04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
-      <source>GMT -03</source>
-      <translation>GMT -03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
-      <source>GMT -01</source>
-      <translation>GMT -01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
-      <source>GMT</source>
-      <translation>GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
-      <source>GMT +01</source>
-      <translation>GMT +01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
-      <source>GMT +02</source>
-      <translation>GMT +02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
-      <source>GMT +03</source>
-      <translation>GMT +03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
-      <source>GMT +04</source>
-      <translation>GMT +04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
-      <source>GMT +05</source>
-      <translation>GMT +05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
-      <source>GMT +06</source>
-      <translation>GMT +06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
-      <source>GMT +07</source>
-      <translation>GMT +07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
-      <source>GMT +08</source>
-      <translation>GMT +08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
-      <source>GMT +09</source>
-      <translation>GMT +09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
-      <source>GMT +10</source>
-      <translation>GMT +10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
-      <source>GMT +11</source>
-      <translation>GMT +11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
-      <source>UTC</source>
-      <translation>UTC</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>Standaardtijd GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>Standaardtijd Centraal-Europa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>Standaardtijd Midden-Europa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>Standaardtijd Midden-Europa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Standaardtijd West-Europa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>Standaardtijd Oost-Europa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>Standaardtijd FLE</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>Standaardtijd GTB</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>Standaardtijd Wit-Rusland</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>Standaardtijd Rusland</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>Standaardtijd Turkije</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>Standaardtijd Mauritius</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>Standaardtijd Christmas Island</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>Standaardtijd Tonga</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>Standaardtijd Fiji</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Standaardtijd Nieuw-Zeeland</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Standaardtijd Central Pacific</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Standaardtijd West Pacific</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>Standaardtijd Samoa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>Standaardtijd Hawaii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>Standaardtijd Paaseiland</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation type="unfinished">Interne fout</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation type="unfinished"/>
+      <translation>schema</translation>
     </message>
   </context>
   <context>
@@ -13182,6 +12030,119 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
       <source>DC/DC misconfiguration</source>
       <translation>DC/DC verkeerde instelling</translation>
+    </message>
+  </context>
+  <context>
+    <name>VebusError</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+      <source>Device switched off</source>
+      <translation>Apparaat uitgeschakeld</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+      <source>Mixed old/new MK2</source>
+      <translation>Gemengde oude/nieuwe MK2</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+      <source>Expected devices error</source>
+      <translation>Verwachte apparaten fout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+      <source>No other device detected</source>
+      <translation>Geen ander apparaat gedetecteerd</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+      <source>Overvoltage on AC-out</source>
+      <translation>Te hoge spanning op AC uitgang</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+      <source>DDC program error</source>
+      <translation>DDC programmafout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+      <source>VE.Bus BMS without assistant</source>
+      <translation>VE.Bus BMS zonder assistent</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+      <source>Ground relay test failed</source>
+      <translation>Aardrelais test mislukt</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+      <source>System time sync error</source>
+      <translation>Systeem tijd synchronisatiefout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+      <source>Grid relay test fault</source>
+      <translation>Net relais test fout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+      <source>Config mismatch with 2nd mcu</source>
+      <translation>Configuratie komt niet overeen met 2e mcu</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+      <source>Device transmit error</source>
+      <translation>Apparaat zendfout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+      <source>Awaiting configuration or dongle missing</source>
+      <translation>Wachten op configuratie of dongle ontbreekt</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+      <source>Phase master missing</source>
+      <translation>Fase master ontbreekt</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+      <source>Overvoltage has occurred</source>
+      <translation>Te hoge spanning heeft plaatsgevonden</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+      <source>Slave does not have AC input!</source>
+      <translation>Slave heeft geen AC ingang!</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+      <source>Device can't be slave</source>
+      <translation>Apparaat kan geen slave zijn</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+      <source>System protection initiated</source>
+      <translation>Systeembescherming geactiveerd</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+      <source>Firmware incompatibiltiy</source>
+      <translation>Firmware incompatibiliteit</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+      <source>Internal error</source>
+      <translation>Interne fout</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+      <source>Failing relay test prevents connection</source>
+      <translation>Mislukte relais test voorkomt verbinding</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+      <source>VE.Bus error</source>
+      <translation>VE.Bus fout</translation>
     </message>
   </context>
 </TS>

--- a/i18n/venus-gui-v2_pl.ts
+++ b/i18n/venus-gui-v2_pl.ts
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="pl">
   <context>
-    <name/>
+    <name></name>
     <message id="switchable_output_disabled">
       <location filename="../../src/enums.cpp" line="478"/>
       <source>Disabled</source>
@@ -22,6 +22,7 @@
     <message id="solarchargers_state_off">
       <location filename="../../src/enums.cpp" line="331"/>
       <source>Off</source>
+      <extracomment>Digital input state</extracomment>
       <translation>Wył.</translation>
     </message>
     <message id="common_words_auto">
@@ -52,18 +53,25 @@
     <message id="settings_startpage_none">
       <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
       <source>None</source>
+      <extracomment>Indicates no phase</extracomment>
       <translation>Brak</translation>
     </message>
     <message id="common_words_position_ac">
       <location filename="../../components/CommonWords.qml" line="416"/>
       <source>Position</source>
-      <extracomment>AC input or output position</extracomment>
+      <extracomment>EVCS AC input/output position</extracomment>
       <translation>Pozycja</translation>
     </message>
     <message id="settings_minmax_speed">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="193"/>
       <source>Speed</source>
+      <extracomment>A speed measurement value</extracomment>
       <translation>Prędkość</translation>
+    </message>
+    <message id="common_words_state">
+      <location filename="../../components/CommonWords.qml" line="502"/>
+      <source>State</source>
+      <translation>Stan</translation>
     </message>
     <message id="settings_firmware_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="67"/>
@@ -101,8 +109,8 @@
       <source>Solar yield</source>
       <translation>Uzysk solarny</translation>
     </message>
-    <message id="ess_state_external_control">
-      <location filename="../../data/Ess.qml" line="41"/>
+    <message id="inverters_state_externalccontrol">
+      <location filename="../../data/System.qml" line="183"/>
       <source>External control</source>
       <translation>Sterowanie zewnętrzne</translation>
     </message>
@@ -140,6 +148,11 @@
       <location filename="../../components/CommonWords.qml" line="203"/>
       <source>ESS</source>
       <translation>ESS</translation>
+    </message>
+    <message id="pagesettingsconnectivity_ethernet">
+      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
+      <source>Ethernet</source>
+      <translation>Ethernet</translation>
     </message>
     <message id="pagesettingsconnectivity_wifi">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="28"/>
@@ -262,11 +275,6 @@
       <source>Name</source>
       <translation>Nazwa</translation>
     </message>
-    <message id="settings_deviceinfo_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="38"/>
-      <source>Name</source>
-      <translation type="unfinished">Nazwa</translation>
-    </message>
     <message id="settings_deviceinfo_product_id">
       <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
       <source>Product ID</source>
@@ -327,15 +335,20 @@
       <source>Daily run time</source>
       <translation>Dzienny czas pracy</translation>
     </message>
+    <message id="common_words_value_must_be_greater_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="560"/>
+      <source>Value must be greater than stop value</source>
+      <translation>Wartość musi być większa niż wartość zatrzymania</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="563"/>
+      <source>Value must be lower than start value</source>
+      <translation>Wartość musi być niższa niż wartość uruchomienia</translation>
+    </message>
     <message id="settings_minmax_acout_max_power">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="124"/>
       <source>AC output</source>
       <translation>Wyjście AC</translation>
-    </message>
-    <message id="ac_output">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="15"/>
-      <source>AC output</source>
-      <translation type="unfinished">Wyjście AC</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
       <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="25"/>
@@ -382,16 +395,6 @@
       <source>Unavailable monitor, set another</source>
       <translation>Niedostępny monitor, ustaw inny</translation>
     </message>
-    <message id="page_generator_conditions_battery_monitor">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="42"/>
-      <source>Battery monitor</source>
-      <translation type="unfinished">Monitor akumulatora</translation>
-    </message>
-    <message id="page_generator_conditions_unavailable_monitor_set_another">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="44"/>
-      <source>Unavailable monitor, set another</source>
-      <translation type="unfinished">Niedostępny monitor, ustaw inny</translation>
-    </message>
     <message id="page_generator_conditions_on_loss_of_communication">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="68"/>
       <source>On loss of communication</source>
@@ -416,11 +419,6 @@
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="105"/>
       <source>Battery SOC</source>
       <translation>SOC akumulatora</translation>
-    </message>
-    <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="173"/>
-      <source>Periodic run</source>
-      <translation type="unfinished">Przebieg okresowy</translation>
     </message>
     <message id="settings_inverter_high_temperature">
       <location filename="../../data/Generators.qml" line="83"/>
@@ -505,7 +503,7 @@
     <message id="settings_gps_speed_kmh">
       <location filename="../../pages/settings/PageGps.qml" line="83"/>
       <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometres per hour</extracomment>
+      <extracomment>GPS speed data, in kilometers per hour</extracomment>
       <translation>%1 km/h</translation>
     </message>
     <message id="settings_gps_speed_mph">
@@ -523,7 +521,7 @@
     <message id="settings_gps_speed_ms">
       <location filename="../../pages/settings/PageGps.qml" line="95"/>
       <source>%1 m/s</source>
-      <extracomment>GPS speed data, in metres per second</extracomment>
+      <extracomment>GPS speed data, in meters per second</extracomment>
       <translation>%1 m/s</translation>
     </message>
     <message id="settings_gps_course">
@@ -580,21 +578,6 @@
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="64"/>
       <source>%1 (Output %2)</source>
       <translation>%1 (Wyjście %2)</translation>
-    </message>
-    <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">Aktywny monitor akumulatora</translation>
-    </message>
-    <message id="settings_batteries_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="101"/>
-      <source>Name</source>
-      <translation type="unfinished">Nazwa</translation>
-    </message>
-    <message id="settings_batteries_enter_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="103"/>
-      <source>Enter name</source>
-      <translation type="unfinished">Wprowadź nazwę</translation>
     </message>
     <message id="settings_briefview_center_active_battery_monitor">
       <location filename="../../components/listitems/ListBriefCenterDetails.qml" line="27"/>
@@ -656,45 +639,25 @@
       <source>CAN-bus profile</source>
       <translation>Profil CAN-bus</translation>
     </message>
-    <message id="settings_disabled">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="31"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Wyłączone</translation>
-    </message>
-    <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</translation>
-    </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
       <location filename="../../pages/settings/CanbusProfile.qml" line="42"/>
       <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
       <translation>VE.Can &amp; CAN-bus BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
       <source>Oceanvolt (250 kbit/s)</source>
       <translation>Oceanvolt (250 kbit/s)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
       <source>RV-C (250 kbit/s)</source>
       <translation>RV-C (250 kbit/s)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
       <source>Up, but no services (250 kbit/s)</source>
       <translation>Działa, ale brak usług (250 kbit/s)</translation>
-    </message>
-    <message id="settings_canopen_motordrive_250">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
-      <source>CANopen Motor drive (250 kbit/s)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_canopen_motordrive_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
-      <source>CANopen Motor drive (500 kbit/s)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_devices">
       <location filename="../../components/CommonWords.qml" line="166"/>
@@ -731,11 +694,6 @@
       <source>Check Unique id numbers</source>
       <translation>Sprawdź Unikalne numery identyfikacyjne</translation>
     </message>
-    <message id="settings_canbus_unique_id_press_to_check">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Press to check</source>
-      <translation type="unfinished">Naciśnij, aby sprawdzić</translation>
-    </message>
     <message id="settings_canbus_unique_id_conflict">
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="125"/>
       <source>There is another device connected with this unique number, please select a new number.</source>
@@ -745,11 +703,6 @@
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="133"/>
       <source>OK: No other device is connected with this unique number.</source>
       <translation>OK: Żadne inne urządzenie nie jest połączone z tym unikalnym numerem.</translation>
-    </message>
-    <message id="pagesettingsintegrations_canopenmotordrive">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
-      <source>CANopen motor drives</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_network_status">
       <location filename="../../components/CommonWords.qml" line="349"/>
@@ -884,11 +837,6 @@
       <source>Unavailable sensor, set another</source>
       <translation>Czujnik niedostępny, ustaw inny</translation>
     </message>
-    <message id="settings_system_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="81"/>
-      <source>Unavailable sensor, set another</source>
-      <translation type="unfinished">Czujnik niedostępny, ustaw inny</translation>
-    </message>
     <message id="settings_dvcc_used_sensor">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="120"/>
       <source>Used sensor</source>
@@ -945,12 +893,6 @@
       <source>Auto selected</source>
       <translation>Wybór automatyczny</translation>
     </message>
-    <message id="settings_dvcc_auto_selected_none">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="208"/>
-      <source>None</source>
-      <extracomment>Indicates no option is selected</extracomment>
-      <translation type="unfinished">Brak</translation>
-    </message>
     <message id="settings_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
       <source>Build date/time</source>
@@ -986,12 +928,6 @@
       <source>Installing %1</source>
       <extracomment>%1 = firmware version</extracomment>
       <translation>Instalacja %1</translation>
-    </message>
-    <message id="settings_firmware_offline_press_to_install">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">Naciśnij, aby zaktualizować do %1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="90"/>
@@ -1062,12 +998,6 @@
       <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
       <translation>Instalacja %1 %2%</translation>
     </message>
-    <message id="settings_firmware_online_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="86"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">Instalowanie %1...</translation>
-    </message>
     <message id="settings_firmware_update_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="109"/>
       <source>Update build date/time</source>
@@ -1097,11 +1027,6 @@
       <location filename="../../pages/settings/PageSettingsFronius.qml" line="56"/>
       <source>TCP port</source>
       <translation>Port TCP</translation>
-    </message>
-    <message id="page_settings_fronius_modbus_settings">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
-      <source>Modbus port and unit ID settings</source>
-      <translation type="unfinished"/>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
       <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
@@ -1153,16 +1078,6 @@
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="64"/>
       <source>AC-Out MP</source>
       <translation>AC-Out MP</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="52"/>
-      <source>AC-In1 L%1</source>
-      <translation type="unfinished">AC-In1 L%1</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="56"/>
-      <source>AC-In1 --</source>
-      <translation type="unfinished">AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="70"/>
@@ -1330,12 +1245,6 @@
       <source>Reset service timer</source>
       <translation>Resetowanie zegara serwisowego</translation>
     </message>
-    <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
-      <source>Volume</source>
-      <extracomment>Title for a list of units of volume (e.g. cubic metres, litres, gallons)</extracomment>
-      <translation type="unfinished">Objętość</translation>
-    </message>
     <message id="settings_gps_format">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="69"/>
       <source>Format</source>
@@ -1438,42 +1347,6 @@ Jeśli to nie zadziała, sprawdź kartę sim w telefonie, aby upewnić się, że
       <source>Wrong PIN</source>
       <translation>Nieprawidłowy PIN</translation>
     </message>
-    <message id="page_settings_gsm_ok">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>OK</source>
-      <translation type="unfinished">OK</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="128"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">Nieznany błąd</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_state">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="153"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Nieznany</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_value">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="182"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Nieznany</translation>
-    </message>
-    <message id="page_settings_gsm_offline">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="173"/>
-      <source>Offline</source>
-      <translation type="unfinished">Offline</translation>
-    </message>
-    <message id="page_settings_gsm_connecting">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="176"/>
-      <source>Connecting</source>
-      <translation type="unfinished">Łączenie</translation>
-    </message>
-    <message id="page_settings_gsm_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="179"/>
-      <source>Connected</source>
-      <translation type="unfinished">Podłączony</translation>
-    </message>
     <message id="page_settings_gsm_pin">
       <location filename="../../pages/settings/PageSettingsGsm.qml" line="191"/>
       <source>PIN</source>
@@ -1530,32 +1403,32 @@ Jeśli to nie zadziała, sprawdź kartę sim w telefonie, aby upewnić się, że
       <translation>Pomiary sieciowe</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
       <source>External meter</source>
       <translation>Miernik zewnętrzny</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="67"/>
       <source>Inverter/Charger</source>
       <translation>Inwerter/Ładowarka</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
       <source>Multiphase regulation</source>
       <translation>Regulacja wielofazowa</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="91"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
       <source>Total of all phases</source>
       <translation>Suma wszystkich faz</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="95"/>
       <source>Individual phase</source>
       <translation>Faza indywidualna</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="99"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="101"/>
       <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
@@ -1564,68 +1437,13 @@ CAUTION: Use only if required by the utility provider.</source>
 UWAGA: Używać tylko wtedy, gdy jest to wymagane przez dostawcę mediów.</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="104"/>
       <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
       <translation>Suma wszystkich faz jest inteligentnie regulowana w celu osiągnięcia wartości zadanej sieci (wydajność systemu jest zoptymalizowana).
 
 Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
-    </message>
-    <message id="settings_ess_min_soc">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation type="unfinished">Minimalny SOC (o ile nie nastąpi awaria sieci)</translation>
-    </message>
-    <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="129"/>
-      <source>Active SOC limit</source>
-      <translation type="unfinished">Aktywny limit SOC</translation>
-    </message>
-    <message id="settings_ess_battery_life_sustain">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
-      <source>Sustain</source>
-      <translation type="unfinished">Podtrzymanie</translation>
-    </message>
-    <message id="settings_ess_battery_life_recharge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="157"/>
-      <source>Recharge</source>
-      <translation type="unfinished">Ładowanie ponowne</translation>
-    </message>
-    <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <source>Scheduled charge levels</source>
-      <translation type="unfinished">Zaplanowane poziomy ładowania</translation>
-    </message>
-    <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="257"/>
-      <source>Active (%1)</source>
-      <translation type="unfinished">Aktywny (%1)</translation>
-    </message>
-    <message id="settings_ess_inactive">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="259"/>
-      <source>Inactive</source>
-      <translation type="unfinished">Nieaktywny</translation>
-    </message>
-    <message id="settings_ess_dynamic">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="293"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">Dynamiczny ESS</translation>
-    </message>
-    <message id="settings_ess_deprecated">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="319"/>
-      <source>Deprecated settings</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_charge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="326"/>
-      <source>Battery charge limit (% of CCL)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_discharge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="337"/>
-      <source>Battery discharge limit (% of DCL)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_rs_ess_min_soc">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="40"/>
@@ -1637,13 +1455,8 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <source>Active SOC limit</source>
       <translation>Aktywny limit SOC</translation>
     </message>
-    <message id="scheduled_charge_inactive">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
-      <source>Inactive</source>
-      <translation type="unfinished">Nieaktywny</translation>
-    </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="245"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="247"/>
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
       <source>Peak shaving</source>
       <translation>Równanie wartości szczytowych</translation>
@@ -1659,12 +1472,12 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <translation>Zawsze</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="151"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
       <source>Discharge disabled</source>
       <translation>Rozładowanie wyłączone</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
       <source>Slow charge</source>
       <translation>Powolne ładowanie</translation>
     </message>
@@ -1679,32 +1492,32 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <translation>Ładowanie ponowne</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="165"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="167"/>
       <source>Limit charge power</source>
       <translation>Limit mocy ładowania</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="183"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="185"/>
       <source>Maximum charge power</source>
       <translation>Maksymalna moc ładowania</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="196"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="198"/>
       <source>Limit inverter power</source>
       <translation>Limit mocy inwertera</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="214"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="216"/>
       <source>Maximum inverter power</source>
       <translation>Maksymalna moc inwertera</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="225"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="227"/>
       <source>Grid setpoint</source>
       <translation>Wartość zadana sieci</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="236"/>
       <source>Grid feed-in</source>
       <translation>Zasilanie z sieci</translation>
     </message>
@@ -1743,8 +1556,8 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <source>Door alarm</source>
       <translation>Alarm drzwiowy</translation>
     </message>
-    <message id="digitalinputs_type_bilgepump">
-      <location filename="../../src/enums.cpp" line="201"/>
+    <message id="switchable_output_bilge_pump">
+      <location filename="../../src/enums.cpp" line="424"/>
       <source>Bilge pump</source>
       <translation>Pompa zęzowa</translation>
     </message>
@@ -1796,11 +1609,6 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <source>Deferred by %1s</source>
       <extracomment>%1 = number of seconds</extracomment>
       <translation>Odroczone o %1s</translation>
-    </message>
-    <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="75"/>
-      <source>Are you sure?</source>
-      <translation type="unfinished">Jesteś pewien?</translation>
     </message>
     <message id="settings_vrm_portal_id">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="87"/>
@@ -1939,11 +1747,6 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <source>External storage</source>
       <translation>Pamięć zewnętrzna</translation>
     </message>
-    <message id="settings_vrm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="308"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">Nieznany błąd</translation>
-    </message>
     <message id="settings_vrm_no_error">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="311"/>
       <source>No Error</source>
@@ -2029,37 +1832,10 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <source>Function</source>
       <translation>Funkcja</translation>
     </message>
-    <message id="settings_relay_disabled">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="54"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="98"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Wyłączone</translation>
-    </message>
     <message id="settings_relay_alarm_relay">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="56"/>
       <source>Alarm relay</source>
       <translation>Przekaźnik alarmowy</translation>
-    </message>
-    <message id="settings_relay_tank_pump">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="62"/>
-      <source>Tank pump</source>
-      <translation type="unfinished">Pompa zbiornika</translation>
-    </message>
-    <message id="settings_relay_manual">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="64"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="100"/>
-      <source>Manual</source>
-      <translation type="unfinished">Ręcznie</translation>
-    </message>
-    <message id="settings_relay_polarity_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
-      <source>Polarity (Relay 1)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_relay_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
-      <source>Polarity</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_normally_open">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="83"/>
@@ -2075,11 +1851,6 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="93"/>
       <source>Function (Relay 2)</source>
       <translation>Funkcja (Przekaźnik 2)</translation>
-    </message>
-    <message id="settings_relay_polarity_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
-      <source>Polarity (Relay 2)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_temp_control_rules">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="119"/>
@@ -2111,12 +1882,6 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
       <source>Press to boot</source>
       <translation>Naciśnij, aby uruchomić</translation>
-    </message>
-    <message id="settings_firmware_backup_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
-      <translation type="unfinished">Firmware %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
@@ -2152,6 +1917,7 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
     <message id="nav_boat">
       <location filename="../../pages/boat/BoatPage.qml" line="14"/>
       <source>Boat</source>
+      <extracomment>The 'Boat' page</extracomment>
       <translation>Łódź</translation>
     </message>
     <message id="settings_system_name">
@@ -2219,11 +1985,6 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <source>Solar charger current control</source>
       <translation>Regulacja prądu ładowarki słonecznej</translation>
     </message>
-    <message id="settings_system_status_bms_params">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
-      <source>BMS control</source>
-      <translation type="unfinished">Kontrola BMS</translation>
-    </message>
     <message id="common_words_bms_control">
       <location filename="../../components/CommonWords.qml" line="101"/>
       <source>BMS control</source>
@@ -2238,11 +1999,6 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
       <source>Pump state</source>
       <translation>Stan pompy</translation>
-    </message>
-    <message id="settings_pump_auto">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="56"/>
-      <source>Auto</source>
-      <translation type="unfinished">Auto</translation>
     </message>
     <message id="settings_tank_sensor">
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
@@ -2271,11 +2027,6 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="35"/>
       <source>Unplugged</source>
       <translation>Odłączone</translation>
-    </message>
-    <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="16"/>
-      <source>Name</source>
-      <translation type="unfinished">Nazwa</translation>
     </message>
     <message id="settings_tcpip_hidden">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="21"/>
@@ -2317,16 +2068,6 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="99"/>
       <source>IP configuration</source>
       <translation>Konfiguracja IP</translation>
-    </message>
-    <message id="settings_tcpip_manual">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="105"/>
-      <source>Manual</source>
-      <translation type="unfinished">Ręcznie</translation>
-    </message>
-    <message id="settings_tcpip_off">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="107"/>
-      <source>Off</source>
-      <translation type="unfinished">Wył.</translation>
     </message>
     <message id="settings_tcpip_fixed">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="109"/>
@@ -2382,21 +2123,6 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="30"/>
       <source>Create access point</source>
       <translation>Utwórz punkt dostępu</translation>
-    </message>
-    <message id="settings_wifi_access_point_enter_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="68"/>
-      <source>Enter password</source>
-      <translation type="unfinished">Wprowadź hasło</translation>
-    </message>
-    <message id="page_settings_wifi_invalid_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
-      <source>Password length must be either 0 or between 10 and 63 characters long</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_wifi_password_updated">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
-      <source>Password updated</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_wifi_networks">
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="86"/>
@@ -2539,20 +2265,10 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <extracomment>Network status: Standalone</extracomment>
       <translation>Standalone</translation>
     </message>
-    <message id="charger_standalone">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="45"/>
-      <source>Standalone</source>
-      <translation type="unfinished">Standalone</translation>
-    </message>
     <message id="charger_charge">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="48"/>
       <source>Charge</source>
       <translation>Ładowanie</translation>
-    </message>
-    <message id="charger_external_control">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="51"/>
-      <source>External control</source>
-      <translation type="unfinished">Sterowanie zewnętrzne</translation>
     </message>
     <message id="charger_charge_hub_1">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="54"/>
@@ -2584,16 +2300,6 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <source>Master setting</source>
       <translation>Ustawienie Mastera</translation>
     </message>
-    <message id="charger_slave">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="85"/>
-      <source>Slave</source>
-      <translation type="unfinished">Slave</translation>
-    </message>
-    <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation type="unfinished">Napięcie ładowania</translation>
-    </message>
     <message id="systemsettings_networkstatus_slave">
       <location filename="../../data/SystemSettings.qml" line="148"/>
       <source>Slave</source>
@@ -2615,14 +2321,15 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <source>Group &amp; Charge master</source>
       <translation>Group &amp; Charge master</translation>
     </message>
-    <message id="genset_charge_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="365"/>
+    <message id="charger_charge_voltage">
+      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
       <source>Charge voltage</source>
       <translation>Napięcie ładowania</translation>
     </message>
     <message id="common_words_reset">
       <location filename="../../components/CommonWords.qml" line="448"/>
       <source>Reset</source>
+      <extracomment>Reset the BMS control</extracomment>
       <translation>Resetuj</translation>
     </message>
     <message id="solarcharger_load">
@@ -2651,14 +2358,14 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <extracomment>Voltage alarm is at "Warning" level</extracomment>
       <translation>Ostrzeżenie</translation>
     </message>
-    <message id="listitems_alarm_level_alarm">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="25"/>
+    <message id="digitalinputs_state_alarm">
+      <location filename="../../src/enums.cpp" line="270"/>
       <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
+      <extracomment>Relay function is 'alarm'</extracomment>
       <translation>Alarm</translation>
     </message>
-    <message id="devicelist_tankshape_volume">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="190"/>
+    <message id="components_volumeunit_volume">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
       <source>Volume</source>
       <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
       <translation>Objętość</translation>
@@ -2808,26 +2515,10 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <source>Relay function</source>
       <translation>Funkcja przekaźnika</translation>
     </message>
-    <message id="batterysettingrelay_alarm">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation type="unfinished">Alarm</translation>
-    </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
       <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
       <source>Charger or generator start/stop</source>
       <translation>Ładowarka lub generator start/stop</translation>
-    </message>
-    <message id="batterysettingrelay_manual_control">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
-      <source>Manual control</source>
-      <translation type="unfinished">Sterowanie ręczne</translation>
-    </message>
-    <message id="batterysettingrelay_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">Przepalony bezpiecznik</translation>
     </message>
     <message id="common_words_manual_control">
       <location filename="../../components/CommonWords.qml" line="302"/>
@@ -2853,12 +2544,6 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
       <source>Status LEDs</source>
       <translation>Diody stanu</translation>
-    </message>
-    <message id="batterydiagnostics_none">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
-      <source>None</source>
-      <extracomment>Indicates no alarm is set</extracomment>
-      <translation type="unfinished">Brak</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
@@ -2888,7 +2573,7 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
     <message id="common_words_switch">
       <location filename="../../components/CommonWords.qml" line="525"/>
       <source>Switch</source>
-      <extracomment>Change the mode value</extracomment>
+      <extracomment>Change the battery mode</extracomment>
       <translation>Przełącznik</translation>
     </message>
     <message id="devicelist_battery_initializing">
@@ -2956,21 +2641,6 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <source>Top section voltage</source>
       <translation>Napięcie sekcji górnej</translation>
     </message>
-    <message id="battery_bank_error_communication">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="96"/>
-      <source>Communication error</source>
-      <translation type="unfinished">Błąd komunikacji</translation>
-    </message>
-    <message id="battery_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="182"/>
-      <source>State of health</source>
-      <translation type="unfinished">Stan ogólny</translation>
-    </message>
-    <message id="battery_bus_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="212"/>
-      <source>Bus voltage</source>
-      <translation type="unfinished">Napięcie magistrali</translation>
-    </message>
     <message id="battery_bottom_section_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="228"/>
       <source>Bottom section voltage</source>
@@ -3016,16 +2686,6 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <source>IO</source>
       <translation>IO</translation>
     </message>
-    <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="391"/>
-      <source>System</source>
-      <translation type="unfinished">System</translation>
-    </message>
-    <message id="battery_press_to_redetect">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="433"/>
-      <source>Press to redetect</source>
-      <translation type="unfinished">Naciśnij, aby wykryć ponownie</translation>
-    </message>
     <message id="pagesettingsgeneral_system">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="107"/>
       <source>System</source>
@@ -3066,16 +2726,6 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <source>Low SOC</source>
       <translation>Niski SOC</translation>
     </message>
-    <message id="batteryalarms_high_battery_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
-      <source>High battery voltage</source>
-      <translation type="unfinished">Wysokie napięcie akumulatora</translation>
-    </message>
-    <message id="batteryalarms_low_soc">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low SOC</source>
-      <translation type="unfinished">Niski SOC</translation>
-    </message>
     <message id="batteryalarms_low_starter_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="73"/>
       <source>Low starter voltage</source>
@@ -3095,11 +2745,6 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
       <source>Mid-point voltage</source>
       <translation>Napięcie środkowe</translation>
-    </message>
-    <message id="batteryalarms_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">Przepalony bezpiecznik</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
@@ -3293,11 +2938,6 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <source>Restore factory defaults</source>
       <translation>Przywrócenie ustawień fabrycznych</translation>
     </message>
-    <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation type="unfinished">Naciśnij, aby przywrócić</translation>
-    </message>
     <message id="vebus_backup_press_to_restore">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="362"/>
       <source>Press to restore</source>
@@ -3337,11 +2977,6 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="18"/>
       <source>Capacity</source>
       <translation>Pojemność</translation>
-    </message>
-    <message id="batterysettingsbattery_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
-      <source>Capacity</source>
-      <translation type="unfinished">Pojemność</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
@@ -3418,11 +3053,6 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <source>No power on busbar</source>
       <translation>Brak prądu na szynie zbiorczej</translation>
     </message>
-    <message id="lynxdistributor_connection_lost">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
-      <source>Connection lost</source>
-      <translation type="unfinished">Utrata połączenia</translation>
-    </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
       <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
       <source>%n fuse(s) blown</source>
@@ -3431,6 +3061,7 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
         <numerusform>Przepalony bezpiecznik %n</numerusform>
         <numerusform>Przepalone bezpieczniki %n</numerusform>
         <numerusform>Przepalone bezpieczniki %n</numerusform>
+        <numerusform>Przepalony(e) bezpiecznik(i) %n</numerusform>
       </translation>
     </message>
     <message id="lynxdistributor_no_information_available">
@@ -3459,26 +3090,6 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <source>Shutdowns due error</source>
       <translation>Wyłączenia z powodu błędu</translation>
     </message>
-    <message id="lynxiondiagnostics_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
-      <source>Last error</source>
-      <translation type="unfinished">Ostatni błąd</translation>
-    </message>
-    <message id="lynxiondiagnostics_2nd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
-      <source>2nd last error</source>
-      <translation type="unfinished">2. ostatni błąd</translation>
-    </message>
-    <message id="lynxiondiagnostics_3rd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
-      <source>3rd last error</source>
-      <translation type="unfinished">3. ostatni błąd</translation>
-    </message>
-    <message id="lynxiondiagnostics_4th_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
-      <source>4th last error</source>
-      <translation type="unfinished">4. ostatni błąd</translation>
-    </message>
     <message id="lynxionio_system_switch">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
       <source>System Switch</source>
@@ -3498,11 +3109,6 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <location filename="../../components/CommonWords.qml" line="54"/>
       <source>Batteries</source>
       <translation>Akumulatory</translation>
-    </message>
-    <message id="lynxionsystem_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
-      <source>Capacity</source>
-      <translation type="unfinished">Pojemność</translation>
     </message>
     <message id="lynxionsystem_parallel">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="30"/>
@@ -3524,20 +3130,10 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <source>Min/max cell temperature</source>
       <translation>Min/max temperatura celi</translation>
     </message>
-    <message id="lynxionsystem_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="92"/>
-      <source>Balancing</source>
-      <translation type="unfinished">Balansowanie</translation>
-    </message>
     <message id="lynxionsystem_balancer_balancing">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
       <source>Balancing</source>
       <translation>Balansowanie</translation>
-    </message>
-    <message id="lynxionsystem_balancer_unknown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="117"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Nieznany</translation>
     </message>
     <message id="dc_output">
       <location filename="../../components/listitems/ListDcOutputQuantityGroup.qml" line="16"/>
@@ -3645,11 +3241,6 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <source>Remaining</source>
       <translation>Pozostało</translation>
     </message>
-    <message id="devicelist_tanksensor_sensor_battery">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="51"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">Akumulator czujników</translation>
-    </message>
     <message id="temperature_sensor_battery">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="112"/>
       <source>Sensor battery</source>
@@ -3678,7 +3269,7 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
     <message id="devicelist_tanksetup_custom">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="53"/>
       <source>Custom</source>
-      <translation type="unfinished">Niestandardowe</translation>
+      <translation>Niestandardowe</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="59"/>
@@ -3711,34 +3302,34 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <translation>Wartość czujnika</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="75"/>
       <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
       <translation>Nie zdefiniowano niestandardowego kształtu. Można zdefiniować jeden z maksymalnie dziesięcioma punktami. Należy pamiętać, że wartości 0% i 100% są domyślne.</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="91"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="89"/>
       <source>Point %1</source>
       <extracomment>%1 = the point number</extracomment>
       <translation>Punkt %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="133"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="179"/>
       <source>Add point</source>
       <translation>Dodaj punkt</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="156"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="205"/>
       <source>Sensor level</source>
       <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
       <translation>Poziom czujnika</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="256"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="311"/>
       <source>Duplicate sensor level values are not allowed.</source>
       <translation>Zduplikowane wartości poziomu czujnika są niedozwolone.</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="262"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="317"/>
       <source>Volume values must be increasing.</source>
       <translation>Wartości wolumenu muszą rosnąć.</translation>
     </message>
@@ -3778,11 +3369,6 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <source>Switch position</source>
       <translation>Pozycja przełącznika</translation>
     </message>
-    <message id="ac-in-setup_single_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="142"/>
-      <source>Single phase</source>
-      <translation type="unfinished">Jednofazowy</translation>
-    </message>
     <message id="ac-in-setup_two_phase">
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="144"/>
       <source>2-phase</source>
@@ -3792,11 +3378,6 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="146"/>
       <source>3-phase</source>
       <translation>3-fazowy</translation>
-    </message>
-    <message id="ac-in-setup_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="161"/>
-      <source>Devices</source>
-      <translation type="unfinished">Urządzenia</translation>
     </message>
     <message id="ac-in-genset_ac">
       <location filename="../../components/PageGensetModel.qml" line="194"/>
@@ -3890,12 +3471,6 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <extracomment>%1 = CT device number</extracomment>
       <translation>CT %1</translation>
     </message>
-    <message id="smappeect_phase_none">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation type="unfinished">Brak</translation>
-    </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
       <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
       <source>Flashing LED indicates this CT</source>
@@ -3909,11 +3484,13 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
     <message id="common_words_setting_disabled_when_dmc_connected">
       <location filename="../../components/CommonWords.qml" line="355"/>
       <source>This setting is disabled when a Digital Multi Control is connected.</source>
+      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>To ustawienie jest wyłączone, gdy podłączone jest cyfrowe urządzenie Multi Control.</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
       <location filename="../../components/CommonWords.qml" line="358"/>
       <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>To ustawienie jest wyłączone, gdy podłączony jest VE.Bus BMS.</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
@@ -3931,16 +3508,6 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="21"/>
       <source>Inverted</source>
       <translation>Odwrócona</translation>
-    </message>
-    <message id="digitalinput_enable_alarm">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="48"/>
-      <source>Enable alarm</source>
-      <translation type="unfinished">Włącz alarm</translation>
-    </message>
-    <message id="digitalinput_inverted">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="54"/>
-      <source>Inverted</source>
-      <translation type="unfinished">Odwrócona</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
       <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="60"/>
@@ -3977,16 +3544,6 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <source>Wind speed</source>
       <translation>Prędkość wiatru</translation>
     </message>
-    <message id="page_meteo_battery_voltage">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="99"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">Akumulator czujników</translation>
-    </message>
-    <message id="meteo_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="120"/>
-      <source>Low</source>
-      <translation type="unfinished">Niski</translation>
-    </message>
     <message id="page_meteo_settings_auto_detect">
       <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
       <source>Auto-detect</source>
@@ -4017,16 +3574,6 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <source>Reset counter</source>
       <translation>Wyzeruj licznik</translation>
     </message>
-    <message id="temperature_short_circuited">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="32"/>
-      <source>Short circuited</source>
-      <translation type="unfinished">Zwarcie</translation>
-    </message>
-    <message id="temperature_reverse_polarity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="35"/>
-      <source>Reverse polarity</source>
-      <translation type="unfinished">Odwrotna polaryzacja</translation>
-    </message>
     <message id="temperature_sensor_battery_low">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
       <source>Sensor battery low</source>
@@ -4041,36 +3588,6 @@ Używać, o ile nie jest to zabronione przez dostawcę mediów.</translation>
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="62"/>
       <source>Pressure</source>
       <translation>Ciśnienie</translation>
-    </message>
-    <message id="temperature_pm25">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
-      <source>PM2.5</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_co2">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>CO₂</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_voc">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
-      <source>VOC index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_nox">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
-      <source>NOx index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_luminosity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
-      <source>Luminosity</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="133"/>
-      <source>Low</source>
-      <translation type="unfinished">Niski</translation>
     </message>
     <message id="temperature_offset">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
@@ -4124,25 +3641,10 @@ UWAGA: Aktualizacja może tymczasowo zatrzymać system.</translation>
       <source>Updating the MK3, values will reappear after the update is complete</source>
       <translation>Aktualizacja MK3, wartości pojawią się ponownie po jej zakończeniu</translation>
     </message>
-    <message id="vebus_device_charging_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="78"/>
-      <source>Charging the battery to 100%</source>
-      <translation type="unfinished">Ładowanie akumulatora do 100%</translation>
-    </message>
     <message id="vebus_device_charging_the_battery_to_100">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="93"/>
       <source>Charging the battery to 100%</source>
       <translation>Ładowanie akumulatora do 100%</translation>
-    </message>
-    <message id="vebus_device_page_microgrid_parameters">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
-      <source>Microgrid parameters</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="vebus_device_page_advanced">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
-      <source>Advanced</source>
-      <translation type="unfinished">Zaawansowane</translation>
     </message>
     <message id="vebus_device_in_progress">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="80"/>
@@ -4198,15 +3700,15 @@ Czy chcesz kontynuować?</translation>
       <source>DC Current</source>
       <translation>Prąd DC</translation>
     </message>
+    <message id="vebus_device_page_advanced">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
+      <source>Advanced</source>
+      <translation>Zaawansowane</translation>
+    </message>
     <message id="common_words_alarm_setup">
       <location filename="../../components/CommonWords.qml" line="65"/>
       <source>Alarm setup</source>
       <translation>Ustawienia alarmu</translation>
-    </message>
-    <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
-      <translation type="unfinished">VE.Bus BMS w razie potrzeby automatycznie wyłącza system, aby chronić akumulator. Sterowanie systemem z poziomu Color Control nie jest więc możliwe.</translation>
     </message>
     <message id="vebus_device_bms_not_found">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="240"/>
@@ -4247,7 +3749,7 @@ Czy chcesz kontynuować?</translation>
     <message id="vebus_device_starting">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="117"/>
       <source>Starting...</source>
-      <translation type="unfinished">Rozpoczynanie...</translation>
+      <translation>Rozpoczynanie...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="120"/>
@@ -4313,16 +3815,6 @@ Czy chcesz kontynuować?</translation>
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="260"/>
       <source>ESS Relay test</source>
       <translation>Badanie przekaźnika ESS</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_completed">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="266"/>
-      <source>Completed</source>
-      <translation type="unfinished">Zakończono</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_pending">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="268"/>
-      <source>Pending</source>
-      <translation type="unfinished">W oczekiwaniu...</translation>
     </message>
     <message id="cycle_history_completed">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
@@ -4509,6 +4001,7 @@ Czy chcesz kontynuować?</translation>
     <message id="rssystemalarms_overload">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
       <source>Overload</source>
+      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
       <translation>Przeciążenie</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
@@ -4521,11 +4014,6 @@ Czy chcesz kontynuować?</translation>
       <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
       <source>Voltage Sensor</source>
       <translation>Czujnik Napięcia</translation>
-    </message>
-    <message id="vebus_device_phase_rotation">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
-      <source>Phase rotation</source>
-      <translation type="unfinished"/>
     </message>
     <message id="rssystemalarms_phase_rotation">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
@@ -4557,12 +4045,6 @@ Czy chcesz kontynuować?</translation>
       <source>VE.Bus BMS version</source>
       <translation>Wersja VE.Bus BMS</translation>
     </message>
-    <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="15"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="52"/>
-      <source>Minimum SOC</source>
-      <translation type="unfinished">Minimalny SOC</translation>
-    </message>
     <message id="ess_unless_grid_fails">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="32"/>
       <source>Unless grid fails</source>
@@ -4582,7 +4064,7 @@ Czy chcesz kontynuować?</translation>
     <message id="common_words_ac_input_role">
       <location filename="../../components/CommonWords.qml" line="24"/>
       <source>Role</source>
-      <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
       <translation>Rola</translation>
     </message>
     <message id="common_words_ac_load">
@@ -4621,18 +4103,6 @@ Czy chcesz kontynuować?</translation>
       <source>Active</source>
       <extracomment>Status is 'active'</extracomment>
       <translation>Aktywny</translation>
-    </message>
-    <message id="common_words_alarm">
-      <location filename="../../components/CommonWords.qml" line="51"/>
-      <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
-      <translation type="unfinished">Alarm</translation>
-    </message>
-    <message id="common_words_alarm_setting_overload">
-      <location filename="../../components/CommonWords.qml" line="58"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation type="unfinished">Przeciążenie</translation>
     </message>
     <message id="common_words_alarm_status">
       <location filename="../../components/CommonWords.qml" line="68"/>
@@ -4679,8 +4149,8 @@ Czy chcesz kontynuować?</translation>
       <source>Charge current</source>
       <translation>Prąd ładowania</translation>
     </message>
-    <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="125"/>
+    <message id="battery_mode_charging">
+      <location filename="../../src/enums.cpp" line="30"/>
       <source>Charging</source>
       <extracomment>"Charging" state</extracomment>
       <translation>Ładowanie</translation>
@@ -4694,7 +4164,7 @@ Czy chcesz kontynuować?</translation>
     <message id="digitalinputs_state_closed">
       <location filename="../../src/enums.cpp" line="262"/>
       <source>Closed</source>
-      <extracomment>Digital input state</extracomment>
+      <extracomment>Status is 'closed'</extracomment>
       <translation>Zamknięte</translation>
     </message>
     <message id="evchargers_status_connected">
@@ -4702,8 +4172,8 @@ Czy chcesz kontynuować?</translation>
       <source>Connected</source>
       <translation>Podłączony</translation>
     </message>
-    <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="143"/>
+    <message id="temperature_slider_current">
+      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
       <source>Current</source>
       <extracomment>Electric current, as measured in Amps</extracomment>
       <translation>Prąd</translation>
@@ -4730,9 +4200,10 @@ Czy chcesz kontynuować?</translation>
       <extracomment>Title for device information</extracomment>
       <translation>Urządzenie</translation>
     </message>
-    <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="172"/>
+    <message id="battery_mode_discharging">
+      <location filename="../../src/enums.cpp" line="34"/>
       <source>Discharging</source>
+      <extracomment>Battery mode</extracomment>
       <translation>Rozładowanie</translation>
     </message>
     <message id="wifimodel_disconnected">
@@ -4818,13 +4289,14 @@ Czy chcesz kontynuować?</translation>
       <source>%1 Hour(s)</source>
       <translation>%1 Godzina(y)</translation>
     </message>
-    <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="251"/>
+    <message id="battery_mode_idle">
+      <location filename="../../src/enums.cpp" line="26"/>
       <source>Idle</source>
+      <extracomment>Battery mode</extracomment>
       <translation>Bezczynność</translation>
     </message>
-    <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="258"/>
+    <message id="scheduled_charge_inactive">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
       <source>Inactive</source>
       <extracomment>Status is 'inactive'</extracomment>
       <translation>Nieaktywny</translation>
@@ -4926,8 +4398,8 @@ Czy chcesz kontynuować?</translation>
       <source>Offline</source>
       <translation>Offline</translation>
     </message>
-    <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="17"/>
+    <message id="digitalinputs_state_ok">
+      <location filename="../../src/enums.cpp" line="266"/>
       <source>OK</source>
       <extracomment>Voltage alarm is at "OK" level</extracomment>
       <translation>OK</translation>
@@ -4935,6 +4407,7 @@ Czy chcesz kontynuować?</translation>
     <message id="switchable_output_on">
       <location filename="../../src/enums.cpp" line="471"/>
       <source>On</source>
+      <extracomment>Digital input state</extracomment>
       <translation>Wł.</translation>
     </message>
     <message id="common_words_online">
@@ -4945,7 +4418,7 @@ Czy chcesz kontynuować?</translation>
     <message id="digitalinputs_state_open">
       <location filename="../../src/enums.cpp" line="258"/>
       <source>Open</source>
-      <extracomment>Digital input open</extracomment>
+      <extracomment>Status is 'open'</extracomment>
       <translation>Otwórz</translation>
     </message>
     <message id="common_words_password">
@@ -5005,9 +4478,10 @@ Czy chcesz kontynuować?</translation>
       <source>Remove</source>
       <translation>Usuń</translation>
     </message>
-    <message id="switch_state_running">
-      <location filename="../../src/enums.cpp" line="363"/>
+    <message id="switchable_output_running">
+      <location filename="../../src/enums.cpp" line="468"/>
       <source>Running</source>
+      <extracomment>Status = "running"</extracomment>
       <translation>W toku</translation>
     </message>
     <message id="common_words_scanning">
@@ -5074,7 +4548,7 @@ Czy chcesz kontynuować?</translation>
     <message id="pvinverter_statusCode_startup">
       <location filename="../../src/enums.cpp" line="296"/>
       <source>Startup (%1)</source>
-      <extracomment>PV inverter status code. %1 = the startup status number</extracomment>
+      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
       <translation>Uruchomienie (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
@@ -5129,8 +4603,10 @@ Czy chcesz kontynuować?</translation>
       <source>Unique Identity Number</source>
       <translation>Unikalny Numer Identyfikacyjny</translation>
     </message>
-    <message id="settings_radio_button_group_unknown">
-      <location filename="../../components/listitems/core/ListRadioButtonGroup.qml" line="44"/>
+    <message id="Unknown">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
       <source>Unknown</source>
       <translation>Nieznany</translation>
     </message>
@@ -5285,11 +4761,6 @@ Czy chcesz kontynuować?</translation>
       <source>Error while checking for firmware updates</source>
       <translation>Błąd podczas sprawdzania aktualizacji oprogramowania</translation>
     </message>
-    <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation type="unfinished">Błąd podczas sprawdzania aktualizacji oprogramowania</translation>
-    </message>
     <message id="settings_firmware_downloading_and_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="63"/>
       <source>Downloading and installing firmware %1...</source>
@@ -5316,6 +4787,66 @@ Czy chcesz kontynuować?</translation>
       <source>No firmware found</source>
       <translation>Nie znaleziono oprogramowania</translation>
     </message>
+    <message id="tank_type_fuel">
+      <location filename="../../src/enums.cpp" line="495"/>
+      <source>Fuel</source>
+      <translation>Paliwo</translation>
+    </message>
+    <message id="tank_type_fresh_water">
+      <location filename="../../src/enums.cpp" line="498"/>
+      <source>Fresh water</source>
+      <translation>Woda słodka</translation>
+    </message>
+    <message id="tank_type_waste_water">
+      <location filename="../../src/enums.cpp" line="501"/>
+      <source>Waste water</source>
+      <translation>Ścieki</translation>
+    </message>
+    <message id="tank_type_live_well">
+      <location filename="../../src/enums.cpp" line="504"/>
+      <source>Live well</source>
+      <translation>Zbiornik na ryby</translation>
+    </message>
+    <message id="tank_type_oil">
+      <location filename="../../src/enums.cpp" line="507"/>
+      <source>Oil</source>
+      <translation>Olej</translation>
+    </message>
+    <message id="tank_type_black_water">
+      <location filename="../../src/enums.cpp" line="510"/>
+      <source>Black water</source>
+      <translation>Czarna woda</translation>
+    </message>
+    <message id="tank_type_gasoline">
+      <location filename="../../src/enums.cpp" line="513"/>
+      <source>Gasoline</source>
+      <translation>Benzyna</translation>
+    </message>
+    <message id="tank_type_diesel">
+      <location filename="../../src/enums.cpp" line="516"/>
+      <source>Diesel</source>
+      <translation>Diesel</translation>
+    </message>
+    <message id="tank_type_lpg">
+      <location filename="../../src/enums.cpp" line="519"/>
+      <source>LPG</source>
+      <translation>LPG</translation>
+    </message>
+    <message id="tank_type_lng">
+      <location filename="../../src/enums.cpp" line="522"/>
+      <source>LNG</source>
+      <translation>LNG</translation>
+    </message>
+    <message id="tank_type_hydraulic_oil">
+      <location filename="../../src/enums.cpp" line="525"/>
+      <source>Hydraulic oil</source>
+      <translation>Olej hydrauliczny</translation>
+    </message>
+    <message id="tank_type_raw_water">
+      <location filename="../../src/enums.cpp" line="528"/>
+      <source>Raw water</source>
+      <translation>Woda surowa</translation>
+    </message>
     <message id="listItem_no_access">
       <location filename="../../components/listitems/core/ListItem.qml" line="102"/>
       <source>Setting locked for access level</source>
@@ -5329,6 +4860,7 @@ Czy chcesz kontynuować?</translation>
     <message id="welcome_brief_title">
       <location filename="../../pages/welcome/WelcomeView.qml" line="81"/>
       <source>Brief</source>
+      <extracomment>The 'Brief' page</extracomment>
       <translation>Krótki</translation>
     </message>
     <message id="welcome_overview_title">
@@ -5345,23 +4877,6 @@ Czy chcesz kontynuować?</translation>
       <location filename="../../pages/NotificationsPage.qml" line="13"/>
       <source>Notifications</source>
       <translation>Powiadomienia</translation>
-    </message>
-    <message id="notifications_page_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="43"/>
-      <source>Active Notifications</source>
-      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_page_inactive_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="47"/>
-      <source>Inactive Notifications</source>
-      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_no_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="106"/>
-      <source>No active notifications</source>
-      <translation type="unfinished"/>
     </message>
     <message id="utils_formatTimestamp_now">
       <location filename="../../components/Utils.js" line="258"/>
@@ -5466,11 +4981,6 @@ Czy chcesz kontynuować?</translation>
       <source>Self-consumption above limit</source>
       <translation>Zużycie własne powyżej limitu</translation>
     </message>
-    <message id="cgwacs_battery_schedule_pv">
-      <location filename="../../components/listitems/ListChargeSchedule.qml" line="171"/>
-      <source>PV</source>
-      <translation type="unfinished">PV</translation>
-    </message>
     <message id="settings_multirs_pv">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="185"/>
       <source>PV</source>
@@ -5481,8 +4991,8 @@ Czy chcesz kontynuować?</translation>
       <source>PV &amp; Battery</source>
       <translation>PV i Akumulator</translation>
     </message>
-    <message id="settings_firmware_checking">
-      <location filename="../../components/listitems/ListFirmwareCheckButton.qml" line="16"/>
+    <message id="pagesettingssupportstate_firmware_checking">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
       <source>Checking...</source>
       <translation>Sprawdzanie...</translation>
     </message>
@@ -5490,12 +5000,6 @@ Czy chcesz kontynuować?</translation>
       <location filename="../../components/listitems/ListAlarmState.qml" line="11"/>
       <source>Alarm state</source>
       <translation>Stan alarmów</translation>
-    </message>
-    <message id="devicelist_battery_alarm_state">
-      <location filename="../../components/listitems/ListAlarmState.qml" line="19"/>
-      <source>Alarm</source>
-      <extracomment>Alarm state is active</extracomment>
-      <translation type="unfinished">Alarm</translation>
     </message>
     <message id="clear_history_button_clear_history">
       <location filename="../../components/listitems/ListClearHistoryButton.qml" line="15"/>
@@ -5647,11 +5151,6 @@ Czy chcesz kontynuować?</translation>
       <source>Max Voltage</source>
       <translation>Maks. Napięcie</translation>
     </message>
-    <message id="charger_history_box_max_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="64"/>
-      <source>Max Voltage</source>
-      <translation type="unfinished">Maks. Napięcie</translation>
-    </message>
     <message id="charger_history_box_max_current">
       <location filename="../../components/SolarDetailBox.qml" line="70"/>
       <source>Max Current</source>
@@ -5662,24 +5161,6 @@ Czy chcesz kontynuować?</translation>
       <source>Charge time</source>
       <extracomment>Statistics for battery charging time</extracomment>
       <translation>Czas ładowania</translation>
-    </message>
-    <message id="charger_history_box_bulk">
-      <location filename="../../components/SolarDetailBox.qml" line="136"/>
-      <source>Bulk</source>
-      <extracomment>Battery: time spent in 'Bulk' mode</extracomment>
-      <translation type="unfinished">Bulk</translation>
-    </message>
-    <message id="charger_history_box_float">
-      <location filename="../../components/SolarDetailBox.qml" line="148"/>
-      <source>Float</source>
-      <extracomment>Battery: time spent in 'Float' mode</extracomment>
-      <translation type="unfinished">Float</translation>
-    </message>
-    <message id="charger_history_hr">
-      <location filename="../../components/SolarDetailBox.qml" line="174"/>
-      <source>hr</source>
-      <extracomment>Abbreviation of "hour"</extracomment>
-      <translation type="unfinished">g</translation>
     </message>
     <message id="solarchargers_state_bulk">
       <location filename="../../src/enums.cpp" line="337"/>
@@ -5751,11 +5232,6 @@ Czy chcesz kontynuować?</translation>
       <source>Connecting</source>
       <translation>Łączenie</translation>
     </message>
-    <message id="splash_view_connecting">
-      <location filename="../../components/SplashView.qml" line="288"/>
-      <source>Connecting</source>
-      <translation type="unfinished">Łączenie</translation>
-    </message>
     <message id="splash_view_connected">
       <location filename="../../components/SplashView.qml" line="290"/>
       <source>Connected, awaiting broker messages</source>
@@ -5811,6 +5287,11 @@ Czy chcesz kontynuować?</translation>
       <source>MQTT protocol level 5 error</source>
       <translation>Błąd poziomu 5 protokołu MQTT</translation>
     </message>
+    <message id="common_words_silence_alarm">
+      <location filename="../../components/CommonWords.qml" line="476"/>
+      <source>Silence alarm</source>
+      <translation>Wyciszenie alarmu</translation>
+    </message>
     <message id="vebus_device_page_total_power">
       <location filename="../../components/ThreePhaseQuantityTable.qml" line="47"/>
       <source>Total Power</source>
@@ -5861,20 +5342,10 @@ Czy chcesz kontynuować?</translation>
       <source>Retrieving IP address</source>
       <translation>Pobieranie adresu IP</translation>
     </message>
-    <message id="utils_connman_connected">
-      <location filename="../../components/Utils.js" line="292"/>
-      <source>Connected</source>
-      <translation type="unfinished">Podłączony</translation>
-    </message>
     <message id="utils_connman_disconnect">
       <location filename="../../components/Utils.js" line="295"/>
       <source>Disconnect</source>
       <translation>Odłącz</translation>
-    </message>
-    <message id="utils_connman_disconnected">
-      <location filename="../../components/Utils.js" line="299"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Odłączone</translation>
     </message>
     <message id="overview_widget_acloads_title">
       <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
@@ -5912,11 +5383,6 @@ Czy chcesz kontynuować?</translation>
       <source>Shore current limit</source>
       <translation>Ograniczenie prądu brzegowego</translation>
     </message>
-    <message id="acInputs_statusCode_stopping">
-      <location filename="../../data/AcInputs.qml" line="170"/>
-      <source>Stopping</source>
-      <translation type="unfinished">Zatrzymywanie</translation>
-    </message>
     <message id="page_generator_stopping">
       <location filename="../../data/Generators.qml" line="44"/>
       <source>Stopping</source>
@@ -5932,7 +5398,7 @@ Czy chcesz kontynuować?</translation>
       <location filename="../../data/common/TankDescription.qml" line="24"/>
       <location filename="../../src/device.cpp" line="133"/>
       <source>%1 tank (%2)</source>
-      <extracomment>Tank description. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
       <translation>%1 zbiornik (%2)</translation>
     </message>
     <message id="dcMeter_ac_charger">
@@ -5981,11 +5447,6 @@ Czy chcesz kontynuować?</translation>
       <location filename="../../data/Ess.qml" line="20"/>
       <source>Keep batteries charged</source>
       <translation>Utrzymuj akumulatory naładowane</translation>
-    </message>
-    <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="50"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Odłączone</translation>
     </message>
     <message id="evchargers_status_charged">
       <location filename="../../data/EvChargers.qml" line="58"/>
@@ -6046,16 +5507,6 @@ Czy chcesz kontynuować?</translation>
       <location filename="../../data/EvChargers.qml" line="97"/>
       <source>Start charging</source>
       <translation>Rozpocznij ładowanie</translation>
-    </message>
-    <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="113"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Nieznany</translation>
-    </message>
-    <message id="evchargers_mode_scheduled">
-      <location filename="../../data/EvChargers.qml" line="126"/>
-      <source>Scheduled</source>
-      <translation type="unfinished">Zaplanowane</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
       <location filename="../../data/System.qml" line="195"/>
@@ -6180,11 +5631,6 @@ Czy chcesz kontynuować?</translation>
       <source>Power supply mode</source>
       <translation>Tryb zasilania</translation>
     </message>
-    <message id="inverters_state_sustain">
-      <location filename="../../data/System.qml" line="158"/>
-      <source>Sustain</source>
-      <translation type="unfinished">Podtrzymanie</translation>
-    </message>
     <message id="inverters_state_wakeup">
       <location filename="../../data/System.qml" line="162"/>
       <source>Wake up</source>
@@ -6219,16 +5665,6 @@ Czy chcesz kontynuować?</translation>
       <location filename="../../data/System.qml" line="180"/>
       <source>Test</source>
       <translation>Test</translation>
-    </message>
-    <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="183"/>
-      <source>External control</source>
-      <translation type="unfinished">Sterowanie zewnętrzne</translation>
-    </message>
-    <message id="inverters_state_dynamic_ess">
-      <location filename="../../data/System.qml" line="198"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">Dynamiczny ESS</translation>
     </message>
     <message id="settings_rs_ess_dess">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="97"/>
@@ -6307,17 +5743,14 @@ Czy chcesz kontynuować?</translation>
     <message id="ess_recommended">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="73"/>
       <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
-      <translation>W przypadku baterii litowych nie zaleca się ładowania poniżej 10%. W przypadku innych typów baterii należy sprawdzić w arkuszu danych minimalny poziom zalecany przez producenta.</translation>
-    </message>
-    <message id="controlcard_generator_label_autostart">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="63"/>
-      <source>Autostart</source>
-      <translation type="unfinished">Autostart</translation>
+      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
+      <translation>W przypadku akumulatorów litowych nie zaleca się rozładowania poniżej 10%. W przypadku innych typów akumulatorów należy sprawdzić w arkuszu danych minimalny poziom zalecany przez producenta.</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
       <location filename="../../pages/controlcards/GeneratorCard.qml" line="70"/>
       <source>Start and stop the generator based on the configured autostart conditions.</source>
-      <translation>Uruchomienie i zatrzymanie generatora na podstawie skonfigurowanych warunków autostartu.</translation>
+      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
+      <translation>Start i stop generatora na podstawie skonfigurowanych warunków autostartu.</translation>
     </message>
     <message id="generator_dialog_disabled">
       <location filename="../../components/GeneratorManualControlButton.qml" line="103"/>
@@ -6333,33 +5766,31 @@ Czy chcesz kontynuować?</translation>
       <location filename="../../pages/controlcards/InverterChargerCard.qml" line="23"/>
       <source>Inverter (%1)</source>
       <extracomment>%1 = the inverter name</extracomment>
-      <translation>Falownik (%1)</translation>
+      <translation>Inwerter (%1)</translation>
     </message>
     <message id="controlcard_inverter_charger">
       <location filename="../../pages/controlcards/InverterChargerCard.qml" line="26"/>
       <source>Inverter / Charger (%1)</source>
       <extracomment>%1 = the inverter/charger name</extracomment>
-      <translation>Falownik / ładowarka (%1)</translation>
+      <oldsource>Inverter / Charger</oldsource>
+      <translation>Inwerter / Ładowarka (%1)</translation>
     </message>
     <message id="settings_page_debug_quit_application">
       <location filename="../../pages/settings/debug/PageDebug.qml" line="36"/>
       <source>Quit application</source>
+      <oldsource>Quit Application</oldsource>
       <translation>Zakończ Aplikację</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
       <location filename="../../components/PageGensetModel.qml" line="53"/>
       <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to "Connected genset helper relay".</source>
-      <translation>Ten sterownik agregatu wymaga przekaźnika pomocniczego do sterowania, ale przekaźnik pomocniczy nie jest skonfigurowany. Skonfiguruj przekaźnik 1 w Ustawienia → Przekaźnik na "Podłączony przekaźnik pomocniczy agregatu".</translation>
+      <translation>Ten sterownik agregatu wymaga przekaźnika pomocniczego do sterowania, ale przekaźnik pomocniczy nie jest skonfigurowany. Skonfiguruj Przekaźnik 1 w Ustawienia → Przekaźnik na "Podłączony przekaźnik pomocniczy agregatu".</translation>
     </message>
     <message id="settings_page_relay_generator_run_time">
       <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
       <source>Current run time</source>
+      <oldsource>Run time</oldsource>
       <translation>Bieżący czas pracy</translation>
-    </message>
-    <message id="settings_page_genset_generator_run_time">
-      <location filename="../../components/PageGensetModel.qml" line="102"/>
-      <source>Current run time</source>
-      <translation type="unfinished">Bieżący czas pracy</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
       <location filename="../../components/PageGensetModel.qml" line="110"/>
@@ -6386,19 +5817,10 @@ Czy chcesz kontynuować?</translation>
       <source>Remote start mode</source>
       <translation>Tryb zdalnego uruchamiania</translation>
     </message>
-    <message id="ac-in-genset_speed">
-      <location filename="../../components/PageGensetModel.qml" line="245"/>
-      <source>Speed</source>
-      <translation type="unfinished">Prędkość</translation>
-    </message>
-    <message id="ac-in-genset_load">
-      <location filename="../../components/PageGensetModel.qml" line="252"/>
-      <source>Load</source>
-      <translation type="unfinished">Ładowanie</translation>
-    </message>
     <message id="ac-in-genset_oil_pressure">
       <location filename="../../components/PageGensetModel.qml" line="260"/>
       <source>Oil pressure</source>
+      <oldsource>Oil Pressure</oldsource>
       <translation>Ciśnienie oleju</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
@@ -6414,7 +5836,7 @@ Czy chcesz kontynuować?</translation>
     <message id="page_genset_model_dc_genset_settings">
       <location filename="../../components/PageGensetModel.qml" line="338"/>
       <source>DC genset settings</source>
-      <translation>Ustawienia agregatu prądu stałego</translation>
+      <translation>Ustawienia agregatu DC</translation>
     </message>
     <message id="genset_charge_voltage_controlled_by_bms">
       <location filename="../../components/PageGensetModel.qml" line="376"/>
@@ -6429,7 +5851,7 @@ Czy chcesz kontynuować?</translation>
     <message id="common_words_bms_control_info">
       <location filename="../../components/CommonWords.qml" line="104"/>
       <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
-      <translation>Kontrola BMS jest włączana automatycznie, gdy obecny jest system BMS. Zresetuj ją, jeśli konfiguracja systemu uległa zmianie lub jeśli nie ma systemu BMS.</translation>
+      <translation>Kontrola BMS jest włączana automatycznie, gdy obecny jest BMS. Zresetuj ją, jeśli konfiguracja systemu uległa zmianie lub jeśli nie ma BMS.</translation>
     </message>
     <message id="battery_bank_error">
       <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="90"/>
@@ -6444,22 +5866,22 @@ Czy chcesz kontynuować?</translation>
     <message id="battery_bank_error_incorrect_number_of_batteries">
       <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="102"/>
       <source>Incorrect number of batteries</source>
-      <translation>Nieprawidłowa liczba baterii</translation>
+      <translation>Nieprawidłowa liczba akumulatorów</translation>
     </message>
     <message id="battery_bank_error_invalid_configuration">
       <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="105"/>
       <source>Invalid battery configuration</source>
-      <translation>Nieprawidłowa konfiguracja baterii</translation>
+      <translation>Nieprawidłowa konfiguracja akumulatorów</translation>
     </message>
     <message id="devicelist_battery_total_capacity">
       <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="143"/>
       <source>Total Capacity</source>
-      <translation>Całkowita pojemność</translation>
+      <translation>Całkowita Pojemność</translation>
     </message>
     <message id="devicelist_battery_system_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="155"/>
       <source>System voltage</source>
-      <translation>Napięcie instalacji [V]</translation>
+      <translation>Napięcie instalacji</translation>
     </message>
     <message id="devicelist_battery_number_of_bmses">
       <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="169"/>
@@ -6469,7 +5891,7 @@ Czy chcesz kontynuować?</translation>
     <message id="batteryalarms_high_cell_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
       <source>High cell voltage</source>
-      <translation>Wysokie napięcie ogniwa</translation>
+      <translation>Wysokie napięcie celi</translation>
     </message>
     <message id="batteryalarms_high_current">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="45"/>
@@ -6479,7 +5901,7 @@ Czy chcesz kontynuować?</translation>
     <message id="batteryalarms_bms_cable">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="169"/>
       <source>BMS cable fault</source>
-      <translation>Usterka kabla BMS</translation>
+      <translation>Usterka przewodu BMS</translation>
     </message>
     <message id="batteryalarms_contactor">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="176"/>
@@ -6494,17 +5916,19 @@ Czy chcesz kontynuować?</translation>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
       <source>High starter battery voltage alarms</source>
+      <oldsource>High starter batttery voltage alarms</oldsource>
       <translation>Alarmy wysokiego napięcia akumulatora rozruchowego</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
       <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
-      <translation>Należy pamiętać, że zmiana ustawienia czasu do rozładowania podłogi powoduje również zmianę ustawienia niskiego stanu naładowania w menu przekaźnika.</translation>
+      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
+      <translation>Uwaga, zmiana ustawienia minimalnego czasu do rozładowania powoduje również zmianę ustawienia niskiego stanu naładowania w menu przekaźnika.</translation>
     </message>
     <message id="lynxionsystem_cells_per_battery">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="42"/>
       <source>Cells per battery</source>
-      <translation>Ogniwa na baterię</translation>
+      <translation>Ogniwa na akumulator</translation>
     </message>
     <message id="lynxionsystem_balancer_status">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="100"/>
@@ -6575,12 +5999,13 @@ Czy chcesz kontynuować?</translation>
       <location filename="../../pages/settings/devicelist/delegates/DeviceListDelegate_solarcharger.qml" line="34"/>
       <source>Error: #%1</source>
       <extracomment>%1 = error number</extracomment>
+      <oldsource>Error: %1</oldsource>
       <translation>Błąd: #%1</translation>
     </message>
     <message id="devicelistpage_genset">
       <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="103"/>
       <source>Genset</source>
-      <translation>Genset</translation>
+      <translation>Agregat</translation>
     </message>
     <message id="page_meteo_wind_direction">
       <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="72"/>
@@ -6595,7 +6020,7 @@ Czy chcesz kontynuować?</translation>
     <message id="page_meteo_daily_yield">
       <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="89"/>
       <source>Today's yield</source>
-      <translation>Dzisiejsza rentowność</translation>
+      <translation>Dzisiejszy uzysk</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_full">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="69"/>
@@ -6621,7 +6046,7 @@ Czy chcesz kontynuować?</translation>
     <message id="settings_generator_condition_skip_warmup">
       <location filename="../../pages/settings/GeneratorCondition.qml" line="193"/>
       <source>Skip generator warm-up</source>
-      <translation>Pomiń rozgrzewkę generatora</translation>
+      <translation>Pomiń rozgrzewanie generatora</translation>
     </message>
     <message id="settings_generator_condition_tank_level_enable_warning">
       <location filename="../../pages/settings/GeneratorCondition.qml" line="200"/>
@@ -6631,17 +6056,14 @@ Czy chcesz kontynuować?</translation>
     <message id="settings_page_relay_generator_auto_start_enabled">
       <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
       <source>Autostart functionality</source>
-      <translation>Funkcja automatycznego uruchamiania</translation>
+      <oldsource>Auto start functionality</oldsource>
+      <translation>Funkcja auto start</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="97"/>
       <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
       <translation>Upewnij się, że generator nie jest podłączony do wejścia AC %1 podczas korzystania z tej opcji</translation>
-    </message>
-    <message id="page_generator_conditions_inverter_high_temperature">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="139"/>
-      <source>Inverter high temperature</source>
-      <translation type="unfinished">Wysoka temperatura inwertera</translation>
     </message>
     <message id="page_generator_conditions_tank_level">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="159"/>
@@ -6651,12 +6073,12 @@ Czy chcesz kontynuować?</translation>
     <message id="page_generator_conditions_stop_on_tank_level">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="162"/>
       <source>Stop on tank level</source>
-      <translation>Zatrzymanie na poziomie zbiornika</translation>
+      <translation>Stop na poziomie zbiornika</translation>
     </message>
     <message id="settings_page_run_time_and_service_time_to_service">
       <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="150"/>
       <source>Runtime until service</source>
-      <translation>Czas działania do momentu uruchomienia usługi</translation>
+      <translation>Czas działania do serwisu</translation>
     </message>
     <message id="page_settings_run_time_and_service_service_time_disabled">
       <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="172"/>
@@ -6666,35 +6088,39 @@ Czy chcesz kontynuować?</translation>
     <message id="page_settings_run_time_and_service_service_timer_has_been_reset">
       <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="185"/>
       <source>The service timer has been reset</source>
-      <translation>Licznik czasu usługi został zresetowany</translation>
+      <translation>Licznik serwisowy został zresetowany</translation>
     </message>
     <message id="settings_generator_function_not_enabled">
       <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
       <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
-      <translation>Funkcja uruchamiania/zatrzymywania agregatu nie jest włączona, przejdź do ustawień przekaźnika i ustaw funkcję na "Uruchamianie/zatrzymywanie agregatu".</translation>
+      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
+      <translation>Funkcja start/stop agregatu nie jest włączona, przejdź do ustawień przekaźnika i ustaw funkcję na "Start/stop agregatu"</translation>
     </message>
     <message id="settings_batteries_intro">
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="45"/>
       <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
-      <translation>To menu służy do definiowania danych akumulatora wyświetlanych po kliknięciu ikony Akumulator na stronie Przegląd. Ten sam wybór jest również widoczny w portalu VRM Portal.</translation>
+      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
+      <translation>To menu służy do definiowania danych akumulatora wyświetlanych po kliknięciu ikony Akumulator na stronie Przegląd. Ten sam wybór jest również widoczny w VRM Portal.</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
       <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
       <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
       <translation>Ciągłe skanowanie może zakłócać działanie sieci Wi-Fi.</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
       <source>CAN-bus BMS LV (500 kbit/s)</source>
-      <translation>Magistrala CAN BMS LV (500 kbit/s)</translation>
+      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
+      <translation>CAN-bus BMS LV (500 kbit/s)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
       <source>CAN-bus BMS HV (500 kbit/s)</source>
-      <translation>Magistrala CAN BMS HV (500 kbit/s)</translation>
+      <translation>CAN-bus BMS HV (500 kbit/s)</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
       <source>Up, but no services (500 kbit/s)</source>
       <translation>Jest sieć, ale brak usług (500 kbit/s)</translation>
     </message>
@@ -6707,41 +6133,6 @@ Czy chcesz kontynuować?</translation>
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="127"/>
       <source>Brief page</source>
       <translation>Krótka strona</translation>
-    </message>
-    <message id="settings_displayoff_1min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="46"/>
-      <source>1 min</source>
-      <translation type="unfinished">1 min</translation>
-    </message>
-    <message id="settings_displayoff_10min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="48"/>
-      <source>10 min</source>
-      <translation type="unfinished">10 min</translation>
-    </message>
-    <message id="settings_displayoff_30min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="50"/>
-      <source>30 min</source>
-      <translation type="unfinished">30 min</translation>
-    </message>
-    <message id="settings_displayoff_never">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="52"/>
-      <source>Never</source>
-      <translation type="unfinished">Nigdy</translation>
-    </message>
-    <message id="settings_remote_console_appearance_auto">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="112"/>
-      <source>Auto</source>
-      <translation type="unfinished">Auto</translation>
-    </message>
-    <message id="settings_brief_view_start_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="119"/>
-      <source>Start page</source>
-      <translation type="unfinished">Strona startowa</translation>
-    </message>
-    <message id="settings_display_boat_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="135"/>
-      <source>Boat page</source>
-      <translation type="unfinished">Strona łodzi</translation>
     </message>
     <message id="settings_display_minmax">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="148"/>
@@ -6766,17 +6157,17 @@ Czy chcesz kontynuować?</translation>
     <message id="settings_display_classic_ui">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="179"/>
       <source>Classic UI</source>
-      <translation>Klasyczny UI</translation>
+      <translation>Klasyczny interfejs</translation>
     </message>
     <message id="settings_display_new_ui">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="184"/>
       <source>New UI</source>
-      <translation>Nowy interfejs użytkownika</translation>
+      <translation>Nowy interfejs</translation>
     </message>
     <message id="settings_restarting_app">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="215"/>
       <source>Restarting application...</source>
-      <translation>Ponowne uruchamianie aplikacji...</translation>
+      <translation>Restart aplikacji...</translation>
     </message>
     <message id="settings_app_restarted">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="218"/>
@@ -6796,21 +6187,6 @@ Czy chcesz kontynuować?</translation>
       <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
       <translation>%1 jest ustawione na %2</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_unsupported_device">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="50"/>
-      <source>Unsupported GX device</source>
-      <translation type="unfinished">Nieobsługiwane urządzenie GX</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_clean">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="55"/>
-      <source>Clean</source>
-      <translation type="unfinished">Wyczyść</translation>
-    </message>
-    <message id="pagesettingsgeneral_firmware">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="112"/>
-      <source>Firmware</source>
-      <translation type="unfinished">Firmware</translation>
-    </message>
     <message id="pagesettingsgeneral_access_and_security">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
       <source>Access &amp; Security</source>
@@ -6824,7 +6200,7 @@ Czy chcesz kontynuować?</translation>
     <message id="pagesettingsgeneral_display_and_appearance">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="135"/>
       <source>Display &amp; Appearance</source>
-      <translation>Wyświetlacz i wygląd</translation>
+      <translation>Wyświetlacz i Wygląd</translation>
     </message>
     <message id="pagesettingsgeneral_alarms_and_feedback">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="141"/>
@@ -6844,6 +6220,7 @@ Czy chcesz kontynuować?</translation>
     <message id="settings_language_please_wait">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="209"/>
       <source>Please wait while the language is changed.</source>
+      <oldsource>Please wait while the language is changed</oldsource>
       <translation>Poczekaj na zmianę języka.</translation>
     </message>
     <message id="settings_briefview_totals">
@@ -6854,17 +6231,12 @@ Czy chcesz kontynuować?</translation>
     <message id="settings_briefview_battery_not_connected">
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="50"/>
       <source>Battery is not connected.</source>
-      <translation>Bateria nie jest podłączona.</translation>
+      <translation>Akumulator nie jest podłączony.</translation>
     </message>
     <message id="settings_briefview_tank_not_connected">
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="71"/>
       <source>Tank is not connected.</source>
       <translation>Zbiornik nie jest podłączony.</translation>
-    </message>
-    <message id="settings_briefview_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="83"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">Aktywny monitor akumulatora</translation>
     </message>
     <message id="settings_briefview_individual_batteries">
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="86"/>
@@ -6874,17 +6246,17 @@ Czy chcesz kontynuować?</translation>
     <message id="settings_briefview_individual_tanks">
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="96"/>
       <source>Individual tanks</source>
-      <translation>Zbiorniki indywidualne</translation>
+      <translation>Pojedyncze zbiorniki</translation>
     </message>
     <message id="settings_briefview_unconnected_battery">
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="183"/>
       <source>Battery not connected</source>
-      <translation>Akumulator nie jest podłączony</translation>
+      <translation>Akumulator niepodłączony</translation>
     </message>
     <message id="settings_briefview_unconnected_tank">
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="192"/>
       <source>Tank not connected</source>
-      <translation>Zbiornik nie jest podłączony</translation>
+      <translation>Zbiornik niepodłączony</translation>
     </message>
     <message id="settings_briefview_not_configured">
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="196"/>
@@ -6915,6 +6287,7 @@ Czy chcesz kontynuować?</translation>
     <message id="settings_dvcc_charge_current_limits">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="30"/>
       <source>Charge current limits</source>
+      <oldsource>Charge Current limits</oldsource>
       <translation>Limity prądu ładowania</translation>
     </message>
     <message id="settings_firmware_official_release">
@@ -6947,12 +6320,12 @@ Czy chcesz kontynuować?</translation>
     <message id="page_settings_fronius_inverter_power_limiting_label">
       <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="73"/>
       <source>This PV inverter has support for power limiting. Disable this setting if it interferes with normal operation.</source>
-      <translation>Ten falownik fotowoltaiczny obsługuje ograniczanie mocy. Wyłącz to ustawienie, jeśli przeszkadza ono w normalnej pracy.</translation>
+      <translation>Ten inwerter PV obsługuje ograniczanie mocy. Wyłącz to ustawienie, jeśli przeszkadza ono w normalnej pracy.</translation>
     </message>
     <message id="page_setting_fronius_inverters_add_a_pv_inverter">
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="26"/>
       <source>Add a PV inverter by using the “Find PV Inverter” function or by entering an IP address manually on the previous page.</source>
-      <translation>Dodaj falownik PV za pomocą funkcji "Znajdź falownik PV" lub wprowadzając adres IP ręcznie na poprzedniej stronie.</translation>
+      <translation>Dodaj inwerter PV za pomocą funkcji "Znajdź inwerter PV" lub wprowadź adres IP ręcznie na poprzedniej stronie.</translation>
     </message>
     <message id="settings_local_network_security_profile">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="124"/>
@@ -6994,11 +6367,6 @@ Czy chcesz kontynuować?</translation>
       <source>No password and the network communication is not encrypted</source>
       <translation>Brak hasła i komunikacja sieciowa nie jest szyfrowana</translation>
     </message>
-    <message id="settings_logout_now">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
-      <source>Log out now</source>
-      <translation type="unfinished">Wyloguj się teraz</translation>
-    </message>
     <message id="settings_security_profile_password_incorrect_length">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="28"/>
       <source>Password needs to be at least 8 characters long</source>
@@ -7025,49 +6393,34 @@ Czy chcesz kontynuować?</translation>
 • The network communication is encrypted
 • A secure connection with VRM is enabled
 • Insecure settings cannot be enabled</source>
-      <translation>- Usługi sieci lokalnej są chronione hasłem
-- Komunikacja sieciowa jest szyfrowana
-- Włączone jest bezpieczne połączenie z VRM
-- Nie można włączyć niezabezpieczonych ustawień</translation>
+      <translation>• Usługi sieci lokalnej są chronione hasłem
+• Komunikacja sieciowa jest szyfrowana
+• Włączone jest bezpieczne połączenie z VRM
+• Nie można włączyć niezabezpieczonych ustawień</translation>
     </message>
     <message id="settings_security_profile_weak_description">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="244"/>
       <source>• Local network services are password protected
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>- Lokalne usługi sieciowe są chronione hasłem
-- Włączony jest również niezaszyfrowany dostęp do lokalnych stron internetowych (HTTP/HTTPS).</translation>
+      <translation>• Lokalne usługi sieciowe są chronione hasłem
+• Włączony jest również niezaszyfrowany dostęp do lokalnych stron internetowych (HTTP/HTTPS).</translation>
     </message>
     <message id="settings_security_profile_unsecured_description">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="247"/>
       <source>• Local network services do not need a password
 • Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
-      <translation>- Lokalne usługi sieciowe nie wymagają hasła
-- Włączony jest również niezaszyfrowany dostęp do lokalnych stron internetowych (HTTP/HTTPS).</translation>
+      <translation>• Lokalne usługi sieciowe nie wymagają hasła
+• Włączony jest również niezaszyfrowany dostęp do lokalnych stron internetowych (HTTP/HTTPS).</translation>
     </message>
     <message id="access_and_security_page_will_reload">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="118"/>
       <source>Page will automatically reload in 5 seconds</source>
       <translation>Strona przeładuje się automatycznie za 5 sekund</translation>
     </message>
-    <message id="settings_security_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="159"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">Hasło musi składać się z co najmniej 8 znaków</translation>
-    </message>
     <message id="settings_root_password">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="269"/>
       <source>Root password</source>
-      <translation>Hasło główne</translation>
-    </message>
-    <message id="settings_root_enter_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="272"/>
-      <source>Enter password</source>
-      <translation type="unfinished">Wprowadź hasło</translation>
-    </message>
-    <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="277"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">Hasło musi składać się z co najmniej 8 znaków</translation>
+      <translation>Hasło root</translation>
     </message>
     <message id="settings_root_password_changed_to">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="283"/>
@@ -7084,6 +6437,11 @@ Czy chcesz kontynuować?</translation>
       <source>Logout</source>
       <translation>Wyloguj</translation>
     </message>
+    <message id="settings_logout_now">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
+      <source>Log out now</source>
+      <translation>Wyloguj się teraz</translation>
+    </message>
     <message id="settings_logout_dialog_title">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="335"/>
       <source>Log out?</source>
@@ -7097,7 +6455,7 @@ Czy chcesz kontynuować?</translation>
     <message id="settings_logout_dialog_accept_text">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="339"/>
       <source>Log out</source>
-      <translation>wyloguj</translation>
+      <translation>Wyloguj</translation>
     </message>
     <message id="settings_enable_status_leds">
       <location filename="../../pages/settings/PageSettingsAlarmsAndFeedback.qml" line="30"/>
@@ -7112,17 +6470,17 @@ Czy chcesz kontynuować?</translation>
     <message id="settings_page_debug_quit">
       <location filename="../../pages/settings/debug/PageDebug.qml" line="39"/>
       <source>Quit</source>
-      <translation>Odejdź</translation>
+      <translation>Wyjdź</translation>
     </message>
     <message id="settings_page_debug_display_cpu_usage">
       <location filename="../../pages/settings/debug/PageDebug.qml" line="68"/>
       <source>Display CPU usage</source>
-      <translation>Wyświetlanie użycia procesora</translation>
+      <translation>Wyświetl użycie procesora</translation>
     </message>
     <message id="settings_page_generator_warm_up_cool_down">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="48"/>
       <source>Warm-up &amp; cool-down</source>
-      <translation>Rozgrzewka i ochłonięcie</translation>
+      <translation>Rozgrzanie i studzenie</translation>
     </message>
     <message id="page_settings_generator_stop_time">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="79"/>
@@ -7132,22 +6490,24 @@ Czy chcesz kontynuować?</translation>
     <message id="page_settings_generator_detect_generator_at_dc">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="127"/>
       <source>Alarm if DC generator is not providing power</source>
-      <translation>Alarm, jeśli generator prądu stałego nie zapewnia zasilania</translation>
+      <translation>Alarm, jeśli generator DC nie zapewnia zasilania</translation>
     </message>
     <message id="page_settings_generator_detect_at_dc_in_generator_set">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="133"/>
       <source>An alarm will be triggered when the DC genset does not reach at least 5A within the first 5 minutes after starting</source>
-      <translation>Alarm zostanie wyzwolony, gdy agregat DC nie osiągnie co najmniej 5A w ciągu pierwszych 5 minut po uruchomieniu.</translation>
+      <translation>Alarm uruchomi się, gdy agregat DC nie osiągnie co najmniej 5 A w ciągu pierwszych 5 minut po uruchomieniu</translation>
     </message>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="141"/>
       <source>Alarm when generator is not in autostart mode</source>
+      <oldsource>Alarm when generator is not in auto start mode</oldsource>
       <translation>Alarm, gdy generator nie jest w trybie autostartu</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="147"/>
       <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
-      <translation>Alarm zostanie wyzwolony, gdy funkcja autostartu pozostanie wyłączona przez ponad 10 minut.</translation>
+      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
+      <translation>Alarm uruchomi się, gdy funkcja autostartu pozostanie wyłączona przez ponad 10 minut</translation>
     </message>
     <message id="settings_units_amps_exceptions">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="50"/>
@@ -7162,32 +6522,37 @@ Czy chcesz kontynuować?</translation>
     <message id="settings_ess_use_this_option_for_peak_shaving">
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
       <source>Use this option for peak shaving.</source>
+      <oldsource>Use this option for peak shaving.
+
+The peak shaving threshold is set using the AC input current limit setting.
+
+See documentation for further information.</oldsource>
       <translation>Ta opcja służy do ograniczenia mocy szczytowej.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
       <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
-      <translation>Próg ograniczeniu szczytowej jest ustawiany za pomocą ustawienia limitu prądu wejściowego AC. Więcej informacji w dokumentacji.</translation>
+      <translation>Próg ograniczania mocy szczytowej jest ustawiany poprzez limit prądu wejściowego AC. Więcej informacji znajdziesz w dokumentacji.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_with_grid_meter">
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
       <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
-      <translation>Na tym ekranie można zmienić progi ograniczania szczytów dla importu i eksportu. Więcej informacji można znaleźć w dokumentacji.</translation>
+      <translation>Na tym ekranie można zmienić progi ograniczania mocy szczytowej dla importu i eksportu. Więcej informacji zznajdziesz w dokumentacji.</translation>
     </message>
     <message id="settings_ess_limit_system_ac_import_current">
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
       <source>Limit system AC import current</source>
-      <translation>Ograniczenie prądu importowego AC systemu</translation>
+      <translation>Ograniczenie prądu importowanego AC</translation>
     </message>
     <message id="settings_ess_limit_ac_import_restrictions">
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="100"/>
       <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
-      <translation>Aby korzystać z tej funkcji, funkcja Grid metering musi być ustawiona na External meter i musi być zainstalowany aktualny asystent ESS.</translation>
+      <translation>Aby korzystać z tej funkcji, funkcja Pomiar sieci musi być ustawiona na Pomiar zewnętrzny i musi być zainstalowany aktualny asystent ESS.</translation>
     </message>
     <message id="settings_ess_max_system_import_current">
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="105"/>
       <source>Maximum system import current (per phase)</source>
-      <translation>Maksymalny prąd importowy systemu (na fazę)</translation>
+      <translation>Maksymalny prąd poboru systemu (na fazę)</translation>
     </message>
     <message id="settings_ess_limit_system_ac_export_current">
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="119"/>
@@ -7197,7 +6562,7 @@ Czy chcesz kontynuować?</translation>
     <message id="settings_ess_limit_ac_export_restrictions">
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="133"/>
       <source>Grid metering must be set to External meter to use this feature.</source>
-      <translation>Aby korzystać z tej funkcji, pomiar sieci musi być ustawiony na licznik zewnętrzny.</translation>
+      <translation>Aby korzystać z tej funkcji, pomiar sieci musi być ustawiony na Zewnętrzny.</translation>
     </message>
     <message id="settings_ess_max_system_export_current">
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="138"/>
@@ -7205,17 +6570,17 @@ Czy chcesz kontynuować?</translation>
       <translation>Maksymalny prąd eksportu systemu (na fazę)</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="71"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="73"/>
       <source>Self-consumption from battery</source>
       <translation>Zużycie własne z akumulatora</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="76"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
       <source>All system loads</source>
       <translation>Wszystkie obciążenia systemu</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="80"/>
       <source>Only critical loads</source>
       <translation>Tylko obciążenia krytyczne</translation>
     </message>
@@ -7232,7 +6597,7 @@ Czy chcesz kontynuować?</translation>
     <message id="pagesettingsintegrations_pv_inverters">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="38"/>
       <source>PV Inverters</source>
-      <translation>Falowniki PV</translation>
+      <translation>Inwertery PV</translation>
     </message>
     <message id="pagesettingsintegrations_energy_meters">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="44"/>
@@ -7262,7 +6627,7 @@ Czy chcesz kontynuować?</translation>
     <message id="pagesettingsintegrations_relays">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="118"/>
       <source>Relays</source>
-      <translation>Zamierzasz włączyć &lt;b&gt; {isOn} przekaźnik {relayNumber}. Czy na pewno chcesz kontynuować?</translation>
+      <translation>Przekaźniki</translation>
     </message>
     <message id="pagesettingsintegrations_digital_io">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="132"/>
@@ -7273,26 +6638,6 @@ Czy chcesz kontynuować?</translation>
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="194"/>
       <source>Server Applications</source>
       <translation>Aplikacje Serwerowe</translation>
-    </message>
-    <message id="pagesettingsintegrations_venus_os_enable_large_features">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
-      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_large_victron_community">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="274"/>
-      <source>Victron Community</source>
-      <translation type="unfinished">Społeczność Victron</translation>
-    </message>
-    <message id="pagesettingsintegrations_ui_plugins">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
-      <source>UI Plugins</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
-      <source>Integrates with the device list</source>
-      <translation type="unfinished"/>
     </message>
     <message id="pagesettingssupportstate_modbus_tcp_server">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="453"/>
@@ -7383,7 +6728,7 @@ Czy chcesz kontynuować?</translation>
     <message id="settings_relay_tank_pump_can_now_be_found">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="20"/>
       <source>The Tank Pump can now be found in the devices list</source>
-      <translation>Pompę zbiornika można teraz znaleźć na liście urządzeń</translation>
+      <translation>Pompę Zbiornika można teraz znaleźć na liście urządzeń</translation>
     </message>
     <message id="settings_relay_no_temperature_sensors">
       <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="39"/>
@@ -7393,27 +6738,12 @@ Czy chcesz kontynuować?</translation>
     <message id="settings_firmware_switching_not_possible_indeterminate_profile">
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
       <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
-      <translation>Zmiana wersji oprogramowania sprzętowego nie jest możliwa bez wybrania opcji "Network Security Profile" w "Settings / General".</translation>
-    </message>
-    <message id="pagesettingsconnectivity_ethernet">
-      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
-      <source>Ethernet</source>
-      <translation type="unfinished">Ethernet</translation>
+      <translation>Zmiana wersji oprogramowania sprzętowego nie jest możliwa bez wybrania opcji "Profil Zabezpieczeń Systemu" w "Ustawienia / Ogólne".</translation>
     </message>
     <message id="pagesettingsconnectivity_mobile_network">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="53"/>
       <source>Mobile Network</source>
       <translation>Sieć Komórkowa</translation>
-    </message>
-    <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Boat</source>
-      <translation type="unfinished">Łódź</translation>
-    </message>
-    <message id="settings_system_name_auto">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="32"/>
-      <source>Automatic</source>
-      <translation type="unfinished">Automatycznie</translation>
     </message>
     <message id="pagesettingssystem_ac_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
@@ -7423,32 +6753,27 @@ Czy chcesz kontynuować?</translation>
     <message id="pagesettingssystem_inputs_and_monitoring">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="62"/>
       <source>Inputs and Monitoring</source>
-      <translation>Dane wejściowe i monitorowanie</translation>
+      <translation>Wejścia i Monitorowanie</translation>
     </message>
     <message id="pagesettingssystem_energy_storage_System">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="69"/>
       <source>Energy Storage System</source>
-      <translation>System magazynowania energii</translation>
+      <translation>System magazynowania energii (ESS)</translation>
     </message>
     <message id="pagesettingssystem_batteries_and_bms">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="81"/>
       <source>Batteries and Battery Management Systems (BMS)</source>
-      <translation>Akumulatory i systemy zarządzania akumulatorami (BMS)</translation>
+      <translation>Akumulatory i Systemy zarządzania akumulatorami (BMS)</translation>
     </message>
     <message id="settings_system_charge_control">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="87"/>
       <source>Charge Control</source>
-      <translation>Kontrola ładowania</translation>
+      <translation>Kontrola Ładowania</translation>
     </message>
     <message id="pagesettingssystem_distributed_voltage_and_current_control">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="89"/>
       <source>Distributed Voltage and Current Control (DVCC)</source>
       <translation>Rozproszona Kontrola Napięcia i Prądu (DVCC)</translation>
-    </message>
-    <message id="settings_system_grid">
-      <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="18"/>
-      <source>Grid</source>
-      <translation type="unfinished">Sieć</translation>
     </message>
     <message id="settings_system_ac_position">
       <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="58"/>
@@ -7463,7 +6788,7 @@ Czy chcesz kontynuować?</translation>
     <message id="settings_system_ac_input_only_description">
       <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="66"/>
       <source>The AC output of the Inverter/Charger is not used.</source>
-      <translation>Wyjście AC inwertera/ładowarki nie jest używane.</translation>
+      <translation>Wyjście AC Inwertera/Ładowarki nie jest używane.</translation>
     </message>
     <message id="settings_system_ac_output_only">
       <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="71"/>
@@ -7473,7 +6798,7 @@ Czy chcesz kontynuować?</translation>
     <message id="settings_system_ac_output_only_description">
       <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="73"/>
       <source>All AC loads are on the output of the Inverter/Charger.</source>
-      <translation>Wszystkie obciążenia AC znajdują się na wyjściu inwertera/ładowarki.</translation>
+      <translation>Wszystkie obciążenia AC znajdują się na wyjściu Inwertera/Ładowarki.</translation>
     </message>
     <message id="settings_system_ac_input_and_output">
       <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="77"/>
@@ -7483,21 +6808,24 @@ Czy chcesz kontynuować?</translation>
     <message id="settings_system_ac_input_and_output_description">
       <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="79"/>
       <source>The system will automatically display loads on the input of the Inverter/Charger if a grid meter is present. Loads on the output are always displayed.</source>
-      <translation>System automatycznie wyświetli obciążenia na wejściu falownika/ładowarki, jeśli obecny jest miernik sieci. Obciążenia na wyjściu są zawsze wyświetlane.</translation>
+      <translation>System automatycznie wyświetli obciążenia na wejściu Inwertera/Ładowarki jeśli występuje miernik sieci. Obciążenia na wyjściu są wyświetlane zawsze.</translation>
     </message>
     <message id="settings_system_has_dc_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="97"/>
       <source>Display DC Loads</source>
+      <oldsource>Has DC system</oldsource>
       <translation>Wyświetl Obciążenia DC</translation>
     </message>
     <message id="settings_system_battery_measurements">
       <location filename="../../pages/settings/PageSettingsBatteries.qml" line="65"/>
       <source>Battery measurements</source>
-      <translation>Pomiary baterii</translation>
+      <oldsource>Battery Measurements</oldsource>
+      <translation>Pomiary akumulatora</translation>
     </message>
     <message id="settings_system_system_status">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
       <source>System status</source>
+      <oldsource>System Status</oldsource>
       <translation>Status systemu</translation>
     </message>
     <message id="settings_tcpip_wired">
@@ -7508,12 +6836,14 @@ Czy chcesz kontynuować?</translation>
     <message id="settings_vecan_device_instance">
       <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
       <source>VE.Can Device Instance</source>
-      <translation>Wystąpienie urządzenia VE.Can</translation>
+      <oldsource>Device Instance</oldsource>
+      <translation>VE.Can Device Instance</translation>
     </message>
     <message id="settings_vecan_device_number">
       <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="32"/>
       <source>VE.Can Instance# %1</source>
-      <translation>VE.Can Instance# %1</translation>
+      <oldsource>Device# %1</oldsource>
+      <translation>VE.Can Instancja# %1</translation>
     </message>
     <message id="settings_tz_antarctica">
       <location filename="../../pages/settings/PageTzInfo.qml" line="232"/>
@@ -7543,6 +6873,7 @@ Czy chcesz kontynuować?</translation>
     <message id="settings_vrm">
       <location filename="../../pages/SettingsPage.qml" line="59"/>
       <source>VRM</source>
+      <extracomment>Forced by %2 to dark</extracomment>
       <translation>VRM</translation>
     </message>
     <message id="settings_remote_monitoring_portal">
@@ -7550,20 +6881,10 @@ Czy chcesz kontynuować?</translation>
       <source>Remote monitoring portal</source>
       <translation>Portal zdalnego monitorowania</translation>
     </message>
-    <message id="settings_advanced">
-      <location filename="../../pages/SettingsPage.qml" line="68"/>
-      <source>Advanced</source>
-      <translation type="unfinished">Zaawansowane</translation>
-    </message>
-    <message id="settings_integrations">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
+    <message id="pagesettingssupportstate_integrations">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
       <source>Integrations</source>
       <translation>Integracje</translation>
-    </message>
-    <message id="settings_relays_sensors_tanks">
-      <location filename="../../pages/SettingsPage.qml" line="75"/>
-      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
-      <translation type="unfinished">Przekaźniki, czujniki, zbiorniki, falowniki PV, Modbus, MQTT...</translation>
     </message>
     <message id="settings_acdcsystem_ess_dvcc_battery">
       <location filename="../../pages/SettingsPage.qml" line="84"/>
@@ -7573,7 +6894,7 @@ Czy chcesz kontynuować?</translation>
     <message id="settings_debug_and_develop">
       <location filename="../../pages/SettingsPage.qml" line="91"/>
       <source>Debug &amp; Develop</source>
-      <translation>Debugowanie i rozwój</translation>
+      <translation>Debugowanie i Rozwój</translation>
     </message>
     <message id="settings_profilingtools_debugstatistics_appversion">
       <location filename="../../pages/SettingsPage.qml" line="93"/>
@@ -7583,17 +6904,19 @@ Czy chcesz kontynuować?</translation>
     <message id="settings_system_setup">
       <location filename="../../pages/SettingsPage.qml" line="82"/>
       <source>System Setup</source>
-      <translation>Konfiguracja systemu</translation>
+      <oldsource>System setup</oldsource>
+      <translation>Konfiguracja Systemu</translation>
     </message>
     <message id="settings_vrm_device_instances">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
       <source>VRM device instances</source>
-      <translation>Instancje Urządzenia VRM</translation>
+      <oldsource>VRM Device Instances</oldsource>
+      <translation>Instancje urządzenia VRM</translation>
     </message>
     <message id="solarcharger_not_supported">
       <location filename="../../pages/solar/PageSolarCharger.qml" line="67"/>
       <source>Unfortunately the connected MPPT Solar Charger is not compatible.</source>
-      <translation>Niestety podłączona ładowarka słoneczna MPPT nie jest kompatybilna.</translation>
+      <translation>Niestety podłączona Ładowarka Słoneczna MPPT nie jest kompatybilna.</translation>
     </message>
     <message id="solarcharger_not_supported_reason_70_15">
       <location filename="../../pages/solar/PageSolarCharger.qml" line="71"/>
@@ -7603,35 +6926,17 @@ Czy chcesz kontynuować?</translation>
     <message id="solarcharger_not_supported_reason_version">
       <location filename="../../pages/solar/PageSolarCharger.qml" line="74"/>
       <source>The firmware version in the MPPT Solar Charger must be v1.09 or later. Contact Victron Service for update instructions and files.</source>
-      <translation>Wersja oprogramowania sprzętowego w ładowarce MPPT Solar Charger musi być w wersji v1.09 lub nowszej. Aby uzyskać instrukcje i pliki aktualizacji, należy skontaktować się z serwisem Victron.</translation>
-    </message>
-    <message id="solarcharger_pv">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="102"/>
-      <source>PV</source>
-      <extracomment>PV power for solar charger</extracomment>
-      <translation type="unfinished">PV</translation>
+      <translation>Wersja oprogramowania w regulatorze MPPT Solar Charger musi być v1.09 lub nowsza. W celu uzyskania instrukcji aktualizacji i plików skontaktuj się z Serwisem Victron.</translation>
     </message>
     <message id="solarcharger_total_power">
       <location filename="../../pages/solar/PageSolarCharger.qml" line="127"/>
       <source>Total PV power</source>
-      <translation>Moc pv ogółem</translation>
-    </message>
-    <message id="solarcharger_total_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="211"/>
-      <source>Total yield</source>
-      <extracomment>Solar charger total yield</extracomment>
-      <translation type="unfinished">Całkowita wydajność</translation>
-    </message>
-    <message id="solarcharger_system_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="220"/>
-      <source>System yield</source>
-      <extracomment>Solar charger system yield</extracomment>
-      <translation type="unfinished">Uzysk systemu</translation>
+      <translation>Moc PV ogółem</translation>
     </message>
     <message id="settings_multirs_total_yield">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="63"/>
       <source>Total yield</source>
-      <translation>Całkowita wydajność</translation>
+      <translation>Całkowity uzysk</translation>
     </message>
     <message id="settings_multirs_system_yield">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="71"/>
@@ -7652,32 +6957,35 @@ Czy chcesz kontynuować?</translation>
     <message id="common_words_bms_controlled">
       <location filename="../../components/CommonWords.qml" line="107"/>
       <source>BMS controlled</source>
-      <translation>BMS Kontrolowane</translation>
+      <translation>Kontrola BMS</translation>
     </message>
     <message id="page_vebus_charge_battery">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="108"/>
       <source>Charge battery</source>
-      <translation>Ładowanie akumulatora</translation>
+      <translation>Ładuj akumulator</translation>
     </message>
     <message id="vebus_device_update_firmware">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="133"/>
       <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
-      <translation>Ta funkcja wymaga oprogramowania sprzętowego w wersji 400 lub nowszej. Aby zaktualizować urządzenie Multi/Quattro, należy skontaktować się z instalatorem.</translation>
+      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
+      <translation>Ta funkcja wymaga oprogramowania w wersji 400 lub nowszej. Aby zaktualizować urządzenie Multi/Quattro, skontaktuj się z instalatorem.</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="139"/>
       <source>Charger not ready, equalization cannot be started</source>
+      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
       <translation>Ładowarka nie jest gotowa, nie można uruchomić wyrównywania</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="143"/>
       <source>Equalization cannot be triggered during bulk charge state</source>
-      <translation>Wyrównanie nie może zostać uruchomione w stanie ładowania zbiorczego</translation>
+      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
+      <translation>Wyrównanie nie może zostać uruchomione w fazie ładowania Bulk</translation>
     </message>
     <message id="vebus_device_restart_vebus_system_restart_confirmation_description">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="235"/>
       <source>Restarting the VE.Bus system will reset any inverter on the bus, and result in a loss of power to their outputs.</source>
-      <translation>Ponowne uruchomienie systemu VE.Bus spowoduje zresetowanie dowolnego falownika na magistrali i utratę zasilania jego wyjść.</translation>
+      <translation>Ponowne uruchomienie systemu VE.Bus spowoduje zresetowanie inwerterów na magistrali i utratę zasilania ich wyjść.</translation>
     </message>
     <message id="common_words_dynamic_power_limit">
       <location filename="../../components/CommonWords.qml" line="595"/>
@@ -7692,80 +7000,22 @@ Czy chcesz kontynuować?</translation>
     <message id="controlcard_generator_autostarted">
       <location filename="../../components/CommonWords.qml" line="86"/>
       <source>Auto-started • %1</source>
-      <translation>Automatyczne uruchamianie - %1</translation>
-    </message>
-    <message id="common_words_battery">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_boat_page">
-      <location filename="../../components/CommonWords.qml" line="111"/>
-      <source>Boat</source>
-      <extracomment>The 'Boat' page</extracomment>
-      <translation type="unfinished">Łódź</translation>
-    </message>
-    <message id="common_words_brief_page">
-      <location filename="../../components/CommonWords.qml" line="115"/>
-      <source>Brief</source>
-      <extracomment>The 'Brief' page</extracomment>
-      <translation type="unfinished">Krótki</translation>
-    </message>
-    <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation type="unfinished">Zamknięte</translation>
-    </message>
-    <message id="common_words_color">
-      <location filename="../../components/CommonWords.qml" line="136"/>
-      <source>Color</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_connected">
-      <location filename="../../components/CommonWords.qml" line="139"/>
-      <source>Connected</source>
-      <translation type="unfinished">Podłączony</translation>
+      <translation>Automatyczne uruchamianie • %1</translation>
     </message>
     <message id="common_words_daily_history">
       <location filename="../../components/CommonWords.qml" line="152"/>
       <source>Daily history</source>
       <translation>Historia codzienna</translation>
     </message>
-    <message id="common_words_disabled">
-      <location filename="../../components/CommonWords.qml" line="169"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Wyłączone</translation>
-    </message>
-    <message id="common_words_disconnected">
-      <location filename="../../components/CommonWords.qml" line="175"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Odłączone</translation>
-    </message>
-    <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="191"/>
-      <source>Error</source>
-      <translation type="unfinished">Błąd</translation>
-    </message>
     <message id="common_words_error_not_a_number">
       <location filename="../../components/CommonWords.qml" line="200"/>
       <source>'%1' is not a number.</source>
       <translation>'%1' nie jest liczbą.</translation>
     </message>
-    <message id="common_words_generator">
-      <location filename="../../components/CommonWords.qml" line="217"/>
-      <source>Generator</source>
-      <translation type="unfinished">Generator</translation>
-    </message>
     <message id="common_words_input_current_limit">
       <location filename="../../components/CommonWords.qml" line="261"/>
       <source>Input current limit</source>
       <translation>Ograniczenie prądu wejściowego</translation>
-    </message>
-    <message id="common_words_inverter_charger">
-      <location filename="../../components/CommonWords.qml" line="264"/>
-      <source>Inverter / Charger</source>
-      <translation type="unfinished">Inwerter / Ładowarka</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
       <location filename="../../components/CommonWords.qml" line="268"/>
@@ -7778,12 +7028,6 @@ Czy chcesz kontynuować?</translation>
       <source>Manual stop</source>
       <translation>Zatrzymanie ręczne</translation>
     </message>
-    <message id="common_words_max">
-      <location filename="../../components/CommonWords.qml" line="315"/>
-      <source>Max</source>
-      <extracomment>Short for Maximum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_maximum_current">
       <location filename="../../components/CommonWords.qml" line="318"/>
       <source>Maximum current</source>
@@ -7794,62 +7038,10 @@ Czy chcesz kontynuować?</translation>
       <source>Maximum power</source>
       <translation>Maksymalna moc</translation>
     </message>
-    <message id="common_words_min">
-      <location filename="../../components/CommonWords.qml" line="331"/>
-      <source>Min</source>
-      <extracomment>Short for Minimum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_minimum_current">
       <location filename="../../components/CommonWords.qml" line="334"/>
       <source>Minimum current</source>
       <translation>Minimalny prąd</translation>
-    </message>
-    <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="433"/>
-      <source>No</source>
-      <translation type="unfinished">Nie</translation>
-    </message>
-    <message id="common_words_none_option">
-      <location filename="../../components/CommonWords.qml" line="364"/>
-      <source>None</source>
-      <translation type="unfinished">Brak</translation>
-    </message>
-    <message id="common_words_none_errors">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>None</source>
-      <extracomment>Indicates there are no errors</extracomment>
-      <translation type="unfinished">Brak</translation>
-    </message>
-    <message id="common_words_not_available">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Not available</source>
-      <translation type="unfinished">Niedostępne</translation>
-    </message>
-    <message id="common_words_off">
-      <location filename="../../components/CommonWords.qml" line="377"/>
-      <source>Off</source>
-      <translation type="unfinished">Wył.</translation>
-    </message>
-    <message id="common_words_ok">
-      <location filename="../../components/CommonWords.qml" line="383"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="41"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="45"/>
-      <source>OK</source>
-      <translation type="unfinished">OK</translation>
-    </message>
-    <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="386"/>
-      <source>On</source>
-      <translation type="unfinished">Wł.</translation>
-    </message>
-    <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="393"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation type="unfinished">Otwórz</translation>
     </message>
     <message id="common_words_open_circuit">
       <location filename="../../components/CommonWords.qml" line="396"/>
@@ -7861,109 +7053,18 @@ Czy chcesz kontynuować?</translation>
       <source>Overall history</source>
       <translation>Historia ogólna</translation>
     </message>
-    <message id="common_words_press">
-      <location filename="../../components/CommonWords.qml" line="419"/>
-      <source>Press</source>
-      <translation type="unfinished">Prasa</translation>
-    </message>
-    <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation type="unfinished">W toku</translation>
-    </message>
-    <message id="common_words_settings">
-      <location filename="../../components/CommonWords.qml" line="467"/>
-      <source>Settings</source>
-      <translation type="unfinished">Ustawienia</translation>
-    </message>
-    <message id="common_words_silence_alarm">
-      <location filename="../../components/CommonWords.qml" line="476"/>
-      <source>Silence alarm</source>
-      <translation type="unfinished">Wyciszenie alarmu</translation>
-    </message>
     <message id="common_words_soc">
       <location filename="../../components/CommonWords.qml" line="480"/>
       <source>SOC %1</source>
       <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
       <translation>SOC %1</translation>
     </message>
-    <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation type="unfinished">Prędkość</translation>
-    </message>
-    <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="487"/>
-      <source>Standby</source>
-      <translation type="unfinished">Czuwanie</translation>
-    </message>
-    <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="502"/>
-      <source>State</source>
-      <translation type="unfinished">Stan</translation>
-    </message>
-    <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="512"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation type="unfinished">Uruchomienie (%1)</translation>
-    </message>
-    <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>Stopped</source>
-      <translation type="unfinished">Zatrzymany</translation>
-    </message>
-    <message id="common_words_total_power">
-      <location filename="../../components/CommonWords.qml" line="540"/>
-      <source>Total power</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="547"/>
-      <source>Type</source>
-      <translation type="unfinished">Typ</translation>
-    </message>
-    <message id="common_words_unknown_status">
-      <location filename="../../components/CommonWords.qml" line="554"/>
-      <source>Unknown</source>
-      <extracomment>Status = "unknown"</extracomment>
-      <translation type="unfinished">Nieznany</translation>
-    </message>
-    <message id="common_words_value_must_be_greater_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="557"/>
-      <source>Value must be greater than start value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_value_must_be_greater_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="560"/>
-      <source>Value must be greater than stop value</source>
-      <translation type="unfinished">Wartość musi być większa niż wartość zatrzymania</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="563"/>
-      <source>Value must be lower than start value</source>
-      <translation type="unfinished">Wartość musi być niższa niż wartość uruchomienia</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="566"/>
-      <source>Value must be lower than stop value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="581"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="431"/>
-      <source>Yes</source>
-      <translation type="unfinished">Tak</translation>
-    </message>
     <message id="common_words_yield_today">
       <location filename="../../components/CommonWords.qml" line="592"/>
       <source>Yield Today</source>
       <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
-      <translation>Wydajność w dniu dzisiejszym</translation>
+      <oldsource>Yield today</oldsource>
+      <translation>Uzysk dziś</translation>
     </message>
     <message id="common_words_format_error">
       <location filename="../../components/CommonWords.qml" line="632"/>
@@ -7984,15 +7085,16 @@ Czy chcesz kontynuować?</translation>
     <message id="controlcard_inverter_mode">
       <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="30"/>
       <source>Inverter mode</source>
-      <translation>Tryb falownika</translation>
+      <translation>Tryb inwertera</translation>
     </message>
     <message id="settings_firmware_installed_rebooting">
       <location filename="../../components/FirmwareUpdate.qml" line="79"/>
       <source>Firmware installed, device rebooting</source>
-      <translation>Zainstalowane oprogramowanie sprzętowe, ponowne uruchomienie urządzenia</translation>
+      <oldsource>Firmware installed, rebooting.</oldsource>
+      <translation>Oprogramowanie zainstalowane, restart urządzenia</translation>
     </message>
-    <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/RadioButtonListPage.qml" line="121"/>
+    <message id="modaldialog_confirm">
+      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
       <source>Confirm</source>
       <extracomment>Confirm password, and verify it if possible</extracomment>
       <translation>Potwierdź</translation>
@@ -8010,11 +7112,13 @@ Czy chcesz kontynuować?</translation>
     <message id="cgwacs_battery_schedule_duration">
       <location filename="../../components/listitems/ListChargeSchedule.qml" line="144"/>
       <source>Duration</source>
+      <oldsource>Duration (hh:mm)</oldsource>
       <translation>Czas trwania</translation>
     </message>
     <message id="settings_relay_deactivation_value">
       <location filename="../../components/TemperatureRelaySettings.qml" line="86"/>
       <source>Deactivation value</source>
+      <oldsource>Deativation value</oldsource>
       <translation>Wartość dezaktywująca</translation>
     </message>
     <message id="splash_view_device_disconnected">
@@ -8025,7 +7129,7 @@ Czy chcesz kontynuować?</translation>
     <message id="splash_view_awaiting_heartbeat">
       <location filename="../../components/SplashView.qml" line="299"/>
       <source>Connected to VRM, awaiting device</source>
-      <translation>Podłączony do VRM, oczekujące urządzenie</translation>
+      <translation>Podłączony do VRM, oczekuję na urządzenie</translation>
     </message>
     <message id="splash_view_heartbeat_missing">
       <location filename="../../components/SplashView.qml" line="349"/>
@@ -8035,12 +7139,12 @@ Czy chcesz kontynuować?</translation>
     <message id="splash_view_heartbeat_inactive">
       <location filename="../../components/SplashView.qml" line="351"/>
       <source>Device is not connected to VRM</source>
-      <translation>Urządzenie nie jest podłączone do VRM</translation>
+      <translation>Urządzenie niepodłączone do VRM</translation>
     </message>
     <message id="acInputs_evcharger">
       <location filename="../../data/AcInputs.qml" line="48"/>
       <source>EV Charger</source>
-      <translation>Ładowarka solarna</translation>
+      <translation>Ładowarka EV</translation>
     </message>
     <message id="acInputs_heat_pump">
       <location filename="../../data/AcInputs.qml" line="50"/>
@@ -8062,33 +7166,10 @@ Czy chcesz kontynuować?</translation>
       <source>Temperature warning</source>
       <translation>Ostrzeżenie o temperaturze</translation>
     </message>
-    <message id="battery_mode_idle">
-      <location filename="../../src/enums.cpp" line="26"/>
-      <source>Idle</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Bezczynność</translation>
-    </message>
-    <message id="battery_mode_charging">
-      <location filename="../../src/enums.cpp" line="30"/>
-      <source>Charging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Ładowanie</translation>
-    </message>
-    <message id="battery_mode_discharging">
-      <location filename="../../src/enums.cpp" line="34"/>
-      <source>Discharging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Rozładowanie</translation>
-    </message>
-    <message id="dcMeter_bilge_pump">
-      <location filename="../../src/enums.cpp" line="115"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">Pompa zęzowa</translation>
-    </message>
     <message id="switch_state_channel_fault">
       <location filename="../../src/enums.cpp" line="372"/>
       <source>Channel Fault</source>
-      <translation>Usterka kanału</translation>
+      <translation>Usterka Kanału</translation>
     </message>
     <message id="switch_state_channel_Trippped">
       <location filename="../../src/enums.cpp" line="375"/>
@@ -8108,32 +7189,12 @@ Czy chcesz kontynuować?</translation>
     <message id="switchable_output_dimmable">
       <location filename="../../src/enums.cpp" line="395"/>
       <source>Dimmable</source>
-      <translation>Możliwość ściemniania</translation>
+      <translation>Ściemnialny</translation>
     </message>
     <message id="switchable_output_slave_of">
       <location filename="../../src/enums.cpp" line="405"/>
       <source>Slave of %1</source>
       <translation>Slave %1</translation>
-    </message>
-    <message id="switchable_output_numeric_input">
-      <location filename="../../src/enums.cpp" line="418"/>
-      <source>Numeric input</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bilge_pump">
-      <location filename="../../src/enums.cpp" line="424"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">Pompa zęzowa</translation>
-    </message>
-    <message id="switchable_output_not_running">
-      <location filename="../../src/enums.cpp" line="448"/>
-      <source>Not running</source>
-      <translation type="unfinished">Nie działa</translation>
-    </message>
-    <message id="switchable_output_off">
-      <location filename="../../src/enums.cpp" line="451"/>
-      <source>Off</source>
-      <translation type="unfinished">Wył.</translation>
     </message>
     <message id="switchable_output_powered">
       <location filename="../../src/enums.cpp" line="455"/>
@@ -8143,7 +7204,7 @@ Czy chcesz kontynuować?</translation>
     <message id="switchable_output_tripped">
       <location filename="../../src/enums.cpp" line="458"/>
       <source>Tripped</source>
-      <translation>Potknięcie</translation>
+      <translation>Zadziałał</translation>
     </message>
     <message id="switchable_output_short">
       <location filename="../../src/enums.cpp" line="475"/>
@@ -8158,27 +7219,30 @@ Czy chcesz kontynuować?</translation>
     <message id="ess_state_keep_batteries_charged_button">
       <location filename="../../data/Ess.qml" line="22"/>
       <source>Keep charged</source>
-      <translation>Przechowywać naładowane</translation>
+      <translation>Utrzymuj naładowane</translation>
     </message>
     <message id="evchargers_status_welded_contacts_error">
       <location filename="../../data/EvChargers.qml" line="76"/>
       <source>Welded contacts test error (shorted)</source>
-      <translation>Błąd testu styków spawanych (zwarcie)</translation>
+      <oldsource>Welded contacts error</oldsource>
+      <translation>Błąd testu styków lutowanych (zwarcie)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
       <location filename="../../data/EvChargers.qml" line="100"/>
       <source>Switching to 3 phase</source>
+      <oldsource>Switching to 3-phase</oldsource>
       <translation>Przełączanie na 3 fazy</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
       <location filename="../../data/EvChargers.qml" line="103"/>
       <source>Switching to 1 phase</source>
+      <oldsource>Switching to single phase</oldsource>
       <translation>Przełączanie na 1 fazę</translation>
     </message>
     <message id="evchargers_status_stop_charging">
       <location filename="../../data/EvChargers.qml" line="106"/>
       <source>Stop charging</source>
-      <translation>Zatrzymanie ładowania</translation>
+      <translation>Zatrzymaj ładowanie</translation>
     </message>
     <message id="evchargers_status_reserved">
       <location filename="../../data/EvChargers.qml" line="110"/>
@@ -8208,12 +7272,12 @@ Czy chcesz kontynuować?</translation>
     <message id="settings_ac_load_condition">
       <location filename="../../data/Generators.qml" line="74"/>
       <source>AC load condition</source>
-      <translation>Stan obciążenia prądem przemiennym</translation>
+      <translation>Stan obciążenia prądem AC</translation>
     </message>
     <message id="settings_battery_current_condition">
       <location filename="../../data/Generators.qml" line="77"/>
       <source>Battery current condition</source>
-      <translation>Aktualny stan akumulatora</translation>
+      <translation>Stan prądu akumulatora</translation>
     </message>
     <message id="settings_battery_voltage_condition">
       <location filename="../../data/Generators.qml" line="80"/>
@@ -8223,7 +7287,7 @@ Czy chcesz kontynuować?</translation>
     <message id="settings_inverter_overload_condition">
       <location filename="../../data/Generators.qml" line="86"/>
       <source>Inverter overload condition</source>
-      <translation>Stan przeciążenia falownika</translation>
+      <translation>Stan przeciążenia inwertera</translation>
     </message>
     <message id="application_content_touch_input_on">
       <location filename="../../ApplicationContent.qml" line="54"/>
@@ -8238,13 +7302,13 @@ Czy chcesz kontynuować?</translation>
     <message id="application_content_touch_input_disabled">
       <location filename="../../ApplicationContent.qml" line="70"/>
       <source>Touch input disabled</source>
-      <translation>Wprowadzanie dotykowe wyłączone</translation>
+      <translation>Wprowadzanie dotykowe dezaktywowane</translation>
     </message>
     <message id="inverter_ac-out_num">
       <location filename="../../components/InverterAcOutSettings.qml" line="44"/>
       <source>AC Out L%1</source>
       <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>Wyjście AC L%1</translation>
+      <translation>AC Out L%1</translation>
     </message>
     <message id="notification_description_and_value">
       <location filename="../../components/NotificationDelegate.qml" line="76"/>
@@ -8260,7 +7324,7 @@ Czy chcesz kontynuować?</translation>
     <message id="systemreason_charge_discharge_disabled">
       <location filename="../../components/SystemReason.qml" line="47"/>
       <source>ESS %1 Charge/Discharge Disabled</source>
-      <translation>ESS %1 Ładowanie/rozładowywanie wyłączone</translation>
+      <translation>ESS %1 Ładowanie/Rozładowywanie Wyłączone</translation>
     </message>
     <message id="systemreason_charge_disabled">
       <location filename="../../components/SystemReason.qml" line="50"/>
@@ -8287,7 +7351,7 @@ Czy chcesz kontynuować?</translation>
       <source>Autostart will be disabled and the generator won't automatically start based on the configured conditions.
 If the generator is currently running due to a autostart condition, disabling autostart will also stop it immediately.</source>
       <translation>Autostart zostanie wyłączony, a generator nie uruchomi się automatycznie w oparciu o skonfigurowane warunki.
-Jeśli generator jest obecnie uruchomiony z powodu warunków autostartu, wyłączenie autostartu również natychmiast go zatrzyma.</translation>
+Jeśli generator jest teraz uruchomiony z powodu warunków autostartu, wyłączenie autostartu również go zatrzyma.</translation>
     </message>
     <message id="controlcard_inverter_charger_ess_mode">
       <location filename="../../components/dialogs/InverterChargerEssModeDialog.qml" line="18"/>
@@ -8302,7 +7366,7 @@ Jeśli generator jest obecnie uruchomiony z powodu warunków autostartu, wyłąc
     <message id="settings_briefview_center_temperature_services">
       <location filename="../../components/listitems/ListBriefCenterDetails.qml" line="35"/>
       <source>Temperature services</source>
-      <translation>Usługi związane z temperaturą</translation>
+      <translation>Usługi temperatury</translation>
     </message>
     <message id="rs_current_limit_not_adjustable">
       <location filename="../../components/listitems/ListCurrentLimitButton.qml" line="28"/>
@@ -8325,17 +7389,6 @@ Jeśli generator jest obecnie uruchomiony z powodu warunków autostartu, wyłąc
       <source>Open link</source>
       <translation>Otwórz link</translation>
     </message>
-    <message id="listlink_show_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="43"/>
-      <source>Show QR code</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="listlink_scan_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="52"/>
-      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
-      <extracomment>%1 = url text</extracomment>
-      <translation type="unfinished">Zeskanuj kod QR za pomocą urządzenia przenośnego.&lt;br /&gt;Lub wstaw łącze: %1</translation>
-    </message>
     <message id="settings_services_mqtt_access">
       <location filename="../../components/listitems/ListMqttAccessSwitch.qml" line="11"/>
       <source>MQTT Access</source>
@@ -8349,7 +7402,7 @@ Jeśli generator jest obecnie uruchomiony z powodu warunków autostartu, wyłąc
     <message id="reboot_button_press_ok_to_reboot">
       <location filename="../../components/listitems/ListRebootButton.qml" line="24"/>
       <source>Press 'OK' to reboot</source>
-      <translation>Naciśnij "OK", aby ponownie uruchomić komputer</translation>
+      <translation>Naciśnij "OK", aby  uruchomić ponownie</translation>
     </message>
     <message id="reboot_button_dialoglayer_rebooting">
       <location filename="../../components/dialogs/ModalRebootingDialog.qml" line="14"/>
@@ -8379,7 +7432,7 @@ Jeśli generator jest obecnie uruchomiony z powodu warunków autostartu, wyłąc
     <message id="overview_widget_essential_loads_title">
       <location filename="../../components/widgets/EssentialLoadsWidget.qml" line="13"/>
       <source>Essential Loads</source>
-      <translation>Podstawowe obciążenia</translation>
+      <translation>Podstawowe Obciążenia</translation>
     </message>
     <message id="rs_alarm_low_ac_out_voltage">
       <location filename="../../data/InverterChargers.qml" line="30"/>
@@ -8407,12 +7460,6 @@ Jeśli generator jest obecnie uruchomiony z powodu warunków autostartu, wyłąc
       <extracomment>The 'Brief' page, with the side panel opened</extracomment>
       <translation>Skrót (panel boczny otwarty)</translation>
     </message>
-    <message id="startpage_option_overview">
-      <location filename="../../data/StartPageConfiguration.qml" line="37"/>
-      <source>Overview</source>
-      <extracomment>The 'Overview' page</extracomment>
-      <translation type="unfinished">Przegląd</translation>
-    </message>
     <message id="startpage_option_levels_tanks">
       <location filename="../../data/StartPageConfiguration.qml" line="43"/>
       <source>Levels (Tanks)</source>
@@ -8431,14 +7478,14 @@ Jeśli generator jest obecnie uruchomiony z powodu warunków autostartu, wyłąc
       <translation>Lista akumulatorów</translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
+      <location filename="../../pages/DialogLayer.qml" line="56"/>
       <source>GX device has been updated</source>
       <translation>Urządzenie GX zostało zaktualizowane</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
+      <location filename="../../pages/DialogLayer.qml" line="58"/>
       <source>Page will automatically reload in ten seconds to load the latest version.</source>
-      <translation>Strona zostanie automatycznie przeładowana za dziesięć sekund, aby załadować najnowszą wersję.</translation>
+      <translation>Strona przeładuje się za dziesięć sekund, aby wgrać najnowszą wersję.</translation>
     </message>
     <message id="controlcard_evcs_title">
       <location filename="../../pages/controlcards/EVCSCard.qml" line="21"/>
@@ -8449,7 +7496,7 @@ Jeśli generator jest obecnie uruchomiony z powodu warunków autostartu, wyłąc
     <message id="inverter_chargers_title">
       <location filename="../../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
       <source>Inverter/Chargers</source>
-      <translation>Falowniki/ładowarki</translation>
+      <translation>Inwertery/Ładowarki</translation>
     </message>
     <message id="settings_cgwacs_no_energy_meters">
       <location filename="../../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
@@ -8458,13 +7505,13 @@ Jeśli generator jest obecnie uruchomiony z powodu warunków autostartu, wyłąc
 Note that this menu only shows Carlo Gavazzi meters connected over RS485. For any other meter, including Carlo Gavazzi meters connected over ethernet, see the Modbus TCP/UDP devices menu instead.</source>
       <translation>Nie znaleziono liczników energii
 
-Należy pamiętać, że to menu pokazuje tylko liczniki Carlo Gavazzi podłączone przez RS485. W przypadku innych liczników, w tym liczników Carlo Gavazzi podłączonych przez sieć Ethernet, należy zapoznać się z menu urządzeń Modbus TCP/UDP.</translation>
+Należy pamiętać, że to menu pokazuje tylko liczniki Carlo Gavazzi podłączone przez RS485. W przypadku innych liczników, w tym Carlo Gavazzi podłączonych przez sieć Ethernet, zapoznaj się z menu urządzeń Modbus TCP/UDP.</translation>
     </message>
     <message id="settings_minmax_autorange">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
       <source>Auto-ranging</source>
       <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
-      <translation>Automatyczne przełączanie</translation>
+      <translation>Automatyczny zakres</translation>
     </message>
     <message id="settings_minmax_autorange_desc">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="21"/>
@@ -8479,7 +7526,7 @@ Należy pamiętać, że to menu pokazuje tylko liczniki Carlo Gavazzi podłączo
     <message id="settings_minmax_reset_range_values">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="37"/>
       <source>Reset Range Values</source>
-      <translation>Resetowanie wartości zakresu</translation>
+      <translation>Resetowanie Wartości Zakresu</translation>
     </message>
     <message id="settings_minmax_reset_are_you_sure">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="39"/>
@@ -8501,12 +7548,12 @@ Należy pamiętać, że to menu pokazuje tylko liczniki Carlo Gavazzi podłączo
     <message id="settings_minmax_acout_max_acin1">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="130"/>
       <source>Maximum current: AC in 1 connected</source>
-      <translation>Maksymalny prąd: AC w 1 podłączonym</translation>
+      <translation>Maksymalny prąd: AC in 1 połączone</translation>
     </message>
     <message id="settings_minmax_acout_max_acin2">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="139"/>
       <source>Maximum current: AC in 2 connected</source>
-      <translation>Maksymalny prąd: AC w 2 podłączonych</translation>
+      <translation>Maksymalny prąd: AC in 2 połączone</translation>
     </message>
     <message id="settings_minmax_acout_max">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="148"/>
@@ -8530,6 +7577,7 @@ Należy pamiętać, że to menu pokazuje tylko liczniki Carlo Gavazzi podłączo
         <numerusform>Po %n minutach</numerusform>
         <numerusform>Po %n minutach</numerusform>
         <numerusform>Po %n minutach</numerusform>
+        <numerusform>Po %n minutach</numerusform>
       </translation>
     </message>
     <message id="settings_startpage_description">
@@ -8550,12 +7598,12 @@ Należy pamiętać, że to menu pokazuje tylko liczniki Carlo Gavazzi podłączo
     <message id="settings_startpage_auto_description">
       <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="97"/>
       <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
-      <translation>Po minucie bezczynności bieżąca strona zostanie wybrana jako strona początkowa, jeśli znajduje się na tej liście.</translation>
+      <translation>Po minucie bezczynności, bieżąca strona zostanie wybrana jako początkowa, jeśli znajduje się na tej liście.</translation>
     </message>
     <message id="settings_ess_buying">
       <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="32"/>
       <source>Buying</source>
-      <translation>Kupowanie</translation>
+      <translation>Kupno</translation>
     </message>
     <message id="settings_ess_selling">
       <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="34"/>
@@ -8565,12 +7613,12 @@ Należy pamiętać, że to menu pokazuje tylko liczniki Carlo Gavazzi podłączo
     <message id="settings_ess_target_soc">
       <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
       <source>Target SOC</source>
-      <translation>Cel SOC</translation>
+      <translation>Docelowy SOC</translation>
     </message>
     <message id="page_settings_modbus_scan_for_devices">
       <location filename="../../pages/settings/PageSettingsModbus.qml" line="37"/>
       <source>Scan for devices</source>
-      <translation>Skanowanie w poszukiwaniu urządzeń</translation>
+      <translation>Szukanie urządzeń</translation>
     </message>
     <message id="page_settings_modbus_saved_devices">
       <location filename="../../pages/settings/PageSettingsModbus.qml" line="45"/>
@@ -8580,7 +7628,7 @@ Należy pamiętać, że to menu pokazuje tylko liczniki Carlo Gavazzi podłączo
     <message id="common_words_discovered_devices">
       <location filename="../../components/CommonWords.qml" line="178"/>
       <source>Discovered devices</source>
-      <translation>Odkryte urządzenia</translation>
+      <translation>Wykryte urządzenia</translation>
     </message>
     <message id="add_modbus_tcp_udp_device">
       <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="15"/>
@@ -8607,8 +7655,8 @@ Należy pamiętać, że to menu pokazuje tylko liczniki Carlo Gavazzi podłączo
       <source>Unit</source>
       <translation>Jednostka</translation>
     </message>
-    <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="61"/>
+    <message id="page_settings_fronius_unitid_invalid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
       <source>%1 is not a valid unit number. Use a number between 1-247.</source>
       <translation>%1 nie jest prawidłowym numerem jednostki. Należy użyć liczby z zakresu 1-247.</translation>
     </message>
@@ -8656,7 +7704,7 @@ Należy pamiętać, że to menu pokazuje tylko liczniki Carlo Gavazzi podłączo
     <message id="pagesettingssupportstate_hq_serial_number">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="243"/>
       <source>HQ serial number</source>
-      <translation>Numer seryjny centrali</translation>
+      <translation>Numer seryjny HQ</translation>
     </message>
     <message id="pagesettingssupportstate_data_free_space">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="250"/>
@@ -8666,7 +7714,7 @@ Należy pamiętać, że to menu pokazuje tylko liczniki Carlo Gavazzi podłączo
     <message id="pagesettingssupportstate_installed_firmware_version">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="357"/>
       <source>Installed firmware version</source>
-      <translation>Zainstalowana wersja oprogramowania sprzętowego</translation>
+      <translation>Zainstalowana wersja oprogramowania</translation>
     </message>
     <message id="pagesettingssupportstate_installed_image_type">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="363"/>
@@ -8717,17 +7765,12 @@ Należy pamiętać, że to menu pokazuje tylko liczniki Carlo Gavazzi podłączo
     <message id="devicelist_motordrive_motortemperature">
       <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="30"/>
       <source>Motor Temperature</source>
-      <translation>Temperatura silnika</translation>
+      <translation>Temperatura Silnika</translation>
     </message>
     <message id="devicelist_motordrive_controllertemperature">
       <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="66"/>
       <source>Controller Temperature</source>
-      <translation>Temperatura sterownika</translation>
-    </message>
-    <message id="devicelist_motordrive_motordirectioninverted">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
-      <source>Motor Direction Inverted</source>
-      <translation type="unfinished"/>
+      <translation>Temperatura Sterownika</translation>
     </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
@@ -8773,17 +7816,17 @@ Należy pamiętać, że to menu pokazuje tylko liczniki Carlo Gavazzi podłączo
     <message id="cycle_history_elapsed_time">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
       <source>Elapsed time</source>
-      <translation>Upływający czas</translation>
+      <translation>Czas, który upłynął</translation>
     </message>
     <message id="cycle_history_charge_maintain_ah">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="70"/>
       <source>Charge / maintain (Ah)</source>
-      <translation>Ładowanie/utrzymanie (Ah)</translation>
+      <translation>Ładowanie / utrzymanie (Ah)</translation>
     </message>
     <message id="cycle_history_battery_voltage">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="85"/>
       <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
-      <translation>Bateria (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;koniec&lt;/sub&gt;)</translation>
+      <translation>Akumulaotr (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</translation>
     </message>
     <message id="inverter_maximum_pv_voltage">
       <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
@@ -8839,12 +7882,12 @@ Należy pamiętać, że to menu pokazuje tylko liczniki Carlo Gavazzi podłączo
     <message id="welcome_whatsnew">
       <location filename="../../pages/welcome/WelcomeView.qml" line="34"/>
       <source>What's New</source>
-      <translation>Co nowego</translation>
+      <translation>Con Nowego</translation>
     </message>
     <message id="welcome_skip">
       <location filename="../../pages/welcome/WelcomeView.qml" line="44"/>
       <source>Skip</source>
-      <translation>pomiń</translation>
+      <translation>Pomiń</translation>
     </message>
     <message id="welcome_landing_title">
       <location filename="../../pages/welcome/WelcomeView.qml" line="63"/>
@@ -8858,7 +7901,7 @@ Należy pamiętać, że to menu pokazuje tylko liczniki Carlo Gavazzi podłączo
 With streamlined navigation and a fresh look, everything you love is now even easier to access and more visually appealing.</source>
       <translation>Z przyjemnością przedstawiamy całkowicie przeprojektowany interfejs, który zwiększa zarówno użyteczność, jak i estetykę GX.
 
-Dzięki usprawnionej nawigacji i świeżemu wyglądowi wszystko, co kochasz, jest teraz jeszcze łatwiej dostępne i bardziej atrakcyjne wizualnie.</translation>
+Dzięki usprawnionej nawigacji i świeżemu wyglądowi wszystko, co lubisz, jest teraz jeszcze łatwiej dostępne i bardziej atrakcyjne wizualnie.</translation>
     </message>
     <message id="welcome_colors_title">
       <location filename="../../pages/welcome/WelcomeView.qml" line="73"/>
@@ -8868,27 +7911,27 @@ Dzięki usprawnionej nawigacji i świeżemu wyglądowi wszystko, co kochasz, jes
     <message id="welcome_colors_text">
       <location filename="../../pages/welcome/WelcomeView.qml" line="77"/>
       <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
-      <translation>Różne środowiska wymagają różnych ustawień wyświetlania. Tryby ciemny i jasny zapewniają najlepsze wrażenia z oglądania bez względu na to, gdzie się znajdujesz.</translation>
+      <translation>Różne otoczenia wymagają różnych ustawień wyświetlania. Tryby ciemny i jasny zapewniają najlepsze wrażenia z oglądania bez względu na to, gdzie się znajdujesz.</translation>
     </message>
     <message id="welcome_brief_text">
       <location filename="../../pages/welcome/WelcomeView.qml" line="86"/>
       <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
-      <translation>Wszystkie kluczowe informacje, których potrzebujesz, przedstawione w przejrzystym i prostym układzie. Centralnym elementem jest konfigurowalny widżet z pierścieniami, zapewniający szybki dostęp do szczegółowych informacji o systemie.</translation>
+      <translation>Wszystkie najważniejsze informacje w prostym, przejrzystym układzie. W centrum znajduje się konfigurowalny widżet z pierścieniami, który pozwala jednym rzutem oka sprawdzić stan systemu.</translation>
     </message>
     <message id="welcome_overview_text">
       <location filename="../../pages/welcome/WelcomeView.qml" line="94"/>
       <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
-      <translation>Zyskaj większą kontrolę dzięki naszemu zaktualizowanemu panelowi Overview, zawierającemu dane systemowe w czasie rzeczywistym - wszystko w jednym miejscu dla łatwego monitorowania.</translation>
+      <translation>Zyskaj większą kontrolę dzięki ulepszonemu panelowi Overview, zawierającemu dane systemowe w czasie rzeczywistym - wszystko w jednym miejscu dla łatwego monitorowania.</translation>
     </message>
     <message id="welcome_controls_title">
       <location filename="../../pages/welcome/WelcomeView.qml" line="98"/>
       <source>Controls</source>
-      <translation>Kontrole:</translation>
+      <translation>Kontrolery</translation>
     </message>
     <message id="welcome_controls_text">
       <location filename="../../pages/welcome/WelcomeView.qml" line="101"/>
       <source>All the day to day controls are now combined together in the new Controls pane. Accessible from anywhere by tapping the dedicated button on top left of the display.</source>
-      <translation>Wszystkie codzienne elementy sterujące są teraz połączone w nowym panelu sterowania. Dostęp do niego można uzyskać z dowolnego miejsca, dotykając dedykowanego przycisku w lewym górnym rogu wyświetlacza.</translation>
+      <translation>Wszystkie codzienne funkcje sterowania od teraz w nowym Panelu Sterowania. Otworzysz go jednym stuknięciem w przycisk w lewym górnym rogu wyświetlacza.</translation>
     </message>
     <message id="welcome_units_title">
       <location filename="../../pages/welcome/WelcomeView.qml" line="105"/>
@@ -8919,57 +7962,52 @@ Dzięki usprawnionej nawigacji i świeżemu wyglądowi wszystko, co kochasz, jes
     <message id="welcome_done">
       <location filename="../../pages/welcome/WelcomeView.qml" line="136"/>
       <source>Done</source>
-      <translation type="unfinished">Gotowe</translation>
-    </message>
-    <message id="mk2vsc_state_done">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="20"/>
-      <source>Done</source>
       <translation>Gotowe</translation>
     </message>
     <message id="welcome_next">
       <location filename="../../pages/welcome/WelcomeView.qml" line="138"/>
       <source>Next</source>
-      <translation>następnie</translation>
+      <translation>Następny</translation>
     </message>
     <message id="direction_north">
       <location filename="../../src/units.cpp" line="500"/>
       <source>N</source>
-      <translation>N</translation>
+      <translation>pn.</translation>
     </message>
     <message id="direction_northeast">
       <location filename="../../src/units.cpp" line="502"/>
       <source>NE</source>
-      <translation>Nie</translation>
+      <translation>pn.-wsch.</translation>
     </message>
     <message id="direction_east">
       <location filename="../../src/units.cpp" line="504"/>
       <source>E</source>
-      <translation>E-mail</translation>
+      <translation>wsch.</translation>
     </message>
     <message id="direction_southeast">
       <location filename="../../src/units.cpp" line="506"/>
       <source>SE</source>
-      <translation>Przegląd</translation>
+      <translation>pd.-wsch.</translation>
     </message>
     <message id="direction_south">
       <location filename="../../src/units.cpp" line="508"/>
       <source>S</source>
-      <translation>z</translation>
+      <translation>Pd.</translation>
     </message>
     <message id="direction_southwest">
       <location filename="../../src/units.cpp" line="510"/>
       <source>SW</source>
-      <translation>NE</translation>
+      <translation>Płd. wsch.</translation>
     </message>
     <message id="direction_west">
       <location filename="../../src/units.cpp" line="512"/>
       <source>W</source>
-      <translation>W</translation>
+      <translation>Zach.</translation>
     </message>
     <message id="direction_northwest">
       <location filename="../../src/units.cpp" line="514"/>
       <source>NW</source>
-      <translation>NW</translation>
+      <translation>Pn. zach.</translation>
     </message>
     <message id="genset_controller_multiple_genset_controllers">
       <location filename="../../components/PageGensetModel.qml" line="60"/>
@@ -8981,13 +8019,14 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="settings_tz_etc">
       <location filename="../../pages/settings/PageTzInfo.qml" line="280"/>
       <source>Other</source>
+      <oldsource>Etc</oldsource>
       <translation>Inne</translation>
     </message>
     <message id="ac-in-modeldefault_energy_reverse_x">
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="140"/>
       <source>Reversed Energy L%1</source>
       <extracomment>%1 = phase number (1-3)</extracomment>
-      <translation>Energia odwrócona L%1</translation>
+      <translation>Odwrócona Energia L%1</translation>
     </message>
     <message id="settings_minmax_boat_page">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="182"/>
@@ -8998,6 +8037,11 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
       <location filename="../../src/enums.cpp" line="438"/>
       <source>Unsupported type: %1</source>
       <translation>Nieobsługiwany typ: %1</translation>
+    </message>
+    <message id="common_words_press">
+      <location filename="../../components/CommonWords.qml" line="419"/>
+      <source>Press</source>
+      <translation>Naciśnij</translation>
     </message>
     <message id="output_aux_battery_service_changed_dcdc">
       <location filename="../../components/listitems/ListOutputBatteryRadioButtonGroup.qml" line="27"/>
@@ -9012,22 +8056,22 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="settings_minmax_gauge_display">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="187"/>
       <source>Gauge Display</source>
-      <translation>Wyświetlacz wskaźnika</translation>
+      <translation>Wyświetlacz Wskaźnika</translation>
     </message>
     <message id="settings_minmax_time_to_go">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="195"/>
       <source>Time to go</source>
-      <translation>Czas iść</translation>
+      <translation>Czas do końca</translation>
     </message>
     <message id="settings_minmax_max_speed">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="210"/>
       <source>Max Speed</source>
-      <translation>Prędkość maksymalna</translation>
+      <translation>Prędkość Max.</translation>
     </message>
     <message id="settings_minmax_max_rpm">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="222"/>
       <source>Max RPM</source>
-      <translation>Maks. obr.</translation>
+      <translation>Maks. RPM</translation>
     </message>
     <message id="devicelist_motordrive_coolanttemperature">
       <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="59"/>
@@ -9042,7 +8086,7 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="settings_module_voltage">
       <location filename="../../pages/settings/devicelist/PageSwitch.qml" line="25"/>
       <source>Module Voltage</source>
-      <translation>Napięcie modułu</translation>
+      <translation>Napięcie Modułu</translation>
     </message>
     <message id="page_switchable_output_group">
       <location filename="../../pages/settings/devicelist/switchable-outputs/PageSwitchableOutput.qml" line="46"/>
@@ -9067,12 +8111,12 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="boat_page_time_to_go">
       <location filename="../../pages/boat/TimeToGo.qml" line="55"/>
       <source>Time To Go</source>
-      <translation>Czas iść</translation>
+      <translation>Czas do końca</translation>
     </message>
     <message id="backup_and_restore">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="274"/>
       <source>Backup &amp; Restore</source>
-      <translation>Kopia zapasowa i przywracanie</translation>
+      <translation>Kopia zapasowa i Przywracanie</translation>
     </message>
     <message id="wifimodel_disconnected_ap_on">
       <location filename="../../components/WifiModel.qml" line="23"/>
@@ -9087,12 +8131,12 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="mk2vsc_state_init">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="16"/>
       <source>Init</source>
-      <translation>Inicjał</translation>
+      <translation>Inicj.</translation>
     </message>
     <message id="mk2vsc_state_query_products">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="18"/>
       <source>Query products</source>
-      <translation>Produkty zapytań</translation>
+      <translation>Zapytaj o produkty</translation>
     </message>
     <message id="mk2vsc_state_read_setting_data">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="22"/>
@@ -9102,7 +8146,7 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="mk2vsc_state_read_assistants">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="24"/>
       <source>Read assistants</source>
-      <translation>Czytaj asystentów</translation>
+      <translation>Odczyt modułów pomocniczych</translation>
     </message>
     <message id="mk2vsc_state_read_vebus_configuration">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="26"/>
@@ -9112,7 +8156,7 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="mk2vsc_state_read_grid_info">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="28"/>
       <source>Read grid info</source>
-      <translation>Przeczytaj informacje o siatce</translation>
+      <translation>Czytaj inf. o sieci</translation>
     </message>
     <message id="mk2vsc_state_write_settings_info">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="30"/>
@@ -9122,12 +8166,12 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="mk2vsc_state_write_settings_data">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="32"/>
       <source>Write Settings Data</source>
-      <translation>Zapis danych ustawień</translation>
+      <translation>Zapis Danych Ustawień</translation>
     </message>
     <message id="mk2vsc_state_write_assistants">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="34"/>
       <source>Write assistants</source>
-      <translation>Asystenci pisania</translation>
+      <translation>Zapis modułów pomocniczych</translation>
     </message>
     <message id="mk2vsc_state_write_vebus_configuration">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="36"/>
@@ -9138,13 +8182,6 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="38"/>
       <source>Resetting VE.Bus products</source>
       <translation>Resetowanie produktów VE.Bus</translation>
-    </message>
-    <message id="Unknown">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Nieznany</translation>
     </message>
     <message id="mk2vsc_error_mk2_mk3_comm">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="47"/>
@@ -9159,7 +8196,7 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="mk2vsc_error_incomp_mk2_fw">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="51"/>
       <source>Incompatible MK2 firmware version</source>
-      <translation>Niezgodna wersja oprogramowania sprzętowego MK2</translation>
+      <translation>Niezgodna wersja oprogramowania MK2</translation>
     </message>
     <message id="mk2vsc_error_no_vebus_prod">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="53"/>
@@ -9179,12 +8216,12 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="mk2vsc_error_wrong_pass">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="59"/>
       <source>Wrong password. (Use VeConfigure to set gridcode to None)</source>
-      <translation>Nieprawidłowe hasło. (Użyj VeConfigure, aby ustawić gridcode na None)</translation>
+      <translation>Nieprawidłowe hasło. (Użyj VeConfigure, aby ustawić kod sieci na Brak)</translation>
     </message>
     <message id="mk2vsc_error_malloc">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="61"/>
       <source>Malloc error</source>
-      <translation>Błąd majoroc</translation>
+      <translation>Błąd pamięci (malloc)</translation>
     </message>
     <message id="mk2vsc_error_file_no_settings">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="63"/>
@@ -9194,7 +8231,7 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="mk2vsc_error_file_mismatch">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="65"/>
       <source>Uploaded file does not match model and/or installed firmware version</source>
-      <translation>Przesłany plik nie pasuje do modelu i/lub wersji zainstalowanego oprogramowania sprzętowego.</translation>
+      <translation>Przesłany plik nie pasuje do modelu i/lub wersji zainstalowanego oprogramowania</translation>
     </message>
     <message id="mk2vsc_error_mult_unknown_units">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="67"/>
@@ -9204,7 +8241,7 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="mk2vsc_error_update_single_unit">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="69"/>
       <source>Updating a single unit with another unit's settings is not possible, even if they are of the same type</source>
-      <translation>Aktualizacja pojedynczego urządzenia ustawieniami innego urządzenia nie jest możliwa, nawet jeśli są one tego samego typu</translation>
+      <translation>Aktualizacja danego urządzenia ustawieniami innego urządzenia nie jest możliwa, nawet jeśli są one tego samego typu</translation>
     </message>
     <message id="mk2vsc_error_unit_count_mismatch">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="71"/>
@@ -9264,7 +8301,7 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="mk2vsc_error_vebus_write_fail">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="93"/>
       <source>VE.Bus write of assistant enable/disable setting failed</source>
-      <translation>VE.Bus zapis ustawienia włączenia/wyłączenia asystenta nie powiódł się</translation>
+      <translation>VE.Bus – błąd zapisu wł./wył. modułu pomocniczego</translation>
     </message>
     <message id="mk2vsc_error_vebus_config_fail">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="95"/>
@@ -9279,17 +8316,17 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="mk2vsc_error_assist_write_fail">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="99"/>
       <source>Assistants write failed</source>
-      <translation>Asystenci piszą nieudane</translation>
+      <translation>Błąd zapisu modułów pomocniczych</translation>
     </message>
     <message id="mk2vsc_error_assist_read_fail">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="101"/>
       <source>Assistants read failed</source>
-      <translation>Odczyt asystentów nie powiódł się</translation>
+      <translation>Błąd odczytu modułów pomocniczych</translation>
     </message>
     <message id="mk2vsc_error_grid_info_read_fail">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="103"/>
       <source>Grid info read failed</source>
-      <translation>Odczyt informacji o siatce nie powiódł się</translation>
+      <translation>Odczyt inf. o sieci nie powiódł się</translation>
     </message>
     <message id="mk2vsc_error_os_unknown_app">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="105"/>
@@ -9319,7 +8356,7 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="vebus_backup_result_backup_process_unexpedly_closed">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="122"/>
       <source>Backup process unexpectedly closed</source>
-      <translation>Proces tworzenia kopii zapasowej został nieoczekiwanie zamknięty</translation>
+      <translation>Proces tworzenia kopii zapasowej nieoczekiwanie zamknięty</translation>
     </message>
     <message id="vebus_backup_result_restore_process_unexpedly_closed">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="124"/>
@@ -9334,7 +8371,7 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="incompatible">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="228"/>
       <source>Incompatible</source>
-      <translation>Nieobsługiwany</translation>
+      <translation>Niezgodny</translation>
     </message>
     <message id="backup_name">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="294"/>
@@ -9369,7 +8406,7 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="vebus_backup_backing_up">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="327"/>
       <source>Backing up...</source>
-      <translation>Kopia zapasowa...</translation>
+      <translation>Tworzenie kopii zapasowej...</translation>
     </message>
     <message id="vebus_backup_restore">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="340"/>
@@ -9416,13 +8453,13 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="vebus_backup_firmware_version_specific_message">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="425"/>
       <source>Note: Backup files are VE.Bus firmware version specific and can only be used to restore settings on products with matching firmware versions</source>
-      <translation>Uwaga: Pliki kopii zapasowych są specyficzne dla wersji oprogramowania sprzętowego VE.Bus i mogą być używane tylko do przywracania ustawień w produktach z odpowiednimi wersjami oprogramowania sprzętowego.</translation>
+      <translation>Uwaga: Pliki kopii zapasowych są przeznaczone dla konkretnej wersji oprogramowania VE.Bus i mogą być używane tylko do przywracania ustawień w produktach z odpowiednimi wersjami oprogramowania</translation>
     </message>
     <message id="batteryparameters_charge_request">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="49"/>
       <source>Requests Charging</source>
       <extracomment>Shows if the battery requests charging: yes or no</extracomment>
-      <translation>Żądania ładowania</translation>
+      <translation>Żądanie Ładowania</translation>
     </message>
     <message id="settings_security_profile_change_password">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="186"/>
@@ -9450,11 +8487,6 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
       <source>Changing the GX Password</source>
       <translation>Zmiana hasła GX</translation>
     </message>
-    <message id="modaldialog_confirm">
-      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
-      <source>Confirm</source>
-      <translation type="unfinished">Potwierdź</translation>
-    </message>
     <message id="settings_security_profile_change_password_description">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="83"/>
       <source>Please enter a new GX password:</source>
@@ -9474,17 +8506,17 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="settings_dvcc_control_mk3_usb_inverter_charger_system">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="233"/>
       <source>Control MK3-USB connected inverter/charger system</source>
-      <translation>Steruj systemem falownika/ładowarki podłączonym przez MK3-USB</translation>
+      <translation>Sterowanie systemem inwertera/ładowarki MK3-USB</translation>
     </message>
     <message id="settings_dvcc_control_mk3_usb_inverter_charger_system_caption">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="238"/>
       <source>Enable this setting when having a secondary MultiPlus or Quattro system powered by the same battery bank as the main inverter/charger system. When this setting is enabled, this secondary system will use the CVL and DCL parameters of the selected BMS.</source>
-      <translation>Włącz to ustawienie, jeśli masz dodatkowy system MultiPlus lub Quattro zasilany z tego samego zestawu akumulatorów, co główny system falownika/ładowarki. Po włączeniu tego ustawienia, ten dodatkowy system będzie używał parametrów CVL i DCL wybranego BMS.</translation>
+      <translation>Włącz to ustawienie, jeśli masz dodatkowy system MultiPlus lub Quattro zasilany z tego samego zestawu akumulatorów, co główny system inwertera/ładowarki. Po włączeniu tego ustawienia dodatkowy system będzie używał parametrów CVL i DCL wybranego BMS.</translation>
     </message>
     <message id="settings_vrm_device_registration">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="95"/>
       <source>VRM Device Registration</source>
-      <translation>Rejestracja urządzenia VRM</translation>
+      <translation>Rejestracja Urządzenia VRM</translation>
     </message>
     <message id="settings_access_control_display_firmware">
       <location filename="../../pages/SettingsPage.qml" line="43"/>
@@ -9547,21 +8579,6 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
       <source>Modifications installed</source>
       <translation>Zainstalowane modyfikacje</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_modbus">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="28"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">Serwer Modbus TCP</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_signalk">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="32"/>
-      <source>Signal K</source>
-      <translation type="unfinished">Sygnał K</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_nodered">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="36"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">Node-RED</translation>
-    </message>
     <message id="pagesettingsgeneral_modificationchecks_running_integrations">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="43"/>
       <source>%1 running integrations</source>
@@ -9580,12 +8597,12 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="reboot_button_dialoglayer_reboot_initiated">
       <location filename="../../components/dialogs/ModalRebootingDialog.qml" line="16"/>
       <source>Reboot initiated</source>
-      <translation>Uruchomiono ponowne uruchomienie</translation>
+      <translation>Rozpoczęto restart</translation>
     </message>
     <message id="reboot_button_dialoglayer_rebooting_description">
       <location filename="../../components/dialogs/ModalRebootingDialog.qml" line="19"/>
       <source>Please wait until the device rebooted.</source>
-      <translation>Proszę czekać na ponowne uruchomienie urządzenia.</translation>
+      <translation>Proszę czekać na restart urządzenia.</translation>
     </message>
     <message id="pagesettingssupportstate_modifiedstate_not_available_on_this_device">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="92"/>
@@ -9615,7 +8632,7 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="pagesettingssupportstate_custom_startup_installed_but_disabled_but_enable_next_boot">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="127"/>
       <source>Installed but disabled, enables at next boot</source>
-      <translation>Zainstalowane, ale wyłączone, włączone przy następnym uruchomieniu</translation>
+      <translation>Zainstalowane, ale wyłączone, włączy się przy następnym uruchomieniu</translation>
     </message>
     <message id="pagesettingssupportstate_custom_startup_installed_and_enabled_rc_local_rcS_local">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="133"/>
@@ -9635,17 +8652,7 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="pagesettingssupportstate_custom_startup_installed_and_enabled_but_disable_next_boot">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="142"/>
       <source>Installed and enabled, disables at next boot</source>
-      <translation>Zainstalowane i włączone, wyłączone przy następnym uruchomieniu</translation>
-    </message>
-    <message id="pagesettingssupportstate_firmware_checking">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
-      <source>Checking...</source>
-      <translation type="unfinished">Sprawdzanie...</translation>
-    </message>
-    <message id="pagesettingssupportstate_firmware_unknown">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="166"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Nieznany</translation>
+      <translation>Zainstalowane i włączone, wyłączy się przy następnym uruchomieniu</translation>
     </message>
     <message id="pagesettingssupportstate_support_status">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="228"/>
@@ -9667,12 +8674,7 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="pagesettingssupportstate_disable_custom_startup_scripts_description">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="288"/>
       <source>Press 'OK' to disable custom startup scripts and reboot</source>
-      <translation>Naciśnij 'OK', aby wyłączyć niestandardowe skrypty startowe i uruchomić ponownie</translation>
-    </message>
-    <message id="pagesettingssupportstate_re_enable_custom_startup_scripts">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="309"/>
-      <source>Re-enable custom startup scripts</source>
-      <translation type="unfinished">Włącz ponownie niestandardowe skrypty startowe</translation>
+      <translation>Naciśnij 'OK', aby wyłączyć niestandardowe skrypty startowe i zrestartować</translation>
     </message>
     <message id="pagesettingssupportstate_reenable_and_reboot_now">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="322"/>
@@ -9682,7 +8684,7 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="pagesettingssupportstate_press_ok_to_reenable_and_reboot">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="324"/>
       <source>Press 'OK' to re-enable custom startup scripts and reboot</source>
-      <translation>Naciśnij 'OK', aby ponownie włączyć niestandardowe skrypty startowe i uruchomić ponownie</translation>
+      <translation>Naciśnij 'OK', aby znów włączyć niestandardowe skrypty startowe i zrestartować</translation>
     </message>
     <message id="pagesettingssupportstate_file_system_status">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="345"/>
@@ -9692,22 +8694,17 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="pagesettingssupportstate_latest_official_firmware_installed">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="368"/>
       <source>Latest official firmware version installed?</source>
-      <translation>Czy zainstalowano najnowszą oficjalną wersję oprogramowania układowego?</translation>
+      <translation>Czy zainstalowano najnowszą oficjalną wersję oprogramowania?</translation>
     </message>
     <message id="pagesettingssupportstate_disable_also_custom_startup_scripts">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="428"/>
       <source>Disable also custom startup scripts?</source>
       <translation>Wyłączyć również niestandardowe skrypty startowe?</translation>
     </message>
-    <message id="pagesettingssupportstate_integrations">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
-      <source>Integrations</source>
-      <translation type="unfinished">Integracje</translation>
-    </message>
     <message id="pagesettingssupportstate_orange_items_description">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="494"/>
       <source>Items colored orange are supported and provided by Victron Energy, but using them incorrectly can affect system stability. In case of troubleshooting, disable those first.</source>
-      <translation>Elementy oznaczone kolorem pomarańczowym są obsługiwane i dostarczane przez Victron Energy, ale nieprawidłowe ich użycie może wpłynąć na stabilność systemu. W przypadku rozwiązywania problemów należy je najpierw wyłączyć.</translation>
+      <translation>Elementy oznaczone kolorem pomarańczowym są obsługiwane i dostarczane przez Victron Energy, ale ich nieprawidłowe użycie może wpłynąć na stabilność systemu. W przypadku rozwiązywania problemów należy je najpierw wyłączyć.</translation>
     </message>
     <message id="settings_bluetooth_unavailable_message">
       <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="26"/>
@@ -9715,31 +8712,14 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
       <translation>Podłącz kompatybilny klucz USB Bluetooth, aby włączyć łączność Bluetooth.</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="140"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="142"/>
       <source>BatteryLife state</source>
       <translation>Stan BatteryLife</translation>
     </message>
     <message id="pagesettingsintegrations_device_integrations">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="33"/>
       <source>Device Integrations</source>
-      <translation>Integracje urządzeń</translation>
-    </message>
-    <message id="pagesettingsintegrations_modbus_tcp_server">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="201"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">Serwer Modbus TCP</translation>
-    </message>
-    <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="226"/>
-      <location filename="../../pages/settings/PageSettingsSignalK.qml" line="18"/>
-      <source>Signal K</source>
-      <translation type="unfinished">Sygnał K</translation>
-    </message>
-    <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="241"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">Node-RED</translation>
+      <translation>Integracje Urządzeń</translation>
     </message>
     <message id="settings_venusos_large_documentation">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="267"/>
@@ -9749,12 +8729,13 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="settings_modbus_enable_modbus_tcp">
       <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
       <source>Enable Modbus TCP Server</source>
-      <translation>Włącz serwer Modbus TCP</translation>
+      <oldsource>Enable Modbus/TCP</oldsource>
+      <translation>Włącz Serwer Modbus TCP</translation>
     </message>
     <message id="pagesettingsconnectivity_bluetooth_for_victronconnect_app">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="38"/>
       <source>Bluetooth (for VictronConnect App)</source>
-      <translation>Bluetooth (dla aplikacji VictronConnect)</translation>
+      <translation>Bluetooth (dla Aplikacji VictronConnect)</translation>
     </message>
     <message id="pagesettingsconnectivity_bluetooth_not_available">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="42"/>
@@ -9804,12 +8785,12 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="pagesettingssupportstate_disable_and_reboot_now">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="277"/>
       <source>Disable and reboot now</source>
-      <translation>Wyłącz i uruchom ponownie teraz</translation>
+      <translation>Wyłącz i zrestartuj teraz</translation>
     </message>
     <message id="pagesettingssupportstate_re_enable_and_reboot_now">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="311"/>
       <source>Re-enable and reboot now</source>
-      <translation>Włącz ponownie i uruchom ponownie teraz</translation>
+      <translation>Włącz ponownie i zrestartuj teraz</translation>
     </message>
     <message id="pagesettingssupportstate_update_firmware_to_fix_modified_state">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="375"/>
@@ -9837,16 +8818,18 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="pagesettingssupportstate_update_firmware_to_fix_modified_state_description">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="404"/>
       <source>This will download and update rootfs with the latest official firmware.&lt;br&gt;Internet connectivity is required.&lt;br&gt;Press 'OK' to continue.</source>
-      <translation>Spowoduje to pobranie i aktualizację rootfs przy użyciu najnowszego oficjalnego oprogramowania sprzętowego.&lt;br&gt;Wymagane jest połączenie z Internetem.&lt;br&gt;Naciśnij „OK”, aby kontynuować.</translation>
+      <translation>Spowoduje to pobranie i aktualizację rootfs przy użyciu najnowszego oficjalnego oprogramowania.&lt;br&gt;Wymagane jest połączenie z Internetem.&lt;br&gt;Naciśnij „OK”, aby kontynuować.</translation>
     </message>
     <message id="settings_gps_format_kmh">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="93"/>
       <source>Kilometres per hour</source>
+      <oldsource>Kilometers per hour</oldsource>
       <translation>Kilometry na godzinę</translation>
     </message>
     <message id="settings_gps_format_ms">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="95"/>
       <source>Metres per second</source>
+      <oldsource>Meters per second</oldsource>
       <translation>Metry na sekundę</translation>
     </message>
     <message id="components_volumeunit_cubic_metres">
@@ -9874,15 +8857,15 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
       <source>The Relay can now be found in the devices list</source>
       <translation>Przekaźnik jest teraz dostępny na liście urządzeń</translation>
     </message>
-    <message id="common_words_gx_device_relays">
-      <location filename="../../components/CommonWords.qml" line="223"/>
+    <message id="gx_device_relays">
+      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
       <source>GX device relays</source>
       <translation>Przekaźniki urządzenia GX</translation>
     </message>
     <message id="ess_active_soc_limit_info">
       <location filename="../../pages/controlcards/ESSCard.qml" line="96"/>
       <source>BatteryLife dynamically adjusts the minimum battery state of charge to prevent deep discharges and ensure regular full charges, helping to prolong battery life and maintain system reliability.</source>
-      <translation>Funkcja BatteryLife dynamicznie dostosowuje minimalny stan naładowania akumulatora, aby zapobiec głębokiemu rozładowaniu i zapewnić regularne pełne ładowania, co pomaga przedłużyć żywotność akumulatora i utrzymać niezawodność systemu.</translation>
+      <translation>BatteryLife automatycznie dostosowuje minimalny poziom naładowania akumulatora, aby unikać głębokich rozładowań i zapewniać regularne pełne ładowania, wydłużając żywotność akumulatora i utrzymując niezawodność systemu.</translation>
     </message>
     <message id="settings_canbus_rvc_reverse_current_polarity">
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="69"/>
@@ -9928,12 +8911,6 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
       <source>auto</source>
       <extracomment>Forced by app to %1</extracomment>
       <translation>auto</translation>
-    </message>
-    <message id="settings_remote_console_forced_by_vrm">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="94"/>
-      <source>VRM</source>
-      <extracomment>Forced by %2 to dark</extracomment>
-      <translation type="unfinished">VRM</translation>
     </message>
     <message id="settings_remote_console_forced_by_app">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="97"/>
@@ -9984,6 +8961,7 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="settings_large_access_signal_k">
       <location filename="../../pages/settings/PageSettingsSignalK.qml" line="24"/>
       <source>Access Signal K</source>
+      <oldsource>Access Signal K (local network)</oldsource>
       <translation>Dostęp do Signal K</translation>
     </message>
     <message id="pagesettingsintegrations_shelly_devices">
@@ -9994,12 +8972,13 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="settings_large_access_node_red">
       <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
       <source>Access Node-RED</source>
+      <oldsource>Access Node-RED (local network)</oldsource>
       <translation>Dostęp do Node-RED</translation>
     </message>
     <message id="settings_wifi_access_point_password">
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="66"/>
       <source>Access Point password</source>
-      <translation>Hasło punktu dostępu</translation>
+      <translation>Hasło Punktu Dostępu</translation>
     </message>
     <message id="dcMeter_dccharger">
       <location filename="../../src/enums.cpp" line="118"/>
@@ -10039,7 +9018,7 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
     <message id="dcMeter_inverter">
       <location filename="../../src/enums.cpp" line="145"/>
       <source>Inverter</source>
-      <translation>Falownik</translation>
+      <translation>Inwerter</translation>
     </message>
     <message id="dcMeter_solar_charger">
       <location filename="../../src/enums.cpp" line="151"/>
@@ -10061,57 +9040,6 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
       <source>Wind charger</source>
       <translation>Ładowarka wiatrowa</translation>
     </message>
-    <message id="digitalinputs_type_disabled">
-      <location filename="../../src/enums.cpp" line="192"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Wyłączone</translation>
-    </message>
-    <message id="digitalinputs_state_off">
-      <location filename="../../src/enums.cpp" line="242"/>
-      <source>Off</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Wył.</translation>
-    </message>
-    <message id="digitalinputs_state_on">
-      <location filename="../../src/enums.cpp" line="246"/>
-      <source>On</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Wł.</translation>
-    </message>
-    <message id="digitalinputs_state_ok">
-      <location filename="../../src/enums.cpp" line="266"/>
-      <source>OK</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">OK</translation>
-    </message>
-    <message id="digitalinputs_state_alarm">
-      <location filename="../../src/enums.cpp" line="270"/>
-      <source>Alarm</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Alarm</translation>
-    </message>
-    <message id="digitalinputs_state_running">
-      <location filename="../../src/enums.cpp" line="274"/>
-      <source>Running</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">W toku</translation>
-    </message>
-    <message id="pvinverter_statusCode_running">
-      <location filename="../../src/enums.cpp" line="300"/>
-      <source>Running</source>
-      <extracomment>PV inverter status code</extracomment>
-      <translation type="unfinished">W toku</translation>
-    </message>
-    <message id="solarchargers_state_external control">
-      <location filename="../../src/enums.cpp" line="352"/>
-      <source>External control</source>
-      <translation type="unfinished">Sterowanie zewnętrzne</translation>
-    </message>
-    <message id="switch_state_over_temperature">
-      <location filename="../../src/enums.cpp" line="366"/>
-      <source>Over temperature</source>
-      <translation type="unfinished">Nadmierna temperatura</translation>
-    </message>
     <message id="switchable_output_temperature_setpoint">
       <location filename="../../src/enums.cpp" line="398"/>
       <source>Temperature setpoint</source>
@@ -10121,11 +9049,6 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
       <location filename="../../src/enums.cpp" line="401"/>
       <source>Stepped switch</source>
       <translation>Przełącznik stopniowy</translation>
-    </message>
-    <message id="switchable_output_slave">
-      <location filename="../../src/enums.cpp" line="408"/>
-      <source>Slave</source>
-      <translation type="unfinished">Slave</translation>
     </message>
     <message id="switchable_output_dropdown">
       <location filename="../../src/enums.cpp" line="412"/>
@@ -10137,122 +9060,10 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
       <source>Basic slider</source>
       <translation>Podstawowy suwak</translation>
     </message>
-    <message id="switchable_output_rgb_color_wheel">
-      <location filename="../../src/enums.cpp" line="427"/>
-      <source>RGB color wheel</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_cct_color_wheel">
-      <location filename="../../src/enums.cpp" line="431"/>
-      <source>CCT color wheel</source>
-      <extracomment>Correlated Color Temperature color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_rgbw_color_wheel">
-      <location filename="../../src/enums.cpp" line="435"/>
-      <source>RGB + W color wheel</source>
-      <extracomment>RGB + white color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bypassed">
-      <location filename="../../src/enums.cpp" line="484"/>
-      <source>Bypassed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="tank_type_fuel">
-      <location filename="../../src/enums.cpp" line="495"/>
-      <source>Fuel</source>
-      <translation type="unfinished">Paliwo</translation>
-    </message>
-    <message id="tank_type_fresh_water">
-      <location filename="../../src/enums.cpp" line="498"/>
-      <source>Fresh water</source>
-      <translation type="unfinished">Woda słodka</translation>
-    </message>
-    <message id="tank_type_waste_water">
-      <location filename="../../src/enums.cpp" line="501"/>
-      <source>Waste water</source>
-      <translation type="unfinished">Ścieki</translation>
-    </message>
-    <message id="tank_type_live_well">
-      <location filename="../../src/enums.cpp" line="504"/>
-      <source>Live well</source>
-      <translation type="unfinished">Zbiornik na ryby</translation>
-    </message>
-    <message id="tank_type_oil">
-      <location filename="../../src/enums.cpp" line="507"/>
-      <source>Oil</source>
-      <translation type="unfinished">Olej</translation>
-    </message>
-    <message id="tank_type_black_water">
-      <location filename="../../src/enums.cpp" line="510"/>
-      <source>Black water</source>
-      <translation type="unfinished">Czarna woda</translation>
-    </message>
-    <message id="tank_type_gasoline">
-      <location filename="../../src/enums.cpp" line="513"/>
-      <source>Gasoline</source>
-      <translation type="unfinished">Benzyna</translation>
-    </message>
-    <message id="tank_type_diesel">
-      <location filename="../../src/enums.cpp" line="516"/>
-      <source>Diesel</source>
-      <translation type="unfinished">Diesel</translation>
-    </message>
-    <message id="tank_type_lpg">
-      <location filename="../../src/enums.cpp" line="519"/>
-      <source>LPG</source>
-      <translation type="unfinished">LPG</translation>
-    </message>
-    <message id="tank_type_lng">
-      <location filename="../../src/enums.cpp" line="522"/>
-      <source>LNG</source>
-      <translation type="unfinished">LNG</translation>
-    </message>
-    <message id="tank_type_hydraulic_oil">
-      <location filename="../../src/enums.cpp" line="525"/>
-      <source>Hydraulic oil</source>
-      <translation type="unfinished">Olej hydrauliczny</translation>
-    </message>
-    <message id="tank_type_raw_water">
-      <location filename="../../src/enums.cpp" line="528"/>
-      <source>Raw water</source>
-      <translation type="unfinished">Woda surowa</translation>
-    </message>
-    <message id="microgrid_mode_hybrid_droop">
-      <location filename="../../src/enums.cpp" line="539"/>
-      <source>Hybrid droop</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_following">
-      <location filename="../../src/enums.cpp" line="542"/>
-      <source>Grid-following</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_forming">
-      <location filename="../../src/enums.cpp" line="545"/>
-      <source>Grid-forming</source>
-      <translation type="unfinished"/>
-    </message>
     <message id="switchable_output_three_state_switch">
       <location filename="../../src/enums.cpp" line="421"/>
       <source>Three-state switch</source>
       <translation>Przełącznik trójstanowy</translation>
-    </message>
-    <message id="switchable_output_fault">
-      <location filename="../../src/enums.cpp" line="464"/>
-      <source>Fault</source>
-      <translation type="unfinished">Usterka</translation>
-    </message>
-    <message id="switchable_output_running">
-      <location filename="../../src/enums.cpp" line="468"/>
-      <source>Running</source>
-      <translation type="unfinished">W toku</translation>
-    </message>
-    <message id="switchable_output_trip_low_voltage">
-      <location filename="../../src/enums.cpp" line="481"/>
-      <source>Trip low voltage</source>
-      <translation type="unfinished">Wyłączone</translation>
     </message>
     <message id="settings_modbus_tcp_unit_id_note">
       <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="41"/>
@@ -10274,1906 +9085,432 @@ Urządzenie GX może sterować tylko jednym podłączonym agregatem i wybiera te
       <source>Press to refresh</source>
       <translation>Naciśnij, aby odświeżyć</translation>
     </message>
-    <message id="temperature_type_unknown">
-      <location filename="../../data/EnvironmentInputs.qml" line="65"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Nieznany</translation>
-    </message>
-    <message id="brief_solar_yield">
-      <location filename="../../pages/BriefSidePanel.qml" line="24"/>
-      <source>Solar yield</source>
-      <translation type="unfinished">Uzysk solarny</translation>
-    </message>
-    <message id="brief_dc_input">
-      <location filename="../../pages/BriefSidePanel.qml" line="214"/>
-      <source>DC input</source>
-      <translation type="unfinished">Wejście DC</translation>
-    </message>
-    <message id="brief_ac_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="257"/>
-      <source>AC Loads</source>
-      <translation type="unfinished">Obciążenia AC</translation>
-    </message>
-    <message id="brief_dc_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="284"/>
-      <source>DC Loads</source>
-      <translation type="unfinished">Obciążenia DC</translation>
-    </message>
-    <message id="nav_overview">
-      <location filename="../../pages/OverviewPage.qml" line="450"/>
-      <source>Overview</source>
-      <translation type="unfinished">Przegląd</translation>
-    </message>
-    <message id="settings_state">
-      <location filename="../../pages/settings/PageCanbusStatus.qml" line="116"/>
-      <source>State</source>
-      <translation type="unfinished">Stan</translation>
-    </message>
-    <message id="inverter_pv">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="56"/>
-      <source>PV</source>
-      <translation type="unfinished">PV</translation>
-    </message>
-    <message id="inverter_total_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="76"/>
-      <source>Total yield</source>
-      <translation type="unfinished">Całkowita wydajność</translation>
-    </message>
-    <message id="inverter_system_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="84"/>
-      <source>System yield</source>
-      <translation type="unfinished">Uzysk systemu</translation>
-    </message>
-    <message id="charger_total_pv_power">
-      <location filename="../../pages/solar/SolarDevicePage.qml" line="61"/>
-      <source>Total PV Power</source>
-      <translation type="unfinished">Moc PV ogółem</translation>
-    </message>
-    <message id="vebus_device_alarm_only">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
-      <source>Alarm only</source>
-      <translation type="unfinished">Tylko alarm</translation>
-    </message>
-    <message id="vebus_device_alarms_and_warnings">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
-      <source>Alarms &amp; warnings</source>
-      <translation type="unfinished">Alarmy i ostrzeżenia</translation>
-    </message>
-    <message id="vebus_device_alarm_group_warning">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
-      <source>Warning</source>
-      <translation type="unfinished">Ostrzeżenie</translation>
-    </message>
-    <message id="load_delegate_status">
-      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
-      <source>Status: %1</source>
-      <translation type="unfinished"/>
+    <message id="common_words_total_power">
+      <location filename="../../components/CommonWords.qml" line="540"/>
+      <source>Total power</source>
+      <translation>Moc całkowita</translation>
     </message>
     <message id="venus_os_gui">
       <location filename="../../Main.qml" line="17"/>
       <source>Venus OS GUI</source>
       <extracomment>Application title</extracomment>
-      <translation type="unfinished"/>
       <extra-Context>only shown on desktop systems</extra-Context>
+      <translation>Venus OS GUI</translation>
+    </message>
+    <message id="load_delegate_status">
+      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
+      <source>Status: %1</source>
+      <translation>Status: %1</translation>
+    </message>
+    <message id="settings_relay_polarity_relay1">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
+      <source>Polarity (Relay 1)</source>
+      <translation>Polaryzacja (Przekaźnik 1)</translation>
+    </message>
+    <message id="settings_relay_polarity">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
+      <source>Polarity</source>
+      <translation>Polaryzacja</translation>
+    </message>
+    <message id="settings_relay_polarity_relay2">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
+      <source>Polarity (Relay 2)</source>
+      <translation>Polaryzacja (Przekaźnik 2)</translation>
+    </message>
+    <message id="page_settings_wifi_invalid_password">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
+      <source>Password length must be either 0 or between 10 and 63 characters long</source>
+      <translation>Długość hasła musi wynosić 0 lub od 10 do 63 znaków</translation>
+    </message>
+    <message id="page_settings_wifi_password_updated">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
+      <source>Password updated</source>
+      <translation>Hasło zaktualizowane</translation>
+    </message>
+    <message id="common_words_max">
+      <location filename="../../components/CommonWords.qml" line="315"/>
+      <source>Max</source>
+      <extracomment>Short for Maximum</extracomment>
+      <translation>Maks.</translation>
+    </message>
+    <message id="common_words_min">
+      <location filename="../../components/CommonWords.qml" line="331"/>
+      <source>Min</source>
+      <extracomment>Short for Minimum</extracomment>
+      <translation>Min.</translation>
+    </message>
+    <message id="settings_ess_deprecated">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="321"/>
+      <source>Deprecated settings</source>
+      <translation>Przestarzałe ustawienia</translation>
+    </message>
+    <message id="settings_ess_max_charge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="328"/>
+      <source>Battery charge limit (% of CCL)</source>
+      <translation>Limit ładowania akumulatora (% CCL)</translation>
+    </message>
+    <message id="settings_ess_max_discharge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="339"/>
+      <source>Battery discharge limit (% of DCL)</source>
+      <translation>Limit rozładowania akumulatora (% DCL)</translation>
+    </message>
+    <message id="vebus_device_bms_message">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
+      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
+      <oldsource>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</oldsource>
+      <translation>VE.Bus BMS automatycznie wyłącza system, gdy jest to konieczne, aby chronić akumulator. Sterowanie systemem z urządzenia GX jest więc niemożliwe.</translation>
+    </message>
+    <message id="switchable_output_numeric_input">
+      <location filename="../../src/enums.cpp" line="418"/>
+      <source>Numeric input</source>
+      <translation>Wprowadzanie numeryczne</translation>
     </message>
     <message id="autotoggleswitch_disable_auto_mode_info">
       <location filename="../../components/controls/AutoToggleButton.qml" line="34"/>
       <source>Disable Auto mode first</source>
-      <translation type="unfinished"/>
+      <translation>Najpierw wyłącz tryb Auto</translation>
+    </message>
+    <message id="pagesettingsintegrations_venus_os_enable_large_features">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
+      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
+      <translation>Włącz rozszerzone oprogramowanie Venus OS, aby używać Node-RED lub Signal-K</translation>
+    </message>
+    <message id="settings_relays_sensors_tanks">
+      <location filename="../../pages/SettingsPage.qml" line="75"/>
+      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
+      <oldsource>Relays, Sensors, Tanks, PV Inverters, Modbus, MQTT…</oldsource>
+      <translation>Przekaźniki, Czujniki, Inwertery PV, Modbus, Node-RED</translation>
+    </message>
+    <message id="vebus_device_page_microgrid_parameters">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
+      <source>Microgrid parameters</source>
+      <translation>Parametry mikrosieci</translation>
+    </message>
+    <message id="microgrid_mode_hybrid_droop">
+      <location filename="../../src/enums.cpp" line="539"/>
+      <source>Hybrid droop</source>
+      <translation>Hybrydowy spadek</translation>
+    </message>
+    <message id="microgrid_mode_grid_following">
+      <location filename="../../src/enums.cpp" line="542"/>
+      <source>Grid-following</source>
+      <translation>Śledzenie sieci</translation>
+    </message>
+    <message id="microgrid_mode_grid_forming">
+      <location filename="../../src/enums.cpp" line="545"/>
+      <source>Grid-forming</source>
+      <translation>Tworzenie sieci</translation>
+    </message>
+    <message id="switchable_output_trip_low_voltage">
+      <location filename="../../src/enums.cpp" line="481"/>
+      <source>Trip low voltage</source>
+      <oldsource>Disabled</oldsource>
+      <translation>Wyłączenie przy niskim napięciu</translation>
     </message>
     <message id="microgrid">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="15"/>
       <source>Microgrid</source>
-      <translation type="unfinished"/>
+      <translation>Mikrosieć</translation>
     </message>
     <message id="page_microgrid_active_mode">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="19"/>
       <source>Active mode</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_microgrid_from_p1_to_p2">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="34"/>
-      <source>%1 %2 to %3 %4</source>
-      <extracomment>Describes a range from one quantity to another, e.g. "30 W to 60 W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
-      <translation type="unfinished"/>
+      <translation>Tryb aktywny</translation>
     </message>
     <message id="page_microgrid_hybrid_droop_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="92"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
       <source>Hybrid droop parameters</source>
-      <translation type="unfinished"/>
+      <translation>Parametry spadku hybrydowego</translation>
     </message>
     <message id="page_microgrid_reference_active_power_p0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="105"/>
       <source>Reference active power (P&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Referencyjna moc czynna (P&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_frequency_f0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="108"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="112"/>
       <source>Reference frequency (f&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Referencyjna częstotliwość (f&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_frequency_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="117"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="119"/>
       <source>Frequency droop slope (droop&lt;sub&gt;fP&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Nachylenie spadku częstotliwości (droop&lt;sub&gt;fP&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_reactive_power">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="126"/>
       <source>Reference reactive power (Q&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Referencyjna moc bierna (Q&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_voltage">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="135"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="133"/>
       <source>Reference Voltage (U&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Referencyjne Napięcie (U&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_voltage_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="144"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="140"/>
       <source>Voltage droop slope (droop&lt;sub&gt;UQ&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Nachylenie spadku napięcia (droop&lt;sub&gt;UQ&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_minimum_and_maximum_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="146"/>
       <source>Minimum and maximum parameters</source>
-      <translation type="unfinished"/>
+      <translation>Parametry minimalne i maksymalne</translation>
     </message>
     <message id="page_microgrid_allowed_active_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="156"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
       <source>Allowed active power range</source>
-      <translation type="unfinished"/>
+      <translation>Dopuszczalny zakres mocy czynnej</translation>
     </message>
     <message id="page_microgrid_allowed_reactive_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="164"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="159"/>
       <source>Allowed reactive power range</source>
-      <translation type="unfinished"/>
+      <translation>Dopuszczalny zakres mocy biernej</translation>
     </message>
     <message id="page_microgrid_p_q_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="176"/>
       <source>P-Q direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>Ustawienia bezpośredniego sterowania P-Q</translation>
     </message>
     <message id="page_microgrid_active_power_setpoint_p">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="186"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
       <source>Active power setpoint (P)</source>
-      <translation type="unfinished"/>
+      <translation>Wartość zadana mocy czynnej (P)</translation>
     </message>
     <message id="page_microgrid_reactive_power_setpoint_q">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="194"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="188"/>
       <source>Reactive power setpoint (Q)</source>
-      <translation type="unfinished"/>
+      <translation>Wartość zadana mocy biernej (Q)</translation>
     </message>
     <message id="page_microgrid_allowed_frequency_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="202"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="195"/>
       <source>Allowed frequency range</source>
-      <translation type="unfinished"/>
+      <translation>Dopuszczalny zakres częstotliwości</translation>
     </message>
     <message id="page_microgrid_allowed_voltage_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="210"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="203"/>
       <source>Allowed voltage range</source>
-      <translation type="unfinished"/>
+      <translation>Dopuszczalny zakres napięcia</translation>
     </message>
     <message id="page_microgrid_v_f_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="227"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="220"/>
       <source>V-f direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>Ustawienia bezpośredniego sterowania V-f</translation>
     </message>
     <message id="page_microgrid_voltage_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="225"/>
       <source>Voltage setpoint (U)</source>
-      <translation type="unfinished"/>
+      <translation>Wartość zadana napięcia (U)</translation>
     </message>
     <message id="page_microgrid_frequency_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="240"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
       <source>Frequency setpoint (f)</source>
-      <translation type="unfinished"/>
+      <translation>Wartość zadana częstotliwości (f)</translation>
     </message>
-    <message id="temperature_slider_current">
-      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
-      <source>Current</source>
-      <extracomment>The current temperature measurement</extracomment>
-      <translation type="unfinished">Prąd</translation>
+    <message id="pagesettingsintegrations_canopenmotordrive">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
+      <source>CANopen motor drives</source>
+      <translation>Sterowniki Silników CANopen</translation>
+    </message>
+    <message id="pagesettingsintegrations_ui_plugins">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
+      <source>UI Plugins</source>
+      <translation>Wtyczki interfejsu</translation>
+    </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
+      <source>Motor Direction Inverted</source>
+      <translation>Odwrócony Kierunek Silnika</translation>
     </message>
     <message id="page_settings_canopenmotordrive_scan_for_motor_drives">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="31"/>
       <source>Scan for motor drives</source>
-      <translation type="unfinished"/>
+      <translation>Skanuj w poszukiwaniu napędów silnika</translation>
     </message>
     <message id="page_settings_canopenmotordrive_discovered_motor_drive_ids">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="39"/>
       <source>Discovered motor drive IDs</source>
-      <translation type="unfinished"/>
+      <translation>Odkryto identyfikatory napędu silnika</translation>
     </message>
-    <message id="switchableoutput_gx_device_relays">
-      <location filename="../../src/switchableoutput.cpp" line="388"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">Przekaźniki urządzenia GX</translation>
+    <message id="temperature_pm25">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
+      <source>PM2.5</source>
+      <translation>PM2.5</translation>
     </message>
-    <message id="gx_device_relays">
-      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">Przekaźniki urządzenia GX</translation>
+    <message id="temperature_co2">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+      <source>CO₂</source>
+      <translation>CO₂</translation>
     </message>
-    <message id="color_preset">
-      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
-      <source>Preset</source>
-      <translation type="unfinished"/>
+    <message id="temperature_voc">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
+      <source>VOC index</source>
+      <translation>Indeks VOC</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_location">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
-      <source>Add Modbus port and unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_nox">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
+      <source>NOx index</source>
+      <translation>Indeks NOx</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_unitid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
-      <source>Unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_luminosity">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
+      <source>Luminosity</source>
+      <translation>Jasność</translation>
     </message>
-    <message id="page_settings_fronius_unitid_invalid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation type="unfinished">%1 nie jest prawidłowym numerem jednostki. Należy użyć liczby z zakresu 1-247.</translation>
-    </message>
-    <message id="page_settings_fronius_add_modbus_location_button">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
-      <source>Add</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_locations_note">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
-      <source>The default modbus port is 502 and the default unit ID is 126.
-Here you can add additional ports and unit IDs to scan for PV inverters.</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_location_number">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
-      <source>Port/Unit ID %1</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location_description">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
-      <source>Port: %1 (Unit %2)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
-      <source>Remove Modbus port and unit ID?</source>
-      <translation type="unfinished"/>
+    <message id="switchable_output_bypassed">
+      <location filename="../../src/enums.cpp" line="484"/>
+      <source>Bypassed</source>
+      <translation>Ominięty</translation>
     </message>
     <message id="switchableoutput_list_delegate_auto_status">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="84"/>
       <source>Auto (%1)</source>
       <extracomment>%1 = 'On' or 'Off'</extracomment>
-      <translation type="unfinished"/>
+      <translation>Auto (%1)</translation>
     </message>
     <message id="switchableoutput_list_delegate_state_forced">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="100"/>
       <source>Forced</source>
-      <translation type="unfinished"/>
-    </message>
-  </context>
-  <context>
-    <name>AlternatorError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="22"/>
-      <source>No error</source>
-      <translation>Brak błędu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="25"/>
-      <source>Unknown error: %1</source>
-      <translation>Nieznany błąd: %1</translation>
-    </message>
-  </context>
-  <context>
-    <name>BmsError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="10"/>
-      <source>No error</source>
-      <translation>Brak błędu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="13"/>
-      <source>Battery initialization error</source>
-      <translation>Błąd inicjalizacji baterii</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="16"/>
-      <source>No batteries connected</source>
-      <translation>Brak podłączonych akumulatorów</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="19"/>
-      <source>Unknown battery</source>
-      <translation>Nieznany akumulator</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="22"/>
-      <source>Different battery types</source>
-      <translation>Różne rodzaje baterii</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="25"/>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="40"/>
-      <source>No. of batteries incorrect</source>
-      <translation>Liczba nieprawidłowych baterii</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="28"/>
-      <source>Lynx Shunt not found</source>
-      <translation>Lynx Shunt nie został znaleziony</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="31"/>
-      <source>Battery measure error</source>
-      <translation>Błąd pomiaru ak.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="34"/>
-      <source>Internal calculation error</source>
-      <translation>Wewnętrzny błąd obliczeniowy</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="37"/>
-      <source>No. of batteries in series incorrect</source>
-      <translation>Liczba baterii w szeregu nieprawidłowa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="44"/>
-      <source>Hardware error</source>
-      <translation>Błąd sprzętowy</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="47"/>
-      <source>Watchdog error</source>
-      <translation>Błąd układu Watchdog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="50"/>
-      <source>Over voltage</source>
-      <translation>Nadmierne napięcie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="53"/>
-      <source>Under voltage</source>
-      <translation>Za niskie napięcie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="56"/>
-      <source>Over temperature</source>
-      <translation>Nadmierna temperatura</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="59"/>
-      <source>Under temperature</source>
-      <translation>Za niska temperatura</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="62"/>
-      <source>Under-charge standby</source>
-      <translation>Czuwanie w stanie niedoładowania</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="65"/>
-      <source>ADC error</source>
-      <translation>Błąd ADC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="68"/>
-      <source>Battery comm. error</source>
-      <translation>Błąd kom. akumulatora</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="71"/>
-      <source>Pre-Charge error</source>
-      <translation>Błąd wstępnego ładowania</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="75"/>
-      <source>Safety contactor error</source>
-      <translation>Błąd stycznika bezpieczeństwa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="79"/>
-      <source>Battery update error</source>
-      <translation>Błąd aktualizacji baterii</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="82"/>
-      <source>BMS cable error</source>
-      <translation>Błąd przewodu BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="85"/>
-      <source>Reference voltage failure</source>
-      <translation>Awaria napięcia odniesienia</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="88"/>
-      <source>Wrong system voltage</source>
-      <translation>Nieprawidłowe napięcie systemowe</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="91"/>
-      <source>Pre charge timeout</source>
-      <translation>Limit czasu ładowania wstępnego</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="94"/>
-      <source>ATC/ATD failure</source>
-      <translation>Awaria ATC/ATD</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="98"/>
-      <source>Calibration data lost</source>
-      <translation>Utrata danych kalibracyjnych</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="102"/>
-      <source>Settings invalid</source>
-      <translation>Ustawienia nieważne</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="105"/>
-      <source>Interlock</source>
-      <translation>Blokada</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="108"/>
-      <source>Emergency stop</source>
-      <translation>Wyłącznik awaryjny</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="111"/>
-      <source>Communication timeout</source>
-      <translation>Limit czasu komunikacji</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="114"/>
-      <source>Safety lock</source>
-      <translation>Blokada bezpieczeństwa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="117"/>
-      <source>Terminal over temperature</source>
-      <translation>Przekroczenie temperatury terminala</translation>
-    </message>
-  </context>
-  <context>
-    <name>CRE</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="838"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="843"/>
-      <source>Unknown error: </source>
-      <translation>Nieznany błąd:</translation>
-    </message>
-  </context>
-  <context>
-    <name>ChargerError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="7"/>
-      <source>No error</source>
-      <translation>Brak błędu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="9"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="103"/>
-      <source>Battery high temperature</source>
-      <translation>Wysoka temperatura baterii</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="10"/>
-      <source>Battery high voltage</source>
-      <translation>Wysokie napięcie akumulatora</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="11"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="12"/>
-      <source>Battery Tsense miswired</source>
-      <translation>Tsense ak. źle podłączony</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="13"/>
-      <source>Battery Tsense missing</source>
-      <translation>Brak baterii Tsense</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="14"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="15"/>
-      <source>Battery Vsense miswired</source>
-      <translation>Bateria Vsense źle podłączona</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="16"/>
-      <source>Battery Vsense missing</source>
-      <translation>Brak Vsense akumulatora</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="17"/>
-      <source>Battery high wire losses</source>
-      <translation>Wysokie straty w przewodach aku.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="18"/>
-      <source>Battery low voltage</source>
-      <translation>Niskie napięcie akumulatora</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="19"/>
-      <source>Battery high ripple voltage</source>
-      <translation>Wysokie napięcie tętniące akumulatora</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="20"/>
-      <source>Battery low state of charge</source>
-      <translation>Niski stan naładowania akumulatora</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="21"/>
-      <source>Battery mid-point voltage issue</source>
-      <translation>Problem z napięciem środkowego punktu akumulatora</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="22"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="104"/>
-      <source>Battery temperature too low</source>
-      <translation>Zbyt niska temperatura baterii</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="24"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="106"/>
-      <source>Charger high temperature</source>
-      <translation>Wysoka temperatura ładowarki</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="25"/>
-      <source>Charger excessive current</source>
-      <translation>Nadmierny prąd ładowarki</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="26"/>
-      <source>Charger negative current</source>
-      <translation>Ujemny prąd ładowarki</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="27"/>
-      <source>Charger bulk time expired</source>
-      <translation>Upłynął czas ładowania.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="28"/>
-      <source>Charger current sensor issue</source>
-      <translation>Problem z czujnikiem prądu ładowarki</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="29"/>
-      <source>Internal Tsensor miswired</source>
-      <translation>Wewn. czujnik temperatury źle podłączony</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="30"/>
-      <source>Internal Tsensor missing</source>
-      <translation>Brak wewn. czujnika temperatury</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="31"/>
-      <source>Charger fan not detected</source>
-      <translation>Nie wykryto wentylatora ładowarki</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="32"/>
-      <source>Charger fan over-current</source>
-      <translation>Nadmierny prąd wentylatora ładowarki</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="33"/>
-      <source>Charger terminal overheat</source>
-      <translation>Przegrzanie terminala ładowarki</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="34"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="107"/>
-      <source>Charger short circuit</source>
-      <translation>Zwarcie w ładowarce</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="35"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="108"/>
-      <source>Charger power stage issue</source>
-      <translation>Problem ze stopniem mocy ładowarki</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="36"/>
-      <source>Over-charge protection</source>
-      <translation>Zabezpieczenie przed przeładowaniem</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="38"/>
-      <source>Input high voltage</source>
-      <translation>Wysokie napięcie wejściowe</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="39"/>
-      <source>Input excessive current</source>
-      <translation>Nadmierny prąd wejściowy</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="40"/>
-      <source>Input excessive power</source>
-      <translation>Nadmierna moc wejściowa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="41"/>
-      <source>Input polarity issue</source>
-      <translation>Problem z polaryzacją wejścia</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="42"/>
-      <source>Input voltage absent</source>
-      <translation>Brak napięcia wejściowego</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="43"/>
-      <source>Input shutdown (no retries)</source>
-      <translation>Wyłączenie wejścia (bez ponawiania)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="44"/>
-      <source>Input shutdown (retry)</source>
-      <translation>Wyłączenie wejścia (ponowienie)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="45"/>
-      <source>Input internal failure</source>
-      <translation>Wewnętrzna awaria wejścia</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="47"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="48"/>
-      <source>PV isolation failure</source>
-      <translation>Awaria izolacji PV</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="49"/>
-      <source>Ground fault detected</source>
-      <translation>Wykryto zwarcie doziemne</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="51"/>
-      <source>Inverter overload</source>
-      <translation>Przeciążenie falownika</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="52"/>
-      <source>Inverter temp too high</source>
-      <translation>Za wysoka temperatura inwertera</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="53"/>
-      <source>Inverter peak current</source>
-      <translation>Prąd szczytowy przetwornicy</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="54"/>
-      <source>Inverter internal DC level</source>
-      <translation>Wewnętrzny poziom DC przetwornicy</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="55"/>
-      <source>Inverter wrong ACout level</source>
-      <translation>Błędny poziom ACout przetwornicy</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="56"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="57"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="59"/>
-      <source>Inverter powerstage fault</source>
-      <translation>Błąd stopnia mocy przetwornicy</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="58"/>
-      <source>Inverter connected to AC</source>
-      <translation>Falownik podłączony do prądu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="60"/>
-      <source>ACIN1 relay test fault</source>
-      <translation>Błąd testu przekaźnika ACIN1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="61"/>
-      <source>ACIN2 relay test fault</source>
-      <translation>Błąd testu przekaźnika ACIN2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="63"/>
-      <source>Device disappeared</source>
-      <translation>Urządzenie zniknęło</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="64"/>
-      <source>Incompatible device</source>
-      <translation>Niekompatybilne urządzenie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="65"/>
-      <source>BMS connection lost</source>
-      <translation>Utrata połączenia z BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="66"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="67"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="68"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="69"/>
-      <source>Network misconfigured</source>
-      <translation>Sieć źle skonfigurowana</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="70"/>
-      <source>Phase rotation</source>
-      <translation>Obrót fazowy</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="71"/>
-      <source>Multiple AC inputs</source>
-      <translation>Wiele wejść AC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="72"/>
-      <source>Phase overload</source>
-      <translation>Przeciążenie fazy</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="74"/>
-      <source>Memory write error</source>
-      <translation>Błąd zapisu w pamięci</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="75"/>
-      <source>CPU temperature too high</source>
-      <translation>Zbyt wysoka temperatura procesora</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="76"/>
-      <source>Communication lost</source>
-      <translation>Utracona łączność</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="77"/>
-      <source>Calibration data lost</source>
-      <translation>Utrata danych kalibracyjnych</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="78"/>
-      <source>Incompatible firmware</source>
-      <translation>Niekompatybilne oprogramowanie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="79"/>
-      <source>Incompatible hardware</source>
-      <translation>Niekompatybilny sprzęt</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="80"/>
-      <source>Settings invalid</source>
-      <translation>Ustawienia nieważne</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="81"/>
-      <source>Reference voltage failed</source>
-      <translation>Błąd napięcia referencyjnego</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="82"/>
-      <source>Tester fail</source>
-      <translation>Awaria testera</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="83"/>
-      <source>History invalid</source>
-      <translation>Historia nieważna</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="84"/>
-      <source>kWh counters invalid</source>
-      <translation>Nieprawidłowe liczniki kWh</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="86"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="87"/>
-      <source>DC voltage error</source>
-      <translation>Błąd napięcia DC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="88"/>
-      <source>GFCI sensor error</source>
-      <translation>Błąd sensora GFCI</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="89"/>
-      <source>3V3 supply error</source>
-      <translation>Błąd zasilania 3V3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="90"/>
-      <source>5V supply error</source>
-      <translation>Błąd zasilania 5V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="91"/>
-      <source>12V supply error</source>
-      <translation>Błąd zasilania 12V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="92"/>
-      <source>15V supply error</source>
-      <translation>Błąd zasilania 15V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="94"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="95"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="96"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="97"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="98"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="99"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="100"/>
-      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="101"/>
-      <source>PV Input shutdown</source>
-      <translation>Wyłączenie wejścia PV</translation>
-    </message>
-  </context>
-  <context>
-    <name>DEIF</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="857"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="862"/>
-      <source>Unknown error: </source>
-      <translation>Nieznany błąd:</translation>
-    </message>
-  </context>
-  <context>
-    <name>DSE</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="242"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="247"/>
-      <source>Unknown error: </source>
-      <translation>Nieznany błąd:</translation>
-    </message>
-  </context>
-  <context>
-    <name>EnvironmentInputs</name>
-    <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="18"/>
-      <source>Battery</source>
-      <translation>Bateria</translation>
-    </message>
-    <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="24"/>
-      <source>Fridge</source>
-      <translation>Lodówka</translation>
-    </message>
-    <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="30"/>
-      <source>Generic</source>
-      <translation>Ogólne</translation>
-    </message>
-    <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="36"/>
-      <source>Room</source>
-      <translation>Pokój</translation>
-    </message>
-    <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="42"/>
-      <source>Outdoor</source>
-      <translation>Na zewnątrz</translation>
-    </message>
-    <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="48"/>
-      <source>Water Heater</source>
-      <translation>Nagrzewnica wodna</translation>
-    </message>
-    <message>
-      <location filename="../../data/EnvironmentInputs.qml" line="54"/>
-      <source>Freezer</source>
-      <translation>Zamrażarka</translation>
-    </message>
-  </context>
-  <context>
-    <name>FischerPanda</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="87"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="92"/>
-      <source>Unknown error: </source>
-      <translation>Nieznany błąd:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="98"/>
-      <source>No error</source>
-      <translation>Brak błędu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage L1 too low</source>
-      <translation>Zbyt niskie napięcie AC L1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
-      <source>AC voltage too low</source>
-      <translation>Zbyt niskie napięcie AC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage L1 too high</source>
-      <translation>Zbyt wysokie napięcie AC L1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
-      <source>AC voltage too high</source>
-      <translation>Zbyt wysokie napięcie AC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency L1 too low</source>
-      <translation>Za niska częstotliwość AC L1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
-      <source>AC frequency too low</source>
-      <translation>Zbyt niska częstotliwość AC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency L1 too high</source>
-      <translation>Za wysoka częstotliwość AC L1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
-      <source>AC frequency too high</source>
-      <translation>Zbyt wysoka częstotliwość AC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current L1 too high</source>
-      <translation>Za wysoki prąd AC L1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
-      <source>AC current too high</source>
-      <translation>Zbyt wysoki prąd AC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power L1 too high</source>
-      <translation>Za wysoka moc AC L1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
-      <source>AC power too high</source>
-      <translation>Za wysoka moc AC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="107"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="231"/>
-      <source>Emergency stop</source>
-      <translation>Wyłącznik awaryjny</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="108"/>
-      <source>Servo current too high</source>
-      <translation>Za wysoki prąd serwomechanizmu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="109"/>
-      <source>Oil pressure too low</source>
-      <translation>Zbyt niskie ciśnienie oleju</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="110"/>
-      <source>Oil pressure too high</source>
-      <translation>Za wysokie ciśnienie oleju</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="111"/>
-      <source>Engine temperature too low</source>
-      <translation>Za niska temperatura silnika</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="112"/>
-      <source>Engine temperature too high</source>
-      <translation>Za wysoka temperatura silnika</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="113"/>
-      <source>Winding temperature too low</source>
-      <translation>Za niska temperatura uzwojenia</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="114"/>
-      <source>Winding temperature too high</source>
-      <translation>Zbyt wysoka temperatura uzwojenia</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="115"/>
-      <source>Exhaust temperature too low</source>
-      <translation>Zbyt niska temperatura spalin</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="116"/>
-      <source>Exhaust temperature too high</source>
-      <translation>Za wysoka temperatura spalin</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="117"/>
-      <source>Electronic temperature low</source>
-      <translation>Niska temperatura elektroniki</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="118"/>
-      <source>Electronic temperature high</source>
-      <translation>Wysoka temperatura elektroniki</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="119"/>
-      <source>Starter voltage too low</source>
-      <translation>Zbyt niskie napięcie rozrusznika</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="120"/>
-      <source>Starter current too high</source>
-      <translation>Zbyt wysoki prąd rozrusznika</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="121"/>
-      <source>Glow voltage too low</source>
-      <translation>Zbyt niskie napięcie żarzenia</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="122"/>
-      <source>Glow current too high</source>
-      <translation>Zbyt wysoki prąd żarzenia</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="123"/>
-      <source>Cold-Start-Aid voltage too high</source>
-      <translation>Zbyt wysokie napięcie układu Cold-Start-Aid</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="124"/>
-      <source>Cold-Start-Aid current too high</source>
-      <translation>Zbyt wysoki prąd zimnego rozruchu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="125"/>
-      <source>Fuel holding magnet voltage too low</source>
-      <translation>Zbyt niskie napięcie magnesu przytrzymującego paliwo</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="126"/>
-      <source>Fuel holding magnet current too high</source>
-      <translation>Zbyt wysoki prąd magnesu trzymającego paliwo</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="127"/>
-      <source>Stop solenoid hold coil voltage too low</source>
-      <translation>Zbyt niskie napięcie cewki zatrzymania elektromagnesu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="128"/>
-      <source>Stop solenoid hold coil current too high</source>
-      <translation>Za wysoki prąd zwoju podtrzymującego cewki gaszenia</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="129"/>
-      <source>Stop solenoid pull coil voltage too low </source>
-      <translation>Za niskie napięcie cewki gaszenia silnika</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="130"/>
-      <source>Stop solenoid pull coil current too high</source>
-      <translation>Zbyt wysoki prąd cewki hamulcowej.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="131"/>
-      <source>Fan/water pump voltage too low</source>
-      <translation>Zbyt niskie napięcie wentylatora/pompy wodnej</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="132"/>
-      <source>Fan/water pump current too high</source>
-      <translation>Zbyt wysoki prąd wentylatora/pompy wodnej</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="133"/>
-      <source>Current sensor voltage low</source>
-      <translation>Niskie napięcie czujnika prądu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="134"/>
-      <source>Current sensor current high</source>
-      <translation>Wysoki prąd czujnika prądu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="135"/>
-      <source>Boost output voltage too low</source>
-      <translation>Zbyt niskie napięcie wyjściowe Boost</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="136"/>
-      <source>Boost output current too high</source>
-      <translation>Za wysoki prąd wyjścia doładowania</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="137"/>
-      <source>Bus supply voltage too low</source>
-      <translation>Zbyt niskie napięcie zasilania magistrali</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="138"/>
-      <source>Bus supply current too high</source>
-      <translation>Zbyt wysoki prąd zasilania magistrali</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="139"/>
-      <source>Starter battery voltage too low</source>
-      <translation>Zbyt niskie napięcie akumulatora rozruchowego</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="140"/>
-      <source>Starter battery voltage too high</source>
-      <translation>Za wysokie napięcie akumulatora rozruchowego</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="141"/>
-      <source>Rotation too low</source>
-      <translation>Za niskie obroty</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="142"/>
-      <source>Rotation too high</source>
-      <translation>Za wysokie obroty</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="143"/>
-      <source>Unexpected stop/problem with fuel supply</source>
-      <translation>Nieoczekiwane zatrzymanie/problem z dopływem paliwa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="144"/>
-      <source>Power contactor voltage too low</source>
-      <translation>Zbyt niskie napięcie stycznika zasilania</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="145"/>
-      <source>Power contactor current too high</source>
-      <translation>Za wysoki prąd stycznika mocy</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="146"/>
-      <source>AC voltage L2 too low</source>
-      <translation>Zbyt niskie napięcie AC L2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="147"/>
-      <source>AC voltage L2 too high</source>
-      <translation>Za wysokie napięcie AC L2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="148"/>
-      <source>AC frequency L2 too low</source>
-      <translation>Za niska częstotliwość AC L2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="149"/>
-      <source>AC frequency L2 too high</source>
-      <translation>Częstotliwość AC L2 za wysoka</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="150"/>
-      <source>AC current L2 too high</source>
-      <translation>Za wysoki prąd AC L2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="151"/>
-      <source>AC power L2 too high</source>
-      <translation>Zbyt wysoka moc AC L2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="152"/>
-      <source>AC voltage L3 too low</source>
-      <translation>Zbyt niskie napięcie AC L3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="153"/>
-      <source>AC voltage L3 too high</source>
-      <translation>Za wysokie napięcie AC L3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="154"/>
-      <source>AC frequency L3 too low</source>
-      <translation>Za niska częstotliwość AC L3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="155"/>
-      <source>AC frequency L3 too high</source>
-      <translation>Za wysoka częstotliwość AC L3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="156"/>
-      <source>AC current L3 too high</source>
-      <translation>Prąd zmienny L3 za wysoki</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="157"/>
-      <source>AC power L3 too high</source>
-      <translation>Za wysoka moc AC L3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="158"/>
-      <source>Output Inverter voltage too low</source>
-      <translation>Zbyt niskie napięcie wyjściowe falownika</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="159"/>
-      <source>Output Inverter current too  high</source>
-      <translation>Zbyt wysoki prąd wyjściowy falownika</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="160"/>
-      <source>Universal output (1A) voltage too low</source>
-      <translation>Zbyt niskie napięcie na wyjściu uniwersalnym (1A)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="161"/>
-      <source>Universal output (1A) current too high</source>
-      <translation>Zbyt wysoki prąd wyjścia uniwersalnego (1A)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="162"/>
-      <source>Universal output (5A) voltage too low</source>
-      <translation>Zbyt niskie napięcie na wyjściu uniwersalnym (5A)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="163"/>
-      <source>Universal output (5A) current too high</source>
-      <translation>Zbyt wysoki prąd wyjścia uniwersalnego (5A)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="164"/>
-      <source>AGT DC voltage 1 low</source>
-      <translation>Niskie napięcie AGT DC 1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="165"/>
-      <source>AGT DC voltage 1 high</source>
-      <translation>Napięcie AGT DC 1 wysokie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="166"/>
-      <source>AGT DC current 1 low</source>
-      <translation>Prąd stały AGT 1 niski</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="167"/>
-      <source>AGT DC current 1 high</source>
-      <translation>Prąd stały AGT 1 wysoki</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="168"/>
-      <source>AGT DC voltage 2 low</source>
-      <translation>Niskie napięcie AGT DC 2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="169"/>
-      <source>AGT DC voltage 2 high</source>
-      <translation>Napięcie AGT DC 2 wysokie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="170"/>
-      <source>AGT DC current 2 low</source>
-      <translation>Prąd stały AGT 2 niski</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="171"/>
-      <source>AGT DC current 2 high</source>
-      <translation>Prąd stały AGT 2 wysoki</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="172"/>
-      <source>AGT B6 cooler low</source>
-      <translation>Chłodnica AGT B6 niska</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="173"/>
-      <source>AGT B6 cooler high</source>
-      <translation>Chłodnica AGT B6 wysoka</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="174"/>
-      <source>AGT B6 rail (-) low</source>
-      <translation>Szyna AGT B6 (-) niska</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="175"/>
-      <source>AGT B6 rail (-) high</source>
-      <translation>Szyna AGT B6 (-) wysoka</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="176"/>
-      <source>AGT B6 rail (+) low</source>
-      <translation>Szyna AGT B6 (+) niska</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="177"/>
-      <source>AGT B6 rail (+) high</source>
-      <translation>Szyna AGT B6 (+) wysoka</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="178"/>
-      <source>Fuel temperature too low</source>
-      <translation>Zbyt niska temperatura paliwa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="179"/>
-      <source>Fuel temperature too high</source>
-      <translation>Zbyt wysoka temperatura paliwa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="180"/>
-      <source>Fuel level too low</source>
-      <translation>Za niski poziom paliwa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="183"/>
-      <source>Lost control unit</source>
-      <translation>Zagubiono jednostkę sterującą</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="184"/>
-      <source>Lost panel</source>
-      <translation>Zagubiono panel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="185"/>
-      <source>Service needed</source>
-      <translation>Potrzebny serwis</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="186"/>
-      <source>Lost 3-phase module</source>
-      <translation>Utracono moduł 3-fazowy</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="187"/>
-      <source>Lost AGT module</source>
-      <translation>Zagubiono moduł AGT</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="188"/>
-      <source>Synchronization failure</source>
-      <translation>Błąd synchronizacji</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="189"/>
-      <source>Lost external ECU</source>
-      <translation>Utrata zewnętrznego ECU</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="190"/>
-      <source>Intake airfilter</source>
-      <translation>Filtr powietrza dolotowego</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="191"/>
-      <source>Diagnostic message (ECU)</source>
-      <translation>Komunikat diagnostyczny (ECU)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="192"/>
-      <source>Lost sync. module</source>
-      <translation>Utracono moduł synchr.</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="193"/>
-      <source>Load-balance failed</source>
-      <translation>Nie udało się zrównoważyć obciążenia</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="194"/>
-      <source>Sync-mode deactivated</source>
-      <translation>Tryb synchronizacji wyłączony</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="195"/>
-      <source>Red Stop Lamp (RSL)</source>
-      <translation>Czerwone światło stopu (RSL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="196"/>
-      <source>Amber Warning Lamp (AWL)</source>
-      <translation>Bursztynowe światło ostrzegawcze (AWL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="197"/>
-      <source>Malfunction Indicator Lamp (MIL)</source>
-      <translation>Lampka kontrolna awarii (MIL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="198"/>
-      <source>Protect Lamp (PL)</source>
-      <translation>Lampa ochronna (PL)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="199"/>
-      <source>Rotating field wrong</source>
-      <translation>Nieprawidłowe pole wirujące</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="200"/>
-      <source>Fuel level sensor lost</source>
-      <translation>Utrata czujnika poziomu paliwa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="201"/>
-      <source>Starting without inverter</source>
-      <translation>Rozruch bez falownika</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="202"/>
-      <source>Bus #1 dead</source>
-      <translation>Autobus nr 1 nie działa</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="203"/>
-      <source>Start request denied</source>
-      <translation>Odrzucono wniosek o rozpoczęcie</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="204"/>
-      <source>Remote start denied</source>
-      <translation>Odmowa zdalnego uruchamiania</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="205"/>
-      <source>Forced switch off load relay</source>
-      <translation>Wymuszone wyłączenie przekaźnika obciążenia</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="206"/>
-      <source>Synchronization Module is offline</source>
-      <translation>Moduł synchronizacji jest offline</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="207"/>
-      <source>Lost BMS</source>
-      <translation>Utracony BMS</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="208"/>
-      <source>Converter DC Link Voltage Low/Reverse</source>
-      <translation>Niskie/odwrotne napięcie obwodu pośredniego konwertera</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="209"/>
-      <source>Converter DC Link Current Low</source>
-      <translation>Niski prąd obwodu pośredniego konwertera</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="210"/>
-      <source>Converter DC Precharge Voltage Low</source>
-      <translation>Niskie napięcie wstępnego ładowania DC konwertera</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="211"/>
-      <source>Converter DC Precharge Voltage High</source>
-      <translation>Wysokie napięcie wstępnego ładowania DC konwertera</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="212"/>
-      <source>Converter IGBT/MOSFET Driver Error</source>
-      <translation>Błąd sterownika konwertera IGBT/MOSFET</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="213"/>
-      <source>Converter Error Power Control Loop</source>
-      <translation>Błąd przetwornika Pętla sterowania mocą</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="214"/>
-      <source>Converter AC Frequency Detection</source>
-      <translation>Wykrywanie częstotliwości AC konwertera</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="215"/>
-      <source>Converter Control Value Fail</source>
-      <translation>Błąd wartości kontrolnej konwertera</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="216"/>
-      <source>Factory setting changed</source>
-      <translation>Zmieniono ustawienie fabryczne</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="217"/>
-      <source>Parameter changed in admin mode</source>
-      <translation>Parametr zmieniony w trybie administratora</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="218"/>
-      <source>Manual Intervention (ext. System)</source>
-      <translation>Interwencja ręczna (dodatkowy system)</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="221"/>
-      <source>Init failed</source>
-      <translation>Init failed</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="222"/>
-      <source>Watchdog</source>
-      <translation>Watchdog</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="223"/>
-      <source>Inverter temperature high L1</source>
-      <translation>Wysoka temperatura falownika L1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="224"/>
-      <source>Inverter temperature high L2</source>
-      <translation>Wysoka temperatura falownika L2</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="225"/>
-      <source>Inverter temperature high L3</source>
-      <translation>Wysoka temperatura falownika L3</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="226"/>
-      <source>Inverter temperature high DC link</source>
-      <translation>Wysoka temperatura obwodu pośredniego falownika</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="227"/>
-      <source>Inverter overload</source>
-      <translation>Przeciążenie falownika</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="228"/>
-      <source>Inverter communication lost</source>
-      <translation>Utrata komunikacji z inwerterem</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="229"/>
-      <source>DC overload</source>
-      <translation>Przeciążenie DC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="230"/>
-      <source>DC overvoltage</source>
-      <translation>Przepięcie DC</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="232"/>
-      <source>No connection</source>
-      <translation>Brak połączenia</translation>
-    </message>
-  </context>
-  <context>
-    <name>GensetError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="68"/>
-      <source>No error</source>
-      <translation>Brak błędu</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="79"/>
-      <source>Unknown error: %1</source>
-      <translation>Nieznany błąd: %1</translation>
-    </message>
-  </context>
-  <context>
-    <name>Hatz</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="778"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="784"/>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="790"/>
-      <source>Unknown error: </source>
-      <translation>Nieznany błąd:</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="797"/>
-      <source>Oil pressure</source>
-      <translation>Ciśnienie oleju</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="798"/>
-      <source>Cylinder head overtemperature</source>
-      <translation>Nadmierna temperatura głowicy cylindrów</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="799"/>
-      <source>Charge control</source>
-      <translation>Kontrola ładowania</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="800"/>
-      <source>Speed higher than expected</source>
-      <translation>Prędkość wyższa niż oczekiwana</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="801"/>
-      <source>Overspeed</source>
-      <translation>Nadmierna prędkość</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="803"/>
-      <source>Oiltemperature higher than expected</source>
-      <translation>Temperatura oleju wyższa niż oczekiwano</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="804"/>
-      <source>Oiltemperature open circuit / short to power</source>
-      <translation>Obwód otwarty / zwarcie do zasilania</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="805"/>
-      <source>Oiltemperature short to ground</source>
-      <translation>Zwarcie temperatury do masy</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="806"/>
-      <source>Analog setpoint high / short to power</source>
-      <translation>Analogowa wartość zadana wysoka / zwarcie do zasilania</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="807"/>
-      <source>Analog setpoint low / short to ground</source>
-      <translation>Analogowa wartość zadana niska / zwarcie do masy</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="808"/>
-      <source>TSC1 message receive timeout</source>
-      <translation>Limit czasu odbioru komunikatu TSC1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="809"/>
-      <source>CM1 message receive timeout</source>
-      <translation>Limit czasu odbioru wiadomości CM1</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="810"/>
-      <source>Battery voltage high</source>
-      <translation>Wysokie napięcie baterii</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="811"/>
-      <source>Battery voltage low</source>
-      <translation>Niskie napięcie akumulatora</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="812"/>
-      <source>Speed signal distorted</source>
-      <translation>Zniekształcony sygnał prędkości</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="813"/>
-      <source>Internal 5V sensor supply high</source>
-      <translation>Wysokie wewnętrzne zasilanie czujnika 5V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="814"/>
-      <source>Internal 5V sensor supply low</source>
-      <translation>Niski poziom zasilania wewnętrznego czujnika 5 V</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="815"/>
-      <source>Barometric pressure high</source>
-      <translation>Wysokie ciśnienie barometryczne</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="816"/>
-      <source>Barometric pressure low</source>
-      <translation>Niskie ciśnienie barometryczne</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="817"/>
-      <source>Output fuelpump short to power</source>
-      <translation>Zwarcie wyjściowej pompy paliwa do zasilania</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="818"/>
-      <source>Output fuelpump short to ground</source>
-      <translation>Zwarcie wyjściowej pompy paliwa do masy</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="819"/>
-      <source>Output glow plug short to power</source>
-      <translation>Zwarcie wyjściowej świecy żarowej do zasilania</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="820"/>
-      <source>Output glow plug short to ground</source>
-      <translation>Zwarcie wyjściowej świecy żarowej do masy</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="821"/>
-      <source>Injector open circuit/low side short to ground</source>
-      <translation>Obwód otwarty wtryskiwacza/zwarcie strony dolnej do masy</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="822"/>
-      <source>Injector coil internal short circuit</source>
-      <translation>Wewnętrzne zwarcie cewki wtryskiwacza</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="823"/>
-      <source>Injector low side short to power</source>
-      <translation>Zwarcie dolnej strony wtryskiwacza do zasilania</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="824"/>
-      <source>Service hours expired</source>
-      <translation>Godziny pracy wygasły</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="828"/>
-      <source>Processor failure</source>
-      <translation>Awaria procesora</translation>
-    </message>
-  </context>
-  <context>
-    <name>PageAcInSetup</name>
-    <message>
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="129"/>
-      <source>Set the switch in an unlocked position to modify the settings.</source>
-      <translation>Ustaw przełącznik w pozycji odblokowanej, aby zmodyfikować ustawienia.</translation>
-    </message>
-  </context>
-  <context>
-    <name>QGuiApplication</name>
-    <message>
-      <location filename="../../src/main.cpp" line="120"/>
-      <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
-      <translation>Użyj źródła danych D-Bus: połącz się z podanym adresem D-Bus.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="121"/>
-      <source>address</source>
-      <comment>D-Bus address</comment>
-      <translation>adres</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="126"/>
-      <source>Use D-Bus data source: connect to the default D-Bus address</source>
-      <translation>Użyj źródła danych D-Bus: połącz się z domyślnym adresem D-Bus</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="132"/>
-      <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
-      <translation>Użyj źródła danych MQTT: połącz się z określonym adresem brokera MQTT.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="133"/>
-      <source>address</source>
-      <comment>MQTT broker address</comment>
-      <translation>adres</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="139"/>
-      <source>MQTT data source device portal id.</source>
-      <translation>Identyfikator portalu urządzenia źródła danych MQTT.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="140"/>
-      <source>portalId</source>
-      <translation>identyfikator portalu</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="145"/>
-      <source>MQTT VRM webhost shard</source>
-      <translation>Fragment hosta internetowego MQTT VRM</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="146"/>
-      <source>shard</source>
-      <comment>MQTT VRM webhost shard</comment>
-      <translation>czerep</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="151"/>
-      <source>MQTT data source username</source>
-      <translation>Nazwa użytkownika źródła danych MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="152"/>
-      <source>user</source>
-      <comment>MQTT broker username.</comment>
-      <translation>Użytkownik</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="157"/>
-      <source>MQTT data source password</source>
-      <translation>Hasło źródła danych MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="158"/>
-      <source>pass</source>
-      <comment>MQTT broker password.</comment>
-      <translation>przechodzić</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="163"/>
-      <source>MQTT data source token</source>
-      <translation>Token źródła danych MQTT</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="164"/>
-      <source>token</source>
-      <comment>MQTT broker auth token.</comment>
-      <translation>Kod tokenu</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="169"/>
-      <source>Enable FPS counter</source>
-      <translation>Włącz licznik FPS</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="174"/>
-      <source>Skip splash screen</source>
-      <translation>Pomiń ekran powitalny</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="179"/>
-      <source>Use mock data source for testing.</source>
-      <translation>Użyj próbnego źródła danych do testowania.</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="184"/>
-      <source>Name of mock configuration</source>
-      <translation>Nazwa konfiguracji testowej</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="185"/>
-      <source>mockConfig</source>
-      <comment>Configuration name</comment>
-      <translation>mockConfig</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="191"/>
-      <source>Set to disable mock timers on startup</source>
-      <translation>Ustaw, aby wyłączyć timery testowe przy uruchomieniu</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="196"/>
-      <source>Node-RED URL</source>
-      <translation>Adres URL Node-RED</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="197"/>
-      <source>url</source>
-      <comment>Node-RED URL</comment>
-      <translation>url</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="202"/>
-      <source>Signal K URL</source>
-      <translation>Adres URL Signal K</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="203"/>
-      <source>url</source>
-      <comment>Signal K URL</comment>
-      <translation>adres URL</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="208"/>
-      <source>Color scheme (dark, light, auto, default)</source>
-      <translation>Schemat kolorów (ciemny, jasny, auto, domyślny)</translation>
-    </message>
-    <message>
-      <location filename="../../src/main.cpp" line="209"/>
-      <source>scheme</source>
-      <comment>Color scheme value</comment>
-      <translation>schemat</translation>
+      <translation>Wymuszony</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_settings">
+      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
+      <source>Modbus port and unit ID settings</source>
+      <translation>Ustawienia portu Modbus i ID urządzenia</translation>
+    </message>
+    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
+      <source>Integrates with the device list</source>
+      <translation>Integruje się z listą urządzeń</translation>
+    </message>
+    <message id="common_words_color">
+      <location filename="../../components/CommonWords.qml" line="136"/>
+      <source>Color</source>
+      <translation>Kolor</translation>
+    </message>
+    <message id="common_words_value_must_be_greater_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="557"/>
+      <source>Value must be greater than start value</source>
+      <translation>Wartość musi być większa niż wartość początkowa</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="566"/>
+      <source>Value must be lower than stop value</source>
+      <translation>Wartość musi być niższa niż wartość stop</translation>
+    </message>
+    <message id="notifications_page_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="43"/>
+      <source>Active Notifications</source>
+      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
+      <translation>Aktywne Powiadomienia</translation>
+    </message>
+    <message id="notifications_page_inactive_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="47"/>
+      <source>Inactive Notifications</source>
+      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
+      <translation>Nieaktywne Powiadomienia</translation>
+    </message>
+    <message id="notifications_no_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="106"/>
+      <source>No active notifications</source>
+      <translation>Brak aktywnych powiadomień</translation>
+    </message>
+    <message id="switchable_output_rgb_color_wheel">
+      <location filename="../../src/enums.cpp" line="427"/>
+      <source>RGB color wheel</source>
+      <translation>Koło kolorów RGB</translation>
+    </message>
+    <message id="switchable_output_cct_color_wheel">
+      <location filename="../../src/enums.cpp" line="431"/>
+      <source>CCT color wheel</source>
+      <extracomment>Correlated Color Temperature color wheel</extracomment>
+      <translation>Koło kolorów CCT</translation>
+    </message>
+    <message id="switchable_output_rgbw_color_wheel">
+      <location filename="../../src/enums.cpp" line="435"/>
+      <source>RGB + W color wheel</source>
+      <extracomment>RGB + white color wheel</extracomment>
+      <translation>RGB + koło kolorów w</translation>
+    </message>
+    <message id="listlink_show_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="43"/>
+      <source>Show QR code</source>
+      <translation>Pokaż kod QR</translation>
+    </message>
+    <message id="listlink_scan_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="52"/>
+      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
+      <extracomment>%1 = url text</extracomment>
+      <oldsource>Scan the QR code with your portable device.&lt;br /&gt;Or insert the link: %1</oldsource>
+      <translation>Otwórz kod QR i zeskanuj go za pomocą urządzenia przenośnego.&lt;br /&gt;Lub wpisz link: %1</translation>
+    </message>
+    <message id="color_preset">
+      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
+      <source>Preset</source>
+      <translation>Ustawienie</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
+      <source>Add Modbus port and unit ID</source>
+      <translation>Dodaj port Modbus i ID urządzenia</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_unitid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
+      <source>Unit ID</source>
+      <translation>ID urządzenia</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location_button">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
+      <source>Add</source>
+      <translation>Dodaj</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_locations_note">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
+      <source>The default modbus port is 502 and the default unit ID is 126.
+Here you can add additional ports and unit IDs to scan for PV inverters.</source>
+      <translation>Domyślny port Modbus to 502, a domyślny identyfikator urządzenia to 126. W tym miejscu możesz dodać dodatkowe porty i identyfikatory urządzeń do skanowania w poszukiwaniu inwerterów fotowoltaicznych.</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_location_number">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
+      <source>Port/Unit ID %1</source>
+      <translation>Port/Urządzenie ID %1</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location_description">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
+      <source>Port: %1 (Unit %2)</source>
+      <translation>Port: %1 (Urządzenie ID %2)</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
+      <source>Remove Modbus port and unit ID?</source>
+      <translation>Usunąć port Mobius i ID urządzenia?</translation>
+    </message>
+    <message id="devicelist_tankshape_edit_point">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="182"/>
+      <source>Edit point %1</source>
+      <extracomment>%1 = which point is being edited, a number like "1" or "2"</extracomment>
+      <translation></translation>
+    </message>
+    <message id="settings_canbus_vecan">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
+      <source>VE.Can (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_250">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <source>VE.Can &amp; CANopen E-drive (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_500">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
+      <source>CANopen E-drive (500 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="page_microgrid_from_p1_to_p2">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="39"/>
+      <source>%1%2 to %3%4</source>
+      <extracomment>Describes a range from one quantity to another, e.g. "30W to 60W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
+      <translation></translation>
     </message>
   </context>
   <context>
@@ -12345,7 +9682,7 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
     <message>
       <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
       <source>Atlantic Daylight Time</source>
-      <translation>Czas letni na Atlantyku</translation>
+      <translation>Czas Letni Atlantycki (ADT)</translation>
     </message>
   </context>
   <context>
@@ -12607,7 +9944,7 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
     <message>
       <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
       <source>Mid-Atlantic Standard Time</source>
-      <translation>Mid-Atlantic Standard Time</translation>
+      <translation>Czas standardowy Środkowoatlantycki (MAST)</translation>
     </message>
   </context>
   <context>
@@ -12896,116 +10233,1628 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
     </message>
   </context>
   <context>
-    <name>VebusError</name>
+    <name>AlternatorError</name>
     <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation type="unfinished"/>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="22"/>
+      <source>No error</source>
+      <translation>Brak błędu</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation type="unfinished"/>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="25"/>
+      <source>Unknown error: %1</source>
+      <translation>Nieznany błąd: %1</translation>
+    </message>
+  </context>
+  <context>
+    <name>BmsError</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="10"/>
+      <source>No error</source>
+      <translation>Brak błędu</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation type="unfinished"/>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="13"/>
+      <source>Battery initialization error</source>
+      <translation>Błąd inicjalizacji akumulatora</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation type="unfinished"/>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="16"/>
+      <source>No batteries connected</source>
+      <translation>Brak podłączonych akumulatorów</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation type="unfinished"/>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="19"/>
+      <source>Unknown battery</source>
+      <translation>Nieznany akumulator</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation type="unfinished"/>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="22"/>
+      <source>Different battery types</source>
+      <translation>Różne rodzaje akumulatorów</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation type="unfinished"/>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="25"/>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="40"/>
+      <source>No. of batteries incorrect</source>
+      <translation>Liczba nieprawidłowych akumulatorów</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation type="unfinished"/>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="28"/>
+      <source>Lynx Shunt not found</source>
+      <translation>Lynx Shunt nie został znaleziony</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation type="unfinished"/>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="31"/>
+      <source>Battery measure error</source>
+      <translation>Błąd pomiaru akumulatora</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation type="unfinished"/>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="34"/>
+      <source>Internal calculation error</source>
+      <translation>Wewnętrzny błąd obliczeniowy</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation type="unfinished"/>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="37"/>
+      <source>No. of batteries in series incorrect</source>
+      <translation>Liczba ak. w szeregu nieprawidłowa</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation type="unfinished"/>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="44"/>
+      <source>Hardware error</source>
+      <translation>Błąd sprzętowy</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation type="unfinished"/>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="47"/>
+      <source>Watchdog error</source>
+      <translation>Błąd układu Watchdog</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation type="unfinished"/>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="50"/>
+      <source>Over voltage</source>
+      <translation>Nadmierne napięcie</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation type="unfinished"/>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="53"/>
+      <source>Under voltage</source>
+      <translation>Za niskie napięcie</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation type="unfinished"/>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="56"/>
+      <source>Over temperature</source>
+      <translation>Za wysoka temperatura</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation type="unfinished"/>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="59"/>
+      <source>Under temperature</source>
+      <translation>Za niska temperatura</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation type="unfinished"/>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="62"/>
+      <source>Under-charge standby</source>
+      <translation>Czuwanie w stanie niedoładowania</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation type="unfinished"/>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="65"/>
+      <source>ADC error</source>
+      <translation>Błąd ADC</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation type="unfinished">Błąd wewnętrzny</translation>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="68"/>
+      <source>Battery comm. error</source>
+      <translation>Błąd kom. akumulatora</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation type="unfinished"/>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="71"/>
+      <source>Pre-Charge error</source>
+      <translation>Błąd wstępnego ładowania</translation>
     </message>
     <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation type="unfinished"/>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="75"/>
+      <source>Safety contactor error</source>
+      <translation>Błąd stycznika bezpieczeństwa</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="79"/>
+      <source>Battery update error</source>
+      <translation>Błąd aktualizacji akumulatora</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="82"/>
+      <source>BMS cable error</source>
+      <translation>Błąd przewodu BMS</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="85"/>
+      <source>Reference voltage failure</source>
+      <translation>Awaria napięcia odniesienia</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="88"/>
+      <source>Wrong system voltage</source>
+      <translation>Nieprawidłowe napięcie systemowe</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="91"/>
+      <source>Pre charge timeout</source>
+      <translation>Limit czasu ładowania wstępnego</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="94"/>
+      <source>ATC/ATD failure</source>
+      <translation>Awaria ATC/ATD</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="98"/>
+      <source>Calibration data lost</source>
+      <translation>Utrata danych kalibracyjnych</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="102"/>
+      <source>Settings invalid</source>
+      <translation>Ustawienia nieważne</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="105"/>
+      <source>Interlock</source>
+      <translation>Blokada</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="108"/>
+      <source>Emergency stop</source>
+      <translation>Stop awaryjny</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="111"/>
+      <source>Communication timeout</source>
+      <translation>Limit czasu komunikacji</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="114"/>
+      <source>Safety lock</source>
+      <translation>Blokada bezpieczeństwa</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="117"/>
+      <source>Terminal over temperature</source>
+      <translation>Przekroczenie temperatury terminala</translation>
+    </message>
+  </context>
+  <context>
+    <name>CRE</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="838"/>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="843"/>
+      <source>Unknown error: </source>
+      <translation>Nieznany błąd: </translation>
+    </message>
+  </context>
+  <context>
+    <name>ChargerError</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="7"/>
+      <source>No error</source>
+      <translation>Brak błędu</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="9"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="103"/>
+      <source>Battery high temperature</source>
+      <translation>Wysoka temperatura aku.</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="10"/>
+      <source>Battery high voltage</source>
+      <translation>Wysokie napięcie aku.</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="11"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="12"/>
+      <source>Battery Tsense miswired</source>
+      <translation>Tsense aku. źle podłączony</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="13"/>
+      <source>Battery Tsense missing</source>
+      <translation>Brak aku. Tsense</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="14"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="15"/>
+      <source>Battery Vsense miswired</source>
+      <translation>Bateria Vsense źle podłączona</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="16"/>
+      <source>Battery Vsense missing</source>
+      <translation>Brak Vsense akumulatora</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="17"/>
+      <source>Battery high wire losses</source>
+      <translation>Wysokie straty w przewodach aku.</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="18"/>
+      <source>Battery low voltage</source>
+      <translation>Niskie napięcie akumulatora</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="19"/>
+      <source>Battery high ripple voltage</source>
+      <translation>Wysokie napięcie tętniące akumulatora</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="20"/>
+      <source>Battery low state of charge</source>
+      <translation>Niski stan naładowania akumulatora</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="21"/>
+      <source>Battery mid-point voltage issue</source>
+      <translation>Problem z napięciem środkowego punktu akumulatora</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="22"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="104"/>
+      <source>Battery temperature too low</source>
+      <translation>Zbyt niska temperatura aku.</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="24"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="106"/>
+      <source>Charger high temperature</source>
+      <translation>Wysoka temperatura ładowarki</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="25"/>
+      <source>Charger excessive current</source>
+      <translation>Nadmierny prąd ładowarki</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="26"/>
+      <source>Charger negative current</source>
+      <translation>Ujemny prąd ładowarki</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="27"/>
+      <source>Charger bulk time expired</source>
+      <translation>Upłynął czas fazy Bulk</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="28"/>
+      <source>Charger current sensor issue</source>
+      <translation>Problem z czujnikiem prądu ładowarki</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="29"/>
+      <source>Internal Tsensor miswired</source>
+      <translation>Wewn. czujnik temperatury źle podłączony</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="30"/>
+      <source>Internal Tsensor missing</source>
+      <translation>Brak wewn. czujnika temperatury</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="31"/>
+      <source>Charger fan not detected</source>
+      <translation>Nie wykryto wentylatora ładowarki</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="32"/>
+      <source>Charger fan over-current</source>
+      <translation>Nadmierny prąd wentylatora ładowarki</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="33"/>
+      <source>Charger terminal overheat</source>
+      <translation>Przegrzanie terminala ładowarki</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="34"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="107"/>
+      <source>Charger short circuit</source>
+      <translation>Zwarcie w ładowarce</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="35"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="108"/>
+      <source>Charger power stage issue</source>
+      <translation>Problem ze stopniem mocy ładowarki</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="36"/>
+      <source>Over-charge protection</source>
+      <translation>Zabezpieczenie przed przeładowaniem</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="38"/>
+      <source>Input high voltage</source>
+      <translation>Wysokie napięcie wejściowe</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="39"/>
+      <source>Input excessive current</source>
+      <translation>Nadmierny prąd wejściowy</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="40"/>
+      <source>Input excessive power</source>
+      <translation>Nadmierna moc wejściowa</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="41"/>
+      <source>Input polarity issue</source>
+      <translation>Problem z polaryzacją wejścia</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="42"/>
+      <source>Input voltage absent</source>
+      <translation>Brak napięcia wejściowego</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="43"/>
+      <source>Input shutdown (no retries)</source>
+      <translation>Wyłączenie wejścia (bez ponawiania)</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="44"/>
+      <source>Input shutdown (retry)</source>
+      <translation>Wyłączenie wejścia (ponowienie)</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="45"/>
+      <source>Input internal failure</source>
+      <translation>Wewnętrzna awaria wejścia</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="47"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="48"/>
+      <source>PV isolation failure</source>
+      <translation>Awaria izolacji PV</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="49"/>
+      <source>Ground fault detected</source>
+      <translation>Wykryto błąd uziemienia</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="51"/>
+      <source>Inverter overload</source>
+      <translation>Przeciążenie inwertera</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="52"/>
+      <source>Inverter temp too high</source>
+      <translation>Za wysoka temp. inwertera</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="53"/>
+      <source>Inverter peak current</source>
+      <translation>Prąd szczytowy inwertera</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="54"/>
+      <source>Inverter internal DC level</source>
+      <translation>Wewnętrzny poziom DC Inwertera</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="55"/>
+      <source>Inverter wrong ACout level</source>
+      <translation>Błędny poziom ACout Inwertera</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="56"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="57"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="59"/>
+      <source>Inverter powerstage fault</source>
+      <translation>Błąd stopnia mocy Inwertera</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="58"/>
+      <source>Inverter connected to AC</source>
+      <translation>Inwerter podłączony do AC</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="60"/>
+      <source>ACIN1 relay test fault</source>
+      <translation>Błąd testu przekaźnika ACIN1</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="61"/>
+      <source>ACIN2 relay test fault</source>
+      <translation>Błąd testu przekaźnika ACIN2</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="63"/>
+      <source>Device disappeared</source>
+      <translation>Urządzenie zniknęło</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="64"/>
+      <source>Incompatible device</source>
+      <translation>Niekompatybilne urządzenie</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="65"/>
+      <source>BMS connection lost</source>
+      <translation>Utrata połączenia z BMS</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="66"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="67"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="68"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="69"/>
+      <source>Network misconfigured</source>
+      <translation>Sieć źle skonfigurowana</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="70"/>
+      <source>Phase rotation</source>
+      <translation>Obrót fazowy</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="71"/>
+      <source>Multiple AC inputs</source>
+      <translation>Wiele wejść AC</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="72"/>
+      <source>Phase overload</source>
+      <translation>Przeciążenie fazy</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="74"/>
+      <source>Memory write error</source>
+      <translation>Błąd zapisu w pamięci</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="75"/>
+      <source>CPU temperature too high</source>
+      <translation>Za wysoka temperatura CPU</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="76"/>
+      <source>Communication lost</source>
+      <translation>Utracona łączność</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="77"/>
+      <source>Calibration data lost</source>
+      <translation>Utrata danych kalibracyjnych</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="78"/>
+      <source>Incompatible firmware</source>
+      <translation>Niekompatybilne oprogramowanie</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="79"/>
+      <source>Incompatible hardware</source>
+      <translation>Niekompatybilny sprzęt</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="80"/>
+      <source>Settings invalid</source>
+      <translation>Ustawienia nieważne</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="81"/>
+      <source>Reference voltage failed</source>
+      <translation>Błąd napięcia referencyjnego</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="82"/>
+      <source>Tester fail</source>
+      <translation>Awaria testera</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="83"/>
+      <source>History invalid</source>
+      <translation>Historia nieważna</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="84"/>
+      <source>kWh counters invalid</source>
+      <translation>Nieprawidłowe liczniki kWh</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="86"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="87"/>
+      <source>DC voltage error</source>
+      <translation>Błąd napięcia DC</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="88"/>
+      <source>GFCI sensor error</source>
+      <translation>Błąd sensora GFCI</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="89"/>
+      <source>3V3 supply error</source>
+      <translation>Błąd zasilania 3V3</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="90"/>
+      <source>5V supply error</source>
+      <translation>Błąd zasilania 5 V</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="91"/>
+      <source>12V supply error</source>
+      <translation>Błąd zasilania 12 V</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="92"/>
+      <source>15V supply error</source>
+      <translation>Błąd zasilania 15 V</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="94"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="95"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="96"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="97"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="98"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="99"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="100"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="101"/>
+      <source>PV Input shutdown</source>
+      <translation>Wyłączenie wejścia PV</translation>
+    </message>
+  </context>
+  <context>
+    <name>DEIF</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="857"/>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="862"/>
+      <source>Unknown error: </source>
+      <translation>Nieznany błąd: </translation>
+    </message>
+  </context>
+  <context>
+    <name>DSE</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="242"/>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="247"/>
+      <source>Unknown error: </source>
+      <translation>Nieznany błąd:</translation>
+    </message>
+  </context>
+  <context>
+    <name>EnvironmentInputs</name>
+    <message>
+      <location filename="../../data/EnvironmentInputs.qml" line="18"/>
+      <source>Battery</source>
+      <translation>Akumulator</translation>
+    </message>
+    <message>
+      <location filename="../../data/EnvironmentInputs.qml" line="24"/>
+      <source>Fridge</source>
+      <translation>Lodówka</translation>
+    </message>
+    <message>
+      <location filename="../../data/EnvironmentInputs.qml" line="30"/>
+      <source>Generic</source>
+      <translation>Ogólne</translation>
+    </message>
+    <message>
+      <location filename="../../data/EnvironmentInputs.qml" line="36"/>
+      <source>Room</source>
+      <translation>Pokój</translation>
+    </message>
+    <message>
+      <location filename="../../data/EnvironmentInputs.qml" line="42"/>
+      <source>Outdoor</source>
+      <translation>Na zewnątrz</translation>
+    </message>
+    <message>
+      <location filename="../../data/EnvironmentInputs.qml" line="48"/>
+      <source>Water Heater</source>
+      <translation>Podgrzewacz Wody</translation>
+    </message>
+    <message>
+      <location filename="../../data/EnvironmentInputs.qml" line="54"/>
+      <source>Freezer</source>
+      <translation>Zamrażarka</translation>
+    </message>
+  </context>
+  <context>
+    <name>FischerPanda</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="87"/>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="92"/>
+      <source>Unknown error: </source>
+      <translation>Nieznany błąd: </translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="98"/>
+      <source>No error</source>
+      <translation>Brak błędu</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
+      <source>AC voltage L1 too low</source>
+      <translation>Za niskie napięcie AC L1</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="101"/>
+      <source>AC voltage too low</source>
+      <translation>Za niskie napięcie AC</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
+      <source>AC voltage L1 too high</source>
+      <translation>Za wysokie napięcie AC L1</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="102"/>
+      <source>AC voltage too high</source>
+      <translation>Za wysokie napięcie AC</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
+      <source>AC frequency L1 too low</source>
+      <translation>Za niska częstotliwość AC L1</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="103"/>
+      <source>AC frequency too low</source>
+      <translation>Za niska częstotliwość AC</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
+      <source>AC frequency L1 too high</source>
+      <translation>Za wysoka częstotliwość AC L1</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
+      <source>AC frequency too high</source>
+      <translation>Za wysoka częstotliwość AC</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
+      <source>AC current L1 too high</source>
+      <translation>Za wysoki prąd AC L1</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="105"/>
+      <source>AC current too high</source>
+      <translation>Za wysoki prąd AC</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
+      <source>AC power L1 too high</source>
+      <translation>Za wysoka moc AC L1</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="106"/>
+      <source>AC power too high</source>
+      <translation>Za wysoka moc AC</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="107"/>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="231"/>
+      <source>Emergency stop</source>
+      <translation>Wyłącznik awaryjny</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="108"/>
+      <source>Servo current too high</source>
+      <translation>Za wysoki prąd serwomechanizmu</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="109"/>
+      <source>Oil pressure too low</source>
+      <translation>Za niskie ciśnienie oleju</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="110"/>
+      <source>Oil pressure too high</source>
+      <translation>Za wysokie ciśnienie oleju</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="111"/>
+      <source>Engine temperature too low</source>
+      <translation>Za niska temperatura silnika</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="112"/>
+      <source>Engine temperature too high</source>
+      <translation>Za wysoka temperatura silnika</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="113"/>
+      <source>Winding temperature too low</source>
+      <translation>Za niska temperatura uzwojenia</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="114"/>
+      <source>Winding temperature too high</source>
+      <translation>Za wysoka temperatura uzwojenia</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="115"/>
+      <source>Exhaust temperature too low</source>
+      <translation>Zbyt niska temperatura spalin</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="116"/>
+      <source>Exhaust temperature too high</source>
+      <translation>Za wysoka temperatura spalin</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="117"/>
+      <source>Electronic temperature low</source>
+      <translation>Niska temperatura elektroniki</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="118"/>
+      <source>Electronic temperature high</source>
+      <translation>Wysoka temperatura elektroniki</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="119"/>
+      <source>Starter voltage too low</source>
+      <translation>Za niskie napięcie rozrusznika</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="120"/>
+      <source>Starter current too high</source>
+      <translation>Za wysoki prąd rozrusznika</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="121"/>
+      <source>Glow voltage too low</source>
+      <translation>Za niskie napięcie żarzenia</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="122"/>
+      <source>Glow current too high</source>
+      <translation>Za wysoki prąd żarzenia</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="123"/>
+      <source>Cold-Start-Aid voltage too high</source>
+      <translation>Za wysokie napięcie Cold-Start-Aid</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="124"/>
+      <source>Cold-Start-Aid current too high</source>
+      <translation>Za wysoki prąd Cold-Start-Aid</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="125"/>
+      <source>Fuel holding magnet voltage too low</source>
+      <translation>Za niskie napięcie magnesu trzymającego paliwo</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="126"/>
+      <source>Fuel holding magnet current too high</source>
+      <translation>Za wysoki prąd magnesu trzymającego paliwo</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="127"/>
+      <source>Stop solenoid hold coil voltage too low</source>
+      <translation>Za niskie napięcie cewki podtrzymującej zaworu stop</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="128"/>
+      <source>Stop solenoid hold coil current too high</source>
+      <translation>Za duży prąd cewki podtrzymującej zaworu stop</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="129"/>
+      <source>Stop solenoid pull coil voltage too low </source>
+      <translation>Za niskie napięcie na cewce przyciągającej zaworu stop </translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="130"/>
+      <source>Stop solenoid pull coil current too high</source>
+      <translation>Za wysokie napięcie na cewce przyciągającej zaworu stop</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="131"/>
+      <source>Fan/water pump voltage too low</source>
+      <translation>Za niskie napięcie wentylatora/pompy wody</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="132"/>
+      <source>Fan/water pump current too high</source>
+      <translation>Za wysoki prąd wentylatora/pompy wody</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="133"/>
+      <source>Current sensor voltage low</source>
+      <translation>Niskie napięcie czujnika prądu</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="134"/>
+      <source>Current sensor current high</source>
+      <translation>Wysoki prąd czujnika prądu</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="135"/>
+      <source>Boost output voltage too low</source>
+      <translation>Za niskie napięcie wyjściowe Boost</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="136"/>
+      <source>Boost output current too high</source>
+      <translation>Za wysoki prąd wyjścia doładowania</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="137"/>
+      <source>Bus supply voltage too low</source>
+      <translation>Za niskie napięcie zasilania magistrali</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="138"/>
+      <source>Bus supply current too high</source>
+      <translation>Za wysoki prąd zasilania magistrali</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="139"/>
+      <source>Starter battery voltage too low</source>
+      <translation>Za niskie napięcie akumulatora rozruchowego</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="140"/>
+      <source>Starter battery voltage too high</source>
+      <translation>Za wysokie napięcie akumulatora rozruchowego</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="141"/>
+      <source>Rotation too low</source>
+      <translation>Za niskie obroty</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="142"/>
+      <source>Rotation too high</source>
+      <translation>Za wysokie obroty</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="143"/>
+      <source>Unexpected stop/problem with fuel supply</source>
+      <translation>Nieoczekiwane zatrzymanie/problem z dopływem paliwa</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="144"/>
+      <source>Power contactor voltage too low</source>
+      <translation>Za niskie napięcie stycznika zasilania</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="145"/>
+      <source>Power contactor current too high</source>
+      <translation>Za wysoki prąd stycznika mocy</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="146"/>
+      <source>AC voltage L2 too low</source>
+      <translation>Za niskie napięcie AC L2</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="147"/>
+      <source>AC voltage L2 too high</source>
+      <translation>Za wysokie napięcie AC L2</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="148"/>
+      <source>AC frequency L2 too low</source>
+      <translation>Za niska częstotliwość AC L2</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="149"/>
+      <source>AC frequency L2 too high</source>
+      <translation>Za wysoka częstotliwość AC L2</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="150"/>
+      <source>AC current L2 too high</source>
+      <translation>Za wysoki prąd AC L2</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="151"/>
+      <source>AC power L2 too high</source>
+      <translation>Za wysoka moc AC L2</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="152"/>
+      <source>AC voltage L3 too low</source>
+      <translation>Za niskie napięcie AC L3</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="153"/>
+      <source>AC voltage L3 too high</source>
+      <translation>Za wysokie napięcie AC L3</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="154"/>
+      <source>AC frequency L3 too low</source>
+      <translation>Za niska częstotliwość AC L3</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="155"/>
+      <source>AC frequency L3 too high</source>
+      <translation>Za wysoka częstotliwość AC L3</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="156"/>
+      <source>AC current L3 too high</source>
+      <translation>Za wysoki prąd AC L3</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="157"/>
+      <source>AC power L3 too high</source>
+      <translation>Za wysoka moc AC L3</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="158"/>
+      <source>Output Inverter voltage too low</source>
+      <translation>Zbyt niskie napięcie wyjściowe Inwertera</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="159"/>
+      <source>Output Inverter current too  high</source>
+      <translation>Za wysoki prąd wyjściowy Inwertera</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="160"/>
+      <source>Universal output (1A) voltage too low</source>
+      <translation>Za niskie napięcie na wyjściu uniwersalnym (1A)</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="161"/>
+      <source>Universal output (1A) current too high</source>
+      <translation>Za wysoki prąd na wyjściu uniwersalnym (1A)</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="162"/>
+      <source>Universal output (5A) voltage too low</source>
+      <translation>Za niskie napięcie na wyjściu uniwersalnym (5A)</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="163"/>
+      <source>Universal output (5A) current too high</source>
+      <translation>Za wysoki prąd na wyjściu uniwersalnym (5A)</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="164"/>
+      <source>AGT DC voltage 1 low</source>
+      <translation>Niskie napięcie AGT DC 1</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="165"/>
+      <source>AGT DC voltage 1 high</source>
+      <translation>Wysokie napięcie AGT DC 1</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="166"/>
+      <source>AGT DC current 1 low</source>
+      <translation>Niski prąd stały AGT 1</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="167"/>
+      <source>AGT DC current 1 high</source>
+      <translation>Wysoki prąd stały AGT 1</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="168"/>
+      <source>AGT DC voltage 2 low</source>
+      <translation>Niskie napięcie AGT DC 2</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="169"/>
+      <source>AGT DC voltage 2 high</source>
+      <translation>Wysokie napięcie AGT DC 2</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="170"/>
+      <source>AGT DC current 2 low</source>
+      <translation>Niski prąd stały AGT 2</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="171"/>
+      <source>AGT DC current 2 high</source>
+      <translation>Wysoki prąd stały AGT 2</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="172"/>
+      <source>AGT B6 cooler low</source>
+      <translation>Niska chłodnica AGT B6</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="173"/>
+      <source>AGT B6 cooler high</source>
+      <translation>Chłodnica AGT B6 wysoka</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="174"/>
+      <source>AGT B6 rail (-) low</source>
+      <translation>Szyna AGT B6 (-) niska</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="175"/>
+      <source>AGT B6 rail (-) high</source>
+      <translation>Szyna AGT B6 (-) wysoka</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="176"/>
+      <source>AGT B6 rail (+) low</source>
+      <translation>Szyna AGT B6 (+) niska</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="177"/>
+      <source>AGT B6 rail (+) high</source>
+      <translation>Szyna AGT B6 (+) wysoka</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="178"/>
+      <source>Fuel temperature too low</source>
+      <translation>Za niska temperatura paliwa</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="179"/>
+      <source>Fuel temperature too high</source>
+      <translation>Za wysoka temperatura paliwa</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="180"/>
+      <source>Fuel level too low</source>
+      <translation>Za niski poziom paliwa</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="183"/>
+      <source>Lost control unit</source>
+      <translation>Zagubiono jednostkę sterującą</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="184"/>
+      <source>Lost panel</source>
+      <translation>Zagubiono panel</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="185"/>
+      <source>Service needed</source>
+      <translation>Potrzebny serwis</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="186"/>
+      <source>Lost 3-phase module</source>
+      <translation>Utracono moduł 3-fazowy</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="187"/>
+      <source>Lost AGT module</source>
+      <translation>Zagubiono moduł AGT</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="188"/>
+      <source>Synchronization failure</source>
+      <translation>Błąd synchronizacji</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="189"/>
+      <source>Lost external ECU</source>
+      <translation>Utrata zewnętrznego ECU</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="190"/>
+      <source>Intake airfilter</source>
+      <translation>Filtr powietrza dolotowego</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="191"/>
+      <source>Diagnostic message (ECU)</source>
+      <translation>Komunikat diagnostyczny (ECU)</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="192"/>
+      <source>Lost sync. module</source>
+      <translation>Utracono moduł synchr.</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="193"/>
+      <source>Load-balance failed</source>
+      <translation>Nie udało się zrównoważyć obciążenia</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="194"/>
+      <source>Sync-mode deactivated</source>
+      <translation>Tryb synchronizacji wyłączony</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="195"/>
+      <source>Red Stop Lamp (RSL)</source>
+      <translation>Czerwone Światło Stopu (RSL)</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="196"/>
+      <source>Amber Warning Lamp (AWL)</source>
+      <translation>Bursztynowe Światło Ostrzegawcze (AWL)</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="197"/>
+      <source>Malfunction Indicator Lamp (MIL)</source>
+      <translation>Lampka Kontrolna Awarii (MIL)</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="198"/>
+      <source>Protect Lamp (PL)</source>
+      <translation>Lampa Ochronna (PL)</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="199"/>
+      <source>Rotating field wrong</source>
+      <translation>Nieprawidłowe pole wirujące</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="200"/>
+      <source>Fuel level sensor lost</source>
+      <translation>Utrata czujnika poziomu paliwa</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="201"/>
+      <source>Starting without inverter</source>
+      <translation>Rozruch bez inwertera</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="202"/>
+      <source>Bus #1 dead</source>
+      <translation>Bus #1 nie działa</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="203"/>
+      <source>Start request denied</source>
+      <translation>Odrzucono wniosek o rozpoczęcie</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="204"/>
+      <source>Remote start denied</source>
+      <translation>Odmowa zdalnego uruchamiania</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="205"/>
+      <source>Forced switch off load relay</source>
+      <translation>Wymuszone wyłączenie przekaźnika obciążenia</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="206"/>
+      <source>Synchronization Module is offline</source>
+      <translation>Moduł Synchronizacji jest offline</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="207"/>
+      <source>Lost BMS</source>
+      <translation>Utracono BMS</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="208"/>
+      <source>Converter DC Link Voltage Low/Reverse</source>
+      <translation>Niskie/Odwrócone Napięcie Obwodu DC Konwertera</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="209"/>
+      <source>Converter DC Link Current Low</source>
+      <translation>Niskie Prąd Napięcie Obwodu DC Konwertera</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="210"/>
+      <source>Converter DC Precharge Voltage Low</source>
+      <translation>Niskie Napięcie Wstępnego Ładowania DC Konwertera</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="211"/>
+      <source>Converter DC Precharge Voltage High</source>
+      <translation>Wysokie Napięcie Wstępnego Ładowania DC Konwertera</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="212"/>
+      <source>Converter IGBT/MOSFET Driver Error</source>
+      <translation>Błąd Sterownika Konwertera IGBT/MOSFET</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="213"/>
+      <source>Converter Error Power Control Loop</source>
+      <translation>Błąd w Układzie Sterowania Mocą Konwertera</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="214"/>
+      <source>Converter AC Frequency Detection</source>
+      <translation>Wykrywanie Częstotliwości AC Konwertera</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="215"/>
+      <source>Converter Control Value Fail</source>
+      <translation>Błąd wartości kontrolnej konwertera</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="216"/>
+      <source>Factory setting changed</source>
+      <translation>Zmieniono ustawienie fabryczne</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="217"/>
+      <source>Parameter changed in admin mode</source>
+      <translation>Parametr zmieniony w trybie administratora</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="218"/>
+      <source>Manual Intervention (ext. System)</source>
+      <translation>Interwencja ręczna (zewn. system)</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="221"/>
+      <source>Init failed</source>
+      <translation>Błąd inicjalizacji</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="222"/>
+      <source>Watchdog</source>
+      <translation>Watchdog</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="223"/>
+      <source>Inverter temperature high L1</source>
+      <translation>Wysoka temperatura inwertera L1</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="224"/>
+      <source>Inverter temperature high L2</source>
+      <translation>Wysoka temperatura inwertera L2</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="225"/>
+      <source>Inverter temperature high L3</source>
+      <translation>Wysoka temperatura inwertera L3</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="226"/>
+      <source>Inverter temperature high DC link</source>
+      <translation>Wysoka temperatura DC-link inwertera</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="227"/>
+      <source>Inverter overload</source>
+      <translation>Przeciążenie inwertera</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="228"/>
+      <source>Inverter communication lost</source>
+      <translation>Utrata komunikacji z inwerterem</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="229"/>
+      <source>DC overload</source>
+      <translation>Przeciążenie DC</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="230"/>
+      <source>DC overvoltage</source>
+      <translation>Przepięcie DC</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="232"/>
+      <source>No connection</source>
+      <translation>Brak połączenia</translation>
+    </message>
+  </context>
+  <context>
+    <name>GensetError</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="68"/>
+      <source>No error</source>
+      <translation>Brak błędu</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="79"/>
+      <source>Unknown error: %1</source>
+      <translation>Nieznany błąd: %1</translation>
+    </message>
+  </context>
+  <context>
+    <name>Hatz</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="778"/>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="784"/>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="790"/>
+      <source>Unknown error: </source>
+      <translation>Nieznany błąd:</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="797"/>
+      <source>Oil pressure</source>
+      <translation>Ciśnienie oleju</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="798"/>
+      <source>Cylinder head overtemperature</source>
+      <translation>Nadmierna temperatura głowicy cylindrów</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="799"/>
+      <source>Charge control</source>
+      <translation>Kontrola ładowania</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="800"/>
+      <source>Speed higher than expected</source>
+      <translation>Prędkość wyższa niż oczekiwana</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="801"/>
+      <source>Overspeed</source>
+      <translation>Nadmierna prędkość</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="803"/>
+      <source>Oiltemperature higher than expected</source>
+      <translation>Temperatura oleju wyższa niż oczekiwano</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="804"/>
+      <source>Oiltemperature open circuit / short to power</source>
+      <translation>Obwód otwarty temperatury oleju / zwarcie do zasilania</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="805"/>
+      <source>Oiltemperature short to ground</source>
+      <translation>Zwarcie temperatury oleju do masy</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="806"/>
+      <source>Analog setpoint high / short to power</source>
+      <translation>Analogowa wartość zadana wysoka / zwarcie do zasilania</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="807"/>
+      <source>Analog setpoint low / short to ground</source>
+      <translation>Analogowa wartość zadana niska / zwarcie do masy</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="808"/>
+      <source>TSC1 message receive timeout</source>
+      <translation>Limit czasu odbioru komunikatu TSC1</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="809"/>
+      <source>CM1 message receive timeout</source>
+      <translation>Limit czasu odbioru wiadomości CM1</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="810"/>
+      <source>Battery voltage high</source>
+      <translation>Wysokie napięcie akumulatora</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="811"/>
+      <source>Battery voltage low</source>
+      <translation>Niskie napięcie akumulatora</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="812"/>
+      <source>Speed signal distorted</source>
+      <translation>Zniekształcony sygnał prędkości</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="813"/>
+      <source>Internal 5V sensor supply high</source>
+      <translation>Wysokie napięcie zasilania wewn. czujnika 5 V</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="814"/>
+      <source>Internal 5V sensor supply low</source>
+      <translation>Niskie napięcie zasilania wewn. czujnika 5 V</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="815"/>
+      <source>Barometric pressure high</source>
+      <translation>Wysokie ciśnienie barometryczne</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="816"/>
+      <source>Barometric pressure low</source>
+      <translation>Niskie ciśnienie barometryczne</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="817"/>
+      <source>Output fuelpump short to power</source>
+      <translation>Wyjście pompy paliwa – zwarcie do zasilania</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="818"/>
+      <source>Output fuelpump short to ground</source>
+      <translation>Wyjście pompy paliwa – zwarcie do masy</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="819"/>
+      <source>Output glow plug short to power</source>
+      <translation>Świeca żarowa – zwarcie do zasilania</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="820"/>
+      <source>Output glow plug short to ground</source>
+      <translation>Zwarcie na wyjściu świecy żarowej do masy</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="821"/>
+      <source>Injector open circuit/low side short to ground</source>
+      <translation>Wtryskiwacz – przerwa/zwarcie do masy</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="822"/>
+      <source>Injector coil internal short circuit</source>
+      <translation>Cewka wtryskiwacza – zwarcie wewnętrzne</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="823"/>
+      <source>Injector low side short to power</source>
+      <translation>Wtryskiwacz – zwarcie do plusa</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="824"/>
+      <source>Service hours expired</source>
+      <translation>Godziny pracy wygasły</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="828"/>
+      <source>Processor failure</source>
+      <translation>Awaria procesora</translation>
+    </message>
+  </context>
+  <context>
+    <name>PageAcInSetup</name>
+    <message>
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="129"/>
+      <source>Set the switch in an unlocked position to modify the settings.</source>
+      <translation>Ustaw przełącznik w pozycji odblokowanej, aby zmodyfikować ustawienia.</translation>
+    </message>
+  </context>
+  <context>
+    <name>QGuiApplication</name>
+    <message>
+      <location filename="../../src/main.cpp" line="120"/>
+      <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
+      <translation>Użyj źródła danych D-Bus: połącz się z podanym adresem D-Bus.</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="121"/>
+      <source>address</source>
+      <comment>D-Bus address</comment>
+      <translation>adres</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="126"/>
+      <source>Use D-Bus data source: connect to the default D-Bus address</source>
+      <translation>Użyj źródła danych D-Bus: połącz się z domyślnym adresem D-Bus</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="132"/>
+      <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
+      <translation>Użyj źródła danych MQTT: połącz się z określonym adresem brokera MQTT.</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="133"/>
+      <source>address</source>
+      <comment>MQTT broker address</comment>
+      <translation>adres</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="139"/>
+      <source>MQTT data source device portal id.</source>
+      <translation>Źródło danych MQTT, ID urządzenia w portalu</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="140"/>
+      <source>portalId</source>
+      <translation>ID portalu</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="145"/>
+      <source>MQTT VRM webhost shard</source>
+      <translation>Fragment hosta internetowego MQTT VRM</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="146"/>
+      <source>shard</source>
+      <comment>MQTT VRM webhost shard</comment>
+      <translation>fragment</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="151"/>
+      <source>MQTT data source username</source>
+      <translation>Nazwa użytkownika źródła danych MQTT</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="152"/>
+      <source>user</source>
+      <comment>MQTT broker username.</comment>
+      <translation>użytkownik</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="157"/>
+      <source>MQTT data source password</source>
+      <translation>Hasło źródła danych MQTT</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="158"/>
+      <source>pass</source>
+      <comment>MQTT broker password.</comment>
+      <translation>hasło</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="163"/>
+      <source>MQTT data source token</source>
+      <translation>Token źródła danych MQTT</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="164"/>
+      <source>token</source>
+      <comment>MQTT broker auth token.</comment>
+      <translation>token</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="169"/>
+      <source>Enable FPS counter</source>
+      <translation>Włącz licznik FPS</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="174"/>
+      <source>Skip splash screen</source>
+      <translation>Pomiń ekran powitalny</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="179"/>
+      <source>Use mock data source for testing.</source>
+      <translation>Użyj próbnego źródła danych do testowania.</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="184"/>
+      <source>Name of mock configuration</source>
+      <translation>Nazwa konfiguracji testowej</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="185"/>
+      <source>mockConfig</source>
+      <comment>Configuration name</comment>
+      <translation>mockConfig</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="191"/>
+      <source>Set to disable mock timers on startup</source>
+      <translation>Ustaw, aby wyłączyć timery testowe przy uruchomieniu</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="196"/>
+      <source>Node-RED URL</source>
+      <translation>Adres URL Node-RED</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="197"/>
+      <source>url</source>
+      <comment>Node-RED URL</comment>
+      <translation>url</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="202"/>
+      <source>Signal K URL</source>
+      <translation>Adres URL Signal K</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="203"/>
+      <source>url</source>
+      <comment>Signal K URL</comment>
+      <translation>url</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="208"/>
+      <source>Color scheme (dark, light, auto, default)</source>
+      <translation>Schemat kolorów (ciemny, jasny, auto, domyślny)</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="209"/>
+      <source>scheme</source>
+      <comment>Color scheme value</comment>
+      <translation>schemat</translation>
     </message>
   </context>
   <context>
@@ -13029,7 +11878,7 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
     <message>
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="159"/>
       <source>Battery high temperature</source>
-      <translation>Wysoka temperatura baterii</translation>
+      <translation>Wysoka temperatura akumulatora</translation>
     </message>
     <message>
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="162"/>
@@ -13064,7 +11913,7 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
     <message>
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="181"/>
       <source>Field drive FET high temperature</source>
-      <translation>Napęd polowy FET wysoka temperatura</translation>
+      <translation>Wysoka temp. napędu polowego FET</translation>
     </message>
     <message>
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="184"/>
@@ -13084,7 +11933,7 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
     <message>
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="193"/>
       <source>Alternator Voltage exceeded configured max</source>
-      <translation>Napięcie alternatora przekroczyło skonfigurowane maksimum</translation>
+      <translation type="unfinished">Napięcie Alternatora przekroczyło skonfigurowane maks.</translation>
     </message>
     <message>
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="196"/>
@@ -13124,22 +11973,22 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
     <message>
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="217"/>
       <source>Battery low voltage disconnect</source>
-      <translation>Odłączenie niskiego napięcia akumulatora</translation>
+      <translation>Odłączenie przy niskim napięciu akumulatora</translation>
     </message>
     <message>
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="220"/>
       <source>Battery high current disconnect</source>
-      <translation>Odłączenie wysokiego prądu akumulatora</translation>
+      <translation>Akumulator – odłączenie przy wysokim prądzie</translation>
     </message>
     <message>
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="223"/>
       <source>Battery high temperature disconnect</source>
-      <translation>Odłączenie wysokiej temperatury akumulatora</translation>
+      <translation>Akumulator – odłączenie przy wysokiej temperaturze</translation>
     </message>
     <message>
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="226"/>
       <source>Battery low temperature disconnect</source>
-      <translation>Odłączenie akumulatora przy niskiej temperaturze</translation>
+      <translation>Akumulator – odłączenie przy niskiej temperaturze</translation>
     </message>
     <message>
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="229"/>
@@ -13185,6 +12034,119 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
       <source>DC/DC misconfiguration</source>
       <translation>Nieprawidłowa konfiguracja DC/DC</translation>
+    </message>
+  </context>
+  <context>
+    <name>VebusError</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+      <source>Device switched off</source>
+      <translation>Urządzenie wyłączone</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+      <source>Mixed old/new MK2</source>
+      <translation>Mieszane stare/nowe MK2</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+      <source>Expected devices error</source>
+      <translation>Błąd oczekiwanych urządzeń</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+      <source>No other device detected</source>
+      <translation>Nie wykryto innych urządzeń</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+      <source>Overvoltage on AC-out</source>
+      <translation>Przepięcie na wyjściu AC</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+      <source>DDC program error</source>
+      <translation>Błąd programu DDC</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+      <source>VE.Bus BMS without assistant</source>
+      <translation>VE.Bus BMS bez asystenta</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+      <source>Ground relay test failed</source>
+      <translation>Test przekaźnika uziemienia nie powiódł się</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+      <source>System time sync error</source>
+      <translation>Błąd synchronizacji czasu systemowego</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+      <source>Grid relay test fault</source>
+      <translation>Błąd testu przekaźnika sieciowego</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+      <source>Config mismatch with 2nd mcu</source>
+      <translation>Niezgodność konfiguracji z 2. MCU</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+      <source>Device transmit error</source>
+      <translation>Błąd transmisji urządzenia</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+      <source>Awaiting configuration or dongle missing</source>
+      <translation>Oczekiwanie na konfigurację lub brak dongla</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+      <source>Phase master missing</source>
+      <translation>Brak fazy głównej</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+      <source>Overvoltage has occurred</source>
+      <translation>Wystąpiło przepięcie</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+      <source>Slave does not have AC input!</source>
+      <translation>Urządzenie podrzędne nie ma wejścia AC!</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+      <source>Device can't be slave</source>
+      <translation>Urządzenie nie może być podrzędne</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+      <source>System protection initiated</source>
+      <translation>Uruchomiono ochronę systemu</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+      <source>Firmware incompatibiltiy</source>
+      <translation>Niezgodność oprogramowania</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+      <source>Internal error</source>
+      <translation>Błąd wewnętrzny</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+      <source>Failing relay test prevents connection</source>
+      <translation>Nieudany test przekaźnika uniemożliwia połączenie</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+      <source>VE.Bus error</source>
+      <translation>Błąd VE.Bus</translation>
     </message>
   </context>
 </TS>

--- a/i18n/venus-gui-v2_ro.ts
+++ b/i18n/venus-gui-v2_ro.ts
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="ro">
   <context>
-    <name/>
+    <name></name>
     <message id="switchable_output_disabled">
       <location filename="../../src/enums.cpp" line="478"/>
       <source>Disabled</source>
@@ -22,6 +22,7 @@
     <message id="solarchargers_state_off">
       <location filename="../../src/enums.cpp" line="331"/>
       <source>Off</source>
+      <extracomment>Digital input state</extracomment>
       <translation>Oprit</translation>
     </message>
     <message id="common_words_auto">
@@ -52,18 +53,25 @@
     <message id="settings_startpage_none">
       <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
       <source>None</source>
+      <extracomment>Indicates no phase</extracomment>
       <translation>Niciuna</translation>
     </message>
     <message id="common_words_position_ac">
       <location filename="../../components/CommonWords.qml" line="416"/>
       <source>Position</source>
-      <extracomment>AC input or output position</extracomment>
+      <extracomment>EVCS AC input/output position</extracomment>
       <translation>Pozitie</translation>
     </message>
     <message id="settings_minmax_speed">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="193"/>
       <source>Speed</source>
+      <extracomment>A speed measurement value</extracomment>
       <translation>Viteza</translation>
+    </message>
+    <message id="common_words_state">
+      <location filename="../../components/CommonWords.qml" line="502"/>
+      <source>State</source>
+      <translation>Stare</translation>
     </message>
     <message id="settings_firmware_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="67"/>
@@ -101,8 +109,8 @@
       <source>Solar yield</source>
       <translation>Producția de energie solară</translation>
     </message>
-    <message id="ess_state_external_control">
-      <location filename="../../data/Ess.qml" line="41"/>
+    <message id="inverters_state_externalccontrol">
+      <location filename="../../data/System.qml" line="183"/>
       <source>External control</source>
       <translation>Control extern</translation>
     </message>
@@ -140,6 +148,11 @@
       <location filename="../../components/CommonWords.qml" line="203"/>
       <source>ESS</source>
       <translation>ESS</translation>
+    </message>
+    <message id="pagesettingsconnectivity_ethernet">
+      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
+      <source>Ethernet</source>
+      <translation>Retea locala</translation>
     </message>
     <message id="pagesettingsconnectivity_wifi">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="28"/>
@@ -262,11 +275,6 @@
       <source>Name</source>
       <translation>Nume</translation>
     </message>
-    <message id="settings_deviceinfo_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="38"/>
-      <source>Name</source>
-      <translation type="unfinished">Nume</translation>
-    </message>
     <message id="settings_deviceinfo_product_id">
       <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
       <source>Product ID</source>
@@ -327,15 +335,20 @@
       <source>Daily run time</source>
       <translation>Timp de functionare zilnic</translation>
     </message>
+    <message id="common_words_value_must_be_greater_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="560"/>
+      <source>Value must be greater than stop value</source>
+      <translation>Valoarea trebuie sa fie mai mare decat valoarea de oprire</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="563"/>
+      <source>Value must be lower than start value</source>
+      <translation>Valoarea trebuie sa fie mai mica decat valoarea de pornire</translation>
+    </message>
     <message id="settings_minmax_acout_max_power">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="124"/>
       <source>AC output</source>
       <translation>Iesire AC</translation>
-    </message>
-    <message id="ac_output">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="15"/>
-      <source>AC output</source>
-      <translation type="unfinished">Iesire AC</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
       <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="25"/>
@@ -382,16 +395,6 @@
       <source>Unavailable monitor, set another</source>
       <translation>Monitor indisponibil, defineste altul</translation>
     </message>
-    <message id="page_generator_conditions_battery_monitor">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="42"/>
-      <source>Battery monitor</source>
-      <translation type="unfinished">Monitor baterie</translation>
-    </message>
-    <message id="page_generator_conditions_unavailable_monitor_set_another">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="44"/>
-      <source>Unavailable monitor, set another</source>
-      <translation type="unfinished">Monitor indisponibil, defineste altul</translation>
-    </message>
     <message id="page_generator_conditions_on_loss_of_communication">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="68"/>
       <source>On loss of communication</source>
@@ -416,11 +419,6 @@
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="105"/>
       <source>Battery SOC</source>
       <translation>SOC baterie</translation>
-    </message>
-    <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="173"/>
-      <source>Periodic run</source>
-      <translation type="unfinished">Functionare periodica</translation>
     </message>
     <message id="settings_inverter_high_temperature">
       <location filename="../../data/Generators.qml" line="83"/>
@@ -505,7 +503,7 @@
     <message id="settings_gps_speed_kmh">
       <location filename="../../pages/settings/PageGps.qml" line="83"/>
       <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometres per hour</extracomment>
+      <extracomment>GPS speed data, in kilometers per hour</extracomment>
       <translation>%1 km/h</translation>
     </message>
     <message id="settings_gps_speed_mph">
@@ -523,7 +521,7 @@
     <message id="settings_gps_speed_ms">
       <location filename="../../pages/settings/PageGps.qml" line="95"/>
       <source>%1 m/s</source>
-      <extracomment>GPS speed data, in metres per second</extracomment>
+      <extracomment>GPS speed data, in meters per second</extracomment>
       <translation>%1 m/s</translation>
     </message>
     <message id="settings_gps_course">
@@ -580,21 +578,6 @@
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="64"/>
       <source>%1 (Output %2)</source>
       <translation>%1 (Iesire %2)</translation>
-    </message>
-    <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">Monitor baterie activ</translation>
-    </message>
-    <message id="settings_batteries_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="101"/>
-      <source>Name</source>
-      <translation type="unfinished">Nume</translation>
-    </message>
-    <message id="settings_batteries_enter_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="103"/>
-      <source>Enter name</source>
-      <translation type="unfinished">Introduceți numele</translation>
     </message>
     <message id="settings_briefview_center_active_battery_monitor">
       <location filename="../../components/listitems/ListBriefCenterDetails.qml" line="27"/>
@@ -656,45 +639,25 @@
       <source>CAN-bus profile</source>
       <translation>Profil CAN-bus</translation>
     </message>
-    <message id="settings_disabled">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="31"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Dezactivat</translation>
-    </message>
-    <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</translation>
-    </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
       <location filename="../../pages/settings/CanbusProfile.qml" line="42"/>
       <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
       <translation>VE.Can &amp; CAN-bus BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
       <source>Oceanvolt (250 kbit/s)</source>
       <translation>Oceanvolt (250 kbit/s)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
       <source>RV-C (250 kbit/s)</source>
       <translation>RV-C (250 kbit/s)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
       <source>Up, but no services (250 kbit/s)</source>
       <translation>În funcțiune, dar fără servicii (250 kbit/s)</translation>
-    </message>
-    <message id="settings_canopen_motordrive_250">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
-      <source>CANopen Motor drive (250 kbit/s)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_canopen_motordrive_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
-      <source>CANopen Motor drive (500 kbit/s)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_devices">
       <location filename="../../components/CommonWords.qml" line="166"/>
@@ -731,11 +694,6 @@
       <source>Check Unique id numbers</source>
       <translation>Verifica numerele de identificare</translation>
     </message>
-    <message id="settings_canbus_unique_id_press_to_check">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Press to check</source>
-      <translation type="unfinished">Apasa pentru a verifica</translation>
-    </message>
     <message id="settings_canbus_unique_id_conflict">
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="125"/>
       <source>There is another device connected with this unique number, please select a new number.</source>
@@ -745,11 +703,6 @@
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="133"/>
       <source>OK: No other device is connected with this unique number.</source>
       <translation>OK: Niciun alt dispozitiv conectat cu acest numar de identificare.</translation>
-    </message>
-    <message id="pagesettingsintegrations_canopenmotordrive">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
-      <source>CANopen motor drives</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_network_status">
       <location filename="../../components/CommonWords.qml" line="349"/>
@@ -884,11 +837,6 @@
       <source>Unavailable sensor, set another</source>
       <translation>Senzor indisponibil, defineste altul</translation>
     </message>
-    <message id="settings_system_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="81"/>
-      <source>Unavailable sensor, set another</source>
-      <translation type="unfinished">Senzor indisponibil, defineste altul</translation>
-    </message>
     <message id="settings_dvcc_used_sensor">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="120"/>
       <source>Used sensor</source>
@@ -945,12 +893,6 @@
       <source>Auto selected</source>
       <translation>Selectat automat</translation>
     </message>
-    <message id="settings_dvcc_auto_selected_none">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="208"/>
-      <source>None</source>
-      <extracomment>Indicates no option is selected</extracomment>
-      <translation type="unfinished">Niciuna</translation>
-    </message>
     <message id="settings_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
       <source>Build date/time</source>
@@ -986,12 +928,6 @@
       <source>Installing %1</source>
       <extracomment>%1 = firmware version</extracomment>
       <translation>Instalare %1</translation>
-    </message>
-    <message id="settings_firmware_offline_press_to_install">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">Apasa pentru a actualiza la %1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="90"/>
@@ -1062,12 +998,6 @@
       <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
       <translation>Instalare %1 %2%</translation>
     </message>
-    <message id="settings_firmware_online_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="86"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">Instalare %1...</translation>
-    </message>
     <message id="settings_firmware_update_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="109"/>
       <source>Update build date/time</source>
@@ -1097,11 +1027,6 @@
       <location filename="../../pages/settings/PageSettingsFronius.qml" line="56"/>
       <source>TCP port</source>
       <translation>Port TCP</translation>
-    </message>
-    <message id="page_settings_fronius_modbus_settings">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
-      <source>Modbus port and unit ID settings</source>
-      <translation type="unfinished"/>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
       <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
@@ -1153,16 +1078,6 @@
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="64"/>
       <source>AC-Out MP</source>
       <translation>AC-Out MP</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="52"/>
-      <source>AC-In1 L%1</source>
-      <translation type="unfinished">AC-In1 L%1</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="56"/>
-      <source>AC-In1 --</source>
-      <translation type="unfinished">AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="70"/>
@@ -1330,12 +1245,6 @@
       <source>Reset service timer</source>
       <translation>Resetați cronometrul de service</translation>
     </message>
-    <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
-      <source>Volume</source>
-      <extracomment>Title for a list of units of volume (e.g. cubic metres, litres, gallons)</extracomment>
-      <translation type="unfinished">Volum</translation>
-    </message>
     <message id="settings_gps_format">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="69"/>
       <source>Format</source>
@@ -1438,42 +1347,6 @@ Daca tot nu functioneaza, verifica cartela sim intr-un telefon pentru a te asigu
       <source>Wrong PIN</source>
       <translation>PIN gresit</translation>
     </message>
-    <message id="page_settings_gsm_ok">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>OK</source>
-      <translation type="unfinished">In regula</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="128"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">Eroare necunoscuta</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_state">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="153"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Necunoscut</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_value">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="182"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Necunoscut</translation>
-    </message>
-    <message id="page_settings_gsm_offline">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="173"/>
-      <source>Offline</source>
-      <translation type="unfinished">Deconectat</translation>
-    </message>
-    <message id="page_settings_gsm_connecting">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="176"/>
-      <source>Connecting</source>
-      <translation type="unfinished">Conectare</translation>
-    </message>
-    <message id="page_settings_gsm_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="179"/>
-      <source>Connected</source>
-      <translation type="unfinished">Conectare</translation>
-    </message>
     <message id="page_settings_gsm_pin">
       <location filename="../../pages/settings/PageSettingsGsm.qml" line="191"/>
       <source>PIN</source>
@@ -1530,32 +1403,32 @@ Daca tot nu functioneaza, verifica cartela sim intr-un telefon pentru a te asigu
       <translation>Masuratori retea</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
       <source>External meter</source>
       <translation>Contor extern</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="67"/>
       <source>Inverter/Charger</source>
       <translation>Invertor/încărcător</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
       <source>Multiphase regulation</source>
       <translation>Reglementari multi-faza</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="91"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
       <source>Total of all phases</source>
       <translation>Total toate fazele</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="95"/>
       <source>Individual phase</source>
       <translation>Faza individuala</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="99"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="101"/>
       <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
@@ -1564,68 +1437,13 @@ CAUTION: Use only if required by the utility provider.</source>
 ATENȚIE: Utilizați numai dacă este solicitat de către furnizorul de utilități.</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="104"/>
       <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
       <translation>Totalul tuturor fazelor este reglat în mod inteligent pentru a atinge punctul de setare al rețelei (eficiența sistemului este optimizată).
 
 Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
-    </message>
-    <message id="settings_ess_min_soc">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation type="unfinished">SOC minim (exceptand deconectarea de la retea)</translation>
-    </message>
-    <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="129"/>
-      <source>Active SOC limit</source>
-      <translation type="unfinished">Limitarea SOC activa</translation>
-    </message>
-    <message id="settings_ess_battery_life_sustain">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
-      <source>Sustain</source>
-      <translation type="unfinished">Sustine</translation>
-    </message>
-    <message id="settings_ess_battery_life_recharge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="157"/>
-      <source>Recharge</source>
-      <translation type="unfinished">Încărcare</translation>
-    </message>
-    <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <source>Scheduled charge levels</source>
-      <translation type="unfinished">Niveluri de încărcare programate</translation>
-    </message>
-    <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="257"/>
-      <source>Active (%1)</source>
-      <translation type="unfinished">Activ (%1)</translation>
-    </message>
-    <message id="settings_ess_inactive">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="259"/>
-      <source>Inactive</source>
-      <translation type="unfinished">Inactiv</translation>
-    </message>
-    <message id="settings_ess_dynamic">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="293"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">SSE dinamic</translation>
-    </message>
-    <message id="settings_ess_deprecated">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="319"/>
-      <source>Deprecated settings</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_charge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="326"/>
-      <source>Battery charge limit (% of CCL)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_discharge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="337"/>
-      <source>Battery discharge limit (% of DCL)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_rs_ess_min_soc">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="40"/>
@@ -1637,13 +1455,8 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <source>Active SOC limit</source>
       <translation>Limitarea SOC activa</translation>
     </message>
-    <message id="scheduled_charge_inactive">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
-      <source>Inactive</source>
-      <translation type="unfinished">Inactiv</translation>
-    </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="245"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="247"/>
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
       <source>Peak shaving</source>
       <translation>Reducere a consumului de energie</translation>
@@ -1659,12 +1472,12 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <translation>Întotdeauna</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="151"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
       <source>Discharge disabled</source>
       <translation>Descarcarea dezactivata</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
       <source>Slow charge</source>
       <translation>Incarcare lenta</translation>
     </message>
@@ -1679,32 +1492,32 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <translation>Încărcare</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="165"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="167"/>
       <source>Limit charge power</source>
       <translation>Limiteaza puterea de incarcare</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="183"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="185"/>
       <source>Maximum charge power</source>
       <translation>Putere de incarcare maxima</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="196"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="198"/>
       <source>Limit inverter power</source>
       <translation>Limiteaza puterea invertorului</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="214"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="216"/>
       <source>Maximum inverter power</source>
       <translation>Putere maxima invertor</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="225"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="227"/>
       <source>Grid setpoint</source>
       <translation>Valoare referinta retea</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="236"/>
       <source>Grid feed-in</source>
       <translation>Injectare in retea</translation>
     </message>
@@ -1743,8 +1556,8 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <source>Door alarm</source>
       <translation>Alarma usa</translation>
     </message>
-    <message id="digitalinputs_type_bilgepump">
-      <location filename="../../src/enums.cpp" line="201"/>
+    <message id="switchable_output_bilge_pump">
+      <location filename="../../src/enums.cpp" line="424"/>
       <source>Bilge pump</source>
       <translation>Pompa de santina</translation>
     </message>
@@ -1796,11 +1609,6 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <source>Deferred by %1s</source>
       <extracomment>%1 = number of seconds</extracomment>
       <translation>Amânat de %1s</translation>
-    </message>
-    <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="75"/>
-      <source>Are you sure?</source>
-      <translation type="unfinished">Sunteți sigur?</translation>
     </message>
     <message id="settings_vrm_portal_id">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="87"/>
@@ -1939,11 +1747,6 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <source>External storage</source>
       <translation>Stocare externa</translation>
     </message>
-    <message id="settings_vrm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="308"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">Eroare necunoscuta</translation>
-    </message>
     <message id="settings_vrm_no_error">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="311"/>
       <source>No Error</source>
@@ -2029,37 +1832,10 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <source>Function</source>
       <translation>Functie</translation>
     </message>
-    <message id="settings_relay_disabled">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="54"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="98"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Dezactivat</translation>
-    </message>
     <message id="settings_relay_alarm_relay">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="56"/>
       <source>Alarm relay</source>
       <translation>Releu alarma</translation>
-    </message>
-    <message id="settings_relay_tank_pump">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="62"/>
-      <source>Tank pump</source>
-      <translation type="unfinished">Pompa de rezervor</translation>
-    </message>
-    <message id="settings_relay_manual">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="64"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="100"/>
-      <source>Manual</source>
-      <translation type="unfinished">Manual</translation>
-    </message>
-    <message id="settings_relay_polarity_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
-      <source>Polarity (Relay 1)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_relay_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
-      <source>Polarity</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_normally_open">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="83"/>
@@ -2075,11 +1851,6 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="93"/>
       <source>Function (Relay 2)</source>
       <translation>Functie (Releu 2)</translation>
-    </message>
-    <message id="settings_relay_polarity_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
-      <source>Polarity (Relay 2)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_temp_control_rules">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="119"/>
@@ -2111,12 +1882,6 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
       <source>Press to boot</source>
       <translation>Apasa pentru a porni</translation>
-    </message>
-    <message id="settings_firmware_backup_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
-      <translation type="unfinished">Firmware %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
@@ -2152,6 +1917,7 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
     <message id="nav_boat">
       <location filename="../../pages/boat/BoatPage.qml" line="14"/>
       <source>Boat</source>
+      <extracomment>The 'Boat' page</extracomment>
       <translation>Ambarcatiune</translation>
     </message>
     <message id="settings_system_name">
@@ -2219,11 +1985,6 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <source>Solar charger current control</source>
       <translation>Control intensitate incarcator solar</translation>
     </message>
-    <message id="settings_system_status_bms_params">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
-      <source>BMS control</source>
-      <translation type="unfinished">Cotrol BMS</translation>
-    </message>
     <message id="common_words_bms_control">
       <location filename="../../components/CommonWords.qml" line="101"/>
       <source>BMS control</source>
@@ -2238,11 +1999,6 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
       <source>Pump state</source>
       <translation>Starea pompei</translation>
-    </message>
-    <message id="settings_pump_auto">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="56"/>
-      <source>Auto</source>
-      <translation type="unfinished">Auto</translation>
     </message>
     <message id="settings_tank_sensor">
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
@@ -2271,11 +2027,6 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="35"/>
       <source>Unplugged</source>
       <translation>Deconectat</translation>
-    </message>
-    <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="16"/>
-      <source>Name</source>
-      <translation type="unfinished">Nume</translation>
     </message>
     <message id="settings_tcpip_hidden">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="21"/>
@@ -2317,16 +2068,6 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="99"/>
       <source>IP configuration</source>
       <translation>Configuratie IP</translation>
-    </message>
-    <message id="settings_tcpip_manual">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="105"/>
-      <source>Manual</source>
-      <translation type="unfinished">Manual</translation>
-    </message>
-    <message id="settings_tcpip_off">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="107"/>
-      <source>Off</source>
-      <translation type="unfinished">Oprit</translation>
     </message>
     <message id="settings_tcpip_fixed">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="109"/>
@@ -2382,21 +2123,6 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="30"/>
       <source>Create access point</source>
       <translation>Creaza puct acces (AP)</translation>
-    </message>
-    <message id="settings_wifi_access_point_enter_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="68"/>
-      <source>Enter password</source>
-      <translation type="unfinished">Introduceți parola</translation>
-    </message>
-    <message id="page_settings_wifi_invalid_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
-      <source>Password length must be either 0 or between 10 and 63 characters long</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_wifi_password_updated">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
-      <source>Password updated</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_wifi_networks">
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="86"/>
@@ -2539,20 +2265,10 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <extracomment>Network status: Standalone</extracomment>
       <translation>De sine statator</translation>
     </message>
-    <message id="charger_standalone">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="45"/>
-      <source>Standalone</source>
-      <translation type="unfinished">De sine statator</translation>
-    </message>
     <message id="charger_charge">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="48"/>
       <source>Charge</source>
       <translation>Incarcare</translation>
-    </message>
-    <message id="charger_external_control">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="51"/>
-      <source>External control</source>
-      <translation type="unfinished">Control extern</translation>
     </message>
     <message id="charger_charge_hub_1">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="54"/>
@@ -2584,16 +2300,6 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <source>Master setting</source>
       <translation>Configurari master</translation>
     </message>
-    <message id="charger_slave">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="85"/>
-      <source>Slave</source>
-      <translation type="unfinished">Secundar</translation>
-    </message>
-    <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation type="unfinished">Tensiune incarcare</translation>
-    </message>
     <message id="systemsettings_networkstatus_slave">
       <location filename="../../data/SystemSettings.qml" line="148"/>
       <source>Slave</source>
@@ -2615,14 +2321,15 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <source>Group &amp; Charge master</source>
       <translation>Grup &amp; incarcare master</translation>
     </message>
-    <message id="genset_charge_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="365"/>
+    <message id="charger_charge_voltage">
+      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
       <source>Charge voltage</source>
       <translation>Tensiune incarcare</translation>
     </message>
     <message id="common_words_reset">
       <location filename="../../components/CommonWords.qml" line="448"/>
       <source>Reset</source>
+      <extracomment>Reset the BMS control</extracomment>
       <translation>Resetare</translation>
     </message>
     <message id="solarcharger_load">
@@ -2651,14 +2358,14 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <extracomment>Voltage alarm is at "Warning" level</extracomment>
       <translation>Avertisment</translation>
     </message>
-    <message id="listitems_alarm_level_alarm">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="25"/>
+    <message id="digitalinputs_state_alarm">
+      <location filename="../../src/enums.cpp" line="270"/>
       <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
+      <extracomment>Relay function is 'alarm'</extracomment>
       <translation>Alarma</translation>
     </message>
-    <message id="devicelist_tankshape_volume">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="190"/>
+    <message id="components_volumeunit_volume">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
       <source>Volume</source>
       <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
       <translation>Volum</translation>
@@ -2808,26 +2515,10 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <source>Relay function</source>
       <translation>Functia releu</translation>
     </message>
-    <message id="batterysettingrelay_alarm">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation type="unfinished">Alarma</translation>
-    </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
       <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
       <source>Charger or generator start/stop</source>
       <translation>Incarcator sau generator start/stop</translation>
-    </message>
-    <message id="batterysettingrelay_manual_control">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
-      <source>Manual control</source>
-      <translation type="unfinished">Control manual</translation>
-    </message>
-    <message id="batterysettingrelay_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">Siguranta arsa</translation>
     </message>
     <message id="common_words_manual_control">
       <location filename="../../components/CommonWords.qml" line="302"/>
@@ -2853,12 +2544,6 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
       <source>Status LEDs</source>
       <translation>LED status</translation>
-    </message>
-    <message id="batterydiagnostics_none">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
-      <source>None</source>
-      <extracomment>Indicates no alarm is set</extracomment>
-      <translation type="unfinished">Niciuna</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
@@ -2888,7 +2573,7 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
     <message id="common_words_switch">
       <location filename="../../components/CommonWords.qml" line="525"/>
       <source>Switch</source>
-      <extracomment>Change the mode value</extracomment>
+      <extracomment>Change the battery mode</extracomment>
       <translation>Comutator</translation>
     </message>
     <message id="devicelist_battery_initializing">
@@ -2956,21 +2641,6 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <source>Top section voltage</source>
       <translation>Tensiune sectiune superioara</translation>
     </message>
-    <message id="battery_bank_error_communication">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="96"/>
-      <source>Communication error</source>
-      <translation type="unfinished">Eroare comunicare</translation>
-    </message>
-    <message id="battery_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="182"/>
-      <source>State of health</source>
-      <translation type="unfinished">State of health</translation>
-    </message>
-    <message id="battery_bus_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="212"/>
-      <source>Bus voltage</source>
-      <translation type="unfinished">Tensiune Bus</translation>
-    </message>
     <message id="battery_bottom_section_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="228"/>
       <source>Bottom section voltage</source>
@@ -3016,16 +2686,6 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <source>IO</source>
       <translation>IO</translation>
     </message>
-    <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="391"/>
-      <source>System</source>
-      <translation type="unfinished">SISTEM</translation>
-    </message>
-    <message id="battery_press_to_redetect">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="433"/>
-      <source>Press to redetect</source>
-      <translation type="unfinished">Apasa pentru redetectare</translation>
-    </message>
     <message id="pagesettingsgeneral_system">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="107"/>
       <source>System</source>
@@ -3066,16 +2726,6 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <source>Low SOC</source>
       <translation>SOC scazut</translation>
     </message>
-    <message id="batteryalarms_high_battery_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
-      <source>High battery voltage</source>
-      <translation type="unfinished">Tensiune ridicata baterie</translation>
-    </message>
-    <message id="batteryalarms_low_soc">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low SOC</source>
-      <translation type="unfinished">SOC scazut</translation>
-    </message>
     <message id="batteryalarms_low_starter_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="73"/>
       <source>Low starter voltage</source>
@@ -3095,11 +2745,6 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
       <source>Mid-point voltage</source>
       <translation>Tensiune punct-median</translation>
-    </message>
-    <message id="batteryalarms_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">Siguranta arsa</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
@@ -3293,11 +2938,6 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <source>Restore factory defaults</source>
       <translation>Restabileste setarile de implicite</translation>
     </message>
-    <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation type="unfinished">Apasa pentru a restabili</translation>
-    </message>
     <message id="vebus_backup_press_to_restore">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="362"/>
       <source>Press to restore</source>
@@ -3337,11 +2977,6 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="18"/>
       <source>Capacity</source>
       <translation>Capacitate</translation>
-    </message>
-    <message id="batterysettingsbattery_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
-      <source>Capacity</source>
-      <translation type="unfinished">Capacitate</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
@@ -3418,11 +3053,6 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <source>No power on busbar</source>
       <translation>Fără alimentare pe bară</translation>
     </message>
-    <message id="lynxdistributor_connection_lost">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
-      <source>Connection lost</source>
-      <translation type="unfinished">Conexiune intrerupta</translation>
-    </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
       <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
       <source>%n fuse(s) blown</source>
@@ -3459,26 +3089,6 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <source>Shutdowns due error</source>
       <translation>Opriri din cauza erorilor</translation>
     </message>
-    <message id="lynxiondiagnostics_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
-      <source>Last error</source>
-      <translation type="unfinished">Ultima eroare</translation>
-    </message>
-    <message id="lynxiondiagnostics_2nd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
-      <source>2nd last error</source>
-      <translation type="unfinished">Penultima eroare</translation>
-    </message>
-    <message id="lynxiondiagnostics_3rd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
-      <source>3rd last error</source>
-      <translation type="unfinished">Ante-penultima eorare</translation>
-    </message>
-    <message id="lynxiondiagnostics_4th_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
-      <source>4th last error</source>
-      <translation type="unfinished">4 erori in urma</translation>
-    </message>
     <message id="lynxionio_system_switch">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
       <source>System Switch</source>
@@ -3498,11 +3108,6 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <location filename="../../components/CommonWords.qml" line="54"/>
       <source>Batteries</source>
       <translation>Baterii</translation>
-    </message>
-    <message id="lynxionsystem_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
-      <source>Capacity</source>
-      <translation type="unfinished">Capacitate</translation>
     </message>
     <message id="lynxionsystem_parallel">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="30"/>
@@ -3524,20 +3129,10 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <source>Min/max cell temperature</source>
       <translation>Min/max temperatura celula</translation>
     </message>
-    <message id="lynxionsystem_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="92"/>
-      <source>Balancing</source>
-      <translation type="unfinished">Echilibrare</translation>
-    </message>
     <message id="lynxionsystem_balancer_balancing">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
       <source>Balancing</source>
       <translation>Echilibrare</translation>
-    </message>
-    <message id="lynxionsystem_balancer_unknown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="117"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Necunoscut</translation>
     </message>
     <message id="dc_output">
       <location filename="../../components/listitems/ListDcOutputQuantityGroup.qml" line="16"/>
@@ -3645,11 +3240,6 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <source>Remaining</source>
       <translation>Ramas</translation>
     </message>
-    <message id="devicelist_tanksensor_sensor_battery">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="51"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">Baterie senzor</translation>
-    </message>
     <message id="temperature_sensor_battery">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="112"/>
       <source>Sensor battery</source>
@@ -3678,7 +3268,7 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
     <message id="devicelist_tanksetup_custom">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="53"/>
       <source>Custom</source>
-      <translation type="unfinished">Personalizat</translation>
+      <translation>Personalizat</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="59"/>
@@ -3711,34 +3301,34 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <translation>Valoare senzor</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="75"/>
       <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
       <translation>Nu este definită nicio formă personalizată. Puteți defini una cu până la zece puncte. Rețineți că 0 % și 100 % sunt implicite.</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="91"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="89"/>
       <source>Point %1</source>
       <extracomment>%1 = the point number</extracomment>
       <translation>Punct %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="133"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="179"/>
       <source>Add point</source>
       <translation>Adauga punct</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="156"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="205"/>
       <source>Sensor level</source>
       <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
       <translation>Nivel senzor</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="256"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="311"/>
       <source>Duplicate sensor level values are not allowed.</source>
       <translation>Nu sunt permise valorile duble ale nivelului senzorului.</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="262"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="317"/>
       <source>Volume values must be increasing.</source>
       <translation>Valorile de volum trebuie să fie în creștere.</translation>
     </message>
@@ -3778,11 +3368,6 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <source>Switch position</source>
       <translation>Comutare pozitie</translation>
     </message>
-    <message id="ac-in-setup_single_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="142"/>
-      <source>Single phase</source>
-      <translation type="unfinished">Monofazat</translation>
-    </message>
     <message id="ac-in-setup_two_phase">
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="144"/>
       <source>2-phase</source>
@@ -3792,11 +3377,6 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="146"/>
       <source>3-phase</source>
       <translation>Trei feze</translation>
-    </message>
-    <message id="ac-in-setup_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="161"/>
-      <source>Devices</source>
-      <translation type="unfinished">Dispozitiv</translation>
     </message>
     <message id="ac-in-genset_ac">
       <location filename="../../components/PageGensetModel.qml" line="194"/>
@@ -3890,12 +3470,6 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <extracomment>%1 = CT device number</extracomment>
       <translation>CT %1</translation>
     </message>
-    <message id="smappeect_phase_none">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation type="unfinished">Niciuna</translation>
-    </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
       <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
       <source>Flashing LED indicates this CT</source>
@@ -3909,11 +3483,13 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
     <message id="common_words_setting_disabled_when_dmc_connected">
       <location filename="../../components/CommonWords.qml" line="355"/>
       <source>This setting is disabled when a Digital Multi Control is connected.</source>
+      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>Această setare este dezactivată la conectarea Digital Multi Control.</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
       <location filename="../../components/CommonWords.qml" line="358"/>
       <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>Această setare este dezactivată la conectarea unui VE.Bus BMS.</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
@@ -3931,16 +3507,6 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="21"/>
       <source>Inverted</source>
       <translation>Inversat</translation>
-    </message>
-    <message id="digitalinput_enable_alarm">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="48"/>
-      <source>Enable alarm</source>
-      <translation type="unfinished">Activeaza alarma</translation>
-    </message>
-    <message id="digitalinput_inverted">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="54"/>
-      <source>Inverted</source>
-      <translation type="unfinished">Inversat</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
       <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="60"/>
@@ -3977,16 +3543,6 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <source>Wind speed</source>
       <translation>Viteza vantului</translation>
     </message>
-    <message id="page_meteo_battery_voltage">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="99"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">Baterie senzor</translation>
-    </message>
-    <message id="meteo_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="120"/>
-      <source>Low</source>
-      <translation type="unfinished">Scazut</translation>
-    </message>
     <message id="page_meteo_settings_auto_detect">
       <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
       <source>Auto-detect</source>
@@ -4017,16 +3573,6 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <source>Reset counter</source>
       <translation>Reseteaza contor</translation>
     </message>
-    <message id="temperature_short_circuited">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="32"/>
-      <source>Short circuited</source>
-      <translation type="unfinished">Scurtcircuitat</translation>
-    </message>
-    <message id="temperature_reverse_polarity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="35"/>
-      <source>Reverse polarity</source>
-      <translation type="unfinished">Polaritate inversata</translation>
-    </message>
     <message id="temperature_sensor_battery_low">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
       <source>Sensor battery low</source>
@@ -4041,36 +3587,6 @@ Utilizați dacă nu este interzis de furnizorul de utilități.</translation>
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="62"/>
       <source>Pressure</source>
       <translation>Presiune</translation>
-    </message>
-    <message id="temperature_pm25">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
-      <source>PM2.5</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_co2">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>CO₂</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_voc">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
-      <source>VOC index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_nox">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
-      <source>NOx index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_luminosity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
-      <source>Luminosity</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="133"/>
-      <source>Low</source>
-      <translation type="unfinished">Scazut</translation>
     </message>
     <message id="temperature_offset">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
@@ -4124,25 +3640,10 @@ NOTE: Actualizarea ar putea opri temporar sistemul.</translation>
       <source>Updating the MK3, values will reappear after the update is complete</source>
       <translation>La actualizarea MK3, valorile vor reapărea după finalizarea actualizării</translation>
     </message>
-    <message id="vebus_device_charging_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="78"/>
-      <source>Charging the battery to 100%</source>
-      <translation type="unfinished">Încărcarea bateriei la 100%.</translation>
-    </message>
     <message id="vebus_device_charging_the_battery_to_100">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="93"/>
       <source>Charging the battery to 100%</source>
       <translation>Încărcarea bateriei la 100%.</translation>
-    </message>
-    <message id="vebus_device_page_microgrid_parameters">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
-      <source>Microgrid parameters</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="vebus_device_page_advanced">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
-      <source>Advanced</source>
-      <translation type="unfinished">Avansat</translation>
     </message>
     <message id="vebus_device_in_progress">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="80"/>
@@ -4198,15 +3699,15 @@ Doriți să continuați?</translation>
       <source>DC Current</source>
       <translation>Intensitate DC</translation>
     </message>
+    <message id="vebus_device_page_advanced">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
+      <source>Advanced</source>
+      <translation>Avansat</translation>
+    </message>
     <message id="common_words_alarm_setup">
       <location filename="../../components/CommonWords.qml" line="65"/>
       <source>Alarm setup</source>
       <translation>Configurare alarma</translation>
-    </message>
-    <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
-      <translation type="unfinished">Un BMS VE.Bus opreste automat sistemul cand este necesara protejarea bateriilor. Prin urmare, controlarea sistemului din Color Control nu este posibila.</translation>
     </message>
     <message id="vebus_device_bms_not_found">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="240"/>
@@ -4247,7 +3748,7 @@ Doriți să continuați?</translation>
     <message id="vebus_device_starting">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="117"/>
       <source>Starting...</source>
-      <translation type="unfinished">Porneste...</translation>
+      <translation>Porneste...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="120"/>
@@ -4313,16 +3814,6 @@ Doriți să continuați?</translation>
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="260"/>
       <source>ESS Relay test</source>
       <translation>Test releu ESS</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_completed">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="266"/>
-      <source>Completed</source>
-      <translation type="unfinished">Finalizat</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_pending">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="268"/>
-      <source>Pending</source>
-      <translation type="unfinished">In asteptare</translation>
     </message>
     <message id="cycle_history_completed">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
@@ -4509,6 +4000,7 @@ Doriți să continuați?</translation>
     <message id="rssystemalarms_overload">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
       <source>Overload</source>
+      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
       <translation>Supraincarcat</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
@@ -4521,11 +4013,6 @@ Doriți să continuați?</translation>
       <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
       <source>Voltage Sensor</source>
       <translation>Senzor tensiune</translation>
-    </message>
-    <message id="vebus_device_phase_rotation">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
-      <source>Phase rotation</source>
-      <translation type="unfinished">Rotirea fazelor</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
@@ -4557,12 +4044,6 @@ Doriți să continuați?</translation>
       <source>VE.Bus BMS version</source>
       <translation>Versiune BMS VE.Bus</translation>
     </message>
-    <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="15"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="52"/>
-      <source>Minimum SOC</source>
-      <translation type="unfinished">SoC minim</translation>
-    </message>
     <message id="ess_unless_grid_fails">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="32"/>
       <source>Unless grid fails</source>
@@ -4582,7 +4063,7 @@ Doriți să continuați?</translation>
     <message id="common_words_ac_input_role">
       <location filename="../../components/CommonWords.qml" line="24"/>
       <source>Role</source>
-      <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
       <translation>Rol</translation>
     </message>
     <message id="common_words_ac_load">
@@ -4621,18 +4102,6 @@ Doriți să continuați?</translation>
       <source>Active</source>
       <extracomment>Status is 'active'</extracomment>
       <translation>Activ</translation>
-    </message>
-    <message id="common_words_alarm">
-      <location filename="../../components/CommonWords.qml" line="51"/>
-      <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
-      <translation type="unfinished">Alarma</translation>
-    </message>
-    <message id="common_words_alarm_setting_overload">
-      <location filename="../../components/CommonWords.qml" line="58"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation type="unfinished">Supraincarcat</translation>
     </message>
     <message id="common_words_alarm_status">
       <location filename="../../components/CommonWords.qml" line="68"/>
@@ -4679,8 +4148,8 @@ Doriți să continuați?</translation>
       <source>Charge current</source>
       <translation>Intensitate incarcare</translation>
     </message>
-    <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="125"/>
+    <message id="battery_mode_charging">
+      <location filename="../../src/enums.cpp" line="30"/>
       <source>Charging</source>
       <extracomment>"Charging" state</extracomment>
       <translation>Încărcare</translation>
@@ -4694,7 +4163,7 @@ Doriți să continuați?</translation>
     <message id="digitalinputs_state_closed">
       <location filename="../../src/enums.cpp" line="262"/>
       <source>Closed</source>
-      <extracomment>Digital input state</extracomment>
+      <extracomment>Status is 'closed'</extracomment>
       <translation>Inchis</translation>
     </message>
     <message id="evchargers_status_connected">
@@ -4702,8 +4171,8 @@ Doriți să continuați?</translation>
       <source>Connected</source>
       <translation>Conectare</translation>
     </message>
-    <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="143"/>
+    <message id="temperature_slider_current">
+      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
       <source>Current</source>
       <extracomment>Electric current, as measured in Amps</extracomment>
       <translation>Intensitate</translation>
@@ -4730,9 +4199,10 @@ Doriți să continuați?</translation>
       <extracomment>Title for device information</extracomment>
       <translation>Dispozitiv</translation>
     </message>
-    <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="172"/>
+    <message id="battery_mode_discharging">
+      <location filename="../../src/enums.cpp" line="34"/>
       <source>Discharging</source>
+      <extracomment>Battery mode</extracomment>
       <translation>descarcare</translation>
     </message>
     <message id="wifimodel_disconnected">
@@ -4818,13 +4288,14 @@ Doriți să continuați?</translation>
       <source>%1 Hour(s)</source>
       <translation>%1 oră/ore</translation>
     </message>
-    <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="251"/>
+    <message id="battery_mode_idle">
+      <location filename="../../src/enums.cpp" line="26"/>
       <source>Idle</source>
+      <extracomment>Battery mode</extracomment>
       <translation>inactiv</translation>
     </message>
-    <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="258"/>
+    <message id="scheduled_charge_inactive">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
       <source>Inactive</source>
       <extracomment>Status is 'inactive'</extracomment>
       <translation>Inactiv</translation>
@@ -4926,8 +4397,8 @@ Doriți să continuați?</translation>
       <source>Offline</source>
       <translation>Deconectat</translation>
     </message>
-    <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="17"/>
+    <message id="digitalinputs_state_ok">
+      <location filename="../../src/enums.cpp" line="266"/>
       <source>OK</source>
       <extracomment>Voltage alarm is at "OK" level</extracomment>
       <translation>In regula</translation>
@@ -4935,6 +4406,7 @@ Doriți să continuați?</translation>
     <message id="switchable_output_on">
       <location filename="../../src/enums.cpp" line="471"/>
       <source>On</source>
+      <extracomment>Digital input state</extracomment>
       <translation>Pornit</translation>
     </message>
     <message id="common_words_online">
@@ -4945,7 +4417,7 @@ Doriți să continuați?</translation>
     <message id="digitalinputs_state_open">
       <location filename="../../src/enums.cpp" line="258"/>
       <source>Open</source>
-      <extracomment>Digital input open</extracomment>
+      <extracomment>Status is 'open'</extracomment>
       <translation>Deschis</translation>
     </message>
     <message id="common_words_password">
@@ -5005,9 +4477,10 @@ Doriți să continuați?</translation>
       <source>Remove</source>
       <translation>Elimina</translation>
     </message>
-    <message id="switch_state_running">
-      <location filename="../../src/enums.cpp" line="363"/>
+    <message id="switchable_output_running">
+      <location filename="../../src/enums.cpp" line="468"/>
       <source>Running</source>
+      <extracomment>Status = "running"</extracomment>
       <translation>Functioneaza</translation>
     </message>
     <message id="common_words_scanning">
@@ -5074,7 +4547,7 @@ Doriți să continuați?</translation>
     <message id="pvinverter_statusCode_startup">
       <location filename="../../src/enums.cpp" line="296"/>
       <source>Startup (%1)</source>
-      <extracomment>PV inverter status code. %1 = the startup status number</extracomment>
+      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
       <translation>Pornire (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
@@ -5129,8 +4602,10 @@ Doriți să continuați?</translation>
       <source>Unique Identity Number</source>
       <translation>Numar Unic de Identificare</translation>
     </message>
-    <message id="settings_radio_button_group_unknown">
-      <location filename="../../components/listitems/core/ListRadioButtonGroup.qml" line="44"/>
+    <message id="Unknown">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
       <source>Unknown</source>
       <translation>Necunoscut</translation>
     </message>
@@ -5285,11 +4760,6 @@ Doriți să continuați?</translation>
       <source>Error while checking for firmware updates</source>
       <translation>Eroare în timpul verificării actualizărilor de firmware</translation>
     </message>
-    <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation type="unfinished">Eroare în timpul verificării actualizărilor de firmware</translation>
-    </message>
     <message id="settings_firmware_downloading_and_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="63"/>
       <source>Downloading and installing firmware %1...</source>
@@ -5316,6 +4786,66 @@ Doriți să continuați?</translation>
       <source>No firmware found</source>
       <translation>Nu s-a gasit niciun firmware</translation>
     </message>
+    <message id="tank_type_fuel">
+      <location filename="../../src/enums.cpp" line="495"/>
+      <source>Fuel</source>
+      <translation>Combustibil</translation>
+    </message>
+    <message id="tank_type_fresh_water">
+      <location filename="../../src/enums.cpp" line="498"/>
+      <source>Fresh water</source>
+      <translation>Apa dulce</translation>
+    </message>
+    <message id="tank_type_waste_water">
+      <location filename="../../src/enums.cpp" line="501"/>
+      <source>Waste water</source>
+      <translation>Apa reziduala</translation>
+    </message>
+    <message id="tank_type_live_well">
+      <location filename="../../src/enums.cpp" line="504"/>
+      <source>Live well</source>
+      <translation>Live well</translation>
+    </message>
+    <message id="tank_type_oil">
+      <location filename="../../src/enums.cpp" line="507"/>
+      <source>Oil</source>
+      <translation>Ulei</translation>
+    </message>
+    <message id="tank_type_black_water">
+      <location filename="../../src/enums.cpp" line="510"/>
+      <source>Black water</source>
+      <translation>APA REZIDUALA</translation>
+    </message>
+    <message id="tank_type_gasoline">
+      <location filename="../../src/enums.cpp" line="513"/>
+      <source>Gasoline</source>
+      <translation>Benzină</translation>
+    </message>
+    <message id="tank_type_diesel">
+      <location filename="../../src/enums.cpp" line="516"/>
+      <source>Diesel</source>
+      <translation>Motorină</translation>
+    </message>
+    <message id="tank_type_lpg">
+      <location filename="../../src/enums.cpp" line="519"/>
+      <source>LPG</source>
+      <translation>GPL</translation>
+    </message>
+    <message id="tank_type_lng">
+      <location filename="../../src/enums.cpp" line="522"/>
+      <source>LNG</source>
+      <translation>GNL</translation>
+    </message>
+    <message id="tank_type_hydraulic_oil">
+      <location filename="../../src/enums.cpp" line="525"/>
+      <source>Hydraulic oil</source>
+      <translation>Ulei hidraulic</translation>
+    </message>
+    <message id="tank_type_raw_water">
+      <location filename="../../src/enums.cpp" line="528"/>
+      <source>Raw water</source>
+      <translation>Apă crudă</translation>
+    </message>
     <message id="listItem_no_access">
       <location filename="../../components/listitems/core/ListItem.qml" line="102"/>
       <source>Setting locked for access level</source>
@@ -5329,6 +4859,7 @@ Doriți să continuați?</translation>
     <message id="welcome_brief_title">
       <location filename="../../pages/welcome/WelcomeView.qml" line="81"/>
       <source>Brief</source>
+      <extracomment>The 'Brief' page</extracomment>
       <translation>Pe scurt</translation>
     </message>
     <message id="welcome_overview_title">
@@ -5345,23 +4876,6 @@ Doriți să continuați?</translation>
       <location filename="../../pages/NotificationsPage.qml" line="13"/>
       <source>Notifications</source>
       <translation>Notificari</translation>
-    </message>
-    <message id="notifications_page_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="43"/>
-      <source>Active Notifications</source>
-      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_page_inactive_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="47"/>
-      <source>Inactive Notifications</source>
-      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_no_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="106"/>
-      <source>No active notifications</source>
-      <translation type="unfinished"/>
     </message>
     <message id="utils_formatTimestamp_now">
       <location filename="../../components/Utils.js" line="258"/>
@@ -5466,11 +4980,6 @@ Doriți să continuați?</translation>
       <source>Self-consumption above limit</source>
       <translation>Autoconsum peste limită</translation>
     </message>
-    <message id="cgwacs_battery_schedule_pv">
-      <location filename="../../components/listitems/ListChargeSchedule.qml" line="171"/>
-      <source>PV</source>
-      <translation type="unfinished">PV</translation>
-    </message>
     <message id="settings_multirs_pv">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="185"/>
       <source>PV</source>
@@ -5481,8 +4990,8 @@ Doriți să continuați?</translation>
       <source>PV &amp; Battery</source>
       <translation>Fotovoltaic și baterie</translation>
     </message>
-    <message id="settings_firmware_checking">
-      <location filename="../../components/listitems/ListFirmwareCheckButton.qml" line="16"/>
+    <message id="pagesettingssupportstate_firmware_checking">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
       <source>Checking...</source>
       <translation>Se verifica...</translation>
     </message>
@@ -5490,12 +4999,6 @@ Doriți să continuați?</translation>
       <location filename="../../components/listitems/ListAlarmState.qml" line="11"/>
       <source>Alarm state</source>
       <translation>Stare alarma</translation>
-    </message>
-    <message id="devicelist_battery_alarm_state">
-      <location filename="../../components/listitems/ListAlarmState.qml" line="19"/>
-      <source>Alarm</source>
-      <extracomment>Alarm state is active</extracomment>
-      <translation type="unfinished">Alarma</translation>
     </message>
     <message id="clear_history_button_clear_history">
       <location filename="../../components/listitems/ListClearHistoryButton.qml" line="15"/>
@@ -5647,11 +5150,6 @@ Doriți să continuați?</translation>
       <source>Max Voltage</source>
       <translation>Tensiune maximă</translation>
     </message>
-    <message id="charger_history_box_max_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="64"/>
-      <source>Max Voltage</source>
-      <translation type="unfinished">Tensiune maximă</translation>
-    </message>
     <message id="charger_history_box_max_current">
       <location filename="../../components/SolarDetailBox.qml" line="70"/>
       <source>Max Current</source>
@@ -5662,24 +5160,6 @@ Doriți să continuați?</translation>
       <source>Charge time</source>
       <extracomment>Statistics for battery charging time</extracomment>
       <translation>Timp de încărcare</translation>
-    </message>
-    <message id="charger_history_box_bulk">
-      <location filename="../../components/SolarDetailBox.qml" line="136"/>
-      <source>Bulk</source>
-      <extracomment>Battery: time spent in 'Bulk' mode</extracomment>
-      <translation type="unfinished">Bulk</translation>
-    </message>
-    <message id="charger_history_box_float">
-      <location filename="../../components/SolarDetailBox.qml" line="148"/>
-      <source>Float</source>
-      <extracomment>Battery: time spent in 'Float' mode</extracomment>
-      <translation type="unfinished">Float</translation>
-    </message>
-    <message id="charger_history_hr">
-      <location filename="../../components/SolarDetailBox.qml" line="174"/>
-      <source>hr</source>
-      <extracomment>Abbreviation of "hour"</extracomment>
-      <translation type="unfinished">oră</translation>
     </message>
     <message id="solarchargers_state_bulk">
       <location filename="../../src/enums.cpp" line="337"/>
@@ -5751,11 +5231,6 @@ Doriți să continuați?</translation>
       <source>Connecting</source>
       <translation>Conectare</translation>
     </message>
-    <message id="splash_view_connecting">
-      <location filename="../../components/SplashView.qml" line="288"/>
-      <source>Connecting</source>
-      <translation type="unfinished">Conectare</translation>
-    </message>
     <message id="splash_view_connected">
       <location filename="../../components/SplashView.qml" line="290"/>
       <source>Connected, awaiting broker messages</source>
@@ -5811,6 +5286,11 @@ Doriți să continuați?</translation>
       <source>MQTT protocol level 5 error</source>
       <translation>Eroare de nivel 5 al protocolului MQTT</translation>
     </message>
+    <message id="common_words_silence_alarm">
+      <location filename="../../components/CommonWords.qml" line="476"/>
+      <source>Silence alarm</source>
+      <translation>Opriți alarma</translation>
+    </message>
     <message id="vebus_device_page_total_power">
       <location filename="../../components/ThreePhaseQuantityTable.qml" line="47"/>
       <source>Total Power</source>
@@ -5861,20 +5341,10 @@ Doriți să continuați?</translation>
       <source>Retrieving IP address</source>
       <translation>Obtinere adresa IP</translation>
     </message>
-    <message id="utils_connman_connected">
-      <location filename="../../components/Utils.js" line="292"/>
-      <source>Connected</source>
-      <translation type="unfinished">Conectare</translation>
-    </message>
     <message id="utils_connman_disconnect">
       <location filename="../../components/Utils.js" line="295"/>
       <source>Disconnect</source>
       <translation>Deconectat</translation>
-    </message>
-    <message id="utils_connman_disconnected">
-      <location filename="../../components/Utils.js" line="299"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Deconectat</translation>
     </message>
     <message id="overview_widget_acloads_title">
       <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
@@ -5912,11 +5382,6 @@ Doriți să continuați?</translation>
       <source>Shore current limit</source>
       <translation>Limita de curent la mal</translation>
     </message>
-    <message id="acInputs_statusCode_stopping">
-      <location filename="../../data/AcInputs.qml" line="170"/>
-      <source>Stopping</source>
-      <translation type="unfinished">Oprire</translation>
-    </message>
     <message id="page_generator_stopping">
       <location filename="../../data/Generators.qml" line="44"/>
       <source>Stopping</source>
@@ -5932,7 +5397,7 @@ Doriți să continuați?</translation>
       <location filename="../../data/common/TankDescription.qml" line="24"/>
       <location filename="../../src/device.cpp" line="133"/>
       <source>%1 tank (%2)</source>
-      <extracomment>Tank description. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
       <translation>%1 rezervor (%2)</translation>
     </message>
     <message id="dcMeter_ac_charger">
@@ -5981,11 +5446,6 @@ Doriți să continuați?</translation>
       <location filename="../../data/Ess.qml" line="20"/>
       <source>Keep batteries charged</source>
       <translation>Mentine bateriile incarcate</translation>
-    </message>
-    <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="50"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Deconectat</translation>
     </message>
     <message id="evchargers_status_charged">
       <location filename="../../data/EvChargers.qml" line="58"/>
@@ -6046,16 +5506,6 @@ Doriți să continuați?</translation>
       <location filename="../../data/EvChargers.qml" line="97"/>
       <source>Start charging</source>
       <translation>Pornire încărcare</translation>
-    </message>
-    <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="113"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Necunoscut</translation>
-    </message>
-    <message id="evchargers_mode_scheduled">
-      <location filename="../../data/EvChargers.qml" line="126"/>
-      <source>Scheduled</source>
-      <translation type="unfinished">Programat</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
       <location filename="../../data/System.qml" line="195"/>
@@ -6180,11 +5630,6 @@ Doriți să continuați?</translation>
       <source>Power supply mode</source>
       <translation>Mod sursa de alimentare</translation>
     </message>
-    <message id="inverters_state_sustain">
-      <location filename="../../data/System.qml" line="158"/>
-      <source>Sustain</source>
-      <translation type="unfinished">Sustine</translation>
-    </message>
     <message id="inverters_state_wakeup">
       <location filename="../../data/System.qml" line="162"/>
       <source>Wake up</source>
@@ -6219,16 +5664,6 @@ Doriți să continuați?</translation>
       <location filename="../../data/System.qml" line="180"/>
       <source>Test</source>
       <translation>Test</translation>
-    </message>
-    <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="183"/>
-      <source>External control</source>
-      <translation type="unfinished">Control extern</translation>
-    </message>
-    <message id="inverters_state_dynamic_ess">
-      <location filename="../../data/System.qml" line="198"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">SSE dinamic</translation>
     </message>
     <message id="settings_rs_ess_dess">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="97"/>
@@ -6307,16 +5742,13 @@ Doriți să continuați?</translation>
     <message id="ess_recommended">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="73"/>
       <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
       <translation>Pentru bateriile cu litiu, nu se recomandă o încărcare sub 10 %. Pentru alte tipuri de baterii, verificați fișa tehnică pentru nivelul minim recomandat de producător.</translation>
-    </message>
-    <message id="controlcard_generator_label_autostart">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="63"/>
-      <source>Autostart</source>
-      <translation type="unfinished">Pornire automată</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
       <location filename="../../pages/controlcards/GeneratorCard.qml" line="70"/>
       <source>Start and stop the generator based on the configured autostart conditions.</source>
+      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
       <translation>Porniți și opriți generatorul pe baza condițiilor de pornire automată configurate.</translation>
     </message>
     <message id="generator_dialog_disabled">
@@ -6339,11 +5771,13 @@ Doriți să continuați?</translation>
       <location filename="../../pages/controlcards/InverterChargerCard.qml" line="26"/>
       <source>Inverter / Charger (%1)</source>
       <extracomment>%1 = the inverter/charger name</extracomment>
+      <oldsource>Inverter / Charger</oldsource>
       <translation>Invertor/Încărcător (%1)</translation>
     </message>
     <message id="settings_page_debug_quit_application">
       <location filename="../../pages/settings/debug/PageDebug.qml" line="36"/>
       <source>Quit application</source>
+      <oldsource>Quit Application</oldsource>
       <translation>Părăsiți aplicația</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
@@ -6354,12 +5788,8 @@ Doriți să continuați?</translation>
     <message id="settings_page_relay_generator_run_time">
       <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
       <source>Current run time</source>
+      <oldsource>Run time</oldsource>
       <translation>Timpul curent de funcționare</translation>
-    </message>
-    <message id="settings_page_genset_generator_run_time">
-      <location filename="../../components/PageGensetModel.qml" line="102"/>
-      <source>Current run time</source>
-      <translation type="unfinished">Timpul curent de funcționare</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
       <location filename="../../components/PageGensetModel.qml" line="110"/>
@@ -6386,19 +5816,10 @@ Doriți să continuați?</translation>
       <source>Remote start mode</source>
       <translation>Modul de pornire de la distanță</translation>
     </message>
-    <message id="ac-in-genset_speed">
-      <location filename="../../components/PageGensetModel.qml" line="245"/>
-      <source>Speed</source>
-      <translation type="unfinished">Viteza</translation>
-    </message>
-    <message id="ac-in-genset_load">
-      <location filename="../../components/PageGensetModel.qml" line="252"/>
-      <source>Load</source>
-      <translation type="unfinished">Incarcare</translation>
-    </message>
     <message id="ac-in-genset_oil_pressure">
       <location filename="../../components/PageGensetModel.qml" line="260"/>
       <source>Oil pressure</source>
+      <oldsource>Oil Pressure</oldsource>
       <translation>Presiunea uleiului</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
@@ -6494,11 +5915,13 @@ Doriți să continuați?</translation>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
       <source>High starter battery voltage alarms</source>
+      <oldsource>High starter batttery voltage alarms</oldsource>
       <translation>Alarme de tensiune ridicată a bateriei de pornire</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
       <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
       <translation>Rețineți că modificarea setării Time-to-go discharge floor (Timp până la descărcarea minimă) modifică și setarea Low state-of-charge (Stare de încărcare scăzută) din meniul releu.</translation>
     </message>
     <message id="lynxionsystem_cells_per_battery">
@@ -6575,6 +5998,7 @@ Doriți să continuați?</translation>
       <location filename="../../pages/settings/devicelist/delegates/DeviceListDelegate_solarcharger.qml" line="34"/>
       <source>Error: #%1</source>
       <extracomment>%1 = error number</extracomment>
+      <oldsource>Error: %1</oldsource>
       <translation>Eroare: #%1</translation>
     </message>
     <message id="devicelistpage_genset">
@@ -6631,17 +6055,14 @@ Doriți să continuați?</translation>
     <message id="settings_page_relay_generator_auto_start_enabled">
       <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
       <source>Autostart functionality</source>
+      <oldsource>Auto start functionality</oldsource>
       <translation>Funcționalitatea de pornire automată</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="97"/>
       <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
       <translation>Asigurați-vă că generatorul nu este conectat la intrarea de curent alternativ %1 în momentul în care se utilizează această opțiune</translation>
-    </message>
-    <message id="page_generator_conditions_inverter_high_temperature">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="139"/>
-      <source>Inverter high temperature</source>
-      <translation type="unfinished">Temperatura ridicata invertor</translation>
     </message>
     <message id="page_generator_conditions_tank_level">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="159"/>
@@ -6671,30 +6092,34 @@ Doriți să continuați?</translation>
     <message id="settings_generator_function_not_enabled">
       <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
       <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
+      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
       <translation>Funcția de pornire/oprire a generatorului nu este activă, mergeți la setări releu și setați funcția la \„Pornirea/oprirea generatorului\”</translation>
     </message>
     <message id="settings_batteries_intro">
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="45"/>
       <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
       <translation>Utilizați acest meniu pentru a defini datele despre baterie afișate în momentul în care faceți clic pe pictograma Baterie de pe pagina Prezentare generală. Aceeași selecție este vizibilă și pe portalul VRM.</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
       <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
       <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
       <translation>Scanarea continuă poate interfera cu Wi-Fi-ul.</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
       <source>CAN-bus BMS LV (500 kbit/s)</source>
+      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
       <translation>CAN-bus BMS LV (500 kbit/s)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
       <source>CAN-bus BMS HV (500 kbit/s)</source>
       <translation>CAN-bus BMS HV (500 kbit/s)</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
       <source>Up, but no services (500 kbit/s)</source>
       <translation>În funcțiune, dar fără servicii (500 kbit/s)</translation>
     </message>
@@ -6707,41 +6132,6 @@ Doriți să continuați?</translation>
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="127"/>
       <source>Brief page</source>
       <translation>Scurtă pagină</translation>
-    </message>
-    <message id="settings_displayoff_1min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="46"/>
-      <source>1 min</source>
-      <translation type="unfinished">1 min</translation>
-    </message>
-    <message id="settings_displayoff_10min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="48"/>
-      <source>10 min</source>
-      <translation type="unfinished">10 min</translation>
-    </message>
-    <message id="settings_displayoff_30min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="50"/>
-      <source>30 min</source>
-      <translation type="unfinished">30 min</translation>
-    </message>
-    <message id="settings_displayoff_never">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="52"/>
-      <source>Never</source>
-      <translation type="unfinished">Niciodata</translation>
-    </message>
-    <message id="settings_remote_console_appearance_auto">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="112"/>
-      <source>Auto</source>
-      <translation type="unfinished">Auto</translation>
-    </message>
-    <message id="settings_brief_view_start_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="119"/>
-      <source>Start page</source>
-      <translation type="unfinished">Pagina de pornire</translation>
-    </message>
-    <message id="settings_display_boat_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="135"/>
-      <source>Boat page</source>
-      <translation type="unfinished">Pagina ambarcațiunii</translation>
     </message>
     <message id="settings_display_minmax">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="148"/>
@@ -6796,21 +6186,6 @@ Doriți să continuați?</translation>
       <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
       <translation>%1 este setat la %2</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_unsupported_device">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="50"/>
-      <source>Unsupported GX device</source>
-      <translation type="unfinished">Dispozitiv GX nesuportat</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_clean">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="55"/>
-      <source>Clean</source>
-      <translation type="unfinished">Curăță</translation>
-    </message>
-    <message id="pagesettingsgeneral_firmware">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="112"/>
-      <source>Firmware</source>
-      <translation type="unfinished">Firmware</translation>
-    </message>
     <message id="pagesettingsgeneral_access_and_security">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
       <source>Access &amp; Security</source>
@@ -6844,6 +6219,7 @@ Doriți să continuați?</translation>
     <message id="settings_language_please_wait">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="209"/>
       <source>Please wait while the language is changed.</source>
+      <oldsource>Please wait while the language is changed</oldsource>
       <translation>Vă rugăm să așteptați în timp ce se schimbă limba.</translation>
     </message>
     <message id="settings_briefview_totals">
@@ -6860,11 +6236,6 @@ Doriți să continuați?</translation>
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="71"/>
       <source>Tank is not connected.</source>
       <translation>Rezervorul nu este conectat.</translation>
-    </message>
-    <message id="settings_briefview_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="83"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">Monitor baterie activ</translation>
     </message>
     <message id="settings_briefview_individual_batteries">
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="86"/>
@@ -6915,6 +6286,7 @@ Doriți să continuați?</translation>
     <message id="settings_dvcc_charge_current_limits">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="30"/>
       <source>Charge current limits</source>
+      <oldsource>Charge Current limits</oldsource>
       <translation>Limite de curent de încărcare</translation>
     </message>
     <message id="settings_firmware_official_release">
@@ -6994,11 +6366,6 @@ Doriți să continuați?</translation>
       <source>No password and the network communication is not encrypted</source>
       <translation>Nu există parolă și comunicarea prin rețea nu este criptată</translation>
     </message>
-    <message id="settings_logout_now">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
-      <source>Log out now</source>
-      <translation type="unfinished">Deconectați-vă acum</translation>
-    </message>
     <message id="settings_security_profile_password_incorrect_length">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="28"/>
       <source>Password needs to be at least 8 characters long</source>
@@ -7049,25 +6416,10 @@ Doriți să continuați?</translation>
       <source>Page will automatically reload in 5 seconds</source>
       <translation>Pagina se va reîncărca automat în 5 secunde</translation>
     </message>
-    <message id="settings_security_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="159"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">Parola trebuie să aibă cel puțin 8 caractere</translation>
-    </message>
     <message id="settings_root_password">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="269"/>
       <source>Root password</source>
       <translation>Parolă rădăcină</translation>
-    </message>
-    <message id="settings_root_enter_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="272"/>
-      <source>Enter password</source>
-      <translation type="unfinished">Introduceți parola</translation>
-    </message>
-    <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="277"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">Parola trebuie să aibă cel puțin 8 caractere</translation>
     </message>
     <message id="settings_root_password_changed_to">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="283"/>
@@ -7083,6 +6435,11 @@ Doriți să continuați?</translation>
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="321"/>
       <source>Logout</source>
       <translation>Deconectare</translation>
+    </message>
+    <message id="settings_logout_now">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
+      <source>Log out now</source>
+      <translation>Deconectați-vă acum</translation>
     </message>
     <message id="settings_logout_dialog_title">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="335"/>
@@ -7142,11 +6499,13 @@ Doriți să continuați?</translation>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="141"/>
       <source>Alarm when generator is not in autostart mode</source>
+      <oldsource>Alarm when generator is not in auto start mode</oldsource>
       <translation>Alarmă atunci când generatorul nu este în modul de pornire automată</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="147"/>
       <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
       <translation>Se va declanșa o alarmă atunci când funcția de pornire automată este lăsată dezactivată pentru mai mult de 10 minute</translation>
     </message>
     <message id="settings_units_amps_exceptions">
@@ -7162,6 +6521,11 @@ Doriți să continuați?</translation>
     <message id="settings_ess_use_this_option_for_peak_shaving">
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
       <source>Use this option for peak shaving.</source>
+      <oldsource>Use this option for peak shaving.
+
+The peak shaving threshold is set using the AC input current limit setting.
+
+See documentation for further information.</oldsource>
       <translation>Utilizați această opțiune pentru reducerea vârfurilor de tensiune.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
@@ -7205,17 +6569,17 @@ Doriți să continuați?</translation>
       <translation>Curent maxim de export al sistemului (pe fază)</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="71"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="73"/>
       <source>Self-consumption from battery</source>
       <translation>Autoconsum din baterie</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="76"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
       <source>All system loads</source>
       <translation>Toate sarcinile sistemului</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="80"/>
       <source>Only critical loads</source>
       <translation>Numai sarcini critice</translation>
     </message>
@@ -7273,26 +6637,6 @@ Doriți să continuați?</translation>
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="194"/>
       <source>Server Applications</source>
       <translation>Aplicații server</translation>
-    </message>
-    <message id="pagesettingsintegrations_venus_os_enable_large_features">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
-      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_large_victron_community">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="274"/>
-      <source>Victron Community</source>
-      <translation type="unfinished">Comunitatea Victron</translation>
-    </message>
-    <message id="pagesettingsintegrations_ui_plugins">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
-      <source>UI Plugins</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
-      <source>Integrates with the device list</source>
-      <translation type="unfinished"/>
     </message>
     <message id="pagesettingssupportstate_modbus_tcp_server">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="453"/>
@@ -7395,25 +6739,10 @@ Doriți să continuați?</translation>
       <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
       <translation>Schimbarea versiunii firmware nu este posibilă fără a selecta "Profil de securitate rețea" în "Setări / General".</translation>
     </message>
-    <message id="pagesettingsconnectivity_ethernet">
-      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
-      <source>Ethernet</source>
-      <translation type="unfinished">Retea locala</translation>
-    </message>
     <message id="pagesettingsconnectivity_mobile_network">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="53"/>
       <source>Mobile Network</source>
       <translation>Rețea mobilă</translation>
-    </message>
-    <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Boat</source>
-      <translation type="unfinished">Ambarcatiune</translation>
-    </message>
-    <message id="settings_system_name_auto">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="32"/>
-      <source>Automatic</source>
-      <translation type="unfinished">Automa</translation>
     </message>
     <message id="pagesettingssystem_ac_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
@@ -7444,11 +6773,6 @@ Doriți să continuați?</translation>
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="89"/>
       <source>Distributed Voltage and Current Control (DVCC)</source>
       <translation>Controlul distribuit al tensiunii și curentului (DVCC)</translation>
-    </message>
-    <message id="settings_system_grid">
-      <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="18"/>
-      <source>Grid</source>
-      <translation type="unfinished">Retea</translation>
     </message>
     <message id="settings_system_ac_position">
       <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="58"/>
@@ -7488,16 +6812,19 @@ Doriți să continuați?</translation>
     <message id="settings_system_has_dc_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="97"/>
       <source>Display DC Loads</source>
+      <oldsource>Has DC system</oldsource>
       <translation>Afișare sarcini de curent continuu</translation>
     </message>
     <message id="settings_system_battery_measurements">
       <location filename="../../pages/settings/PageSettingsBatteries.qml" line="65"/>
       <source>Battery measurements</source>
+      <oldsource>Battery Measurements</oldsource>
       <translation>Masuratori baterie</translation>
     </message>
     <message id="settings_system_system_status">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
       <source>System status</source>
+      <oldsource>System Status</oldsource>
       <translation>Stare sistem</translation>
     </message>
     <message id="settings_tcpip_wired">
@@ -7508,11 +6835,13 @@ Doriți să continuați?</translation>
     <message id="settings_vecan_device_instance">
       <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
       <source>VE.Can Device Instance</source>
+      <oldsource>Device Instance</oldsource>
       <translation>Instanțe de dispozitiv VE.Can</translation>
     </message>
     <message id="settings_vecan_device_number">
       <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="32"/>
       <source>VE.Can Instance# %1</source>
+      <oldsource>Device# %1</oldsource>
       <translation>Instanță număr VE.Can %1</translation>
     </message>
     <message id="settings_tz_antarctica">
@@ -7543,6 +6872,7 @@ Doriți să continuați?</translation>
     <message id="settings_vrm">
       <location filename="../../pages/SettingsPage.qml" line="59"/>
       <source>VRM</source>
+      <extracomment>Forced by %2 to dark</extracomment>
       <translation>VRM</translation>
     </message>
     <message id="settings_remote_monitoring_portal">
@@ -7550,20 +6880,10 @@ Doriți să continuați?</translation>
       <source>Remote monitoring portal</source>
       <translation>Portal de monitorizare la distanță</translation>
     </message>
-    <message id="settings_advanced">
-      <location filename="../../pages/SettingsPage.qml" line="68"/>
-      <source>Advanced</source>
-      <translation type="unfinished">Avansat</translation>
-    </message>
-    <message id="settings_integrations">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
+    <message id="pagesettingssupportstate_integrations">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
       <source>Integrations</source>
       <translation>Integrări</translation>
-    </message>
-    <message id="settings_relays_sensors_tanks">
-      <location filename="../../pages/SettingsPage.qml" line="75"/>
-      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
-      <translation type="unfinished">Relee, senzori, rezervoare, invertoare fotovoltaice, Modbus, MQTT...</translation>
     </message>
     <message id="settings_acdcsystem_ess_dvcc_battery">
       <location filename="../../pages/SettingsPage.qml" line="84"/>
@@ -7583,11 +6903,13 @@ Doriți să continuați?</translation>
     <message id="settings_system_setup">
       <location filename="../../pages/SettingsPage.qml" line="82"/>
       <source>System Setup</source>
+      <oldsource>System setup</oldsource>
       <translation>Configurare sistem</translation>
     </message>
     <message id="settings_vrm_device_instances">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
       <source>VRM device instances</source>
+      <oldsource>VRM Device Instances</oldsource>
       <translation>Instanțe de dispozitive VRM</translation>
     </message>
     <message id="solarcharger_not_supported">
@@ -7605,28 +6927,10 @@ Doriți să continuați?</translation>
       <source>The firmware version in the MPPT Solar Charger must be v1.09 or later. Contact Victron Service for update instructions and files.</source>
       <translation>Versiunea firmware din încărcătorul solar MPPT trebuie să fie v1.09 sau mai recentă. Contactați service-ul Victron pentru instrucțiuni și fișiere de actualizare.</translation>
     </message>
-    <message id="solarcharger_pv">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="102"/>
-      <source>PV</source>
-      <extracomment>PV power for solar charger</extracomment>
-      <translation type="unfinished">PV</translation>
-    </message>
     <message id="solarcharger_total_power">
       <location filename="../../pages/solar/PageSolarCharger.qml" line="127"/>
       <source>Total PV power</source>
       <translation>Putere totala PV</translation>
-    </message>
-    <message id="solarcharger_total_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="211"/>
-      <source>Total yield</source>
-      <extracomment>Solar charger total yield</extracomment>
-      <translation type="unfinished">Randament total</translation>
-    </message>
-    <message id="solarcharger_system_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="220"/>
-      <source>System yield</source>
-      <extracomment>Solar charger system yield</extracomment>
-      <translation type="unfinished">Randament sistem</translation>
     </message>
     <message id="settings_multirs_total_yield">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="63"/>
@@ -7662,16 +6966,19 @@ Doriți să continuați?</translation>
     <message id="vebus_device_update_firmware">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="133"/>
       <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
       <translation>Această funcție necesită versiunea de firmware 400 sau o versiune mai recentă. Contactați instalatorul dumneavoastră pentru a vă actualiza Multi/Quattro.</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="139"/>
       <source>Charger not ready, equalization cannot be started</source>
+      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
       <translation>Incărcătorul nu este pregătit, egalizarea nu poate fi pornită</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="143"/>
       <source>Equalization cannot be triggered during bulk charge state</source>
+      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
       <translation>Egalizarea nu poate fi declansata in starea bulk a incarcarii</translation>
     </message>
     <message id="vebus_device_restart_vebus_system_restart_confirmation_description">
@@ -7694,78 +7001,20 @@ Doriți să continuați?</translation>
       <source>Auto-started • %1</source>
       <translation>Pornit automat • %1</translation>
     </message>
-    <message id="common_words_battery">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery</source>
-      <translation type="unfinished">Baterie</translation>
-    </message>
-    <message id="common_words_boat_page">
-      <location filename="../../components/CommonWords.qml" line="111"/>
-      <source>Boat</source>
-      <extracomment>The 'Boat' page</extracomment>
-      <translation type="unfinished">Ambarcatiune</translation>
-    </message>
-    <message id="common_words_brief_page">
-      <location filename="../../components/CommonWords.qml" line="115"/>
-      <source>Brief</source>
-      <extracomment>The 'Brief' page</extracomment>
-      <translation type="unfinished">Pe scurt</translation>
-    </message>
-    <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation type="unfinished">Inchis</translation>
-    </message>
-    <message id="common_words_color">
-      <location filename="../../components/CommonWords.qml" line="136"/>
-      <source>Color</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_connected">
-      <location filename="../../components/CommonWords.qml" line="139"/>
-      <source>Connected</source>
-      <translation type="unfinished">Conectare</translation>
-    </message>
     <message id="common_words_daily_history">
       <location filename="../../components/CommonWords.qml" line="152"/>
       <source>Daily history</source>
       <translation>Istoric zilnic</translation>
-    </message>
-    <message id="common_words_disabled">
-      <location filename="../../components/CommonWords.qml" line="169"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Dezactivat</translation>
-    </message>
-    <message id="common_words_disconnected">
-      <location filename="../../components/CommonWords.qml" line="175"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Deconectat</translation>
-    </message>
-    <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="191"/>
-      <source>Error</source>
-      <translation type="unfinished">Eroare</translation>
     </message>
     <message id="common_words_error_not_a_number">
       <location filename="../../components/CommonWords.qml" line="200"/>
       <source>'%1' is not a number.</source>
       <translation>"%1" nu este un număr.</translation>
     </message>
-    <message id="common_words_generator">
-      <location filename="../../components/CommonWords.qml" line="217"/>
-      <source>Generator</source>
-      <translation type="unfinished">Generator</translation>
-    </message>
     <message id="common_words_input_current_limit">
       <location filename="../../components/CommonWords.qml" line="261"/>
       <source>Input current limit</source>
       <translation>Limita intensitate curent</translation>
-    </message>
-    <message id="common_words_inverter_charger">
-      <location filename="../../components/CommonWords.qml" line="264"/>
-      <source>Inverter / Charger</source>
-      <translation type="unfinished">Invertor/Încărcător</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
       <location filename="../../components/CommonWords.qml" line="268"/>
@@ -7778,12 +7027,6 @@ Doriți să continuați?</translation>
       <source>Manual stop</source>
       <translation>Oprire manuală</translation>
     </message>
-    <message id="common_words_max">
-      <location filename="../../components/CommonWords.qml" line="315"/>
-      <source>Max</source>
-      <extracomment>Short for Maximum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_maximum_current">
       <location filename="../../components/CommonWords.qml" line="318"/>
       <source>Maximum current</source>
@@ -7794,62 +7037,10 @@ Doriți să continuați?</translation>
       <source>Maximum power</source>
       <translation>Putere maximă</translation>
     </message>
-    <message id="common_words_min">
-      <location filename="../../components/CommonWords.qml" line="331"/>
-      <source>Min</source>
-      <extracomment>Short for Minimum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_minimum_current">
       <location filename="../../components/CommonWords.qml" line="334"/>
       <source>Minimum current</source>
       <translation>Curent minim</translation>
-    </message>
-    <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="433"/>
-      <source>No</source>
-      <translation type="unfinished">Nu</translation>
-    </message>
-    <message id="common_words_none_option">
-      <location filename="../../components/CommonWords.qml" line="364"/>
-      <source>None</source>
-      <translation type="unfinished">Niciuna</translation>
-    </message>
-    <message id="common_words_none_errors">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>None</source>
-      <extracomment>Indicates there are no errors</extracomment>
-      <translation type="unfinished">Niciuna</translation>
-    </message>
-    <message id="common_words_not_available">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Not available</source>
-      <translation type="unfinished">Indisponibil</translation>
-    </message>
-    <message id="common_words_off">
-      <location filename="../../components/CommonWords.qml" line="377"/>
-      <source>Off</source>
-      <translation type="unfinished">Oprit</translation>
-    </message>
-    <message id="common_words_ok">
-      <location filename="../../components/CommonWords.qml" line="383"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="41"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="45"/>
-      <source>OK</source>
-      <translation type="unfinished">In regula</translation>
-    </message>
-    <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="386"/>
-      <source>On</source>
-      <translation type="unfinished">Pornit</translation>
-    </message>
-    <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="393"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation type="unfinished">Deschis</translation>
     </message>
     <message id="common_words_open_circuit">
       <location filename="../../components/CommonWords.qml" line="396"/>
@@ -7861,108 +7052,17 @@ Doriți să continuați?</translation>
       <source>Overall history</source>
       <translation>Istoric general</translation>
     </message>
-    <message id="common_words_press">
-      <location filename="../../components/CommonWords.qml" line="419"/>
-      <source>Press</source>
-      <translation type="unfinished">Apăsați</translation>
-    </message>
-    <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation type="unfinished">Functioneaza</translation>
-    </message>
-    <message id="common_words_settings">
-      <location filename="../../components/CommonWords.qml" line="467"/>
-      <source>Settings</source>
-      <translation type="unfinished">Configurari</translation>
-    </message>
-    <message id="common_words_silence_alarm">
-      <location filename="../../components/CommonWords.qml" line="476"/>
-      <source>Silence alarm</source>
-      <translation type="unfinished">Opriți alarma</translation>
-    </message>
     <message id="common_words_soc">
       <location filename="../../components/CommonWords.qml" line="480"/>
       <source>SOC %1</source>
       <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
       <translation>SoC %1</translation>
     </message>
-    <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation type="unfinished">Viteza</translation>
-    </message>
-    <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="487"/>
-      <source>Standby</source>
-      <translation type="unfinished">Asteptare</translation>
-    </message>
-    <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="502"/>
-      <source>State</source>
-      <translation type="unfinished">Stare</translation>
-    </message>
-    <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="512"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation type="unfinished">Pornire (%1)</translation>
-    </message>
-    <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>Stopped</source>
-      <translation type="unfinished">Oprit</translation>
-    </message>
-    <message id="common_words_total_power">
-      <location filename="../../components/CommonWords.qml" line="540"/>
-      <source>Total power</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="547"/>
-      <source>Type</source>
-      <translation type="unfinished">Tip</translation>
-    </message>
-    <message id="common_words_unknown_status">
-      <location filename="../../components/CommonWords.qml" line="554"/>
-      <source>Unknown</source>
-      <extracomment>Status = "unknown"</extracomment>
-      <translation type="unfinished">Necunoscut</translation>
-    </message>
-    <message id="common_words_value_must_be_greater_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="557"/>
-      <source>Value must be greater than start value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_value_must_be_greater_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="560"/>
-      <source>Value must be greater than stop value</source>
-      <translation type="unfinished">Valoarea trebuie sa fie mai mare decat valoarea de oprire</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="563"/>
-      <source>Value must be lower than start value</source>
-      <translation type="unfinished">Valoarea trebuie sa fie mai mica decat valoarea de pornire</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="566"/>
-      <source>Value must be lower than stop value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="581"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="431"/>
-      <source>Yes</source>
-      <translation type="unfinished">Da</translation>
-    </message>
     <message id="common_words_yield_today">
       <location filename="../../components/CommonWords.qml" line="592"/>
       <source>Yield Today</source>
       <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+      <oldsource>Yield today</oldsource>
       <translation>Randament astăzi</translation>
     </message>
     <message id="common_words_format_error">
@@ -7989,10 +7089,11 @@ Doriți să continuați?</translation>
     <message id="settings_firmware_installed_rebooting">
       <location filename="../../components/FirmwareUpdate.qml" line="79"/>
       <source>Firmware installed, device rebooting</source>
+      <oldsource>Firmware installed, rebooting.</oldsource>
       <translation>Firmware instalat, dispozitiv repornit</translation>
     </message>
-    <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/RadioButtonListPage.qml" line="121"/>
+    <message id="modaldialog_confirm">
+      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
       <source>Confirm</source>
       <extracomment>Confirm password, and verify it if possible</extracomment>
       <translation>Confirmați</translation>
@@ -8010,11 +7111,13 @@ Doriți să continuați?</translation>
     <message id="cgwacs_battery_schedule_duration">
       <location filename="../../components/listitems/ListChargeSchedule.qml" line="144"/>
       <source>Duration</source>
+      <oldsource>Duration (hh:mm)</oldsource>
       <translation>Durată</translation>
     </message>
     <message id="settings_relay_deactivation_value">
       <location filename="../../components/TemperatureRelaySettings.qml" line="86"/>
       <source>Deactivation value</source>
+      <oldsource>Deativation value</oldsource>
       <translation>Valoare de dezactivare</translation>
     </message>
     <message id="splash_view_device_disconnected">
@@ -8062,29 +7165,6 @@ Doriți să continuați?</translation>
       <source>Temperature warning</source>
       <translation>Avertizare de temperatură</translation>
     </message>
-    <message id="battery_mode_idle">
-      <location filename="../../src/enums.cpp" line="26"/>
-      <source>Idle</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">inactiv</translation>
-    </message>
-    <message id="battery_mode_charging">
-      <location filename="../../src/enums.cpp" line="30"/>
-      <source>Charging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Încărcare</translation>
-    </message>
-    <message id="battery_mode_discharging">
-      <location filename="../../src/enums.cpp" line="34"/>
-      <source>Discharging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">descarcare</translation>
-    </message>
-    <message id="dcMeter_bilge_pump">
-      <location filename="../../src/enums.cpp" line="115"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">Pompa de santina</translation>
-    </message>
     <message id="switch_state_channel_fault">
       <location filename="../../src/enums.cpp" line="372"/>
       <source>Channel Fault</source>
@@ -8115,26 +7195,6 @@ Doriți să continuați?</translation>
       <source>Slave of %1</source>
       <translation>Slave pentru %1</translation>
     </message>
-    <message id="switchable_output_numeric_input">
-      <location filename="../../src/enums.cpp" line="418"/>
-      <source>Numeric input</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bilge_pump">
-      <location filename="../../src/enums.cpp" line="424"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">Pompa de santina</translation>
-    </message>
-    <message id="switchable_output_not_running">
-      <location filename="../../src/enums.cpp" line="448"/>
-      <source>Not running</source>
-      <translation type="unfinished">Nu funcționează</translation>
-    </message>
-    <message id="switchable_output_off">
-      <location filename="../../src/enums.cpp" line="451"/>
-      <source>Off</source>
-      <translation type="unfinished">Oprit</translation>
-    </message>
     <message id="switchable_output_powered">
       <location filename="../../src/enums.cpp" line="455"/>
       <source>Powered</source>
@@ -8163,16 +7223,19 @@ Doriți să continuați?</translation>
     <message id="evchargers_status_welded_contacts_error">
       <location filename="../../data/EvChargers.qml" line="76"/>
       <source>Welded contacts test error (shorted)</source>
+      <oldsource>Welded contacts error</oldsource>
       <translation>Eroare de testare a contactelor sudate (în scurtcircuit)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
       <location filename="../../data/EvChargers.qml" line="100"/>
       <source>Switching to 3 phase</source>
+      <oldsource>Switching to 3-phase</oldsource>
       <translation>Comutarea la 3 faze</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
       <location filename="../../data/EvChargers.qml" line="103"/>
       <source>Switching to 1 phase</source>
+      <oldsource>Switching to single phase</oldsource>
       <translation>Comutarea la 1 fază</translation>
     </message>
     <message id="evchargers_status_stop_charging">
@@ -8325,17 +7388,6 @@ If the generator is currently running due to a autostart condition, disabling au
       <source>Open link</source>
       <translation>Deschideți link-ul</translation>
     </message>
-    <message id="listlink_show_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="43"/>
-      <source>Show QR code</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="listlink_scan_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="52"/>
-      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
-      <extracomment>%1 = url text</extracomment>
-      <translation type="unfinished">Scanați codul QR cu dispozitivul dvs. portabil.&lt;br /&gt;Sau introduceți link-ul: %1</translation>
-    </message>
     <message id="settings_services_mqtt_access">
       <location filename="../../components/listitems/ListMqttAccessSwitch.qml" line="11"/>
       <source>MQTT Access</source>
@@ -8407,12 +7459,6 @@ If the generator is currently running due to a autostart condition, disabling au
       <extracomment>The 'Brief' page, with the side panel opened</extracomment>
       <translation>Rezumat (panou lateral deschis)</translation>
     </message>
-    <message id="startpage_option_overview">
-      <location filename="../../data/StartPageConfiguration.qml" line="37"/>
-      <source>Overview</source>
-      <extracomment>The 'Overview' page</extracomment>
-      <translation type="unfinished">Sitem</translation>
-    </message>
     <message id="startpage_option_levels_tanks">
       <location filename="../../data/StartPageConfiguration.qml" line="43"/>
       <source>Levels (Tanks)</source>
@@ -8431,12 +7477,12 @@ If the generator is currently running due to a autostart condition, disabling au
       <translation>Listă baterii</translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
+      <location filename="../../pages/DialogLayer.qml" line="56"/>
       <source>GX device has been updated</source>
       <translation>Dispozitivul GX a fost actualizat</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
+      <location filename="../../pages/DialogLayer.qml" line="58"/>
       <source>Page will automatically reload in ten seconds to load the latest version.</source>
       <translation>Pagina se va reîncărca automat în zece secunde pentru a încărca cea mai recentă versiune.</translation>
     </message>
@@ -8607,8 +7653,8 @@ Rețineți că acest meniu afișează doar contoarele Carlo Gavazzi conectate pr
       <source>Unit</source>
       <translation>Unitate</translation>
     </message>
-    <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="61"/>
+    <message id="page_settings_fronius_unitid_invalid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
       <source>%1 is not a valid unit number. Use a number between 1-247.</source>
       <translation>%1 nu este un număr de unitate valid. Utilizați un număr cuprins între 1-247.</translation>
     </message>
@@ -8723,11 +7769,6 @@ Rețineți că acest meniu afișează doar contoarele Carlo Gavazzi conectate pr
       <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="66"/>
       <source>Controller Temperature</source>
       <translation>Temperatura controller</translation>
-    </message>
-    <message id="devicelist_motordrive_motordirectioninverted">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
-      <source>Motor Direction Inverted</source>
-      <translation type="unfinished"/>
     </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
@@ -8919,11 +7960,6 @@ Cu o navigare simplificată și un aspect nou, tot ceea ce vă place este acum �
     <message id="welcome_done">
       <location filename="../../pages/welcome/WelcomeView.qml" line="136"/>
       <source>Done</source>
-      <translation type="unfinished">Efectuat</translation>
-    </message>
-    <message id="mk2vsc_state_done">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="20"/>
-      <source>Done</source>
       <translation>Efectuat</translation>
     </message>
     <message id="welcome_next">
@@ -8981,6 +8017,7 @@ Dispozitivul GX poate controla un singur grup electrogen conectat și îl ia pe 
     <message id="settings_tz_etc">
       <location filename="../../pages/settings/PageTzInfo.qml" line="280"/>
       <source>Other</source>
+      <oldsource>Etc</oldsource>
       <translation>Altele</translation>
     </message>
     <message id="ac-in-modeldefault_energy_reverse_x">
@@ -8998,6 +8035,11 @@ Dispozitivul GX poate controla un singur grup electrogen conectat și îl ia pe 
       <location filename="../../src/enums.cpp" line="438"/>
       <source>Unsupported type: %1</source>
       <translation>Tip neacceptat: %1</translation>
+    </message>
+    <message id="common_words_press">
+      <location filename="../../components/CommonWords.qml" line="419"/>
+      <source>Press</source>
+      <translation>Apăsați</translation>
     </message>
     <message id="output_aux_battery_service_changed_dcdc">
       <location filename="../../components/listitems/ListOutputBatteryRadioButtonGroup.qml" line="27"/>
@@ -9138,13 +8180,6 @@ Dispozitivul GX poate controla un singur grup electrogen conectat și îl ia pe 
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="38"/>
       <source>Resetting VE.Bus products</source>
       <translation>Resetarea produselor VE.Bus</translation>
-    </message>
-    <message id="Unknown">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Necunoscut</translation>
     </message>
     <message id="mk2vsc_error_mk2_mk3_comm">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="47"/>
@@ -9450,11 +8485,6 @@ Dispozitivul GX poate controla un singur grup electrogen conectat și îl ia pe 
       <source>Changing the GX Password</source>
       <translation>Schimbarea parolei GX</translation>
     </message>
-    <message id="modaldialog_confirm">
-      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
-      <source>Confirm</source>
-      <translation type="unfinished">Confirmați</translation>
-    </message>
     <message id="settings_security_profile_change_password_description">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="83"/>
       <source>Please enter a new GX password:</source>
@@ -9547,21 +8577,6 @@ Dispozitivul GX poate controla un singur grup electrogen conectat și îl ia pe 
       <source>Modifications installed</source>
       <translation>Modificări instalate</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_modbus">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="28"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">Server Modbus TCP</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_signalk">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="32"/>
-      <source>Signal K</source>
-      <translation type="unfinished">Server de Signal K</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_nodered">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="36"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">Server de Node-RED</translation>
-    </message>
     <message id="pagesettingsgeneral_modificationchecks_running_integrations">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="43"/>
       <source>%1 running integrations</source>
@@ -9637,16 +8652,6 @@ Dispozitivul GX poate controla un singur grup electrogen conectat și îl ia pe 
       <source>Installed and enabled, disables at next boot</source>
       <translation>Instalat și activat, se dezactivează la următoarea pornire</translation>
     </message>
-    <message id="pagesettingssupportstate_firmware_checking">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
-      <source>Checking...</source>
-      <translation type="unfinished">Se verifica...</translation>
-    </message>
-    <message id="pagesettingssupportstate_firmware_unknown">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="166"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Necunoscut</translation>
-    </message>
     <message id="pagesettingssupportstate_support_status">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="228"/>
       <source>Support status</source>
@@ -9668,11 +8673,6 @@ Dispozitivul GX poate controla un singur grup electrogen conectat și îl ia pe 
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="288"/>
       <source>Press 'OK' to disable custom startup scripts and reboot</source>
       <translation>Apăsați 'OK' pentru a dezactiva scripturile de pornire personalizate și a reporni</translation>
-    </message>
-    <message id="pagesettingssupportstate_re_enable_custom_startup_scripts">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="309"/>
-      <source>Re-enable custom startup scripts</source>
-      <translation type="unfinished">Reactivare scripturi de pornire personalizate</translation>
     </message>
     <message id="pagesettingssupportstate_reenable_and_reboot_now">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="322"/>
@@ -9699,11 +8699,6 @@ Dispozitivul GX poate controla un singur grup electrogen conectat și îl ia pe 
       <source>Disable also custom startup scripts?</source>
       <translation>Dezactivați și scripturile de pornire personalizate?</translation>
     </message>
-    <message id="pagesettingssupportstate_integrations">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
-      <source>Integrations</source>
-      <translation type="unfinished">Integrări</translation>
-    </message>
     <message id="pagesettingssupportstate_orange_items_description">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="494"/>
       <source>Items colored orange are supported and provided by Victron Energy, but using them incorrectly can affect system stability. In case of troubleshooting, disable those first.</source>
@@ -9715,7 +8710,7 @@ Dispozitivul GX poate controla un singur grup electrogen conectat și îl ia pe 
       <translation>Conectați un dongle USB Bluetooth compatibil pentru a activa conectivitatea Bluetooth.</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="140"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="142"/>
       <source>BatteryLife state</source>
       <translation>Stare BatteryLife</translation>
     </message>
@@ -9723,23 +8718,6 @@ Dispozitivul GX poate controla un singur grup electrogen conectat și îl ia pe 
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="33"/>
       <source>Device Integrations</source>
       <translation>Integrări dispozitive</translation>
-    </message>
-    <message id="pagesettingsintegrations_modbus_tcp_server">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="201"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">Server Modbus TCP</translation>
-    </message>
-    <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="226"/>
-      <location filename="../../pages/settings/PageSettingsSignalK.qml" line="18"/>
-      <source>Signal K</source>
-      <translation type="unfinished">Server de Signal K</translation>
-    </message>
-    <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="241"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">Server de Node-RED</translation>
     </message>
     <message id="settings_venusos_large_documentation">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="267"/>
@@ -9749,6 +8727,7 @@ Dispozitivul GX poate controla un singur grup electrogen conectat și îl ia pe 
     <message id="settings_modbus_enable_modbus_tcp">
       <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
       <source>Enable Modbus TCP Server</source>
+      <oldsource>Enable Modbus/TCP</oldsource>
       <translation>Activare Server Modbus TCP</translation>
     </message>
     <message id="pagesettingsconnectivity_bluetooth_for_victronconnect_app">
@@ -9842,11 +8821,13 @@ Dispozitivul GX poate controla un singur grup electrogen conectat și îl ia pe 
     <message id="settings_gps_format_kmh">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="93"/>
       <source>Kilometres per hour</source>
+      <oldsource>Kilometers per hour</oldsource>
       <translation>Kilometri pe oră</translation>
     </message>
     <message id="settings_gps_format_ms">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="95"/>
       <source>Metres per second</source>
+      <oldsource>Meters per second</oldsource>
       <translation>Metri pe secundă</translation>
     </message>
     <message id="components_volumeunit_cubic_metres">
@@ -9874,8 +8855,8 @@ Dispozitivul GX poate controla un singur grup electrogen conectat și îl ia pe 
       <source>The Relay can now be found in the devices list</source>
       <translation>Releul poate fi găsit acum în lista de dispozitive</translation>
     </message>
-    <message id="common_words_gx_device_relays">
-      <location filename="../../components/CommonWords.qml" line="223"/>
+    <message id="gx_device_relays">
+      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
       <source>GX device relays</source>
       <translation>Relee dispozitiv GX</translation>
     </message>
@@ -9929,12 +8910,6 @@ Dispozitivul GX poate controla un singur grup electrogen conectat și îl ia pe 
       <extracomment>Forced by app to %1</extracomment>
       <translation>automat</translation>
     </message>
-    <message id="settings_remote_console_forced_by_vrm">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="94"/>
-      <source>VRM</source>
-      <extracomment>Forced by %2 to dark</extracomment>
-      <translation type="unfinished">VRM</translation>
-    </message>
     <message id="settings_remote_console_forced_by_app">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="97"/>
       <source>app</source>
@@ -9984,6 +8959,7 @@ Dispozitivul GX poate controla un singur grup electrogen conectat și îl ia pe 
     <message id="settings_large_access_signal_k">
       <location filename="../../pages/settings/PageSettingsSignalK.qml" line="24"/>
       <source>Access Signal K</source>
+      <oldsource>Access Signal K (local network)</oldsource>
       <translation>Accesează Signal K</translation>
     </message>
     <message id="pagesettingsintegrations_shelly_devices">
@@ -9994,6 +8970,7 @@ Dispozitivul GX poate controla un singur grup electrogen conectat și îl ia pe 
     <message id="settings_large_access_node_red">
       <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
       <source>Access Node-RED</source>
+      <oldsource>Access Node-RED (local network)</oldsource>
       <translation>Accesează Node-RED</translation>
     </message>
     <message id="settings_wifi_access_point_password">
@@ -10061,57 +9038,6 @@ Dispozitivul GX poate controla un singur grup electrogen conectat și îl ia pe 
       <source>Wind charger</source>
       <translation>Încărcător eolian</translation>
     </message>
-    <message id="digitalinputs_type_disabled">
-      <location filename="../../src/enums.cpp" line="192"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Dezactivat</translation>
-    </message>
-    <message id="digitalinputs_state_off">
-      <location filename="../../src/enums.cpp" line="242"/>
-      <source>Off</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Oprit</translation>
-    </message>
-    <message id="digitalinputs_state_on">
-      <location filename="../../src/enums.cpp" line="246"/>
-      <source>On</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Pornit</translation>
-    </message>
-    <message id="digitalinputs_state_ok">
-      <location filename="../../src/enums.cpp" line="266"/>
-      <source>OK</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">In regula</translation>
-    </message>
-    <message id="digitalinputs_state_alarm">
-      <location filename="../../src/enums.cpp" line="270"/>
-      <source>Alarm</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Alarma</translation>
-    </message>
-    <message id="digitalinputs_state_running">
-      <location filename="../../src/enums.cpp" line="274"/>
-      <source>Running</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Functioneaza</translation>
-    </message>
-    <message id="pvinverter_statusCode_running">
-      <location filename="../../src/enums.cpp" line="300"/>
-      <source>Running</source>
-      <extracomment>PV inverter status code</extracomment>
-      <translation type="unfinished">Functioneaza</translation>
-    </message>
-    <message id="solarchargers_state_external control">
-      <location filename="../../src/enums.cpp" line="352"/>
-      <source>External control</source>
-      <translation type="unfinished">Control extern</translation>
-    </message>
-    <message id="switch_state_over_temperature">
-      <location filename="../../src/enums.cpp" line="366"/>
-      <source>Over temperature</source>
-      <translation type="unfinished">Temperatura peste limita</translation>
-    </message>
     <message id="switchable_output_temperature_setpoint">
       <location filename="../../src/enums.cpp" line="398"/>
       <source>Temperature setpoint</source>
@@ -10121,11 +9047,6 @@ Dispozitivul GX poate controla un singur grup electrogen conectat și îl ia pe 
       <location filename="../../src/enums.cpp" line="401"/>
       <source>Stepped switch</source>
       <translation>Comutator în trepte</translation>
-    </message>
-    <message id="switchable_output_slave">
-      <location filename="../../src/enums.cpp" line="408"/>
-      <source>Slave</source>
-      <translation type="unfinished">Secundar</translation>
     </message>
     <message id="switchable_output_dropdown">
       <location filename="../../src/enums.cpp" line="412"/>
@@ -10137,122 +9058,10 @@ Dispozitivul GX poate controla un singur grup electrogen conectat și îl ia pe 
       <source>Basic slider</source>
       <translation>Glisor de bază</translation>
     </message>
-    <message id="switchable_output_rgb_color_wheel">
-      <location filename="../../src/enums.cpp" line="427"/>
-      <source>RGB color wheel</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_cct_color_wheel">
-      <location filename="../../src/enums.cpp" line="431"/>
-      <source>CCT color wheel</source>
-      <extracomment>Correlated Color Temperature color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_rgbw_color_wheel">
-      <location filename="../../src/enums.cpp" line="435"/>
-      <source>RGB + W color wheel</source>
-      <extracomment>RGB + white color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bypassed">
-      <location filename="../../src/enums.cpp" line="484"/>
-      <source>Bypassed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="tank_type_fuel">
-      <location filename="../../src/enums.cpp" line="495"/>
-      <source>Fuel</source>
-      <translation type="unfinished">Combustibil</translation>
-    </message>
-    <message id="tank_type_fresh_water">
-      <location filename="../../src/enums.cpp" line="498"/>
-      <source>Fresh water</source>
-      <translation type="unfinished">Apa dulce</translation>
-    </message>
-    <message id="tank_type_waste_water">
-      <location filename="../../src/enums.cpp" line="501"/>
-      <source>Waste water</source>
-      <translation type="unfinished">Apa reziduala</translation>
-    </message>
-    <message id="tank_type_live_well">
-      <location filename="../../src/enums.cpp" line="504"/>
-      <source>Live well</source>
-      <translation type="unfinished">Live well</translation>
-    </message>
-    <message id="tank_type_oil">
-      <location filename="../../src/enums.cpp" line="507"/>
-      <source>Oil</source>
-      <translation type="unfinished">Ulei</translation>
-    </message>
-    <message id="tank_type_black_water">
-      <location filename="../../src/enums.cpp" line="510"/>
-      <source>Black water</source>
-      <translation type="unfinished">APA REZIDUALA</translation>
-    </message>
-    <message id="tank_type_gasoline">
-      <location filename="../../src/enums.cpp" line="513"/>
-      <source>Gasoline</source>
-      <translation type="unfinished">Benzină</translation>
-    </message>
-    <message id="tank_type_diesel">
-      <location filename="../../src/enums.cpp" line="516"/>
-      <source>Diesel</source>
-      <translation type="unfinished">Motorină</translation>
-    </message>
-    <message id="tank_type_lpg">
-      <location filename="../../src/enums.cpp" line="519"/>
-      <source>LPG</source>
-      <translation type="unfinished">GPL</translation>
-    </message>
-    <message id="tank_type_lng">
-      <location filename="../../src/enums.cpp" line="522"/>
-      <source>LNG</source>
-      <translation type="unfinished">GNL</translation>
-    </message>
-    <message id="tank_type_hydraulic_oil">
-      <location filename="../../src/enums.cpp" line="525"/>
-      <source>Hydraulic oil</source>
-      <translation type="unfinished">Ulei hidraulic</translation>
-    </message>
-    <message id="tank_type_raw_water">
-      <location filename="../../src/enums.cpp" line="528"/>
-      <source>Raw water</source>
-      <translation type="unfinished">Apă crudă</translation>
-    </message>
-    <message id="microgrid_mode_hybrid_droop">
-      <location filename="../../src/enums.cpp" line="539"/>
-      <source>Hybrid droop</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_following">
-      <location filename="../../src/enums.cpp" line="542"/>
-      <source>Grid-following</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_forming">
-      <location filename="../../src/enums.cpp" line="545"/>
-      <source>Grid-forming</source>
-      <translation type="unfinished"/>
-    </message>
     <message id="switchable_output_three_state_switch">
       <location filename="../../src/enums.cpp" line="421"/>
       <source>Three-state switch</source>
       <translation>Comutator cu trei stări</translation>
-    </message>
-    <message id="switchable_output_fault">
-      <location filename="../../src/enums.cpp" line="464"/>
-      <source>Fault</source>
-      <translation type="unfinished">Avarie</translation>
-    </message>
-    <message id="switchable_output_running">
-      <location filename="../../src/enums.cpp" line="468"/>
-      <source>Running</source>
-      <translation type="unfinished">Functioneaza</translation>
-    </message>
-    <message id="switchable_output_trip_low_voltage">
-      <location filename="../../src/enums.cpp" line="481"/>
-      <source>Trip low voltage</source>
-      <translation type="unfinished">Dezactivat</translation>
     </message>
     <message id="settings_modbus_tcp_unit_id_note">
       <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="41"/>
@@ -10274,281 +9083,1152 @@ Dispozitivul GX poate controla un singur grup electrogen conectat și îl ia pe 
       <source>Press to refresh</source>
       <translation>Apăsați pentru a reîmprospăta</translation>
     </message>
-    <message id="temperature_type_unknown">
-      <location filename="../../data/EnvironmentInputs.qml" line="65"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Necunoscut</translation>
-    </message>
-    <message id="brief_solar_yield">
-      <location filename="../../pages/BriefSidePanel.qml" line="24"/>
-      <source>Solar yield</source>
-      <translation type="unfinished">Producția de energie solară</translation>
-    </message>
-    <message id="brief_dc_input">
-      <location filename="../../pages/BriefSidePanel.qml" line="214"/>
-      <source>DC input</source>
-      <translation type="unfinished">Intrare CC</translation>
-    </message>
-    <message id="brief_ac_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="257"/>
-      <source>AC Loads</source>
-      <translation type="unfinished">Consumatori AC</translation>
-    </message>
-    <message id="brief_dc_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="284"/>
-      <source>DC Loads</source>
-      <translation type="unfinished">Consumatori DC</translation>
-    </message>
-    <message id="nav_overview">
-      <location filename="../../pages/OverviewPage.qml" line="450"/>
-      <source>Overview</source>
-      <translation type="unfinished">Sitem</translation>
-    </message>
-    <message id="settings_state">
-      <location filename="../../pages/settings/PageCanbusStatus.qml" line="116"/>
-      <source>State</source>
-      <translation type="unfinished">Stare</translation>
-    </message>
-    <message id="inverter_pv">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="56"/>
-      <source>PV</source>
-      <translation type="unfinished">PV</translation>
-    </message>
-    <message id="inverter_total_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="76"/>
-      <source>Total yield</source>
-      <translation type="unfinished">Randament total</translation>
-    </message>
-    <message id="inverter_system_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="84"/>
-      <source>System yield</source>
-      <translation type="unfinished">Randament sistem</translation>
-    </message>
-    <message id="charger_total_pv_power">
-      <location filename="../../pages/solar/SolarDevicePage.qml" line="61"/>
-      <source>Total PV Power</source>
-      <translation type="unfinished">Putere totala PV</translation>
-    </message>
-    <message id="vebus_device_alarm_only">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
-      <source>Alarm only</source>
-      <translation type="unfinished">Doar alarma</translation>
-    </message>
-    <message id="vebus_device_alarms_and_warnings">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
-      <source>Alarms &amp; warnings</source>
-      <translation type="unfinished">Alarma si avertizari</translation>
-    </message>
-    <message id="vebus_device_alarm_group_warning">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
-      <source>Warning</source>
-      <translation type="unfinished">Avertisment</translation>
-    </message>
-    <message id="load_delegate_status">
-      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
-      <source>Status: %1</source>
-      <translation type="unfinished"/>
+    <message id="common_words_total_power">
+      <location filename="../../components/CommonWords.qml" line="540"/>
+      <source>Total power</source>
+      <translation>Putere totală</translation>
     </message>
     <message id="venus_os_gui">
       <location filename="../../Main.qml" line="17"/>
       <source>Venus OS GUI</source>
       <extracomment>Application title</extracomment>
-      <translation type="unfinished"/>
       <extra-Context>only shown on desktop systems</extra-Context>
+      <translation>GUI Venus OS</translation>
+    </message>
+    <message id="load_delegate_status">
+      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
+      <source>Status: %1</source>
+      <translation>Stare: %1</translation>
+    </message>
+    <message id="settings_relay_polarity_relay1">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
+      <source>Polarity (Relay 1)</source>
+      <translation>Polaritate (Releu 1)</translation>
+    </message>
+    <message id="settings_relay_polarity">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
+      <source>Polarity</source>
+      <translation>Polaritate</translation>
+    </message>
+    <message id="settings_relay_polarity_relay2">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
+      <source>Polarity (Relay 2)</source>
+      <translation>Polaritate (Releu 2)</translation>
+    </message>
+    <message id="page_settings_wifi_invalid_password">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
+      <source>Password length must be either 0 or between 10 and 63 characters long</source>
+      <translation>Lungimea parolei trebuie să fie 0 sau între 10 și 63 de caractere</translation>
+    </message>
+    <message id="page_settings_wifi_password_updated">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
+      <source>Password updated</source>
+      <translation>Parola a fost actualizată</translation>
+    </message>
+    <message id="common_words_max">
+      <location filename="../../components/CommonWords.qml" line="315"/>
+      <source>Max</source>
+      <extracomment>Short for Maximum</extracomment>
+      <translation>Maxim</translation>
+    </message>
+    <message id="common_words_min">
+      <location filename="../../components/CommonWords.qml" line="331"/>
+      <source>Min</source>
+      <extracomment>Short for Minimum</extracomment>
+      <translation>Minim</translation>
+    </message>
+    <message id="settings_ess_deprecated">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="321"/>
+      <source>Deprecated settings</source>
+      <translation>Setări depreciate</translation>
+    </message>
+    <message id="settings_ess_max_charge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="328"/>
+      <source>Battery charge limit (% of CCL)</source>
+      <translation>Limită încărcare baterie (% din CCL)</translation>
+    </message>
+    <message id="settings_ess_max_discharge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="339"/>
+      <source>Battery discharge limit (% of DCL)</source>
+      <translation>Limită descărcare baterie (% din DCL)</translation>
+    </message>
+    <message id="vebus_device_bms_message">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
+      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
+      <oldsource>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</oldsource>
+      <translation>Un VE.Bus BMS oprește automat sistemul atunci când este necesar pentru a proteja bateria. Prin urmare, controlul sistemului de pe dispozitivul GX nu este posibil.</translation>
+    </message>
+    <message id="switchable_output_numeric_input">
+      <location filename="../../src/enums.cpp" line="418"/>
+      <source>Numeric input</source>
+      <translation>Intrare numerică</translation>
     </message>
     <message id="autotoggleswitch_disable_auto_mode_info">
       <location filename="../../components/controls/AutoToggleButton.qml" line="34"/>
       <source>Disable Auto mode first</source>
-      <translation type="unfinished"/>
+      <translation>Dezactivați mai întâi modul Auto</translation>
+    </message>
+    <message id="pagesettingsintegrations_venus_os_enable_large_features">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
+      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
+      <translation>Activați firmware-ul Venus OS Large pentru a utiliza Node-RED sau Signal-K</translation>
+    </message>
+    <message id="settings_relays_sensors_tanks">
+      <location filename="../../pages/SettingsPage.qml" line="75"/>
+      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
+      <oldsource>Relays, Sensors, Tanks, PV Inverters, Modbus, MQTT…</oldsource>
+      <translation>Relee, Senzori, Invertoare FV, Modbus, Node-RED</translation>
+    </message>
+    <message id="vebus_device_page_microgrid_parameters">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
+      <source>Microgrid parameters</source>
+      <translation>Parametrii microrețelei</translation>
+    </message>
+    <message id="microgrid_mode_hybrid_droop">
+      <location filename="../../src/enums.cpp" line="539"/>
+      <source>Hybrid droop</source>
+      <translation>Curbă descendentă hibridă</translation>
+    </message>
+    <message id="microgrid_mode_grid_following">
+      <location filename="../../src/enums.cpp" line="542"/>
+      <source>Grid-following</source>
+      <translation>Urmărire rețea</translation>
+    </message>
+    <message id="microgrid_mode_grid_forming">
+      <location filename="../../src/enums.cpp" line="545"/>
+      <source>Grid-forming</source>
+      <translation>Formare rețea</translation>
+    </message>
+    <message id="switchable_output_trip_low_voltage">
+      <location filename="../../src/enums.cpp" line="481"/>
+      <source>Trip low voltage</source>
+      <oldsource>Disabled</oldsource>
+      <translation>Deconectare tensiune joasă</translation>
     </message>
     <message id="microgrid">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="15"/>
       <source>Microgrid</source>
-      <translation type="unfinished"/>
+      <translation>Microrețea</translation>
     </message>
     <message id="page_microgrid_active_mode">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="19"/>
       <source>Active mode</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_microgrid_from_p1_to_p2">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="34"/>
-      <source>%1 %2 to %3 %4</source>
-      <extracomment>Describes a range from one quantity to another, e.g. "30 W to 60 W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
-      <translation type="unfinished"/>
+      <translation>Mod activ</translation>
     </message>
     <message id="page_microgrid_hybrid_droop_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="92"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
       <source>Hybrid droop parameters</source>
-      <translation type="unfinished"/>
+      <translation>Parametrii curbei descendente hibride</translation>
     </message>
     <message id="page_microgrid_reference_active_power_p0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="105"/>
       <source>Reference active power (P&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Putere activă de referință (P&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_frequency_f0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="108"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="112"/>
       <source>Reference frequency (f&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Frecvență de referință (f&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_frequency_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="117"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="119"/>
       <source>Frequency droop slope (droop&lt;sub&gt;fP&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Pantă descendentă a frecvenței (droop&lt;sub&gt;fP&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_reactive_power">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="126"/>
       <source>Reference reactive power (Q&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Putere reactivă de referință (Q&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_voltage">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="135"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="133"/>
       <source>Reference Voltage (U&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Tensiune de referință (U&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_voltage_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="144"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="140"/>
       <source>Voltage droop slope (droop&lt;sub&gt;UQ&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Pantă descendentă a tensiunii (droop&lt;sub&gt;UQ&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_minimum_and_maximum_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="146"/>
       <source>Minimum and maximum parameters</source>
-      <translation type="unfinished"/>
+      <translation>Parametrii minimi și maximi</translation>
     </message>
     <message id="page_microgrid_allowed_active_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="156"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
       <source>Allowed active power range</source>
-      <translation type="unfinished"/>
+      <translation>Interval de putere activă permis</translation>
     </message>
     <message id="page_microgrid_allowed_reactive_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="164"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="159"/>
       <source>Allowed reactive power range</source>
-      <translation type="unfinished"/>
+      <translation>Interval de putere reactivă permis</translation>
     </message>
     <message id="page_microgrid_p_q_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="176"/>
       <source>P-Q direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>Setări de antrenare directă P-Q</translation>
     </message>
     <message id="page_microgrid_active_power_setpoint_p">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="186"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
       <source>Active power setpoint (P)</source>
-      <translation type="unfinished"/>
+      <translation>Punct de referință al puterii active (P)</translation>
     </message>
     <message id="page_microgrid_reactive_power_setpoint_q">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="194"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="188"/>
       <source>Reactive power setpoint (Q)</source>
-      <translation type="unfinished"/>
+      <translation>Punct de referință al puterii reactive (Q)</translation>
     </message>
     <message id="page_microgrid_allowed_frequency_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="202"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="195"/>
       <source>Allowed frequency range</source>
-      <translation type="unfinished"/>
+      <translation>Interval de frecvență permis</translation>
     </message>
     <message id="page_microgrid_allowed_voltage_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="210"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="203"/>
       <source>Allowed voltage range</source>
-      <translation type="unfinished"/>
+      <translation>Interval de tensiune permis</translation>
     </message>
     <message id="page_microgrid_v_f_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="227"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="220"/>
       <source>V-f direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>Setări de antrenare directă V-f</translation>
     </message>
     <message id="page_microgrid_voltage_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="225"/>
       <source>Voltage setpoint (U)</source>
-      <translation type="unfinished"/>
+      <translation>Punct de referință al tensiunii (U)</translation>
     </message>
     <message id="page_microgrid_frequency_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="240"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
       <source>Frequency setpoint (f)</source>
-      <translation type="unfinished"/>
+      <translation>Punct de referință al frecvenței (f)</translation>
     </message>
-    <message id="temperature_slider_current">
-      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
-      <source>Current</source>
-      <extracomment>The current temperature measurement</extracomment>
-      <translation type="unfinished">Intensitate</translation>
+    <message id="pagesettingsintegrations_canopenmotordrive">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
+      <source>CANopen motor drives</source>
+      <translation>Acționări motoare CANopen</translation>
+    </message>
+    <message id="pagesettingsintegrations_ui_plugins">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
+      <source>UI Plugins</source>
+      <translation>Plugin-uri UI</translation>
+    </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
+      <source>Motor Direction Inverted</source>
+      <translation>Direcția motorului inversată</translation>
     </message>
     <message id="page_settings_canopenmotordrive_scan_for_motor_drives">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="31"/>
       <source>Scan for motor drives</source>
-      <translation type="unfinished"/>
+      <translation>Scanează pentru acționări motoare</translation>
     </message>
     <message id="page_settings_canopenmotordrive_discovered_motor_drive_ids">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="39"/>
       <source>Discovered motor drive IDs</source>
-      <translation type="unfinished"/>
+      <translation>ID-uri acționări motoare descoperite</translation>
     </message>
-    <message id="switchableoutput_gx_device_relays">
-      <location filename="../../src/switchableoutput.cpp" line="388"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">Relee dispozitiv GX</translation>
+    <message id="temperature_pm25">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
+      <source>PM2.5</source>
+      <translation>PM2.5</translation>
     </message>
-    <message id="gx_device_relays">
-      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">Relee dispozitiv GX</translation>
+    <message id="temperature_co2">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+      <source>CO₂</source>
+      <translation>CO₂</translation>
     </message>
-    <message id="color_preset">
-      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
-      <source>Preset</source>
-      <translation type="unfinished"/>
+    <message id="temperature_voc">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
+      <source>VOC index</source>
+      <translation>Index COV</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_location">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
-      <source>Add Modbus port and unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_nox">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
+      <source>NOx index</source>
+      <translation>Index NOx</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_unitid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
-      <source>Unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_luminosity">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
+      <source>Luminosity</source>
+      <translation>Luminozitate</translation>
     </message>
-    <message id="page_settings_fronius_unitid_invalid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation type="unfinished">%1 nu este un număr de unitate valid. Utilizați un număr cuprins între 1-247.</translation>
-    </message>
-    <message id="page_settings_fronius_add_modbus_location_button">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
-      <source>Add</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_locations_note">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
-      <source>The default modbus port is 502 and the default unit ID is 126.
-Here you can add additional ports and unit IDs to scan for PV inverters.</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_location_number">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
-      <source>Port/Unit ID %1</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location_description">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
-      <source>Port: %1 (Unit %2)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
-      <source>Remove Modbus port and unit ID?</source>
-      <translation type="unfinished"/>
+    <message id="switchable_output_bypassed">
+      <location filename="../../src/enums.cpp" line="484"/>
+      <source>Bypassed</source>
+      <translation>Ocolit</translation>
     </message>
     <message id="switchableoutput_list_delegate_auto_status">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="84"/>
       <source>Auto (%1)</source>
       <extracomment>%1 = 'On' or 'Off'</extracomment>
-      <translation type="unfinished"/>
+      <translation>Automat (%1)</translation>
     </message>
     <message id="switchableoutput_list_delegate_state_forced">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="100"/>
       <source>Forced</source>
-      <translation type="unfinished"/>
+      <translation>Forțat</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_settings">
+      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
+      <source>Modbus port and unit ID settings</source>
+      <translation>Setări port Modbus și ID unitate</translation>
+    </message>
+    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
+      <source>Integrates with the device list</source>
+      <translation>Se integrează cu lista de dispozitive</translation>
+    </message>
+    <message id="common_words_color">
+      <location filename="../../components/CommonWords.qml" line="136"/>
+      <source>Color</source>
+      <translation>Culoare</translation>
+    </message>
+    <message id="common_words_value_must_be_greater_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="557"/>
+      <source>Value must be greater than start value</source>
+      <translation>Valoarea trebuie să fie mai mare decât valoarea de început</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="566"/>
+      <source>Value must be lower than stop value</source>
+      <translation>Valoarea trebuie să fie mai mică decât valoarea de oprire</translation>
+    </message>
+    <message id="notifications_page_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="43"/>
+      <source>Active Notifications</source>
+      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
+      <translation>Notificări active</translation>
+    </message>
+    <message id="notifications_page_inactive_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="47"/>
+      <source>Inactive Notifications</source>
+      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
+      <translation>Notificări inactive</translation>
+    </message>
+    <message id="notifications_no_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="106"/>
+      <source>No active notifications</source>
+      <translation>Nicio notificare activă</translation>
+    </message>
+    <message id="switchable_output_rgb_color_wheel">
+      <location filename="../../src/enums.cpp" line="427"/>
+      <source>RGB color wheel</source>
+      <translation>Roată de culori RGB</translation>
+    </message>
+    <message id="switchable_output_cct_color_wheel">
+      <location filename="../../src/enums.cpp" line="431"/>
+      <source>CCT color wheel</source>
+      <extracomment>Correlated Color Temperature color wheel</extracomment>
+      <translation>Roată de culori CCT</translation>
+    </message>
+    <message id="switchable_output_rgbw_color_wheel">
+      <location filename="../../src/enums.cpp" line="435"/>
+      <source>RGB + W color wheel</source>
+      <extracomment>RGB + white color wheel</extracomment>
+      <translation>Roată de culori RGB + W</translation>
+    </message>
+    <message id="listlink_show_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="43"/>
+      <source>Show QR code</source>
+      <translation>Afișează codul QR</translation>
+    </message>
+    <message id="listlink_scan_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="52"/>
+      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
+      <extracomment>%1 = url text</extracomment>
+      <oldsource>Scan the QR code with your portable device.&lt;br /&gt;Or insert the link: %1</oldsource>
+      <translation>Deschideți codul QR pentru a-l scana cu dispozitivul portabil.&lt;br /&gt;Sau introduceți linkul: %1</translation>
+    </message>
+    <message id="color_preset">
+      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
+      <source>Preset</source>
+      <translation>Presetare</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
+      <source>Add Modbus port and unit ID</source>
+      <translation>Adaugă port Modbus și ID unitate</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_unitid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
+      <source>Unit ID</source>
+      <translation>ID unitate</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location_button">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
+      <source>Add</source>
+      <translation>Adaugă</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_locations_note">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
+      <source>The default modbus port is 502 and the default unit ID is 126.
+Here you can add additional ports and unit IDs to scan for PV inverters.</source>
+      <translation>Portul Modbus implicit este 502, iar ID-ul unității implicit este 126.
+Aici puteți adăuga porturi și ID-uri de unitate suplimentare pentru a căuta invertoare fotovoltaice.</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_location_number">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
+      <source>Port/Unit ID %1</source>
+      <translation>Port/ID unitate %1</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location_description">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
+      <source>Port: %1 (Unit %2)</source>
+      <translation>Port: %1 (Unitate %2)</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
+      <source>Remove Modbus port and unit ID?</source>
+      <translation>Elimină portul Modbus și ID-ul unității?</translation>
+    </message>
+    <message id="devicelist_tankshape_edit_point">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="182"/>
+      <source>Edit point %1</source>
+      <extracomment>%1 = which point is being edited, a number like "1" or "2"</extracomment>
+      <translation></translation>
+    </message>
+    <message id="settings_canbus_vecan">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
+      <source>VE.Can (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_250">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <source>VE.Can &amp; CANopen E-drive (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_500">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
+      <source>CANopen E-drive (500 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="page_microgrid_from_p1_to_p2">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="39"/>
+      <source>%1%2 to %3%4</source>
+      <extracomment>Describes a range from one quantity to another, e.g. "30W to 60W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
+      <translation></translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAfricaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
+      <source>Morocco Standard Time</source>
+      <translation>Ora standard Maroc</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
+      <source>W. Central Africa Standard Time</source>
+      <translation>Ora standard Africa Centrală si de Vest</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
+      <source>South Africa Standard Time</source>
+      <translation>Ora standard Africa de Sud</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
+      <source>Namibia Standard Time</source>
+      <translation>Ora standard Namibia</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
+      <source>Egypt Standard Time</source>
+      <translation>Ora standard Egipt</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
+      <source>E. Africa Standard Time</source>
+      <translation>Ora standard Africa de Est</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAmericaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
+      <source>Argentina Standard Time</source>
+      <translation>Ora standard Argentina</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
+      <source>E. South America Standard Time</source>
+      <translation>Ora standard America de Sud si de Est</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
+      <source>Greenland Standard Time</source>
+      <translation>Ora standard Groenlanda</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
+      <source>Montevideo Standard Time</source>
+      <translation>Ora standard Montevideo</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
+      <source>Newfoundland Standard Time</source>
+      <translation>Ora standard Newfoundland</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
+      <source>SA Eastern Standard Time</source>
+      <translation>Ora standard SA de Est</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
+      <source>Atlantic Standard Time</source>
+      <translation>Ora standard Atlantic</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
+      <source>Central Brazilian Standard Time</source>
+      <translation>Ora standard Brazilia Centrala</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>Ora standard Pacific SA</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
+      <source>Paraguay Standard Time</source>
+      <translation>Ora standard Paraguay</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
+      <source>SA Western Standard Time</source>
+      <translation>Ora standard SA de Vest</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
+      <source>Venezuela Standard Time</source>
+      <translation>Ora standard Venezuela</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
+      <source>Eastern Standard Time</source>
+      <translation>Ora standard de Est</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
+      <source>SA Pacific Standard Time</source>
+      <translation>Ora standard SA Pacific</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
+      <source>US Eastern Standard Time</source>
+      <translation>Ora standard Statele Unite de Est</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
+      <source>Canada Central Standard Time</source>
+      <translation>Ora standard Canada Centrala</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
+      <source>Central America Standard Time</source>
+      <translation>Ora standard America Centrala</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
+      <source>Central Standard Time (Mexico)</source>
+      <translation>Ora standard Centrala (Mexic)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
+      <source>Central Standard Time</source>
+      <translation>Ora standard Centrala</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
+      <source>Mountain Standard Time (Mexico)</source>
+      <translation>Ora standard montana (Mexic)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
+      <source>Mountain Standard Time</source>
+      <translation>Ora standard montana</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
+      <source>US Mountain Standard Time</source>
+      <translation>Ora standard montana Statele Unite</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
+      <source>Pacific Standard Time (Mexico)</source>
+      <translation>Ora standard Pacific (Mexic)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
+      <source>Pacific Standard Time</source>
+      <translation>Ora standard Pacific</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
+      <source>Alaskan Standard Time</source>
+      <translation>Ora standard Alaska</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
+      <source>Hawaii-Aleutian</source>
+      <translation>Ora standard Hawaii-Aleutian</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
+      <source>Atlantic Daylight Time</source>
+      <translation>Ora de vară atlantică</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAntarcticaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+      <source>New Zealand Standard Time</source>
+      <translation>Ora standard Noua Zeelanda</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>Ora standard Pacific Central</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+      <source>West Pacific Standard Time</source>
+      <translation>Ora standard Pacific de Vest</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+      <source>W. Australia Standard Time</source>
+      <translation>Ora standard Australia de Vest</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+      <source>SE Asia Standard Time</source>
+      <translation>Ora standard Asia SE</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+      <source>Central Asia Standard Time</source>
+      <translation>Ora standard Asia Centrală</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+      <source>West Asia Standard Time</source>
+      <translation>Ora standard Asia de Vest</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+      <source>E. Africa Standard Time</source>
+      <translation>Ora standard Africa de Est</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>Ora standard Pacific SA</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+      <source>SA Western Standard Time</source>
+      <translation>Ora standard SA de Vest</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzArcticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
+      <source>W. Europe Standard Time</source>
+      <translation>Ora Europei de Vest</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAsiaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
+      <source>Kamchatka Standard Time</source>
+      <translation>Ora standard Kamceatka</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
+      <source>Magadan Standard Time</source>
+      <translation>Ora standard Magadan</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
+      <source>Vladivostok Standard Time</source>
+      <translation>Ora standard Vladivostok</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
+      <source>Yakutsk Standard Time</source>
+      <translation>Ora standard Yakutsk</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
+      <source>Tokyo Standard Time</source>
+      <translation>Ora standard Tokyo</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
+      <source>Korea Standard Time</source>
+      <translation>Ora standard Coreea</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
+      <source>Singapore Standard Time</source>
+      <translation>Ora standard Singapore</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
+      <source>Ulaanbaatar Standard Time</source>
+      <translation>Ora standard Ulaanbaatar</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
+      <source>Taipei Standard Time</source>
+      <translation>Ora standard Taipei</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
+      <source>North Asia East Standard Time</source>
+      <translation>Ora standard Asia de Nord-Est</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
+      <source>China Standard Time</source>
+      <translation>Ora standard China</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
+      <source>SE Asia Standard Time</source>
+      <translation>Ora standard Asia SE</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
+      <source>North Asia Standard Time</source>
+      <translation>Ora standard Asia de Nord</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
+      <source>Myanmar Standard Time</source>
+      <translation>Ora standard Myanmar</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
+      <source>N. Central Asia Standard Time</source>
+      <translation>Ora standard Asia Centrală-Nord</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
+      <source>Central Asia Standard Time</source>
+      <translation>Ora standard Asia Centrală</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
+      <source>Bangladesh Standard Time</source>
+      <translation>Ora standard Bangladesh</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
+      <source>Nepal Standard Time</source>
+      <translation>Ora standard Nepal</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
+      <source>Sri Lanka Standard Time</source>
+      <translation>Ora standard Sri Lanka</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
+      <source>India Standard Time</source>
+      <translation>Ora standard India</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
+      <source>West Asia Standard Time</source>
+      <translation>Ora standard Asia de Vest</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
+      <source>Pakistan Standard Time</source>
+      <translation>Ora standard Pakistan</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
+      <source>Ekaterinburg Standard Time</source>
+      <translation>Ora standard Ekaterinburg</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
+      <source>Georgian Standard Time</source>
+      <translation>Ora standard Georgia</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
+      <source>Caucasus Standard Time</source>
+      <translation>Ora standard Caucaz</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
+      <source>Azerbaijan Standard Time</source>
+      <translation>Ora standard Azerbaijan</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
+      <source>Arabian Standard Time</source>
+      <translation>Ora standard Araba</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
+      <source>Afghanistan Standard Time</source>
+      <translation>Ora standard Afghanistan</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
+      <source>Iran Standard Time</source>
+      <translation>Ora standard Iran</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
+      <source>Arabic Standard Time</source>
+      <translation>Ora standard Araba</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
+      <source>Arab Standard Time</source>
+      <translation>Ora standard Araba</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
+      <source>Syria Standard Time</source>
+      <translation>Ora standard Syria</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
+      <source>Middle East Standard Time</source>
+      <translation>Ora standard Orientul Mijlociu</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
+      <source>Jordan Standard Time</source>
+      <translation>Ora standard Iordania</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
+      <source>Israel Standard Time</source>
+      <translation>Ora standard Israel</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAtlanticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+      <source>Greenwich Standard Time</source>
+      <translation>Greenwich Mean Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+      <source>Azores Standard Time</source>
+      <translation>Ora standard Azore</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+      <source>Cape Verde Standard Time</source>
+      <translation>Ora standard Capul Verde</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
+      <source>Mid-Atlantic Standard Time</source>
+      <translation>Ora standard Atlantic Central</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAustraliaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+      <source>Tasmania Standard Time</source>
+      <translation>Ora standard Tazmania</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+      <source>E. Australia Standard Time</source>
+      <translation>Ora standard Australia de Est</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+      <source>AUS Eastern Standard Time</source>
+      <translation>Ora standard AUS de Est</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+      <source>Cen. Australia Standard Time</source>
+      <translation>Ora standard Australia Centrala</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+      <source>AUS Central Standard Time</source>
+      <translation>Ora standard AUS Centrala</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+      <source>W. Australia Standard Time</source>
+      <translation>Ora standard Australia de Vest</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEtcData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
+      <source>GMT +12</source>
+      <translation>GMT +12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
+      <source>GMT -02</source>
+      <translation>GMT -02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
+      <source>GMT -11</source>
+      <translation>GMT -11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
+      <source>GMT -13</source>
+      <translation>GMT -13</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
+      <source>GMT -12</source>
+      <translation>GMT -12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
+      <source>GMT -10</source>
+      <translation>GMT -10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
+      <source>GMT -09</source>
+      <translation>GMT -09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
+      <source>GMT -08</source>
+      <translation>GMT -08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
+      <source>GMT -07</source>
+      <translation>GMT -07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
+      <source>GMT -06</source>
+      <translation>GMT -06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
+      <source>GMT -05</source>
+      <translation>GMT -05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
+      <source>GMT -04</source>
+      <translation>GMT -04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
+      <source>GMT -03</source>
+      <translation>GMT -03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
+      <source>GMT -01</source>
+      <translation>GMT -01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
+      <source>GMT</source>
+      <translation>GMT</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
+      <source>GMT +01</source>
+      <translation>GMT +01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
+      <source>GMT +02</source>
+      <translation>GMT +02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
+      <source>GMT +03</source>
+      <translation>GMT +03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
+      <source>GMT +04</source>
+      <translation>GMT +04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
+      <source>GMT +05</source>
+      <translation>GMT +05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
+      <source>GMT +06</source>
+      <translation>GMT +06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
+      <source>GMT +07</source>
+      <translation>GMT +07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
+      <source>GMT +08</source>
+      <translation>GMT +08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
+      <source>GMT +09</source>
+      <translation>GMT +09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
+      <source>GMT +10</source>
+      <translation>GMT +10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
+      <source>GMT +11</source>
+      <translation>GMT +11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
+      <source>UTC</source>
+      <translation>UTC</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEuropeData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
+      <source>GMT Standard Time</source>
+      <translation>Ora GMT</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
+      <source>Central Europe Standard Time</source>
+      <translation>Ora Europei Centrale</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
+      <source>Central European Standard Time</source>
+      <translation>Ora Central Europeana</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
+      <source>Romance Standard Time</source>
+      <translation>Ora standard Romance</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
+      <source>W. Europe Standard Time</source>
+      <translation>Ora Europei de Vest</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
+      <source>E. Europe Standard Time</source>
+      <translation>Ora Europei de Est</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
+      <source>FLE Standard Time</source>
+      <translation>Ora standard FLE</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
+      <source>GTB Standard Time</source>
+      <translation>Ora standard GTB</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
+      <source>Belarus Standard Time</source>
+      <translation>Ora standard Belarus</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
+      <source>Russian Standard Time</source>
+      <translation>Ora Standard Rusă</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
+      <source>Turkey Standard Time</source>
+      <translation>Ora standard Turcia</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzIndianData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
+      <source>Mauritius Standard Time</source>
+      <translation>Ora standard Mauritius</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
+      <source>Christmas Island Standard Time</source>
+      <translation>Ora standard a Insulei Crăciunului</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzPacificData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
+      <source>Tonga Standard Time</source>
+      <translation>Ora standard Tonga</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
+      <source>Fiji Standard Time</source>
+      <translation>Ora Standard Fiji</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
+      <source>New Zealand Standard Time</source>
+      <translation>Ora standard Noua Zeelanda</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>Ora standard Pacific Central</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
+      <source>West Pacific Standard Time</source>
+      <translation>Ora standard Pacific de Vest</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
+      <source>Samoa Standard Time</source>
+      <translation>Samoa Ora Standard</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
+      <source>Hawaiian Standard Time</source>
+      <translation>Ora standard Hawaii</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
+      <source>Easter Island Standard Time</source>
+      <translation>Ora standard a Insulei Paștelui</translation>
     </message>
   </context>
   <context>
@@ -12177,838 +11857,6 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
     </message>
   </context>
   <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>Ora standard Maroc</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>Ora standard Africa Centrală si de Vest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>Ora standard Africa de Sud</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>Ora standard Namibia</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>Ora standard Egipt</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Ora standard Africa de Est</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>Ora standard Argentina</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>Ora standard America de Sud si de Est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>Ora standard Groenlanda</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>Ora standard Montevideo</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>Ora standard Newfoundland</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>Ora standard SA de Est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Atlantic Standard Time</source>
-      <translation>Ora standard Atlantic</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>Ora standard Brazilia Centrala</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Ora standard Pacific SA</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>Paraguay Standard Time</source>
-      <translation>Ora standard Paraguay</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>SA Western Standard Time</source>
-      <translation>Ora standard SA de Vest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Venezuela Standard Time</source>
-      <translation>Ora standard Venezuela</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>Eastern Standard Time</source>
-      <translation>Ora standard de Est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>Ora standard SA Pacific</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>US Eastern Standard Time</source>
-      <translation>Ora standard Statele Unite de Est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Canada Central Standard Time</source>
-      <translation>Ora standard Canada Centrala</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central America Standard Time</source>
-      <translation>Ora standard America Centrala</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>Ora standard Centrala (Mexic)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Central Standard Time</source>
-      <translation>Ora standard Centrala</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>Ora standard montana (Mexic)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>Mountain Standard Time</source>
-      <translation>Ora standard montana</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>US Mountain Standard Time</source>
-      <translation>Ora standard montana Statele Unite</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>Ora standard Pacific (Mexic)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Pacific Standard Time</source>
-      <translation>Ora standard Pacific</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Alaskan Standard Time</source>
-      <translation>Ora standard Alaska</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>Ora standard Hawaii-Aleutian</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Daylight Time</source>
-      <translation>Ora de vară atlantică</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Ora standard Noua Zeelanda</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Ora standard Pacific Central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Ora standard Pacific de Vest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Ora standard Australia de Vest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Ora standard Asia SE</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Ora standard Asia Centrală</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>Ora standard Asia de Vest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Ora standard Africa de Est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Ora standard Pacific SA</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>Ora standard SA de Vest</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Ora Europei de Vest</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>Ora standard Kamceatka</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>Ora standard Magadan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>Ora standard Vladivostok</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>Ora standard Yakutsk</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>Ora standard Tokyo</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>Ora standard Coreea</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>Ora standard Singapore</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>Ora standard Ulaanbaatar</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>Ora standard Taipei</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>Ora standard Asia de Nord-Est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>Ora standard China</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Ora standard Asia SE</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>Ora standard Asia de Nord</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>Ora standard Myanmar</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>Ora standard Asia Centrală-Nord</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Ora standard Asia Centrală</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>Ora standard Bangladesh</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>Ora standard Nepal</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>Ora standard Sri Lanka</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>Ora standard India</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>Ora standard Asia de Vest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>Ora standard Pakistan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>Ora standard Ekaterinburg</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>Ora standard Georgia</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>Ora standard Caucaz</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>Ora standard Azerbaijan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>Ora standard Araba</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>Ora standard Afghanistan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>Ora standard Iran</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>Ora standard Araba</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>Ora standard Araba</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>Ora standard Syria</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>Ora standard Orientul Mijlociu</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>Ora standard Iordania</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>Ora standard Israel</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>Greenwich Mean Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>Ora standard Azore</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>Ora standard Capul Verde</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>Ora standard Atlantic Central</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>Ora standard Tazmania</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>Ora standard Australia de Est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>Ora standard AUS de Est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>Ora standard Australia Centrala</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>Ora standard AUS Centrala</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Ora standard Australia de Vest</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
-      <source>GMT +12</source>
-      <translation>GMT +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
-      <source>GMT -02</source>
-      <translation>GMT -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT -13</source>
-      <translation>GMT -13</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT -12</source>
-      <translation>GMT -12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -10</source>
-      <translation>GMT -10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -09</source>
-      <translation>GMT -09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>GMT -08</source>
-      <translation>GMT -08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
-      <source>GMT -07</source>
-      <translation>GMT -07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
-      <source>GMT -06</source>
-      <translation>GMT -06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
-      <source>GMT -05</source>
-      <translation>GMT -05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
-      <source>GMT -04</source>
-      <translation>GMT -04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
-      <source>GMT -03</source>
-      <translation>GMT -03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
-      <source>GMT -01</source>
-      <translation>GMT -01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
-      <source>GMT</source>
-      <translation>GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
-      <source>GMT +01</source>
-      <translation>GMT +01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
-      <source>GMT +02</source>
-      <translation>GMT +02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
-      <source>GMT +03</source>
-      <translation>GMT +03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
-      <source>GMT +04</source>
-      <translation>GMT +04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
-      <source>GMT +05</source>
-      <translation>GMT +05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
-      <source>GMT +06</source>
-      <translation>GMT +06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
-      <source>GMT +07</source>
-      <translation>GMT +07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
-      <source>GMT +08</source>
-      <translation>GMT +08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
-      <source>GMT +09</source>
-      <translation>GMT +09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
-      <source>GMT +10</source>
-      <translation>GMT +10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
-      <source>GMT +11</source>
-      <translation>GMT +11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
-      <source>UTC</source>
-      <translation>UTC</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>Ora GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>Ora Europei Centrale</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>Ora Central Europeana</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>Ora standard Romance</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Ora Europei de Vest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>Ora Europei de Est</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>Ora standard FLE</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>Ora standard GTB</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>Ora standard Belarus</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>Ora Standard Rusă</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>Ora standard Turcia</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>Ora standard Mauritius</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>Ora standard a Insulei Crăciunului</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>Ora standard Tonga</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>Ora Standard Fiji</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Ora standard Noua Zeelanda</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Ora standard Pacific Central</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Ora standard Pacific de Vest</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>Samoa Ora Standard</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>Ora standard Hawaii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>Ora standard a Insulei Paștelui</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation type="unfinished">Eroare interna</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation type="unfinished"/>
-    </message>
-  </context>
-  <context>
     <name>Wakespeed</name>
     <message>
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
@@ -13185,6 +12033,119 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
       <source>DC/DC misconfiguration</source>
       <translation>Configurare greșită CD/CD</translation>
+    </message>
+  </context>
+  <context>
+    <name>VebusError</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+      <source>Device switched off</source>
+      <translation>Dispozitiv oprit</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+      <source>Mixed old/new MK2</source>
+      <translation>MK2 vechi/nou amestecat</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+      <source>Expected devices error</source>
+      <translation>Eroare dispozitive așteptate</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+      <source>No other device detected</source>
+      <translation>Niciun alt dispozitiv detectat</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+      <source>Overvoltage on AC-out</source>
+      <translation>Supratensiune pe AC-out</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+      <source>DDC program error</source>
+      <translation>Eroare program DDC</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+      <source>VE.Bus BMS without assistant</source>
+      <translation>VE.Bus BMS fără asistent</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+      <source>Ground relay test failed</source>
+      <translation>Testul releului de împământare a eșuat</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+      <source>System time sync error</source>
+      <translation>Eroare de sincronizare a orei sistemului</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+      <source>Grid relay test fault</source>
+      <translation>Defecțiune test releu rețea</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+      <source>Config mismatch with 2nd mcu</source>
+      <translation>Nepotrivire configurație cu al 2-lea mcu</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+      <source>Device transmit error</source>
+      <translation>Eroare de transmisie dispozitiv</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+      <source>Awaiting configuration or dongle missing</source>
+      <translation>Așteaptă configurare sau lipsește dongle-ul</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+      <source>Phase master missing</source>
+      <translation>Lipsește master-ul de fază</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+      <source>Overvoltage has occurred</source>
+      <translation>A apărut o supratensiune</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+      <source>Slave does not have AC input!</source>
+      <translation>Slave-ul nu are intrare AC!</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+      <source>Device can't be slave</source>
+      <translation>Dispozitivul nu poate fi slave</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+      <source>System protection initiated</source>
+      <translation>Protecția sistemului a fost inițiată</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+      <source>Firmware incompatibiltiy</source>
+      <translation>Incompatibilitate firmware</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+      <source>Internal error</source>
+      <translation>Eroare internă</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+      <source>Failing relay test prevents connection</source>
+      <translation>Testul releului eșuat împiedică conectarea</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+      <source>VE.Bus error</source>
+      <translation>Eroare VE.Bus</translation>
     </message>
   </context>
 </TS>

--- a/i18n/venus-gui-v2_ru.ts
+++ b/i18n/venus-gui-v2_ru.ts
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="ru">
   <context>
-    <name/>
+    <name></name>
     <message id="switchable_output_disabled">
       <location filename="../../src/enums.cpp" line="478"/>
       <source>Disabled</source>
@@ -22,6 +22,7 @@
     <message id="solarchargers_state_off">
       <location filename="../../src/enums.cpp" line="331"/>
       <source>Off</source>
+      <extracomment>Digital input state</extracomment>
       <translation>Выкл</translation>
     </message>
     <message id="common_words_auto">
@@ -52,18 +53,25 @@
     <message id="settings_startpage_none">
       <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
       <source>None</source>
+      <extracomment>Indicates no phase</extracomment>
       <translation>Нет</translation>
     </message>
     <message id="common_words_position_ac">
       <location filename="../../components/CommonWords.qml" line="416"/>
       <source>Position</source>
-      <extracomment>AC input or output position</extracomment>
+      <extracomment>EVCS AC input/output position</extracomment>
       <translation>Положение</translation>
     </message>
     <message id="settings_minmax_speed">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="193"/>
       <source>Speed</source>
+      <extracomment>A speed measurement value</extracomment>
       <translation>Скорость</translation>
+    </message>
+    <message id="common_words_state">
+      <location filename="../../components/CommonWords.qml" line="502"/>
+      <source>State</source>
+      <translation>Состояние</translation>
     </message>
     <message id="settings_firmware_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="67"/>
@@ -101,8 +109,8 @@
       <source>Solar yield</source>
       <translation>Выход солнечной энергии</translation>
     </message>
-    <message id="ess_state_external_control">
-      <location filename="../../data/Ess.qml" line="41"/>
+    <message id="inverters_state_externalccontrol">
+      <location filename="../../data/System.qml" line="183"/>
       <source>External control</source>
       <translation>Внешнее управление</translation>
     </message>
@@ -140,6 +148,11 @@
       <location filename="../../components/CommonWords.qml" line="203"/>
       <source>ESS</source>
       <translation>ESS</translation>
+    </message>
+    <message id="pagesettingsconnectivity_ethernet">
+      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
+      <source>Ethernet</source>
+      <translation>Ethernet</translation>
     </message>
     <message id="pagesettingsconnectivity_wifi">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="28"/>
@@ -262,11 +275,6 @@
       <source>Name</source>
       <translation>Имя</translation>
     </message>
-    <message id="settings_deviceinfo_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="38"/>
-      <source>Name</source>
-      <translation type="unfinished">Имя</translation>
-    </message>
     <message id="settings_deviceinfo_product_id">
       <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
       <source>Product ID</source>
@@ -327,15 +335,20 @@
       <source>Daily run time</source>
       <translation>Ежедневное время работы</translation>
     </message>
+    <message id="common_words_value_must_be_greater_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="560"/>
+      <source>Value must be greater than stop value</source>
+      <translation>Значение должно быть выше, чем конечное значение</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="563"/>
+      <source>Value must be lower than start value</source>
+      <translation>Значение должно быть ниже, чем начальное значение</translation>
+    </message>
     <message id="settings_minmax_acout_max_power">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="124"/>
       <source>AC output</source>
       <translation>AC выход</translation>
-    </message>
-    <message id="ac_output">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="15"/>
-      <source>AC output</source>
-      <translation type="unfinished">AC выход</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
       <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="25"/>
@@ -382,16 +395,6 @@
       <source>Unavailable monitor, set another</source>
       <translation>Батарейный монитор недоступен, выберите другой</translation>
     </message>
-    <message id="page_generator_conditions_battery_monitor">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="42"/>
-      <source>Battery monitor</source>
-      <translation type="unfinished">Батарейный монитор</translation>
-    </message>
-    <message id="page_generator_conditions_unavailable_monitor_set_another">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="44"/>
-      <source>Unavailable monitor, set another</source>
-      <translation type="unfinished">Батарейный монитор недоступен, выберите другой</translation>
-    </message>
     <message id="page_generator_conditions_on_loss_of_communication">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="68"/>
       <source>On loss of communication</source>
@@ -416,11 +419,6 @@
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="105"/>
       <source>Battery SOC</source>
       <translation>Состояние заряда аккумулятора</translation>
-    </message>
-    <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="173"/>
-      <source>Periodic run</source>
-      <translation type="unfinished">Периодическое включение</translation>
     </message>
     <message id="settings_inverter_high_temperature">
       <location filename="../../data/Generators.qml" line="83"/>
@@ -505,7 +503,7 @@
     <message id="settings_gps_speed_kmh">
       <location filename="../../pages/settings/PageGps.qml" line="83"/>
       <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometres per hour</extracomment>
+      <extracomment>GPS speed data, in kilometers per hour</extracomment>
       <translation>%1 км/ч</translation>
     </message>
     <message id="settings_gps_speed_mph">
@@ -523,7 +521,7 @@
     <message id="settings_gps_speed_ms">
       <location filename="../../pages/settings/PageGps.qml" line="95"/>
       <source>%1 m/s</source>
-      <extracomment>GPS speed data, in metres per second</extracomment>
+      <extracomment>GPS speed data, in meters per second</extracomment>
       <translation>%1 м/с</translation>
     </message>
     <message id="settings_gps_course">
@@ -580,21 +578,6 @@
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="64"/>
       <source>%1 (Output %2)</source>
       <translation>%1 (Выход %2)</translation>
-    </message>
-    <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">Активный мониторинг батареи</translation>
-    </message>
-    <message id="settings_batteries_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="101"/>
-      <source>Name</source>
-      <translation type="unfinished">Имя</translation>
-    </message>
-    <message id="settings_batteries_enter_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="103"/>
-      <source>Enter name</source>
-      <translation type="unfinished">Введите имя</translation>
     </message>
     <message id="settings_briefview_center_active_battery_monitor">
       <location filename="../../components/listitems/ListBriefCenterDetails.qml" line="27"/>
@@ -656,45 +639,25 @@
       <source>CAN-bus profile</source>
       <translation>Профиль CAN-шины</translation>
     </message>
-    <message id="settings_disabled">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="31"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Отключено</translation>
-    </message>
-    <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; Lynx Ion BMS (250 кбит/с)</translation>
-    </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
       <location filename="../../pages/settings/CanbusProfile.qml" line="42"/>
       <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
       <translation>VE.Can &amp; CAN-bus BMS (250 кбит/с)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
       <source>Oceanvolt (250 kbit/s)</source>
       <translation>Oceanvolt (250 кбит/с)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
       <source>RV-C (250 kbit/s)</source>
       <translation>RV-C (250 кбит/с)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
       <source>Up, but no services (250 kbit/s)</source>
       <translation>Вверх, но без услуг (250 кбит/с)</translation>
-    </message>
-    <message id="settings_canopen_motordrive_250">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
-      <source>CANopen Motor drive (250 kbit/s)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_canopen_motordrive_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
-      <source>CANopen Motor drive (500 kbit/s)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_devices">
       <location filename="../../components/CommonWords.qml" line="166"/>
@@ -731,11 +694,6 @@
       <source>Check Unique id numbers</source>
       <translation>Проверка уникальных идентификационных номеров</translation>
     </message>
-    <message id="settings_canbus_unique_id_press_to_check">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Press to check</source>
-      <translation type="unfinished">Нажмите для проверки</translation>
-    </message>
     <message id="settings_canbus_unique_id_conflict">
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="125"/>
       <source>There is another device connected with this unique number, please select a new number.</source>
@@ -745,11 +703,6 @@
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="133"/>
       <source>OK: No other device is connected with this unique number.</source>
       <translation>ОК: ни одно другое устройство не связано с этим уникальным номером.</translation>
-    </message>
-    <message id="pagesettingsintegrations_canopenmotordrive">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
-      <source>CANopen motor drives</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_network_status">
       <location filename="../../components/CommonWords.qml" line="349"/>
@@ -884,11 +837,6 @@
       <source>Unavailable sensor, set another</source>
       <translation>Датчик недоступен, установите другой</translation>
     </message>
-    <message id="settings_system_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="81"/>
-      <source>Unavailable sensor, set another</source>
-      <translation type="unfinished">Датчик недоступен, установите другой</translation>
-    </message>
     <message id="settings_dvcc_used_sensor">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="120"/>
       <source>Used sensor</source>
@@ -945,12 +893,6 @@
       <source>Auto selected</source>
       <translation>Автоматический выбор</translation>
     </message>
-    <message id="settings_dvcc_auto_selected_none">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="208"/>
-      <source>None</source>
-      <extracomment>Indicates no option is selected</extracomment>
-      <translation type="unfinished">Нет</translation>
-    </message>
     <message id="settings_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
       <source>Build date/time</source>
@@ -986,12 +928,6 @@
       <source>Installing %1</source>
       <extracomment>%1 = firmware version</extracomment>
       <translation>Установка %1</translation>
-    </message>
-    <message id="settings_firmware_offline_press_to_install">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">Нажмите обновить до %1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="90"/>
@@ -1062,12 +998,6 @@
       <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
       <translation>Устанавливается %1%2 %</translation>
     </message>
-    <message id="settings_firmware_online_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="86"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">Устанавливается %1...</translation>
-    </message>
     <message id="settings_firmware_update_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="109"/>
       <source>Update build date/time</source>
@@ -1097,11 +1027,6 @@
       <location filename="../../pages/settings/PageSettingsFronius.qml" line="56"/>
       <source>TCP port</source>
       <translation>Порт TCP</translation>
-    </message>
-    <message id="page_settings_fronius_modbus_settings">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
-      <source>Modbus port and unit ID settings</source>
-      <translation type="unfinished"/>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
       <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
@@ -1153,16 +1078,6 @@
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="64"/>
       <source>AC-Out MP</source>
       <translation>AC-Out MP</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="52"/>
-      <source>AC-In1 L%1</source>
-      <translation type="unfinished">AC-In1 L%1</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="56"/>
-      <source>AC-In1 --</source>
-      <translation type="unfinished">AC-In1...</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="70"/>
@@ -1330,12 +1245,6 @@
       <source>Reset service timer</source>
       <translation>Сброс таймера обслуживания</translation>
     </message>
-    <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
-      <source>Volume</source>
-      <extracomment>Title for a list of units of volume (e.g. cubic metres, litres, gallons)</extracomment>
-      <translation type="unfinished">Объем</translation>
-    </message>
     <message id="settings_gps_format">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="69"/>
       <source>Format</source>
@@ -1438,42 +1347,6 @@ If that doesn't work, check sim-card in a phone to make sure that there is credi
       <source>Wrong PIN</source>
       <translation>Неверный PIN-код</translation>
     </message>
-    <message id="page_settings_gsm_ok">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>OK</source>
-      <translation type="unfinished">Ok</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="128"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">Неизвестная ошибка</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_state">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="153"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Неизвестно</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_value">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="182"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Неизвестно</translation>
-    </message>
-    <message id="page_settings_gsm_offline">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="173"/>
-      <source>Offline</source>
-      <translation type="unfinished">Оффлайн</translation>
-    </message>
-    <message id="page_settings_gsm_connecting">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="176"/>
-      <source>Connecting</source>
-      <translation type="unfinished">Подключение</translation>
-    </message>
-    <message id="page_settings_gsm_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="179"/>
-      <source>Connected</source>
-      <translation type="unfinished">Подключено</translation>
-    </message>
     <message id="page_settings_gsm_pin">
       <location filename="../../pages/settings/PageSettingsGsm.qml" line="191"/>
       <source>PIN</source>
@@ -1530,32 +1403,32 @@ If that doesn't work, check sim-card in a phone to make sure that there is credi
       <translation>Счетик сети</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
       <source>External meter</source>
       <translation>Внешний замер</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="67"/>
       <source>Inverter/Charger</source>
       <translation>Инвертор/зарядное устройство</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
       <source>Multiphase regulation</source>
       <translation>Многофазное регулирование</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="91"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
       <source>Total of all phases</source>
       <translation>Общее всех фаз</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="95"/>
       <source>Individual phase</source>
       <translation>Отдельная фаза</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="99"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="101"/>
       <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
@@ -1564,68 +1437,13 @@ CAUTION: Use only if required by the utility provider.</source>
 ВНИМАНИЕ: Используйте только в том случае, если этого требует поставщик коммунальных услуг.</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="104"/>
       <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
       <translation>Суммарная мощность всех фаз интеллектуально регулируется для достижения заданного значения в сети (эффективность системы оптимизирована).
 
 Используйте, если это не запрещено поставщиком коммунальных услуг.</translation>
-    </message>
-    <message id="settings_ess_min_soc">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation type="unfinished">Минимум SOC разряда (без неисправности сети)</translation>
-    </message>
-    <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="129"/>
-      <source>Active SOC limit</source>
-      <translation type="unfinished">Действующее ограничение состояния заряда батареи</translation>
-    </message>
-    <message id="settings_ess_battery_life_sustain">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
-      <source>Sustain</source>
-      <translation type="unfinished">Удержание</translation>
-    </message>
-    <message id="settings_ess_battery_life_recharge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="157"/>
-      <source>Recharge</source>
-      <translation type="unfinished">Зарядка</translation>
-    </message>
-    <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <source>Scheduled charge levels</source>
-      <translation type="unfinished">Запланированные уровни заряда</translation>
-    </message>
-    <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="257"/>
-      <source>Active (%1)</source>
-      <translation type="unfinished">Активно (%1)</translation>
-    </message>
-    <message id="settings_ess_inactive">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="259"/>
-      <source>Inactive</source>
-      <translation type="unfinished">Неактивно</translation>
-    </message>
-    <message id="settings_ess_dynamic">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="293"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">Динамическая ESS (система включения аварийного сигнала)</translation>
-    </message>
-    <message id="settings_ess_deprecated">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="319"/>
-      <source>Deprecated settings</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_charge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="326"/>
-      <source>Battery charge limit (% of CCL)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_discharge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="337"/>
-      <source>Battery discharge limit (% of DCL)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_rs_ess_min_soc">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="40"/>
@@ -1637,13 +1455,8 @@ Use unless prohibited by the utility provider.</source>
       <source>Active SOC limit</source>
       <translation>Действующее ограничение состояния заряда батареи</translation>
     </message>
-    <message id="scheduled_charge_inactive">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
-      <source>Inactive</source>
-      <translation type="unfinished">Неактивно</translation>
-    </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="245"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="247"/>
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
       <source>Peak shaving</source>
       <translation>Ограничение пиковой нагрузки</translation>
@@ -1659,12 +1472,12 @@ Use unless prohibited by the utility provider.</source>
       <translation>Всегда</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="151"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
       <source>Discharge disabled</source>
       <translation>Разряд отключен</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
       <source>Slow charge</source>
       <translation>Медленный заряд</translation>
     </message>
@@ -1679,32 +1492,32 @@ Use unless prohibited by the utility provider.</source>
       <translation>Зарядка</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="165"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="167"/>
       <source>Limit charge power</source>
       <translation>Ограничение мощности заряда</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="183"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="185"/>
       <source>Maximum charge power</source>
       <translation>Максимальная мощность заряда</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="196"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="198"/>
       <source>Limit inverter power</source>
       <translation>Ограничение мощности инвертора</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="214"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="216"/>
       <source>Maximum inverter power</source>
       <translation>Максимальная мощность инвертора</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="225"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="227"/>
       <source>Grid setpoint</source>
       <translation>Точка установки сети</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="236"/>
       <source>Grid feed-in</source>
       <translation>Подача сети</translation>
     </message>
@@ -1743,8 +1556,8 @@ Use unless prohibited by the utility provider.</source>
       <source>Door alarm</source>
       <translation>Дверная сигнализация</translation>
     </message>
-    <message id="digitalinputs_type_bilgepump">
-      <location filename="../../src/enums.cpp" line="201"/>
+    <message id="switchable_output_bilge_pump">
+      <location filename="../../src/enums.cpp" line="424"/>
       <source>Bilge pump</source>
       <translation>Трюмный насос</translation>
     </message>
@@ -1796,11 +1609,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Deferred by %1s</source>
       <extracomment>%1 = number of seconds</extracomment>
       <translation>Отложено на %1 сек.</translation>
-    </message>
-    <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="75"/>
-      <source>Are you sure?</source>
-      <translation type="unfinished">Вы уверены?</translation>
     </message>
     <message id="settings_vrm_portal_id">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="87"/>
@@ -1939,11 +1747,6 @@ Use unless prohibited by the utility provider.</source>
       <source>External storage</source>
       <translation>Внешнее накопитель</translation>
     </message>
-    <message id="settings_vrm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="308"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">Неизвестная ошибка</translation>
-    </message>
     <message id="settings_vrm_no_error">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="311"/>
       <source>No Error</source>
@@ -2029,37 +1832,10 @@ Use unless prohibited by the utility provider.</source>
       <source>Function</source>
       <translation>Функция</translation>
     </message>
-    <message id="settings_relay_disabled">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="54"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="98"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Отключено</translation>
-    </message>
     <message id="settings_relay_alarm_relay">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="56"/>
       <source>Alarm relay</source>
       <translation>Реле сигнализации</translation>
-    </message>
-    <message id="settings_relay_tank_pump">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="62"/>
-      <source>Tank pump</source>
-      <translation type="unfinished">Насос резервуара</translation>
-    </message>
-    <message id="settings_relay_manual">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="64"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="100"/>
-      <source>Manual</source>
-      <translation type="unfinished">Вручную</translation>
-    </message>
-    <message id="settings_relay_polarity_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
-      <source>Polarity (Relay 1)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_relay_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
-      <source>Polarity</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_normally_open">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="83"/>
@@ -2075,11 +1851,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="93"/>
       <source>Function (Relay 2)</source>
       <translation>Функция (реле 2)</translation>
-    </message>
-    <message id="settings_relay_polarity_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
-      <source>Polarity (Relay 2)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_temp_control_rules">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="119"/>
@@ -2111,12 +1882,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
       <source>Press to boot</source>
       <translation>Нажмите для загрузки</translation>
-    </message>
-    <message id="settings_firmware_backup_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
-      <translation type="unfinished">Прошивка %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
@@ -2152,6 +1917,7 @@ Use unless prohibited by the utility provider.</source>
     <message id="nav_boat">
       <location filename="../../pages/boat/BoatPage.qml" line="14"/>
       <source>Boat</source>
+      <extracomment>The 'Boat' page</extracomment>
       <translation>Лодка</translation>
     </message>
     <message id="settings_system_name">
@@ -2219,11 +1985,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Solar charger current control</source>
       <translation>Контроль тока солнечного зарядного устройства</translation>
     </message>
-    <message id="settings_system_status_bms_params">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
-      <source>BMS control</source>
-      <translation type="unfinished">BMS управление</translation>
-    </message>
     <message id="common_words_bms_control">
       <location filename="../../components/CommonWords.qml" line="101"/>
       <source>BMS control</source>
@@ -2238,11 +1999,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
       <source>Pump state</source>
       <translation>Состояние насоса</translation>
-    </message>
-    <message id="settings_pump_auto">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="56"/>
-      <source>Auto</source>
-      <translation type="unfinished">Авто</translation>
     </message>
     <message id="settings_tank_sensor">
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
@@ -2271,11 +2027,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="35"/>
       <source>Unplugged</source>
       <translation>Отключено</translation>
-    </message>
-    <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="16"/>
-      <source>Name</source>
-      <translation type="unfinished">Имя</translation>
     </message>
     <message id="settings_tcpip_hidden">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="21"/>
@@ -2317,16 +2068,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="99"/>
       <source>IP configuration</source>
       <translation>IP конфигурация</translation>
-    </message>
-    <message id="settings_tcpip_manual">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="105"/>
-      <source>Manual</source>
-      <translation type="unfinished">Вручную</translation>
-    </message>
-    <message id="settings_tcpip_off">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="107"/>
-      <source>Off</source>
-      <translation type="unfinished">Выкл</translation>
     </message>
     <message id="settings_tcpip_fixed">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="109"/>
@@ -2382,21 +2123,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="30"/>
       <source>Create access point</source>
       <translation>Создать точку доступа</translation>
-    </message>
-    <message id="settings_wifi_access_point_enter_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="68"/>
-      <source>Enter password</source>
-      <translation type="unfinished">Введите пароль</translation>
-    </message>
-    <message id="page_settings_wifi_invalid_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
-      <source>Password length must be either 0 or between 10 and 63 characters long</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_wifi_password_updated">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
-      <source>Password updated</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_wifi_networks">
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="86"/>
@@ -2539,20 +2265,10 @@ Use unless prohibited by the utility provider.</source>
       <extracomment>Network status: Standalone</extracomment>
       <translation>Отдельный</translation>
     </message>
-    <message id="charger_standalone">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="45"/>
-      <source>Standalone</source>
-      <translation type="unfinished">Отдельный</translation>
-    </message>
     <message id="charger_charge">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="48"/>
       <source>Charge</source>
       <translation>Нагрузка</translation>
-    </message>
-    <message id="charger_external_control">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="51"/>
-      <source>External control</source>
-      <translation type="unfinished">Внешнее управление</translation>
     </message>
     <message id="charger_charge_hub_1">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="54"/>
@@ -2584,16 +2300,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Master setting</source>
       <translation>Настройка ведущего</translation>
     </message>
-    <message id="charger_slave">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="85"/>
-      <source>Slave</source>
-      <translation type="unfinished">Ведомый</translation>
-    </message>
-    <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation type="unfinished">Напряжение заряда</translation>
-    </message>
     <message id="systemsettings_networkstatus_slave">
       <location filename="../../data/SystemSettings.qml" line="148"/>
       <source>Slave</source>
@@ -2615,14 +2321,15 @@ Use unless prohibited by the utility provider.</source>
       <source>Group &amp; Charge master</source>
       <translation>Ведущий группы &amp; зарядки</translation>
     </message>
-    <message id="genset_charge_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="365"/>
+    <message id="charger_charge_voltage">
+      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
       <source>Charge voltage</source>
       <translation>Напряжение заряда</translation>
     </message>
     <message id="common_words_reset">
       <location filename="../../components/CommonWords.qml" line="448"/>
       <source>Reset</source>
+      <extracomment>Reset the BMS control</extracomment>
       <translation>Сброс</translation>
     </message>
     <message id="solarcharger_load">
@@ -2651,14 +2358,14 @@ Use unless prohibited by the utility provider.</source>
       <extracomment>Voltage alarm is at "Warning" level</extracomment>
       <translation>Предупреждение</translation>
     </message>
-    <message id="listitems_alarm_level_alarm">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="25"/>
+    <message id="digitalinputs_state_alarm">
+      <location filename="../../src/enums.cpp" line="270"/>
       <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
+      <extracomment>Relay function is 'alarm'</extracomment>
       <translation>Тревога</translation>
     </message>
-    <message id="devicelist_tankshape_volume">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="190"/>
+    <message id="components_volumeunit_volume">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
       <source>Volume</source>
       <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
       <translation>Объем</translation>
@@ -2808,26 +2515,10 @@ Use unless prohibited by the utility provider.</source>
       <source>Relay function</source>
       <translation>Функция реле</translation>
     </message>
-    <message id="batterysettingrelay_alarm">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation type="unfinished">Тревога</translation>
-    </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
       <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
       <source>Charger or generator start/stop</source>
       <translation>Запуск/остановка генератора или зарядного устройства</translation>
-    </message>
-    <message id="batterysettingrelay_manual_control">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
-      <source>Manual control</source>
-      <translation type="unfinished">Ручное управление</translation>
-    </message>
-    <message id="batterysettingrelay_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">Предохранитель перегорел</translation>
     </message>
     <message id="common_words_manual_control">
       <location filename="../../components/CommonWords.qml" line="302"/>
@@ -2853,12 +2544,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
       <source>Status LEDs</source>
       <translation>Светодиоды статуса</translation>
-    </message>
-    <message id="batterydiagnostics_none">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
-      <source>None</source>
-      <extracomment>Indicates no alarm is set</extracomment>
-      <translation type="unfinished">Нет</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
@@ -2888,7 +2573,7 @@ Use unless prohibited by the utility provider.</source>
     <message id="common_words_switch">
       <location filename="../../components/CommonWords.qml" line="525"/>
       <source>Switch</source>
-      <extracomment>Change the mode value</extracomment>
+      <extracomment>Change the battery mode</extracomment>
       <translation>Переключатель</translation>
     </message>
     <message id="devicelist_battery_initializing">
@@ -2956,21 +2641,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Top section voltage</source>
       <translation>Напряжение верхней секции</translation>
     </message>
-    <message id="battery_bank_error_communication">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="96"/>
-      <source>Communication error</source>
-      <translation type="unfinished">Ошибка связи</translation>
-    </message>
-    <message id="battery_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="182"/>
-      <source>State of health</source>
-      <translation type="unfinished">Состояние системы</translation>
-    </message>
-    <message id="battery_bus_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="212"/>
-      <source>Bus voltage</source>
-      <translation type="unfinished">Напряжение шины</translation>
-    </message>
     <message id="battery_bottom_section_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="228"/>
       <source>Bottom section voltage</source>
@@ -3016,16 +2686,6 @@ Use unless prohibited by the utility provider.</source>
       <source>IO</source>
       <translation>Ввод/вывод</translation>
     </message>
-    <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="391"/>
-      <source>System</source>
-      <translation type="unfinished">Система</translation>
-    </message>
-    <message id="battery_press_to_redetect">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="433"/>
-      <source>Press to redetect</source>
-      <translation type="unfinished">Нажмите для определения</translation>
-    </message>
     <message id="pagesettingsgeneral_system">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="107"/>
       <source>System</source>
@@ -3066,16 +2726,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Low SOC</source>
       <translation>Низкий SOC</translation>
     </message>
-    <message id="batteryalarms_high_battery_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
-      <source>High battery voltage</source>
-      <translation type="unfinished">Высокое напряжение батареи</translation>
-    </message>
-    <message id="batteryalarms_low_soc">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low SOC</source>
-      <translation type="unfinished">Низкий SOC</translation>
-    </message>
     <message id="batteryalarms_low_starter_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="73"/>
       <source>Low starter voltage</source>
@@ -3095,11 +2745,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
       <source>Mid-point voltage</source>
       <translation>Напряжение центральной точки</translation>
-    </message>
-    <message id="batteryalarms_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">Предохранитель перегорел</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
@@ -3293,11 +2938,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Restore factory defaults</source>
       <translation>Восстановить заводские настройки</translation>
     </message>
-    <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation type="unfinished">Нажмите для восстановления</translation>
-    </message>
     <message id="vebus_backup_press_to_restore">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="362"/>
       <source>Press to restore</source>
@@ -3337,11 +2977,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="18"/>
       <source>Capacity</source>
       <translation>Емкость</translation>
-    </message>
-    <message id="batterysettingsbattery_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
-      <source>Capacity</source>
-      <translation type="unfinished">Емкость</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
@@ -3418,16 +3053,12 @@ Use unless prohibited by the utility provider.</source>
       <source>No power on busbar</source>
       <translation>Нет питания на сборной шине</translation>
     </message>
-    <message id="lynxdistributor_connection_lost">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
-      <source>Connection lost</source>
-      <translation type="unfinished">Соединение потеряно</translation>
-    </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
       <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
       <source>%n fuse(s) blown</source>
       <extracomment>%n = number of fuses that have blown</extracomment>
       <translation>
+        <numerusform>%n предохранитель(и) перегорел</numerusform>
         <numerusform>%n предохранитель(и) перегорел</numerusform>
         <numerusform>%n предохранитель(и) перегорел</numerusform>
         <numerusform>%n предохранитель(и) перегорел</numerusform>
@@ -3459,26 +3090,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Shutdowns due error</source>
       <translation>Отключения из-за ошибок</translation>
     </message>
-    <message id="lynxiondiagnostics_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
-      <source>Last error</source>
-      <translation type="unfinished">Последняя ошибка</translation>
-    </message>
-    <message id="lynxiondiagnostics_2nd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
-      <source>2nd last error</source>
-      <translation type="unfinished">Предпоследняя ошибка</translation>
-    </message>
-    <message id="lynxiondiagnostics_3rd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
-      <source>3rd last error</source>
-      <translation type="unfinished">Третья последняя ошибка</translation>
-    </message>
-    <message id="lynxiondiagnostics_4th_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
-      <source>4th last error</source>
-      <translation type="unfinished">Четвертая последняя ошибка</translation>
-    </message>
     <message id="lynxionio_system_switch">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
       <source>System Switch</source>
@@ -3498,11 +3109,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../components/CommonWords.qml" line="54"/>
       <source>Batteries</source>
       <translation>Батареи</translation>
-    </message>
-    <message id="lynxionsystem_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
-      <source>Capacity</source>
-      <translation type="unfinished">Емкость</translation>
     </message>
     <message id="lynxionsystem_parallel">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="30"/>
@@ -3524,20 +3130,10 @@ Use unless prohibited by the utility provider.</source>
       <source>Min/max cell temperature</source>
       <translation>Мин/макс температура ячейки</translation>
     </message>
-    <message id="lynxionsystem_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="92"/>
-      <source>Balancing</source>
-      <translation type="unfinished">Балансировка</translation>
-    </message>
     <message id="lynxionsystem_balancer_balancing">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
       <source>Balancing</source>
       <translation>Балансировка</translation>
-    </message>
-    <message id="lynxionsystem_balancer_unknown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="117"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Неизвестно</translation>
     </message>
     <message id="dc_output">
       <location filename="../../components/listitems/ListDcOutputQuantityGroup.qml" line="16"/>
@@ -3645,11 +3241,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Remaining</source>
       <translation>Осталось</translation>
     </message>
-    <message id="devicelist_tanksensor_sensor_battery">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="51"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">Датчик батареи</translation>
-    </message>
     <message id="temperature_sensor_battery">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="112"/>
       <source>Sensor battery</source>
@@ -3678,7 +3269,7 @@ Use unless prohibited by the utility provider.</source>
     <message id="devicelist_tanksetup_custom">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="53"/>
       <source>Custom</source>
-      <translation type="unfinished">Настроить</translation>
+      <translation>Настроить</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="59"/>
@@ -3711,34 +3302,34 @@ Use unless prohibited by the utility provider.</source>
       <translation>Значение датчика</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="75"/>
       <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
       <translation>Пользовательская форма не определена. Вы можете определить одну, содержащую до десяти точек. Обратите внимание, что 0% и 100% подразумеваются.</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="91"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="89"/>
       <source>Point %1</source>
       <extracomment>%1 = the point number</extracomment>
       <translation>Точка %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="133"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="179"/>
       <source>Add point</source>
       <translation>Добавить точку</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="156"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="205"/>
       <source>Sensor level</source>
       <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
       <translation>Датчик уровня</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="256"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="311"/>
       <source>Duplicate sensor level values are not allowed.</source>
       <translation>Дублирование значений уровня датчика не допускается.</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="262"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="317"/>
       <source>Volume values must be increasing.</source>
       <translation>Значения объема должны увеличиваться.</translation>
     </message>
@@ -3778,11 +3369,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Switch position</source>
       <translation>Переключить позицию</translation>
     </message>
-    <message id="ac-in-setup_single_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="142"/>
-      <source>Single phase</source>
-      <translation type="unfinished">Одна фаза</translation>
-    </message>
     <message id="ac-in-setup_two_phase">
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="144"/>
       <source>2-phase</source>
@@ -3792,11 +3378,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="146"/>
       <source>3-phase</source>
       <translation>3-фазный</translation>
-    </message>
-    <message id="ac-in-setup_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="161"/>
-      <source>Devices</source>
-      <translation type="unfinished">Устройства</translation>
     </message>
     <message id="ac-in-genset_ac">
       <location filename="../../components/PageGensetModel.qml" line="194"/>
@@ -3890,12 +3471,6 @@ Use unless prohibited by the utility provider.</source>
       <extracomment>%1 = CT device number</extracomment>
       <translation>КТ %1</translation>
     </message>
-    <message id="smappeect_phase_none">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation type="unfinished">Нет</translation>
-    </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
       <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
       <source>Flashing LED indicates this CT</source>
@@ -3909,11 +3484,13 @@ Use unless prohibited by the utility provider.</source>
     <message id="common_words_setting_disabled_when_dmc_connected">
       <location filename="../../components/CommonWords.qml" line="355"/>
       <source>This setting is disabled when a Digital Multi Control is connected.</source>
+      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>Эта настройка отключена, если подключен цифровой мультиконтроллер.</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
       <location filename="../../components/CommonWords.qml" line="358"/>
       <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>Эта настройка отключена, если подключена система VE.Bus BMS.</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
@@ -3931,16 +3508,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="21"/>
       <source>Inverted</source>
       <translation>Инвертировано</translation>
-    </message>
-    <message id="digitalinput_enable_alarm">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="48"/>
-      <source>Enable alarm</source>
-      <translation type="unfinished">Включить оповещения</translation>
-    </message>
-    <message id="digitalinput_inverted">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="54"/>
-      <source>Inverted</source>
-      <translation type="unfinished">Инвертировано</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
       <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="60"/>
@@ -3977,16 +3544,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Wind speed</source>
       <translation>Скорость ветра</translation>
     </message>
-    <message id="page_meteo_battery_voltage">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="99"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">Датчик батареи</translation>
-    </message>
-    <message id="meteo_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="120"/>
-      <source>Low</source>
-      <translation type="unfinished">Низкий</translation>
-    </message>
     <message id="page_meteo_settings_auto_detect">
       <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
       <source>Auto-detect</source>
@@ -4017,16 +3574,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Reset counter</source>
       <translation>Сброс счетчика</translation>
     </message>
-    <message id="temperature_short_circuited">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="32"/>
-      <source>Short circuited</source>
-      <translation type="unfinished">Короткое замыкание</translation>
-    </message>
-    <message id="temperature_reverse_polarity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="35"/>
-      <source>Reverse polarity</source>
-      <translation type="unfinished">Обратная полярность</translation>
-    </message>
     <message id="temperature_sensor_battery_low">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
       <source>Sensor battery low</source>
@@ -4041,36 +3588,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="62"/>
       <source>Pressure</source>
       <translation>Давление</translation>
-    </message>
-    <message id="temperature_pm25">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
-      <source>PM2.5</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_co2">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>CO₂</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_voc">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
-      <source>VOC index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_nox">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
-      <source>NOx index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_luminosity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
-      <source>Luminosity</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="133"/>
-      <source>Low</source>
-      <translation type="unfinished">Низкий</translation>
     </message>
     <message id="temperature_offset">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
@@ -4124,25 +3641,10 @@ NOTE: The update might temporarily stop the system.</source>
       <source>Updating the MK3, values will reappear after the update is complete</source>
       <translation>Обновление MK3, значения снова появятся после завершения обновления</translation>
     </message>
-    <message id="vebus_device_charging_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="78"/>
-      <source>Charging the battery to 100%</source>
-      <translation type="unfinished">Зарядка аккумулятора до 100 %</translation>
-    </message>
     <message id="vebus_device_charging_the_battery_to_100">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="93"/>
       <source>Charging the battery to 100%</source>
       <translation>Зарядка аккумулятора до 100 %</translation>
-    </message>
-    <message id="vebus_device_page_microgrid_parameters">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
-      <source>Microgrid parameters</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="vebus_device_page_advanced">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
-      <source>Advanced</source>
-      <translation type="unfinished">Продвинутый</translation>
     </message>
     <message id="vebus_device_in_progress">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="80"/>
@@ -4198,15 +3700,15 @@ Do you want to continue?</source>
       <source>DC Current</source>
       <translation>Переменный ток</translation>
     </message>
+    <message id="vebus_device_page_advanced">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
+      <source>Advanced</source>
+      <translation>Продвинутый</translation>
+    </message>
     <message id="common_words_alarm_setup">
       <location filename="../../components/CommonWords.qml" line="65"/>
       <source>Alarm setup</source>
       <translation>Настройка сигнализации</translation>
-    </message>
-    <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
-      <translation type="unfinished">A VE.Bus BMS автоматически выключает систему при необходимости защиты батареи. Контролирование системы по Цветному контролю в этом случае невозможно.</translation>
     </message>
     <message id="vebus_device_bms_not_found">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="240"/>
@@ -4247,7 +3749,7 @@ Do you want to continue?</source>
     <message id="vebus_device_starting">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="117"/>
       <source>Starting...</source>
-      <translation type="unfinished">Запуск...</translation>
+      <translation>Запуск...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="120"/>
@@ -4313,16 +3815,6 @@ Do you want to continue?</source>
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="260"/>
       <source>ESS Relay test</source>
       <translation>Тест реле ESS</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_completed">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="266"/>
-      <source>Completed</source>
-      <translation type="unfinished">Завершен</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_pending">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="268"/>
-      <source>Pending</source>
-      <translation type="unfinished">Ожидание...</translation>
     </message>
     <message id="cycle_history_completed">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
@@ -4509,6 +4001,7 @@ Do you want to continue?</source>
     <message id="rssystemalarms_overload">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
       <source>Overload</source>
+      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
       <translation>Перегрузка</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
@@ -4521,11 +4014,6 @@ Do you want to continue?</source>
       <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
       <source>Voltage Sensor</source>
       <translation>Датчик напряжения</translation>
-    </message>
-    <message id="vebus_device_phase_rotation">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
-      <source>Phase rotation</source>
-      <translation type="unfinished">Изменение фазы</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
@@ -4557,12 +4045,6 @@ Do you want to continue?</source>
       <source>VE.Bus BMS version</source>
       <translation>Версия VE.Bus BMS</translation>
     </message>
-    <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="15"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="52"/>
-      <source>Minimum SOC</source>
-      <translation type="unfinished">Минимальное состояние заряда батареи</translation>
-    </message>
     <message id="ess_unless_grid_fails">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="32"/>
       <source>Unless grid fails</source>
@@ -4582,7 +4064,7 @@ Do you want to continue?</source>
     <message id="common_words_ac_input_role">
       <location filename="../../components/CommonWords.qml" line="24"/>
       <source>Role</source>
-      <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
       <translation>Роль</translation>
     </message>
     <message id="common_words_ac_load">
@@ -4621,18 +4103,6 @@ Do you want to continue?</source>
       <source>Active</source>
       <extracomment>Status is 'active'</extracomment>
       <translation>Активно</translation>
-    </message>
-    <message id="common_words_alarm">
-      <location filename="../../components/CommonWords.qml" line="51"/>
-      <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
-      <translation type="unfinished">Тревога</translation>
-    </message>
-    <message id="common_words_alarm_setting_overload">
-      <location filename="../../components/CommonWords.qml" line="58"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation type="unfinished">Перегрузка</translation>
     </message>
     <message id="common_words_alarm_status">
       <location filename="../../components/CommonWords.qml" line="68"/>
@@ -4679,8 +4149,8 @@ Do you want to continue?</source>
       <source>Charge current</source>
       <translation>Ток заряда</translation>
     </message>
-    <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="125"/>
+    <message id="battery_mode_charging">
+      <location filename="../../src/enums.cpp" line="30"/>
       <source>Charging</source>
       <extracomment>"Charging" state</extracomment>
       <translation>заряжается</translation>
@@ -4694,7 +4164,7 @@ Do you want to continue?</source>
     <message id="digitalinputs_state_closed">
       <location filename="../../src/enums.cpp" line="262"/>
       <source>Closed</source>
-      <extracomment>Digital input state</extracomment>
+      <extracomment>Status is 'closed'</extracomment>
       <translation>Закрыто</translation>
     </message>
     <message id="evchargers_status_connected">
@@ -4702,8 +4172,8 @@ Do you want to continue?</source>
       <source>Connected</source>
       <translation>Подключено</translation>
     </message>
-    <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="143"/>
+    <message id="temperature_slider_current">
+      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
       <source>Current</source>
       <extracomment>Electric current, as measured in Amps</extracomment>
       <translation>Ток</translation>
@@ -4730,9 +4200,10 @@ Do you want to continue?</source>
       <extracomment>Title for device information</extracomment>
       <translation>Устройство</translation>
     </message>
-    <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="172"/>
+    <message id="battery_mode_discharging">
+      <location filename="../../src/enums.cpp" line="34"/>
       <source>Discharging</source>
+      <extracomment>Battery mode</extracomment>
       <translation>разряжается</translation>
     </message>
     <message id="wifimodel_disconnected">
@@ -4818,13 +4289,14 @@ Do you want to continue?</source>
       <source>%1 Hour(s)</source>
       <translation>%1 Час(ы)</translation>
     </message>
-    <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="251"/>
+    <message id="battery_mode_idle">
+      <location filename="../../src/enums.cpp" line="26"/>
       <source>Idle</source>
+      <extracomment>Battery mode</extracomment>
       <translation>без нагрузки</translation>
     </message>
-    <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="258"/>
+    <message id="scheduled_charge_inactive">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
       <source>Inactive</source>
       <extracomment>Status is 'inactive'</extracomment>
       <translation>Неактивно</translation>
@@ -4926,8 +4398,8 @@ Do you want to continue?</source>
       <source>Offline</source>
       <translation>Оффлайн</translation>
     </message>
-    <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="17"/>
+    <message id="digitalinputs_state_ok">
+      <location filename="../../src/enums.cpp" line="266"/>
       <source>OK</source>
       <extracomment>Voltage alarm is at "OK" level</extracomment>
       <translation>Ok</translation>
@@ -4935,6 +4407,7 @@ Do you want to continue?</source>
     <message id="switchable_output_on">
       <location filename="../../src/enums.cpp" line="471"/>
       <source>On</source>
+      <extracomment>Digital input state</extracomment>
       <translation>Вкл</translation>
     </message>
     <message id="common_words_online">
@@ -4945,7 +4418,7 @@ Do you want to continue?</source>
     <message id="digitalinputs_state_open">
       <location filename="../../src/enums.cpp" line="258"/>
       <source>Open</source>
-      <extracomment>Digital input open</extracomment>
+      <extracomment>Status is 'open'</extracomment>
       <translation>Открыто</translation>
     </message>
     <message id="common_words_password">
@@ -5005,9 +4478,10 @@ Do you want to continue?</source>
       <source>Remove</source>
       <translation>Удалить</translation>
     </message>
-    <message id="switch_state_running">
-      <location filename="../../src/enums.cpp" line="363"/>
+    <message id="switchable_output_running">
+      <location filename="../../src/enums.cpp" line="468"/>
       <source>Running</source>
+      <extracomment>Status = "running"</extracomment>
       <translation>Работает</translation>
     </message>
     <message id="common_words_scanning">
@@ -5074,7 +4548,7 @@ Do you want to continue?</source>
     <message id="pvinverter_statusCode_startup">
       <location filename="../../src/enums.cpp" line="296"/>
       <source>Startup (%1)</source>
-      <extracomment>PV inverter status code. %1 = the startup status number</extracomment>
+      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
       <translation>Запуск (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
@@ -5129,8 +4603,10 @@ Do you want to continue?</source>
       <source>Unique Identity Number</source>
       <translation>Уникальный идентификационный номер</translation>
     </message>
-    <message id="settings_radio_button_group_unknown">
-      <location filename="../../components/listitems/core/ListRadioButtonGroup.qml" line="44"/>
+    <message id="Unknown">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
       <source>Unknown</source>
       <translation>Неизвестно</translation>
     </message>
@@ -5285,11 +4761,6 @@ Do you want to continue?</source>
       <source>Error while checking for firmware updates</source>
       <translation>Ошибка при проверке обновлений микропрограммы</translation>
     </message>
-    <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation type="unfinished">Ошибка при проверке обновлений микропрограммы</translation>
-    </message>
     <message id="settings_firmware_downloading_and_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="63"/>
       <source>Downloading and installing firmware %1...</source>
@@ -5316,6 +4787,66 @@ Do you want to continue?</source>
       <source>No firmware found</source>
       <translation>Прошивка не обнаружена</translation>
     </message>
+    <message id="tank_type_fuel">
+      <location filename="../../src/enums.cpp" line="495"/>
+      <source>Fuel</source>
+      <translation>Топливо</translation>
+    </message>
+    <message id="tank_type_fresh_water">
+      <location filename="../../src/enums.cpp" line="498"/>
+      <source>Fresh water</source>
+      <translation>Свежая вода</translation>
+    </message>
+    <message id="tank_type_waste_water">
+      <location filename="../../src/enums.cpp" line="501"/>
+      <source>Waste water</source>
+      <translation>Грязная вода</translation>
+    </message>
+    <message id="tank_type_live_well">
+      <location filename="../../src/enums.cpp" line="504"/>
+      <source>Live well</source>
+      <translation>Рабочая скважина</translation>
+    </message>
+    <message id="tank_type_oil">
+      <location filename="../../src/enums.cpp" line="507"/>
+      <source>Oil</source>
+      <translation>Нефть</translation>
+    </message>
+    <message id="tank_type_black_water">
+      <location filename="../../src/enums.cpp" line="510"/>
+      <source>Black water</source>
+      <translation>Темная вода</translation>
+    </message>
+    <message id="tank_type_gasoline">
+      <location filename="../../src/enums.cpp" line="513"/>
+      <source>Gasoline</source>
+      <translation>Бензин</translation>
+    </message>
+    <message id="tank_type_diesel">
+      <location filename="../../src/enums.cpp" line="516"/>
+      <source>Diesel</source>
+      <translation>Дизельное топливо</translation>
+    </message>
+    <message id="tank_type_lpg">
+      <location filename="../../src/enums.cpp" line="519"/>
+      <source>LPG</source>
+      <translation>Сжиженный углеводородный газ</translation>
+    </message>
+    <message id="tank_type_lng">
+      <location filename="../../src/enums.cpp" line="522"/>
+      <source>LNG</source>
+      <translation>Сжиженный природный газ</translation>
+    </message>
+    <message id="tank_type_hydraulic_oil">
+      <location filename="../../src/enums.cpp" line="525"/>
+      <source>Hydraulic oil</source>
+      <translation>Гидравлическое масло</translation>
+    </message>
+    <message id="tank_type_raw_water">
+      <location filename="../../src/enums.cpp" line="528"/>
+      <source>Raw water</source>
+      <translation>Сырая вода</translation>
+    </message>
     <message id="listItem_no_access">
       <location filename="../../components/listitems/core/ListItem.qml" line="102"/>
       <source>Setting locked for access level</source>
@@ -5329,6 +4860,7 @@ Do you want to continue?</source>
     <message id="welcome_brief_title">
       <location filename="../../pages/welcome/WelcomeView.qml" line="81"/>
       <source>Brief</source>
+      <extracomment>The 'Brief' page</extracomment>
       <translation>Краткое описание</translation>
     </message>
     <message id="welcome_overview_title">
@@ -5345,23 +4877,6 @@ Do you want to continue?</source>
       <location filename="../../pages/NotificationsPage.qml" line="13"/>
       <source>Notifications</source>
       <translation>Уведомления</translation>
-    </message>
-    <message id="notifications_page_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="43"/>
-      <source>Active Notifications</source>
-      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_page_inactive_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="47"/>
-      <source>Inactive Notifications</source>
-      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_no_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="106"/>
-      <source>No active notifications</source>
-      <translation type="unfinished"/>
     </message>
     <message id="utils_formatTimestamp_now">
       <location filename="../../components/Utils.js" line="258"/>
@@ -5466,11 +4981,6 @@ Do you want to continue?</source>
       <source>Self-consumption above limit</source>
       <translation>Автономное потребление превысило установленный лимит</translation>
     </message>
-    <message id="cgwacs_battery_schedule_pv">
-      <location filename="../../components/listitems/ListChargeSchedule.qml" line="171"/>
-      <source>PV</source>
-      <translation type="unfinished">фотоэлектрический</translation>
-    </message>
     <message id="settings_multirs_pv">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="185"/>
       <source>PV</source>
@@ -5481,8 +4991,8 @@ Do you want to continue?</source>
       <source>PV &amp; Battery</source>
       <translation>Фотоэлектрические панели и батарея</translation>
     </message>
-    <message id="settings_firmware_checking">
-      <location filename="../../components/listitems/ListFirmwareCheckButton.qml" line="16"/>
+    <message id="pagesettingssupportstate_firmware_checking">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
       <source>Checking...</source>
       <translation>Проверяю...</translation>
     </message>
@@ -5490,12 +5000,6 @@ Do you want to continue?</source>
       <location filename="../../components/listitems/ListAlarmState.qml" line="11"/>
       <source>Alarm state</source>
       <translation>Статус сигнализации</translation>
-    </message>
-    <message id="devicelist_battery_alarm_state">
-      <location filename="../../components/listitems/ListAlarmState.qml" line="19"/>
-      <source>Alarm</source>
-      <extracomment>Alarm state is active</extracomment>
-      <translation type="unfinished">Тревога</translation>
     </message>
     <message id="clear_history_button_clear_history">
       <location filename="../../components/listitems/ListClearHistoryButton.qml" line="15"/>
@@ -5647,11 +5151,6 @@ Do you want to continue?</source>
       <source>Max Voltage</source>
       <translation>Максимальное напряжение</translation>
     </message>
-    <message id="charger_history_box_max_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="64"/>
-      <source>Max Voltage</source>
-      <translation type="unfinished">Максимальное напряжение</translation>
-    </message>
     <message id="charger_history_box_max_current">
       <location filename="../../components/SolarDetailBox.qml" line="70"/>
       <source>Max Current</source>
@@ -5662,24 +5161,6 @@ Do you want to continue?</source>
       <source>Charge time</source>
       <extracomment>Statistics for battery charging time</extracomment>
       <translation>Время зарядки</translation>
-    </message>
-    <message id="charger_history_box_bulk">
-      <location filename="../../components/SolarDetailBox.qml" line="136"/>
-      <source>Bulk</source>
-      <extracomment>Battery: time spent in 'Bulk' mode</extracomment>
-      <translation type="unfinished">Зарядка</translation>
-    </message>
-    <message id="charger_history_box_float">
-      <location filename="../../components/SolarDetailBox.qml" line="148"/>
-      <source>Float</source>
-      <extracomment>Battery: time spent in 'Float' mode</extracomment>
-      <translation type="unfinished">Плавающий</translation>
-    </message>
-    <message id="charger_history_hr">
-      <location filename="../../components/SolarDetailBox.qml" line="174"/>
-      <source>hr</source>
-      <extracomment>Abbreviation of "hour"</extracomment>
-      <translation type="unfinished">hr</translation>
     </message>
     <message id="solarchargers_state_bulk">
       <location filename="../../src/enums.cpp" line="337"/>
@@ -5751,11 +5232,6 @@ Do you want to continue?</source>
       <source>Connecting</source>
       <translation>Подключение</translation>
     </message>
-    <message id="splash_view_connecting">
-      <location filename="../../components/SplashView.qml" line="288"/>
-      <source>Connecting</source>
-      <translation type="unfinished">Подключение</translation>
-    </message>
     <message id="splash_view_connected">
       <location filename="../../components/SplashView.qml" line="290"/>
       <source>Connected, awaiting broker messages</source>
@@ -5811,6 +5287,11 @@ Do you want to continue?</source>
       <source>MQTT protocol level 5 error</source>
       <translation>Ошибка 5-го уровня протокола MQTT</translation>
     </message>
+    <message id="common_words_silence_alarm">
+      <location filename="../../components/CommonWords.qml" line="476"/>
+      <source>Silence alarm</source>
+      <translation>Отключить сигнализацию</translation>
+    </message>
     <message id="vebus_device_page_total_power">
       <location filename="../../components/ThreePhaseQuantityTable.qml" line="47"/>
       <source>Total Power</source>
@@ -5861,20 +5342,10 @@ Do you want to continue?</source>
       <source>Retrieving IP address</source>
       <translation>Получение IP адреса</translation>
     </message>
-    <message id="utils_connman_connected">
-      <location filename="../../components/Utils.js" line="292"/>
-      <source>Connected</source>
-      <translation type="unfinished">Подключено</translation>
-    </message>
     <message id="utils_connman_disconnect">
       <location filename="../../components/Utils.js" line="295"/>
       <source>Disconnect</source>
       <translation>Отключить</translation>
-    </message>
-    <message id="utils_connman_disconnected">
-      <location filename="../../components/Utils.js" line="299"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Отключено</translation>
     </message>
     <message id="overview_widget_acloads_title">
       <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
@@ -5912,11 +5383,6 @@ Do you want to continue?</source>
       <source>Shore current limit</source>
       <translation>Ограничение тока берега</translation>
     </message>
-    <message id="acInputs_statusCode_stopping">
-      <location filename="../../data/AcInputs.qml" line="170"/>
-      <source>Stopping</source>
-      <translation type="unfinished">Остановка</translation>
-    </message>
     <message id="page_generator_stopping">
       <location filename="../../data/Generators.qml" line="44"/>
       <source>Stopping</source>
@@ -5932,7 +5398,7 @@ Do you want to continue?</source>
       <location filename="../../data/common/TankDescription.qml" line="24"/>
       <location filename="../../src/device.cpp" line="133"/>
       <source>%1 tank (%2)</source>
-      <extracomment>Tank description. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
       <translation>%1 танк (%2)</translation>
     </message>
     <message id="dcMeter_ac_charger">
@@ -5981,11 +5447,6 @@ Do you want to continue?</source>
       <location filename="../../data/Ess.qml" line="20"/>
       <source>Keep batteries charged</source>
       <translation>Поддерживайте заряд батарей</translation>
-    </message>
-    <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="50"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Отключено</translation>
     </message>
     <message id="evchargers_status_charged">
       <location filename="../../data/EvChargers.qml" line="58"/>
@@ -6046,16 +5507,6 @@ Do you want to continue?</source>
       <location filename="../../data/EvChargers.qml" line="97"/>
       <source>Start charging</source>
       <translation>Начать зарядку</translation>
-    </message>
-    <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="113"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Неизвестно</translation>
-    </message>
-    <message id="evchargers_mode_scheduled">
-      <location filename="../../data/EvChargers.qml" line="126"/>
-      <source>Scheduled</source>
-      <translation type="unfinished">Запланировано</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
       <location filename="../../data/System.qml" line="195"/>
@@ -6180,11 +5631,6 @@ Do you want to continue?</source>
       <source>Power supply mode</source>
       <translation>Режим поддержки мощности</translation>
     </message>
-    <message id="inverters_state_sustain">
-      <location filename="../../data/System.qml" line="158"/>
-      <source>Sustain</source>
-      <translation type="unfinished">Удержание</translation>
-    </message>
     <message id="inverters_state_wakeup">
       <location filename="../../data/System.qml" line="162"/>
       <source>Wake up</source>
@@ -6219,16 +5665,6 @@ Do you want to continue?</source>
       <location filename="../../data/System.qml" line="180"/>
       <source>Test</source>
       <translation>Тест</translation>
-    </message>
-    <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="183"/>
-      <source>External control</source>
-      <translation type="unfinished">Внешнее управление</translation>
-    </message>
-    <message id="inverters_state_dynamic_ess">
-      <location filename="../../data/System.qml" line="198"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">Динамическая ESS (система включения аварийного сигнала)</translation>
     </message>
     <message id="settings_rs_ess_dess">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="97"/>
@@ -6307,16 +5743,13 @@ Do you want to continue?</source>
     <message id="ess_recommended">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="73"/>
       <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
       <translation>Для литиевых батарей не рекомендуется зарядка ниже 10%. Для других типов аккумуляторов минимальный уровень заряда, рекомендованный производителем, указан в техническом описании.</translation>
-    </message>
-    <message id="controlcard_generator_label_autostart">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="63"/>
-      <source>Autostart</source>
-      <translation type="unfinished">Автоматический запуск</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
       <location filename="../../pages/controlcards/GeneratorCard.qml" line="70"/>
       <source>Start and stop the generator based on the configured autostart conditions.</source>
+      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
       <translation>Запуск и остановка генератора на основе настроенных условий автозапуска.</translation>
     </message>
     <message id="generator_dialog_disabled">
@@ -6339,11 +5772,13 @@ Do you want to continue?</source>
       <location filename="../../pages/controlcards/InverterChargerCard.qml" line="26"/>
       <source>Inverter / Charger (%1)</source>
       <extracomment>%1 = the inverter/charger name</extracomment>
+      <oldsource>Inverter / Charger</oldsource>
       <translation>Инвертор/зарядное устройство (%1)</translation>
     </message>
     <message id="settings_page_debug_quit_application">
       <location filename="../../pages/settings/debug/PageDebug.qml" line="36"/>
       <source>Quit application</source>
+      <oldsource>Quit Application</oldsource>
       <translation>Выйти из приложения</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
@@ -6354,12 +5789,8 @@ Do you want to continue?</source>
     <message id="settings_page_relay_generator_run_time">
       <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
       <source>Current run time</source>
+      <oldsource>Run time</oldsource>
       <translation>Текущее время работы</translation>
-    </message>
-    <message id="settings_page_genset_generator_run_time">
-      <location filename="../../components/PageGensetModel.qml" line="102"/>
-      <source>Current run time</source>
-      <translation type="unfinished">Текущее время работы</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
       <location filename="../../components/PageGensetModel.qml" line="110"/>
@@ -6386,19 +5817,10 @@ Do you want to continue?</source>
       <source>Remote start mode</source>
       <translation>Режим дистанционного запуска</translation>
     </message>
-    <message id="ac-in-genset_speed">
-      <location filename="../../components/PageGensetModel.qml" line="245"/>
-      <source>Speed</source>
-      <translation type="unfinished">Скорость</translation>
-    </message>
-    <message id="ac-in-genset_load">
-      <location filename="../../components/PageGensetModel.qml" line="252"/>
-      <source>Load</source>
-      <translation type="unfinished">Нагрузка</translation>
-    </message>
     <message id="ac-in-genset_oil_pressure">
       <location filename="../../components/PageGensetModel.qml" line="260"/>
       <source>Oil pressure</source>
+      <oldsource>Oil Pressure</oldsource>
       <translation>Давление масла</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
@@ -6494,11 +5916,13 @@ Do you want to continue?</source>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
       <source>High starter battery voltage alarms</source>
+      <oldsource>High starter batttery voltage alarms</oldsource>
       <translation>Сигнализация высокого напряжения стартерной батареи</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
       <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
       <translation>Обратите внимание, что при изменении параметра "Время до разряда" также изменяется параметр "Низкий уровень заряда" в меню реле.</translation>
     </message>
     <message id="lynxionsystem_cells_per_battery">
@@ -6575,6 +5999,7 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/devicelist/delegates/DeviceListDelegate_solarcharger.qml" line="34"/>
       <source>Error: #%1</source>
       <extracomment>%1 = error number</extracomment>
+      <oldsource>Error: %1</oldsource>
       <translation>Ошибка: #%1</translation>
     </message>
     <message id="devicelistpage_genset">
@@ -6631,17 +6056,14 @@ Do you want to continue?</source>
     <message id="settings_page_relay_generator_auto_start_enabled">
       <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
       <source>Autostart functionality</source>
+      <oldsource>Auto start functionality</oldsource>
       <translation>Функциональность автозапуска</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="97"/>
       <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
       <translation>Убедитесь, что генератор не подключен к входу переменного тока %1 при использовании этой опции.</translation>
-    </message>
-    <message id="page_generator_conditions_inverter_high_temperature">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="139"/>
-      <source>Inverter high temperature</source>
-      <translation type="unfinished">Высокая температура инвертера</translation>
     </message>
     <message id="page_generator_conditions_tank_level">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="159"/>
@@ -6671,30 +6093,34 @@ Do you want to continue?</source>
     <message id="settings_generator_function_not_enabled">
       <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
       <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
+      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
       <translation>Функция запуска/остановки генератора не включена, перейдите к настройкам реле и установите функцию "Запуск/остановка генераторной установки".</translation>
     </message>
     <message id="settings_batteries_intro">
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="45"/>
       <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
       <translation>Используйте это меню для определения данных о батарее, отображаемых при нажатии на значок батареи на странице обзора. Этот же выбор отображается и на портале VRM.</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
       <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
       <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
       <translation>Непрерывное сканирование может помешать работе Wi-Fi.</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
       <source>CAN-bus BMS LV (500 kbit/s)</source>
+      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
       <translation>CAN-шина BMS LV (500 кбит/с)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
       <source>CAN-bus BMS HV (500 kbit/s)</source>
       <translation>CAN-шина BMS HV (500 кбит/с)</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
       <source>Up, but no services (500 kbit/s)</source>
       <translation>Вверх, но без услуг (500 кбит/с)</translation>
     </message>
@@ -6707,41 +6133,6 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="127"/>
       <source>Brief page</source>
       <translation>Краткая страница</translation>
-    </message>
-    <message id="settings_displayoff_1min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="46"/>
-      <source>1 min</source>
-      <translation type="unfinished">1 минута</translation>
-    </message>
-    <message id="settings_displayoff_10min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="48"/>
-      <source>10 min</source>
-      <translation type="unfinished">10 минут</translation>
-    </message>
-    <message id="settings_displayoff_30min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="50"/>
-      <source>30 min</source>
-      <translation type="unfinished">30 минут</translation>
-    </message>
-    <message id="settings_displayoff_never">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="52"/>
-      <source>Never</source>
-      <translation type="unfinished">Никогда</translation>
-    </message>
-    <message id="settings_remote_console_appearance_auto">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="112"/>
-      <source>Auto</source>
-      <translation type="unfinished">Авто</translation>
-    </message>
-    <message id="settings_brief_view_start_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="119"/>
-      <source>Start page</source>
-      <translation type="unfinished">Стартовая страница</translation>
-    </message>
-    <message id="settings_display_boat_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="135"/>
-      <source>Boat page</source>
-      <translation type="unfinished">Страница лодки</translation>
     </message>
     <message id="settings_display_minmax">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="148"/>
@@ -6796,21 +6187,6 @@ Do you want to continue?</source>
       <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
       <translation>%1 установлено на %2</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_unsupported_device">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="50"/>
-      <source>Unsupported GX device</source>
-      <translation type="unfinished">Неподдерживаемое устройство GX</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_clean">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="55"/>
-      <source>Clean</source>
-      <translation type="unfinished">Очистить</translation>
-    </message>
-    <message id="pagesettingsgeneral_firmware">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="112"/>
-      <source>Firmware</source>
-      <translation type="unfinished">Прошивка</translation>
-    </message>
     <message id="pagesettingsgeneral_access_and_security">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
       <source>Access &amp; Security</source>
@@ -6844,6 +6220,7 @@ Do you want to continue?</source>
     <message id="settings_language_please_wait">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="209"/>
       <source>Please wait while the language is changed.</source>
+      <oldsource>Please wait while the language is changed</oldsource>
       <translation>Пожалуйста, подождите, пока будет изменен язык.</translation>
     </message>
     <message id="settings_briefview_totals">
@@ -6860,11 +6237,6 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="71"/>
       <source>Tank is not connected.</source>
       <translation>Резервуар не подключен.</translation>
-    </message>
-    <message id="settings_briefview_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="83"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">Активный мониторинг батареи</translation>
     </message>
     <message id="settings_briefview_individual_batteries">
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="86"/>
@@ -6915,6 +6287,7 @@ Do you want to continue?</source>
     <message id="settings_dvcc_charge_current_limits">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="30"/>
       <source>Charge current limits</source>
+      <oldsource>Charge Current limits</oldsource>
       <translation>Пределы тока заряда</translation>
     </message>
     <message id="settings_firmware_official_release">
@@ -6994,11 +6367,6 @@ Do you want to continue?</source>
       <source>No password and the network communication is not encrypted</source>
       <translation>Пароль отсутствует, сетевое взаимодействие не шифруется</translation>
     </message>
-    <message id="settings_logout_now">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
-      <source>Log out now</source>
-      <translation type="unfinished">Выйти из системы</translation>
-    </message>
     <message id="settings_security_profile_password_incorrect_length">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="28"/>
       <source>Password needs to be at least 8 characters long</source>
@@ -7049,25 +6417,10 @@ Do you want to continue?</source>
       <source>Page will automatically reload in 5 seconds</source>
       <translation>Страница автоматически перезагрузится через 5 секунд.</translation>
     </message>
-    <message id="settings_security_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="159"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">Пароль должен состоять не менее чем из 8 символов</translation>
-    </message>
     <message id="settings_root_password">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="269"/>
       <source>Root password</source>
       <translation>Корневой пароль</translation>
-    </message>
-    <message id="settings_root_enter_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="272"/>
-      <source>Enter password</source>
-      <translation type="unfinished">Введите пароль</translation>
-    </message>
-    <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="277"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">Пароль должен состоять не менее чем из 8 символов</translation>
     </message>
     <message id="settings_root_password_changed_to">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="283"/>
@@ -7083,6 +6436,11 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="321"/>
       <source>Logout</source>
       <translation>Выйти</translation>
+    </message>
+    <message id="settings_logout_now">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
+      <source>Log out now</source>
+      <translation>Выйти из системы</translation>
     </message>
     <message id="settings_logout_dialog_title">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="335"/>
@@ -7142,11 +6500,13 @@ Do you want to continue?</source>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="141"/>
       <source>Alarm when generator is not in autostart mode</source>
+      <oldsource>Alarm when generator is not in auto start mode</oldsource>
       <translation>Сигнал тревоги, когда генератор не находится в режиме автозапуска</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="147"/>
       <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
       <translation>Если функция автозапуска не работает более 10 минут, включается сигнал тревоги.</translation>
     </message>
     <message id="settings_units_amps_exceptions">
@@ -7162,6 +6522,11 @@ Do you want to continue?</source>
     <message id="settings_ess_use_this_option_for_peak_shaving">
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
       <source>Use this option for peak shaving.</source>
+      <oldsource>Use this option for peak shaving.
+
+The peak shaving threshold is set using the AC input current limit setting.
+
+See documentation for further information.</oldsource>
       <translation>Используйте эту опцию для пиковой экономии.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
@@ -7205,17 +6570,17 @@ Do you want to continue?</source>
       <translation>Максимальный ток экспорта системы (на фазу)</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="71"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="73"/>
       <source>Self-consumption from battery</source>
       <translation>Самопотребление от аккумулятора</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="76"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
       <source>All system loads</source>
       <translation>Все нагрузки на систему</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="80"/>
       <source>Only critical loads</source>
       <translation>Только критические нагрузки</translation>
     </message>
@@ -7273,26 +6638,6 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="194"/>
       <source>Server Applications</source>
       <translation>Серверные приложения</translation>
-    </message>
-    <message id="pagesettingsintegrations_venus_os_enable_large_features">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
-      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_large_victron_community">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="274"/>
-      <source>Victron Community</source>
-      <translation type="unfinished">Сообщество Victron</translation>
-    </message>
-    <message id="pagesettingsintegrations_ui_plugins">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
-      <source>UI Plugins</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
-      <source>Integrates with the device list</source>
-      <translation type="unfinished"/>
     </message>
     <message id="pagesettingssupportstate_modbus_tcp_server">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="453"/>
@@ -7395,25 +6740,10 @@ Do you want to continue?</source>
       <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
       <translation>Переключение версии прошивки невозможно без выбора "Профиля сетевой безопасности" в разделе "Настройки / Общие".</translation>
     </message>
-    <message id="pagesettingsconnectivity_ethernet">
-      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
-      <source>Ethernet</source>
-      <translation type="unfinished">Ethernet</translation>
-    </message>
     <message id="pagesettingsconnectivity_mobile_network">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="53"/>
       <source>Mobile Network</source>
       <translation>Мобильная сеть</translation>
-    </message>
-    <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Boat</source>
-      <translation type="unfinished">Лодка</translation>
-    </message>
-    <message id="settings_system_name_auto">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="32"/>
-      <source>Automatic</source>
-      <translation type="unfinished">Автоматически</translation>
     </message>
     <message id="pagesettingssystem_ac_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
@@ -7444,11 +6774,6 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="89"/>
       <source>Distributed Voltage and Current Control (DVCC)</source>
       <translation>Распределенное управление напряжением и током (DVCC)</translation>
-    </message>
-    <message id="settings_system_grid">
-      <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="18"/>
-      <source>Grid</source>
-      <translation type="unfinished">Сеть</translation>
     </message>
     <message id="settings_system_ac_position">
       <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="58"/>
@@ -7488,16 +6813,19 @@ Do you want to continue?</source>
     <message id="settings_system_has_dc_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="97"/>
       <source>Display DC Loads</source>
+      <oldsource>Has DC system</oldsource>
       <translation>Отображение нагрузок постоянного тока</translation>
     </message>
     <message id="settings_system_battery_measurements">
       <location filename="../../pages/settings/PageSettingsBatteries.qml" line="65"/>
       <source>Battery measurements</source>
+      <oldsource>Battery Measurements</oldsource>
       <translation>Показатели батареи</translation>
     </message>
     <message id="settings_system_system_status">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
       <source>System status</source>
+      <oldsource>System Status</oldsource>
       <translation>Состояние системы</translation>
     </message>
     <message id="settings_tcpip_wired">
@@ -7508,11 +6836,13 @@ Do you want to continue?</source>
     <message id="settings_vecan_device_instance">
       <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
       <source>VE.Can Device Instance</source>
+      <oldsource>Device Instance</oldsource>
       <translation>Экземпляр устройства VE.Can</translation>
     </message>
     <message id="settings_vecan_device_number">
       <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="32"/>
       <source>VE.Can Instance# %1</source>
+      <oldsource>Device# %1</oldsource>
       <translation>Экземпляр VE.Can# %1</translation>
     </message>
     <message id="settings_tz_antarctica">
@@ -7543,6 +6873,7 @@ Do you want to continue?</source>
     <message id="settings_vrm">
       <location filename="../../pages/SettingsPage.qml" line="59"/>
       <source>VRM</source>
+      <extracomment>Forced by %2 to dark</extracomment>
       <translation>VRM</translation>
     </message>
     <message id="settings_remote_monitoring_portal">
@@ -7550,20 +6881,10 @@ Do you want to continue?</source>
       <source>Remote monitoring portal</source>
       <translation>Портал удаленного мониторинга</translation>
     </message>
-    <message id="settings_advanced">
-      <location filename="../../pages/SettingsPage.qml" line="68"/>
-      <source>Advanced</source>
-      <translation type="unfinished">Продвинутый</translation>
-    </message>
-    <message id="settings_integrations">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
+    <message id="pagesettingssupportstate_integrations">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
       <source>Integrations</source>
       <translation>Интеграции</translation>
-    </message>
-    <message id="settings_relays_sensors_tanks">
-      <location filename="../../pages/SettingsPage.qml" line="75"/>
-      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
-      <translation type="unfinished">Реле, датчики, резервуары, фотоэлектрические инверторы, Modbus, MQTT…</translation>
     </message>
     <message id="settings_acdcsystem_ess_dvcc_battery">
       <location filename="../../pages/SettingsPage.qml" line="84"/>
@@ -7583,11 +6904,13 @@ Do you want to continue?</source>
     <message id="settings_system_setup">
       <location filename="../../pages/SettingsPage.qml" line="82"/>
       <source>System Setup</source>
+      <oldsource>System setup</oldsource>
       <translation>Установка системы</translation>
     </message>
     <message id="settings_vrm_device_instances">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
       <source>VRM device instances</source>
+      <oldsource>VRM Device Instances</oldsource>
       <translation>Экземпляры устройств VRM</translation>
     </message>
     <message id="solarcharger_not_supported">
@@ -7605,28 +6928,10 @@ Do you want to continue?</source>
       <source>The firmware version in the MPPT Solar Charger must be v1.09 or later. Contact Victron Service for update instructions and files.</source>
       <translation>Версия прошивки в MPPT Solar Charger должна быть v1.09 или более поздней. Обратитесь в службу поддержки Victron для получения инструкций и файлов обновления.</translation>
     </message>
-    <message id="solarcharger_pv">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="102"/>
-      <source>PV</source>
-      <extracomment>PV power for solar charger</extracomment>
-      <translation type="unfinished">фотоэлектрический</translation>
-    </message>
     <message id="solarcharger_total_power">
       <location filename="../../pages/solar/PageSolarCharger.qml" line="127"/>
       <source>Total PV power</source>
       <translation>Общая фотоэлектрическая мощность</translation>
-    </message>
-    <message id="solarcharger_total_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="211"/>
-      <source>Total yield</source>
-      <extracomment>Solar charger total yield</extracomment>
-      <translation type="unfinished">Общая выработка</translation>
-    </message>
-    <message id="solarcharger_system_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="220"/>
-      <source>System yield</source>
-      <extracomment>Solar charger system yield</extracomment>
-      <translation type="unfinished">Выработка системы</translation>
     </message>
     <message id="settings_multirs_total_yield">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="63"/>
@@ -7662,16 +6967,19 @@ Do you want to continue?</source>
     <message id="vebus_device_update_firmware">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="133"/>
       <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
       <translation>Для этой функции требуется микропрограмма версии 400 или выше. Для обновления Multi/Quattro обратитесь к своему установщику.</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="139"/>
       <source>Charger not ready, equalization cannot be started</source>
+      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
       <translation>Зарядное устройство не готово, уравнивание не может быть запущено</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="143"/>
       <source>Equalization cannot be triggered during bulk charge state</source>
+      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
       <translation>Уравнивание не может быть запущено в состоянии массового заряда</translation>
     </message>
     <message id="vebus_device_restart_vebus_system_restart_confirmation_description">
@@ -7694,78 +7002,20 @@ Do you want to continue?</source>
       <source>Auto-started • %1</source>
       <translation>Автозапуск - %1</translation>
     </message>
-    <message id="common_words_battery">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery</source>
-      <translation type="unfinished">Батарея</translation>
-    </message>
-    <message id="common_words_boat_page">
-      <location filename="../../components/CommonWords.qml" line="111"/>
-      <source>Boat</source>
-      <extracomment>The 'Boat' page</extracomment>
-      <translation type="unfinished">Лодка</translation>
-    </message>
-    <message id="common_words_brief_page">
-      <location filename="../../components/CommonWords.qml" line="115"/>
-      <source>Brief</source>
-      <extracomment>The 'Brief' page</extracomment>
-      <translation type="unfinished">Краткое описание</translation>
-    </message>
-    <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation type="unfinished">Закрыто</translation>
-    </message>
-    <message id="common_words_color">
-      <location filename="../../components/CommonWords.qml" line="136"/>
-      <source>Color</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_connected">
-      <location filename="../../components/CommonWords.qml" line="139"/>
-      <source>Connected</source>
-      <translation type="unfinished">Подключено</translation>
-    </message>
     <message id="common_words_daily_history">
       <location filename="../../components/CommonWords.qml" line="152"/>
       <source>Daily history</source>
       <translation>Ежедневная история</translation>
-    </message>
-    <message id="common_words_disabled">
-      <location filename="../../components/CommonWords.qml" line="169"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Отключено</translation>
-    </message>
-    <message id="common_words_disconnected">
-      <location filename="../../components/CommonWords.qml" line="175"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Отключено</translation>
-    </message>
-    <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="191"/>
-      <source>Error</source>
-      <translation type="unfinished">Ошибка</translation>
     </message>
     <message id="common_words_error_not_a_number">
       <location filename="../../components/CommonWords.qml" line="200"/>
       <source>'%1' is not a number.</source>
       <translation>'%1' не является числом.</translation>
     </message>
-    <message id="common_words_generator">
-      <location filename="../../components/CommonWords.qml" line="217"/>
-      <source>Generator</source>
-      <translation type="unfinished">Генератор</translation>
-    </message>
     <message id="common_words_input_current_limit">
       <location filename="../../components/CommonWords.qml" line="261"/>
       <source>Input current limit</source>
       <translation>Ограничение входящего тока</translation>
-    </message>
-    <message id="common_words_inverter_charger">
-      <location filename="../../components/CommonWords.qml" line="264"/>
-      <source>Inverter / Charger</source>
-      <translation type="unfinished">Инвертор / зарядное устройство</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
       <location filename="../../components/CommonWords.qml" line="268"/>
@@ -7778,12 +7028,6 @@ Do you want to continue?</source>
       <source>Manual stop</source>
       <translation>Ручная остановка</translation>
     </message>
-    <message id="common_words_max">
-      <location filename="../../components/CommonWords.qml" line="315"/>
-      <source>Max</source>
-      <extracomment>Short for Maximum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_maximum_current">
       <location filename="../../components/CommonWords.qml" line="318"/>
       <source>Maximum current</source>
@@ -7794,62 +7038,10 @@ Do you want to continue?</source>
       <source>Maximum power</source>
       <translation>Максимальная мощность</translation>
     </message>
-    <message id="common_words_min">
-      <location filename="../../components/CommonWords.qml" line="331"/>
-      <source>Min</source>
-      <extracomment>Short for Minimum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_minimum_current">
       <location filename="../../components/CommonWords.qml" line="334"/>
       <source>Minimum current</source>
       <translation>Минимальный ток</translation>
-    </message>
-    <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="433"/>
-      <source>No</source>
-      <translation type="unfinished">Нет</translation>
-    </message>
-    <message id="common_words_none_option">
-      <location filename="../../components/CommonWords.qml" line="364"/>
-      <source>None</source>
-      <translation type="unfinished">Нет</translation>
-    </message>
-    <message id="common_words_none_errors">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>None</source>
-      <extracomment>Indicates there are no errors</extracomment>
-      <translation type="unfinished">Нет</translation>
-    </message>
-    <message id="common_words_not_available">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Not available</source>
-      <translation type="unfinished">Недоступно</translation>
-    </message>
-    <message id="common_words_off">
-      <location filename="../../components/CommonWords.qml" line="377"/>
-      <source>Off</source>
-      <translation type="unfinished">Выкл</translation>
-    </message>
-    <message id="common_words_ok">
-      <location filename="../../components/CommonWords.qml" line="383"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="41"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="45"/>
-      <source>OK</source>
-      <translation type="unfinished">Ok</translation>
-    </message>
-    <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="386"/>
-      <source>On</source>
-      <translation type="unfinished">Вкл</translation>
-    </message>
-    <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="393"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation type="unfinished">Открыто</translation>
     </message>
     <message id="common_words_open_circuit">
       <location filename="../../components/CommonWords.qml" line="396"/>
@@ -7861,108 +7053,17 @@ Do you want to continue?</source>
       <source>Overall history</source>
       <translation>Общая история</translation>
     </message>
-    <message id="common_words_press">
-      <location filename="../../components/CommonWords.qml" line="419"/>
-      <source>Press</source>
-      <translation type="unfinished">Печать</translation>
-    </message>
-    <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation type="unfinished">Работает</translation>
-    </message>
-    <message id="common_words_settings">
-      <location filename="../../components/CommonWords.qml" line="467"/>
-      <source>Settings</source>
-      <translation type="unfinished">Настройки</translation>
-    </message>
-    <message id="common_words_silence_alarm">
-      <location filename="../../components/CommonWords.qml" line="476"/>
-      <source>Silence alarm</source>
-      <translation type="unfinished">Отключить сигнализацию</translation>
-    </message>
     <message id="common_words_soc">
       <location filename="../../components/CommonWords.qml" line="480"/>
       <source>SOC %1</source>
       <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
       <translation>SOC %1%</translation>
     </message>
-    <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation type="unfinished">Скорость</translation>
-    </message>
-    <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="487"/>
-      <source>Standby</source>
-      <translation type="unfinished">Ожидание</translation>
-    </message>
-    <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="502"/>
-      <source>State</source>
-      <translation type="unfinished">Состояние</translation>
-    </message>
-    <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="512"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation type="unfinished">Запуск (%1)</translation>
-    </message>
-    <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>Stopped</source>
-      <translation type="unfinished">Остановлено</translation>
-    </message>
-    <message id="common_words_total_power">
-      <location filename="../../components/CommonWords.qml" line="540"/>
-      <source>Total power</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="547"/>
-      <source>Type</source>
-      <translation type="unfinished">Тип</translation>
-    </message>
-    <message id="common_words_unknown_status">
-      <location filename="../../components/CommonWords.qml" line="554"/>
-      <source>Unknown</source>
-      <extracomment>Status = "unknown"</extracomment>
-      <translation type="unfinished">Неизвестно</translation>
-    </message>
-    <message id="common_words_value_must_be_greater_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="557"/>
-      <source>Value must be greater than start value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_value_must_be_greater_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="560"/>
-      <source>Value must be greater than stop value</source>
-      <translation type="unfinished">Значение должно быть выше, чем конечное значение</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="563"/>
-      <source>Value must be lower than start value</source>
-      <translation type="unfinished">Значение должно быть ниже, чем начальное значение</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="566"/>
-      <source>Value must be lower than stop value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="581"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="431"/>
-      <source>Yes</source>
-      <translation type="unfinished">Да</translation>
-    </message>
     <message id="common_words_yield_today">
       <location filename="../../components/CommonWords.qml" line="592"/>
       <source>Yield Today</source>
       <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+      <oldsource>Yield today</oldsource>
       <translation>Доходность сегодня</translation>
     </message>
     <message id="common_words_format_error">
@@ -7989,10 +7090,11 @@ Do you want to continue?</source>
     <message id="settings_firmware_installed_rebooting">
       <location filename="../../components/FirmwareUpdate.qml" line="79"/>
       <source>Firmware installed, device rebooting</source>
+      <oldsource>Firmware installed, rebooting.</oldsource>
       <translation>Прошивка установлена, устройство перезагружается</translation>
     </message>
-    <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/RadioButtonListPage.qml" line="121"/>
+    <message id="modaldialog_confirm">
+      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
       <source>Confirm</source>
       <extracomment>Confirm password, and verify it if possible</extracomment>
       <translation>Да, отпишите меня</translation>
@@ -8010,11 +7112,13 @@ Do you want to continue?</source>
     <message id="cgwacs_battery_schedule_duration">
       <location filename="../../components/listitems/ListChargeSchedule.qml" line="144"/>
       <source>Duration</source>
+      <oldsource>Duration (hh:mm)</oldsource>
       <translation>Длительность &lt;wbr&gt; (чч:мм)</translation>
     </message>
     <message id="settings_relay_deactivation_value">
       <location filename="../../components/TemperatureRelaySettings.qml" line="86"/>
       <source>Deactivation value</source>
+      <oldsource>Deativation value</oldsource>
       <translation>Значение деактивации</translation>
     </message>
     <message id="splash_view_device_disconnected">
@@ -8062,29 +7166,6 @@ Do you want to continue?</source>
       <source>Temperature warning</source>
       <translation>Предупреждение о температуре</translation>
     </message>
-    <message id="battery_mode_idle">
-      <location filename="../../src/enums.cpp" line="26"/>
-      <source>Idle</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">без нагрузки</translation>
-    </message>
-    <message id="battery_mode_charging">
-      <location filename="../../src/enums.cpp" line="30"/>
-      <source>Charging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">заряжается</translation>
-    </message>
-    <message id="battery_mode_discharging">
-      <location filename="../../src/enums.cpp" line="34"/>
-      <source>Discharging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">разряжается</translation>
-    </message>
-    <message id="dcMeter_bilge_pump">
-      <location filename="../../src/enums.cpp" line="115"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">Трюмный насос</translation>
-    </message>
     <message id="switch_state_channel_fault">
       <location filename="../../src/enums.cpp" line="372"/>
       <source>Channel Fault</source>
@@ -8115,26 +7196,6 @@ Do you want to continue?</source>
       <source>Slave of %1</source>
       <translation>Ведомый %1</translation>
     </message>
-    <message id="switchable_output_numeric_input">
-      <location filename="../../src/enums.cpp" line="418"/>
-      <source>Numeric input</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bilge_pump">
-      <location filename="../../src/enums.cpp" line="424"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">Трюмный насос</translation>
-    </message>
-    <message id="switchable_output_not_running">
-      <location filename="../../src/enums.cpp" line="448"/>
-      <source>Not running</source>
-      <translation type="unfinished">Не работает</translation>
-    </message>
-    <message id="switchable_output_off">
-      <location filename="../../src/enums.cpp" line="451"/>
-      <source>Off</source>
-      <translation type="unfinished">Выкл</translation>
-    </message>
     <message id="switchable_output_powered">
       <location filename="../../src/enums.cpp" line="455"/>
       <source>Powered</source>
@@ -8163,16 +7224,19 @@ Do you want to continue?</source>
     <message id="evchargers_status_welded_contacts_error">
       <location filename="../../data/EvChargers.qml" line="76"/>
       <source>Welded contacts test error (shorted)</source>
+      <oldsource>Welded contacts error</oldsource>
       <translation>Ошибка проверки сварных контактов (короткое замыкание)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
       <location filename="../../data/EvChargers.qml" line="100"/>
       <source>Switching to 3 phase</source>
+      <oldsource>Switching to 3-phase</oldsource>
       <translation>Переключение на 3 фазы</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
       <location filename="../../data/EvChargers.qml" line="103"/>
       <source>Switching to 1 phase</source>
+      <oldsource>Switching to single phase</oldsource>
       <translation>Переключение на 1 фазу</translation>
     </message>
     <message id="evchargers_status_stop_charging">
@@ -8325,17 +7389,6 @@ If the generator is currently running due to a autostart condition, disabling au
       <source>Open link</source>
       <translation>Открытая ссылка</translation>
     </message>
-    <message id="listlink_show_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="43"/>
-      <source>Show QR code</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="listlink_scan_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="52"/>
-      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
-      <extracomment>%1 = url text</extracomment>
-      <translation type="unfinished">Отсканируйте QR-код с помощью портативного устройства.&lt;br /&gt; Или вставьте ссылку: %1</translation>
-    </message>
     <message id="settings_services_mqtt_access">
       <location filename="../../components/listitems/ListMqttAccessSwitch.qml" line="11"/>
       <source>MQTT Access</source>
@@ -8407,12 +7460,6 @@ If the generator is currently running due to a autostart condition, disabling au
       <extracomment>The 'Brief' page, with the side panel opened</extracomment>
       <translation>Брифинг (боковая стенка открыта)</translation>
     </message>
-    <message id="startpage_option_overview">
-      <location filename="../../data/StartPageConfiguration.qml" line="37"/>
-      <source>Overview</source>
-      <extracomment>The 'Overview' page</extracomment>
-      <translation type="unfinished">Обзор</translation>
-    </message>
     <message id="startpage_option_levels_tanks">
       <location filename="../../data/StartPageConfiguration.qml" line="43"/>
       <source>Levels (Tanks)</source>
@@ -8431,12 +7478,12 @@ If the generator is currently running due to a autostart condition, disabling au
       <translation>Список аккумуляторов</translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
+      <location filename="../../pages/DialogLayer.qml" line="56"/>
       <source>GX device has been updated</source>
       <translation>Устройство GX было обновлено</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
+      <location filename="../../pages/DialogLayer.qml" line="58"/>
       <source>Page will automatically reload in ten seconds to load the latest version.</source>
       <translation>Страница автоматически перезагрузится через десять секунд, чтобы загрузить последнюю версию.</translation>
     </message>
@@ -8530,6 +7577,7 @@ Note that this menu only shows Carlo Gavazzi meters connected over RS485. For an
         <numerusform>Через %n минут(ы)</numerusform>
         <numerusform>Через %n минут(ы)</numerusform>
         <numerusform>Через %n минут(ы)</numerusform>
+        <numerusform>Через %n минут(ы)</numerusform>
       </translation>
     </message>
     <message id="settings_startpage_description">
@@ -8607,8 +7655,8 @@ Note that this menu only shows Carlo Gavazzi meters connected over RS485. For an
       <source>Unit</source>
       <translation>Устройство</translation>
     </message>
-    <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="61"/>
+    <message id="page_settings_fronius_unitid_invalid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
       <source>%1 is not a valid unit number. Use a number between 1-247.</source>
       <translation>%1 - это неправильный номер единицы измерения. Используйте число в диапазоне 1-247.</translation>
     </message>
@@ -8723,11 +7771,6 @@ Note that this menu only shows Carlo Gavazzi meters connected over RS485. For an
       <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="66"/>
       <source>Controller Temperature</source>
       <translation>Температура контроллера</translation>
-    </message>
-    <message id="devicelist_motordrive_motordirectioninverted">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
-      <source>Motor Direction Inverted</source>
-      <translation type="unfinished"/>
     </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
@@ -8919,11 +7962,6 @@ With streamlined navigation and a fresh look, everything you love is now even ea
     <message id="welcome_done">
       <location filename="../../pages/welcome/WelcomeView.qml" line="136"/>
       <source>Done</source>
-      <translation type="unfinished">Готово</translation>
-    </message>
-    <message id="mk2vsc_state_done">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="20"/>
-      <source>Done</source>
       <translation>Готово</translation>
     </message>
     <message id="welcome_next">
@@ -8981,6 +8019,7 @@ The GX device can only control one connected genset and takes the one with the l
     <message id="settings_tz_etc">
       <location filename="../../pages/settings/PageTzInfo.qml" line="280"/>
       <source>Other</source>
+      <oldsource>Etc</oldsource>
       <translation>Другие</translation>
     </message>
     <message id="ac-in-modeldefault_energy_reverse_x">
@@ -8998,6 +8037,11 @@ The GX device can only control one connected genset and takes the one with the l
       <location filename="../../src/enums.cpp" line="438"/>
       <source>Unsupported type: %1</source>
       <translation>Неподдерживаемый тип: %1</translation>
+    </message>
+    <message id="common_words_press">
+      <location filename="../../components/CommonWords.qml" line="419"/>
+      <source>Press</source>
+      <translation>Печать</translation>
     </message>
     <message id="output_aux_battery_service_changed_dcdc">
       <location filename="../../components/listitems/ListOutputBatteryRadioButtonGroup.qml" line="27"/>
@@ -9138,13 +8182,6 @@ The GX device can only control one connected genset and takes the one with the l
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="38"/>
       <source>Resetting VE.Bus products</source>
       <translation>Сброс продуктов VE.Bus</translation>
-    </message>
-    <message id="Unknown">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Неизвестно</translation>
     </message>
     <message id="mk2vsc_error_mk2_mk3_comm">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="47"/>
@@ -9450,11 +8487,6 @@ The GX device can only control one connected genset and takes the one with the l
       <source>Changing the GX Password</source>
       <translation>Изменение пароля GX</translation>
     </message>
-    <message id="modaldialog_confirm">
-      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
-      <source>Confirm</source>
-      <translation type="unfinished">Да, отпишите меня</translation>
-    </message>
     <message id="settings_security_profile_change_password_description">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="83"/>
       <source>Please enter a new GX password:</source>
@@ -9547,21 +8579,6 @@ The GX device can only control one connected genset and takes the one with the l
       <source>Modifications installed</source>
       <translation>Установленные модификации</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_modbus">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="28"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">Сервер Modbus TCP</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_signalk">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="32"/>
-      <source>Signal K</source>
-      <translation type="unfinished">Сервер Signal K</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_nodered">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="36"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">Сервер Node-RED</translation>
-    </message>
     <message id="pagesettingsgeneral_modificationchecks_running_integrations">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="43"/>
       <source>%1 running integrations</source>
@@ -9637,16 +8654,6 @@ The GX device can only control one connected genset and takes the one with the l
       <source>Installed and enabled, disables at next boot</source>
       <translation>Установлено и включено; будет отключено при следующей загрузке</translation>
     </message>
-    <message id="pagesettingssupportstate_firmware_checking">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
-      <source>Checking...</source>
-      <translation type="unfinished">Проверяю...</translation>
-    </message>
-    <message id="pagesettingssupportstate_firmware_unknown">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="166"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Неизвестно</translation>
-    </message>
     <message id="pagesettingssupportstate_support_status">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="228"/>
       <source>Support status</source>
@@ -9668,11 +8675,6 @@ The GX device can only control one connected genset and takes the one with the l
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="288"/>
       <source>Press 'OK' to disable custom startup scripts and reboot</source>
       <translation>Нажмите 'OK', чтобы отключить пользовательские скрипты запуска и перезагрузить устройство</translation>
-    </message>
-    <message id="pagesettingssupportstate_re_enable_custom_startup_scripts">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="309"/>
-      <source>Re-enable custom startup scripts</source>
-      <translation type="unfinished">Включить пользовательские скрипты запуска</translation>
     </message>
     <message id="pagesettingssupportstate_reenable_and_reboot_now">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="322"/>
@@ -9699,11 +8701,6 @@ The GX device can only control one connected genset and takes the one with the l
       <source>Disable also custom startup scripts?</source>
       <translation>Отключить также пользовательские скрипты запуска?</translation>
     </message>
-    <message id="pagesettingssupportstate_integrations">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
-      <source>Integrations</source>
-      <translation type="unfinished">Интеграции</translation>
-    </message>
     <message id="pagesettingssupportstate_orange_items_description">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="494"/>
       <source>Items colored orange are supported and provided by Victron Energy, but using them incorrectly can affect system stability. In case of troubleshooting, disable those first.</source>
@@ -9715,7 +8712,7 @@ The GX device can only control one connected genset and takes the one with the l
       <translation>Подключите совместимый USB-адаптер Bluetooth, чтобы включить подключение Bluetooth.</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="140"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="142"/>
       <source>BatteryLife state</source>
       <translation>Состояние BatteryLife</translation>
     </message>
@@ -9723,23 +8720,6 @@ The GX device can only control one connected genset and takes the one with the l
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="33"/>
       <source>Device Integrations</source>
       <translation>Интеграции устройств</translation>
-    </message>
-    <message id="pagesettingsintegrations_modbus_tcp_server">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="201"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">Сервер Modbus TCP</translation>
-    </message>
-    <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="226"/>
-      <location filename="../../pages/settings/PageSettingsSignalK.qml" line="18"/>
-      <source>Signal K</source>
-      <translation type="unfinished">Сервер Signal K</translation>
-    </message>
-    <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="241"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">Сервер Node-RED</translation>
     </message>
     <message id="settings_venusos_large_documentation">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="267"/>
@@ -9749,6 +8729,7 @@ The GX device can only control one connected genset and takes the one with the l
     <message id="settings_modbus_enable_modbus_tcp">
       <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
       <source>Enable Modbus TCP Server</source>
+      <oldsource>Enable Modbus/TCP</oldsource>
       <translation>Включить сервер Modbus TCP</translation>
     </message>
     <message id="pagesettingsconnectivity_bluetooth_for_victronconnect_app">
@@ -9842,11 +8823,13 @@ The GX device can only control one connected genset and takes the one with the l
     <message id="settings_gps_format_kmh">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="93"/>
       <source>Kilometres per hour</source>
+      <oldsource>Kilometers per hour</oldsource>
       <translation>Километров в час</translation>
     </message>
     <message id="settings_gps_format_ms">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="95"/>
       <source>Metres per second</source>
+      <oldsource>Meters per second</oldsource>
       <translation>Метров в секунду</translation>
     </message>
     <message id="components_volumeunit_cubic_metres">
@@ -9874,8 +8857,8 @@ The GX device can only control one connected genset and takes the one with the l
       <source>The Relay can now be found in the devices list</source>
       <translation>Реле теперь можно найти в списке устройств</translation>
     </message>
-    <message id="common_words_gx_device_relays">
-      <location filename="../../components/CommonWords.qml" line="223"/>
+    <message id="gx_device_relays">
+      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
       <source>GX device relays</source>
       <translation>Реле устройств GX</translation>
     </message>
@@ -9929,12 +8912,6 @@ The GX device can only control one connected genset and takes the one with the l
       <extracomment>Forced by app to %1</extracomment>
       <translation>авто</translation>
     </message>
-    <message id="settings_remote_console_forced_by_vrm">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="94"/>
-      <source>VRM</source>
-      <extracomment>Forced by %2 to dark</extracomment>
-      <translation type="unfinished">VRM</translation>
-    </message>
     <message id="settings_remote_console_forced_by_app">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="97"/>
       <source>app</source>
@@ -9984,6 +8961,7 @@ The GX device can only control one connected genset and takes the one with the l
     <message id="settings_large_access_signal_k">
       <location filename="../../pages/settings/PageSettingsSignalK.qml" line="24"/>
       <source>Access Signal K</source>
+      <oldsource>Access Signal K (local network)</oldsource>
       <translation>Доступ к Signal K</translation>
     </message>
     <message id="pagesettingsintegrations_shelly_devices">
@@ -9994,6 +8972,7 @@ The GX device can only control one connected genset and takes the one with the l
     <message id="settings_large_access_node_red">
       <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
       <source>Access Node-RED</source>
+      <oldsource>Access Node-RED (local network)</oldsource>
       <translation>Доступ к Node-RED</translation>
     </message>
     <message id="settings_wifi_access_point_password">
@@ -10061,57 +9040,6 @@ The GX device can only control one connected genset and takes the one with the l
       <source>Wind charger</source>
       <translation>Ветрогенератор</translation>
     </message>
-    <message id="digitalinputs_type_disabled">
-      <location filename="../../src/enums.cpp" line="192"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Отключено</translation>
-    </message>
-    <message id="digitalinputs_state_off">
-      <location filename="../../src/enums.cpp" line="242"/>
-      <source>Off</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Выкл</translation>
-    </message>
-    <message id="digitalinputs_state_on">
-      <location filename="../../src/enums.cpp" line="246"/>
-      <source>On</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Вкл</translation>
-    </message>
-    <message id="digitalinputs_state_ok">
-      <location filename="../../src/enums.cpp" line="266"/>
-      <source>OK</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Ok</translation>
-    </message>
-    <message id="digitalinputs_state_alarm">
-      <location filename="../../src/enums.cpp" line="270"/>
-      <source>Alarm</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Тревога</translation>
-    </message>
-    <message id="digitalinputs_state_running">
-      <location filename="../../src/enums.cpp" line="274"/>
-      <source>Running</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Работает</translation>
-    </message>
-    <message id="pvinverter_statusCode_running">
-      <location filename="../../src/enums.cpp" line="300"/>
-      <source>Running</source>
-      <extracomment>PV inverter status code</extracomment>
-      <translation type="unfinished">Работает</translation>
-    </message>
-    <message id="solarchargers_state_external control">
-      <location filename="../../src/enums.cpp" line="352"/>
-      <source>External control</source>
-      <translation type="unfinished">Внешнее управление</translation>
-    </message>
-    <message id="switch_state_over_temperature">
-      <location filename="../../src/enums.cpp" line="366"/>
-      <source>Over temperature</source>
-      <translation type="unfinished">Перегрев</translation>
-    </message>
     <message id="switchable_output_temperature_setpoint">
       <location filename="../../src/enums.cpp" line="398"/>
       <source>Temperature setpoint</source>
@@ -10121,11 +9049,6 @@ The GX device can only control one connected genset and takes the one with the l
       <location filename="../../src/enums.cpp" line="401"/>
       <source>Stepped switch</source>
       <translation>Многопозиционный переключатель</translation>
-    </message>
-    <message id="switchable_output_slave">
-      <location filename="../../src/enums.cpp" line="408"/>
-      <source>Slave</source>
-      <translation type="unfinished">Ведомый</translation>
     </message>
     <message id="switchable_output_dropdown">
       <location filename="../../src/enums.cpp" line="412"/>
@@ -10137,122 +9060,10 @@ The GX device can only control one connected genset and takes the one with the l
       <source>Basic slider</source>
       <translation>Базовый слайдер</translation>
     </message>
-    <message id="switchable_output_rgb_color_wheel">
-      <location filename="../../src/enums.cpp" line="427"/>
-      <source>RGB color wheel</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_cct_color_wheel">
-      <location filename="../../src/enums.cpp" line="431"/>
-      <source>CCT color wheel</source>
-      <extracomment>Correlated Color Temperature color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_rgbw_color_wheel">
-      <location filename="../../src/enums.cpp" line="435"/>
-      <source>RGB + W color wheel</source>
-      <extracomment>RGB + white color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bypassed">
-      <location filename="../../src/enums.cpp" line="484"/>
-      <source>Bypassed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="tank_type_fuel">
-      <location filename="../../src/enums.cpp" line="495"/>
-      <source>Fuel</source>
-      <translation type="unfinished">Топливо</translation>
-    </message>
-    <message id="tank_type_fresh_water">
-      <location filename="../../src/enums.cpp" line="498"/>
-      <source>Fresh water</source>
-      <translation type="unfinished">Свежая вода</translation>
-    </message>
-    <message id="tank_type_waste_water">
-      <location filename="../../src/enums.cpp" line="501"/>
-      <source>Waste water</source>
-      <translation type="unfinished">Грязная вода</translation>
-    </message>
-    <message id="tank_type_live_well">
-      <location filename="../../src/enums.cpp" line="504"/>
-      <source>Live well</source>
-      <translation type="unfinished">Рабочая скважина</translation>
-    </message>
-    <message id="tank_type_oil">
-      <location filename="../../src/enums.cpp" line="507"/>
-      <source>Oil</source>
-      <translation type="unfinished">Нефть</translation>
-    </message>
-    <message id="tank_type_black_water">
-      <location filename="../../src/enums.cpp" line="510"/>
-      <source>Black water</source>
-      <translation type="unfinished">Темная вода</translation>
-    </message>
-    <message id="tank_type_gasoline">
-      <location filename="../../src/enums.cpp" line="513"/>
-      <source>Gasoline</source>
-      <translation type="unfinished">Бензин</translation>
-    </message>
-    <message id="tank_type_diesel">
-      <location filename="../../src/enums.cpp" line="516"/>
-      <source>Diesel</source>
-      <translation type="unfinished">Дизельное топливо</translation>
-    </message>
-    <message id="tank_type_lpg">
-      <location filename="../../src/enums.cpp" line="519"/>
-      <source>LPG</source>
-      <translation type="unfinished">Сжиженный углеводородный газ</translation>
-    </message>
-    <message id="tank_type_lng">
-      <location filename="../../src/enums.cpp" line="522"/>
-      <source>LNG</source>
-      <translation type="unfinished">Сжиженный природный газ</translation>
-    </message>
-    <message id="tank_type_hydraulic_oil">
-      <location filename="../../src/enums.cpp" line="525"/>
-      <source>Hydraulic oil</source>
-      <translation type="unfinished">Гидравлическое масло</translation>
-    </message>
-    <message id="tank_type_raw_water">
-      <location filename="../../src/enums.cpp" line="528"/>
-      <source>Raw water</source>
-      <translation type="unfinished">Сырая вода</translation>
-    </message>
-    <message id="microgrid_mode_hybrid_droop">
-      <location filename="../../src/enums.cpp" line="539"/>
-      <source>Hybrid droop</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_following">
-      <location filename="../../src/enums.cpp" line="542"/>
-      <source>Grid-following</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_forming">
-      <location filename="../../src/enums.cpp" line="545"/>
-      <source>Grid-forming</source>
-      <translation type="unfinished"/>
-    </message>
     <message id="switchable_output_three_state_switch">
       <location filename="../../src/enums.cpp" line="421"/>
       <source>Three-state switch</source>
       <translation>Трехпозиционный переключатель</translation>
-    </message>
-    <message id="switchable_output_fault">
-      <location filename="../../src/enums.cpp" line="464"/>
-      <source>Fault</source>
-      <translation type="unfinished">Неисправность</translation>
-    </message>
-    <message id="switchable_output_running">
-      <location filename="../../src/enums.cpp" line="468"/>
-      <source>Running</source>
-      <translation type="unfinished">Работает</translation>
-    </message>
-    <message id="switchable_output_trip_low_voltage">
-      <location filename="../../src/enums.cpp" line="481"/>
-      <source>Trip low voltage</source>
-      <translation type="unfinished">Отключено</translation>
     </message>
     <message id="settings_modbus_tcp_unit_id_note">
       <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="41"/>
@@ -10274,281 +9085,1152 @@ The GX device can only control one connected genset and takes the one with the l
       <source>Press to refresh</source>
       <translation>Нажмите для обновления</translation>
     </message>
-    <message id="temperature_type_unknown">
-      <location filename="../../data/EnvironmentInputs.qml" line="65"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Неизвестно</translation>
-    </message>
-    <message id="brief_solar_yield">
-      <location filename="../../pages/BriefSidePanel.qml" line="24"/>
-      <source>Solar yield</source>
-      <translation type="unfinished">Выход солнечной энергии</translation>
-    </message>
-    <message id="brief_dc_input">
-      <location filename="../../pages/BriefSidePanel.qml" line="214"/>
-      <source>DC input</source>
-      <translation type="unfinished">Вход постоянного тока</translation>
-    </message>
-    <message id="brief_ac_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="257"/>
-      <source>AC Loads</source>
-      <translation type="unfinished">AC нагрузки</translation>
-    </message>
-    <message id="brief_dc_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="284"/>
-      <source>DC Loads</source>
-      <translation type="unfinished">dcLoads</translation>
-    </message>
-    <message id="nav_overview">
-      <location filename="../../pages/OverviewPage.qml" line="450"/>
-      <source>Overview</source>
-      <translation type="unfinished">Обзор</translation>
-    </message>
-    <message id="settings_state">
-      <location filename="../../pages/settings/PageCanbusStatus.qml" line="116"/>
-      <source>State</source>
-      <translation type="unfinished">Состояние</translation>
-    </message>
-    <message id="inverter_pv">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="56"/>
-      <source>PV</source>
-      <translation type="unfinished">фотоэлектрический</translation>
-    </message>
-    <message id="inverter_total_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="76"/>
-      <source>Total yield</source>
-      <translation type="unfinished">Общая выработка</translation>
-    </message>
-    <message id="inverter_system_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="84"/>
-      <source>System yield</source>
-      <translation type="unfinished">Выработка системы</translation>
-    </message>
-    <message id="charger_total_pv_power">
-      <location filename="../../pages/solar/SolarDevicePage.qml" line="61"/>
-      <source>Total PV Power</source>
-      <translation type="unfinished">Общая фотоэлектрическая мощность</translation>
-    </message>
-    <message id="vebus_device_alarm_only">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
-      <source>Alarm only</source>
-      <translation type="unfinished">Только оповещения</translation>
-    </message>
-    <message id="vebus_device_alarms_and_warnings">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
-      <source>Alarms &amp; warnings</source>
-      <translation type="unfinished">Тревоги &amp; предупреждения</translation>
-    </message>
-    <message id="vebus_device_alarm_group_warning">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
-      <source>Warning</source>
-      <translation type="unfinished">Предупреждение</translation>
-    </message>
-    <message id="load_delegate_status">
-      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
-      <source>Status: %1</source>
-      <translation type="unfinished"/>
+    <message id="common_words_total_power">
+      <location filename="../../components/CommonWords.qml" line="540"/>
+      <source>Total power</source>
+      <translation>Суммарная мощность</translation>
     </message>
     <message id="venus_os_gui">
       <location filename="../../Main.qml" line="17"/>
       <source>Venus OS GUI</source>
       <extracomment>Application title</extracomment>
-      <translation type="unfinished"/>
       <extra-Context>only shown on desktop systems</extra-Context>
+      <translation>Venus OS GUI</translation>
+    </message>
+    <message id="load_delegate_status">
+      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
+      <source>Status: %1</source>
+      <translation>Состояние: %1</translation>
+    </message>
+    <message id="settings_relay_polarity_relay1">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
+      <source>Polarity (Relay 1)</source>
+      <translation>Полярность (Реле 1)</translation>
+    </message>
+    <message id="settings_relay_polarity">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
+      <source>Polarity</source>
+      <translation>Полярность</translation>
+    </message>
+    <message id="settings_relay_polarity_relay2">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
+      <source>Polarity (Relay 2)</source>
+      <translation>Полярность (Реле 2)</translation>
+    </message>
+    <message id="page_settings_wifi_invalid_password">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
+      <source>Password length must be either 0 or between 10 and 63 characters long</source>
+      <translation>Длина пароля должна быть равна 0 или от 10 до 63 символов</translation>
+    </message>
+    <message id="page_settings_wifi_password_updated">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
+      <source>Password updated</source>
+      <translation>Пароль обновлен</translation>
+    </message>
+    <message id="common_words_max">
+      <location filename="../../components/CommonWords.qml" line="315"/>
+      <source>Max</source>
+      <extracomment>Short for Maximum</extracomment>
+      <translation>Макс.</translation>
+    </message>
+    <message id="common_words_min">
+      <location filename="../../components/CommonWords.qml" line="331"/>
+      <source>Min</source>
+      <extracomment>Short for Minimum</extracomment>
+      <translation>Мин.</translation>
+    </message>
+    <message id="settings_ess_deprecated">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="321"/>
+      <source>Deprecated settings</source>
+      <translation>Устаревшие настройки</translation>
+    </message>
+    <message id="settings_ess_max_charge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="328"/>
+      <source>Battery charge limit (% of CCL)</source>
+      <translation>Предел заряда аккумулятора (% от CCL)</translation>
+    </message>
+    <message id="settings_ess_max_discharge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="339"/>
+      <source>Battery discharge limit (% of DCL)</source>
+      <translation>Предел разряда аккумулятора (% от DCL)</translation>
+    </message>
+    <message id="vebus_device_bms_message">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
+      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
+      <oldsource>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</oldsource>
+      <translation>VE.Bus BMS автоматически отключает систему при необходимости для защиты аккумулятора. Управление системой с устройства GX поэтому невозможно.</translation>
+    </message>
+    <message id="switchable_output_numeric_input">
+      <location filename="../../src/enums.cpp" line="418"/>
+      <source>Numeric input</source>
+      <translation>Числовой ввод</translation>
     </message>
     <message id="autotoggleswitch_disable_auto_mode_info">
       <location filename="../../components/controls/AutoToggleButton.qml" line="34"/>
       <source>Disable Auto mode first</source>
-      <translation type="unfinished"/>
+      <translation>Сначала отключите автоматический режим</translation>
+    </message>
+    <message id="pagesettingsintegrations_venus_os_enable_large_features">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
+      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
+      <translation>Включить расширенную прошивку Venus OS для использования Node-RED или Signal-K</translation>
+    </message>
+    <message id="settings_relays_sensors_tanks">
+      <location filename="../../pages/SettingsPage.qml" line="75"/>
+      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
+      <oldsource>Relays, Sensors, Tanks, PV Inverters, Modbus, MQTT…</oldsource>
+      <translation>Реле, датчики, фотоэлектрические инверторы, Modbus, Node-RED</translation>
+    </message>
+    <message id="vebus_device_page_microgrid_parameters">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
+      <source>Microgrid parameters</source>
+      <translation>Параметры микросети</translation>
+    </message>
+    <message id="microgrid_mode_hybrid_droop">
+      <location filename="../../src/enums.cpp" line="539"/>
+      <source>Hybrid droop</source>
+      <translation>Гибридное регулирование</translation>
+    </message>
+    <message id="microgrid_mode_grid_following">
+      <location filename="../../src/enums.cpp" line="542"/>
+      <source>Grid-following</source>
+      <translation>Следование за сетью</translation>
+    </message>
+    <message id="microgrid_mode_grid_forming">
+      <location filename="../../src/enums.cpp" line="545"/>
+      <source>Grid-forming</source>
+      <translation>Формирование сети</translation>
+    </message>
+    <message id="switchable_output_trip_low_voltage">
+      <location filename="../../src/enums.cpp" line="481"/>
+      <source>Trip low voltage</source>
+      <oldsource>Disabled</oldsource>
+      <translation>Отключение при низком напряжении</translation>
     </message>
     <message id="microgrid">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="15"/>
       <source>Microgrid</source>
-      <translation type="unfinished"/>
+      <translation>Микросеть</translation>
     </message>
     <message id="page_microgrid_active_mode">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="19"/>
       <source>Active mode</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_microgrid_from_p1_to_p2">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="34"/>
-      <source>%1 %2 to %3 %4</source>
-      <extracomment>Describes a range from one quantity to another, e.g. "30 W to 60 W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
-      <translation type="unfinished"/>
+      <translation>Активный режим</translation>
     </message>
     <message id="page_microgrid_hybrid_droop_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="92"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
       <source>Hybrid droop parameters</source>
-      <translation type="unfinished"/>
+      <translation>Параметры гибридного регулирования</translation>
     </message>
     <message id="page_microgrid_reference_active_power_p0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="105"/>
       <source>Reference active power (P&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Опорная активная мощность (P&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_frequency_f0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="108"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="112"/>
       <source>Reference frequency (f&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Опорная частота (f&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_frequency_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="117"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="119"/>
       <source>Frequency droop slope (droop&lt;sub&gt;fP&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Наклон характеристики частотной зависимости мощности (droop&lt;sub&gt;fP&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_reactive_power">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="126"/>
       <source>Reference reactive power (Q&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Опорная реактивная мощность (Q&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_voltage">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="135"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="133"/>
       <source>Reference Voltage (U&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Опорное напряжение (U&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_voltage_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="144"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="140"/>
       <source>Voltage droop slope (droop&lt;sub&gt;UQ&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Наклон характеристики зависимости напряжения от реактивной мощности (droop&lt;sub&gt;UQ&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_minimum_and_maximum_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="146"/>
       <source>Minimum and maximum parameters</source>
-      <translation type="unfinished"/>
+      <translation>Минимальные и максимальные параметры</translation>
     </message>
     <message id="page_microgrid_allowed_active_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="156"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
       <source>Allowed active power range</source>
-      <translation type="unfinished"/>
+      <translation>Разрешенный диапазон активной мощности</translation>
     </message>
     <message id="page_microgrid_allowed_reactive_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="164"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="159"/>
       <source>Allowed reactive power range</source>
-      <translation type="unfinished"/>
+      <translation>Разрешенный диапазон реактивной мощности</translation>
     </message>
     <message id="page_microgrid_p_q_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="176"/>
       <source>P-Q direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>Настройки прямого управления P-Q</translation>
     </message>
     <message id="page_microgrid_active_power_setpoint_p">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="186"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
       <source>Active power setpoint (P)</source>
-      <translation type="unfinished"/>
+      <translation>Уставка активной мощности (P)</translation>
     </message>
     <message id="page_microgrid_reactive_power_setpoint_q">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="194"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="188"/>
       <source>Reactive power setpoint (Q)</source>
-      <translation type="unfinished"/>
+      <translation>Уставка реактивной мощности (Q)</translation>
     </message>
     <message id="page_microgrid_allowed_frequency_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="202"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="195"/>
       <source>Allowed frequency range</source>
-      <translation type="unfinished"/>
+      <translation>Разрешенный диапазон частот</translation>
     </message>
     <message id="page_microgrid_allowed_voltage_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="210"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="203"/>
       <source>Allowed voltage range</source>
-      <translation type="unfinished"/>
+      <translation>Разрешенный диапазон напряжений</translation>
     </message>
     <message id="page_microgrid_v_f_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="227"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="220"/>
       <source>V-f direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>Настройки прямого управления V-f</translation>
     </message>
     <message id="page_microgrid_voltage_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="225"/>
       <source>Voltage setpoint (U)</source>
-      <translation type="unfinished"/>
+      <translation>Уставка напряжения (U)</translation>
     </message>
     <message id="page_microgrid_frequency_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="240"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
       <source>Frequency setpoint (f)</source>
-      <translation type="unfinished"/>
+      <translation>Уставка частоты (f)</translation>
     </message>
-    <message id="temperature_slider_current">
-      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
-      <source>Current</source>
-      <extracomment>The current temperature measurement</extracomment>
-      <translation type="unfinished">Ток</translation>
+    <message id="pagesettingsintegrations_canopenmotordrive">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
+      <source>CANopen motor drives</source>
+      <translation>Приводы CANopen Motor</translation>
+    </message>
+    <message id="pagesettingsintegrations_ui_plugins">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
+      <source>UI Plugins</source>
+      <translation>Плагины UI</translation>
+    </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
+      <source>Motor Direction Inverted</source>
+      <translation>Инвертированное направление двигателя</translation>
     </message>
     <message id="page_settings_canopenmotordrive_scan_for_motor_drives">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="31"/>
       <source>Scan for motor drives</source>
-      <translation type="unfinished"/>
+      <translation>Поиск приводов двигателя</translation>
     </message>
     <message id="page_settings_canopenmotordrive_discovered_motor_drive_ids">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="39"/>
       <source>Discovered motor drive IDs</source>
-      <translation type="unfinished"/>
+      <translation>Обнаруженные идентификаторы приводов двигателя</translation>
     </message>
-    <message id="switchableoutput_gx_device_relays">
-      <location filename="../../src/switchableoutput.cpp" line="388"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">Реле устройств GX</translation>
+    <message id="temperature_pm25">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
+      <source>PM2.5</source>
+      <translation>PM2.5</translation>
     </message>
-    <message id="gx_device_relays">
-      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">Реле устройств GX</translation>
+    <message id="temperature_co2">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+      <source>CO₂</source>
+      <translation>CO₂</translation>
     </message>
-    <message id="color_preset">
-      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
-      <source>Preset</source>
-      <translation type="unfinished"/>
+    <message id="temperature_voc">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
+      <source>VOC index</source>
+      <translation>Индекс VOC</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_location">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
-      <source>Add Modbus port and unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_nox">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
+      <source>NOx index</source>
+      <translation>Индекс NOx</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_unitid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
-      <source>Unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_luminosity">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
+      <source>Luminosity</source>
+      <translation>Освещенность</translation>
     </message>
-    <message id="page_settings_fronius_unitid_invalid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation type="unfinished">%1 - это неправильный номер единицы измерения. Используйте число в диапазоне 1-247.</translation>
-    </message>
-    <message id="page_settings_fronius_add_modbus_location_button">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
-      <source>Add</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_locations_note">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
-      <source>The default modbus port is 502 and the default unit ID is 126.
-Here you can add additional ports and unit IDs to scan for PV inverters.</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_location_number">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
-      <source>Port/Unit ID %1</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location_description">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
-      <source>Port: %1 (Unit %2)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
-      <source>Remove Modbus port and unit ID?</source>
-      <translation type="unfinished"/>
+    <message id="switchable_output_bypassed">
+      <location filename="../../src/enums.cpp" line="484"/>
+      <source>Bypassed</source>
+      <translation>В обход</translation>
     </message>
     <message id="switchableoutput_list_delegate_auto_status">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="84"/>
       <source>Auto (%1)</source>
       <extracomment>%1 = 'On' or 'Off'</extracomment>
-      <translation type="unfinished"/>
+      <translation>Авто (%1)</translation>
     </message>
     <message id="switchableoutput_list_delegate_state_forced">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="100"/>
       <source>Forced</source>
-      <translation type="unfinished"/>
+      <translation>Принудительно</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_settings">
+      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
+      <source>Modbus port and unit ID settings</source>
+      <translation>Настройки порта Modbus и идентификатора устройства</translation>
+    </message>
+    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
+      <source>Integrates with the device list</source>
+      <translation>Интегрируется со списком устройств</translation>
+    </message>
+    <message id="common_words_color">
+      <location filename="../../components/CommonWords.qml" line="136"/>
+      <source>Color</source>
+      <translation>Цвет</translation>
+    </message>
+    <message id="common_words_value_must_be_greater_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="557"/>
+      <source>Value must be greater than start value</source>
+      <translation>Значение должно быть больше начального значения</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="566"/>
+      <source>Value must be lower than stop value</source>
+      <translation>Значение должно быть меньше конечного значения</translation>
+    </message>
+    <message id="notifications_page_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="43"/>
+      <source>Active Notifications</source>
+      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
+      <translation>Активные уведомления</translation>
+    </message>
+    <message id="notifications_page_inactive_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="47"/>
+      <source>Inactive Notifications</source>
+      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
+      <translation>Неактивные уведомления</translation>
+    </message>
+    <message id="notifications_no_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="106"/>
+      <source>No active notifications</source>
+      <translation>Нет активных уведомлений</translation>
+    </message>
+    <message id="switchable_output_rgb_color_wheel">
+      <location filename="../../src/enums.cpp" line="427"/>
+      <source>RGB color wheel</source>
+      <translation>Цветовой круг RGB</translation>
+    </message>
+    <message id="switchable_output_cct_color_wheel">
+      <location filename="../../src/enums.cpp" line="431"/>
+      <source>CCT color wheel</source>
+      <extracomment>Correlated Color Temperature color wheel</extracomment>
+      <translation>Цветовой круг CCT</translation>
+    </message>
+    <message id="switchable_output_rgbw_color_wheel">
+      <location filename="../../src/enums.cpp" line="435"/>
+      <source>RGB + W color wheel</source>
+      <extracomment>RGB + white color wheel</extracomment>
+      <translation>Цветовой круг RGB + W</translation>
+    </message>
+    <message id="listlink_show_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="43"/>
+      <source>Show QR code</source>
+      <translation>Показать QR-код</translation>
+    </message>
+    <message id="listlink_scan_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="52"/>
+      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
+      <extracomment>%1 = url text</extracomment>
+      <oldsource>Scan the QR code with your portable device.&lt;br /&gt;Or insert the link: %1</oldsource>
+      <translation>Откройте QR-код для сканирования портативным устройством.&lt;br /&gt;Или вставьте ссылку: %1</translation>
+    </message>
+    <message id="color_preset">
+      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
+      <source>Preset</source>
+      <translation>Предустановка</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
+      <source>Add Modbus port and unit ID</source>
+      <translation>Добавить порт Modbus и идентификатор устройства</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_unitid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
+      <source>Unit ID</source>
+      <translation>Идентификатор устройства</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location_button">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
+      <source>Add</source>
+      <translation>Добавить</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_locations_note">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
+      <source>The default modbus port is 502 and the default unit ID is 126.
+Here you can add additional ports and unit IDs to scan for PV inverters.</source>
+      <translation>Порт Modbus по умолчанию — 502, а идентификатор устройства по умолчанию — 126.
+Здесь можно добавить дополнительные порты и идентификаторы устройств для сканирования инверторов PV.</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_location_number">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
+      <source>Port/Unit ID %1</source>
+      <translation>Порт/Идентификатор устройства %1</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location_description">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
+      <source>Port: %1 (Unit %2)</source>
+      <translation>Порт: %1 (Устройство %2)</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
+      <source>Remove Modbus port and unit ID?</source>
+      <translation>Удалить порт Modbus и идентификатор устройства?</translation>
+    </message>
+    <message id="devicelist_tankshape_edit_point">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="182"/>
+      <source>Edit point %1</source>
+      <extracomment>%1 = which point is being edited, a number like "1" or "2"</extracomment>
+      <translation></translation>
+    </message>
+    <message id="settings_canbus_vecan">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
+      <source>VE.Can (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_250">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <source>VE.Can &amp; CANopen E-drive (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_500">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
+      <source>CANopen E-drive (500 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="page_microgrid_from_p1_to_p2">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="39"/>
+      <source>%1%2 to %3%4</source>
+      <extracomment>Describes a range from one quantity to another, e.g. "30W to 60W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
+      <translation></translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAfricaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
+      <source>Morocco Standard Time</source>
+      <translation>Морокко, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
+      <source>W. Central Africa Standard Time</source>
+      <translation>Западная Центральная Африка, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
+      <source>South Africa Standard Time</source>
+      <translation>Южная Африка, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
+      <source>Namibia Standard Time</source>
+      <translation>Намибия, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
+      <source>Egypt Standard Time</source>
+      <translation>Египет, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
+      <source>E. Africa Standard Time</source>
+      <translation>Восточная Африка, стандартное время</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAmericaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
+      <source>Argentina Standard Time</source>
+      <translation>Аргентина, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
+      <source>E. South America Standard Time</source>
+      <translation>Восточная Южная Америка, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
+      <source>Greenland Standard Time</source>
+      <translation>Гренландия, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
+      <source>Montevideo Standard Time</source>
+      <translation>Монтевидео, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
+      <source>Newfoundland Standard Time</source>
+      <translation>Ньюфайндленд, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
+      <source>SA Eastern Standard Time</source>
+      <translation>Южная Америка, восточное стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
+      <source>Atlantic Standard Time</source>
+      <translation>Атлантика, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
+      <source>Central Brazilian Standard Time</source>
+      <translation>Центральная Бразилия, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>Южная Америка, Тихий океан, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
+      <source>Paraguay Standard Time</source>
+      <translation>Парагвай, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
+      <source>SA Western Standard Time</source>
+      <translation>Южная Америка, западное стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
+      <source>Venezuela Standard Time</source>
+      <translation>Венесуэла, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
+      <source>Eastern Standard Time</source>
+      <translation>Восточное стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
+      <source>SA Pacific Standard Time</source>
+      <translation>Южная Америка, Тихий океан, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
+      <source>US Eastern Standard Time</source>
+      <translation>США, восточное стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
+      <source>Canada Central Standard Time</source>
+      <translation>Центральная Канада, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
+      <source>Central America Standard Time</source>
+      <translation>Центральная Америка, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
+      <source>Central Standard Time (Mexico)</source>
+      <translation>Центральное стандартное время (Мексика)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
+      <source>Central Standard Time</source>
+      <translation>Центральное стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
+      <source>Mountain Standard Time (Mexico)</source>
+      <translation>Горное стандартное время (Мексика)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
+      <source>Mountain Standard Time</source>
+      <translation>Горное стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
+      <source>US Mountain Standard Time</source>
+      <translation>США, горное стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
+      <source>Pacific Standard Time (Mexico)</source>
+      <translation>Тихоокеанское стандартное время (Мексика)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
+      <source>Pacific Standard Time</source>
+      <translation>Тихоокеанское стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
+      <source>Alaskan Standard Time</source>
+      <translation>Аляска, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
+      <source>Hawaii-Aleutian</source>
+      <translation>Гавайи, Алеуты</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
+      <source>Atlantic Daylight Time</source>
+      <translation>Атлантическое летнее время</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAntarcticaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+      <source>New Zealand Standard Time</source>
+      <translation>Новая Зеландия, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>Центральное Тихоокеанское стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+      <source>West Pacific Standard Time</source>
+      <translation>Западное Тихоокеанское стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+      <source>W. Australia Standard Time</source>
+      <translation>Западная Австралия, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+      <source>SE Asia Standard Time</source>
+      <translation>Юго-Восточная Азия, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+      <source>Central Asia Standard Time</source>
+      <translation>Центральная Азия, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+      <source>West Asia Standard Time</source>
+      <translation>Западная Азия, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+      <source>E. Africa Standard Time</source>
+      <translation>Восточная Африка, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>Южная Америка, Тихий океан, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+      <source>SA Western Standard Time</source>
+      <translation>Южная Америка, западное стандартное время</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzArcticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
+      <source>W. Europe Standard Time</source>
+      <translation>Западная Европа, стандартное время</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAsiaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
+      <source>Kamchatka Standard Time</source>
+      <translation>Камчатка, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
+      <source>Magadan Standard Time</source>
+      <translation>Магадан, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
+      <source>Vladivostok Standard Time</source>
+      <translation>Владивосток, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
+      <source>Yakutsk Standard Time</source>
+      <translation>Якутск, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
+      <source>Tokyo Standard Time</source>
+      <translation>Токио, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
+      <source>Korea Standard Time</source>
+      <translation>Корея, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
+      <source>Singapore Standard Time</source>
+      <translation>Сингапур, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
+      <source>Ulaanbaatar Standard Time</source>
+      <translation>Улан-Батор, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
+      <source>Taipei Standard Time</source>
+      <translation>Тайпей, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
+      <source>North Asia East Standard Time</source>
+      <translation>Северная Азия, восточное стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
+      <source>China Standard Time</source>
+      <translation>Китай, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
+      <source>SE Asia Standard Time</source>
+      <translation>Юго-Восточная Азия, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
+      <source>North Asia Standard Time</source>
+      <translation>Северная Азия, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
+      <source>Myanmar Standard Time</source>
+      <translation>Мьянма, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
+      <source>N. Central Asia Standard Time</source>
+      <translation>Северная Центральная Азия, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
+      <source>Central Asia Standard Time</source>
+      <translation>Центральная Азия, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
+      <source>Bangladesh Standard Time</source>
+      <translation>Бангладеш, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
+      <source>Nepal Standard Time</source>
+      <translation>Непал, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
+      <source>Sri Lanka Standard Time</source>
+      <translation>Шри-Ланка, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
+      <source>India Standard Time</source>
+      <translation>Индия, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
+      <source>West Asia Standard Time</source>
+      <translation>Западная Азия, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
+      <source>Pakistan Standard Time</source>
+      <translation>Пакистан, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
+      <source>Ekaterinburg Standard Time</source>
+      <translation>Екатеринбург, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
+      <source>Georgian Standard Time</source>
+      <translation>Грузия, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
+      <source>Caucasus Standard Time</source>
+      <translation>Кавказ, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
+      <source>Azerbaijan Standard Time</source>
+      <translation>Азербайджан, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
+      <source>Arabian Standard Time</source>
+      <translation>Арабское стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
+      <source>Afghanistan Standard Time</source>
+      <translation>Афганистан, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
+      <source>Iran Standard Time</source>
+      <translation>Иран, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
+      <source>Arabic Standard Time</source>
+      <translation>Арабское стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
+      <source>Arab Standard Time</source>
+      <translation>Арабское стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
+      <source>Syria Standard Time</source>
+      <translation>Сирия, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
+      <source>Middle East Standard Time</source>
+      <translation>Средняя Азия, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
+      <source>Jordan Standard Time</source>
+      <translation>Иордан, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
+      <source>Israel Standard Time</source>
+      <translation>Израиль, стандартное время</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAtlanticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+      <source>Greenwich Standard Time</source>
+      <translation>Гринвич, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+      <source>Azores Standard Time</source>
+      <translation>Азорские острова, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+      <source>Cape Verde Standard Time</source>
+      <translation>Кабо-Верде, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
+      <source>Mid-Atlantic Standard Time</source>
+      <translation>Средняя Атлантика, стандартное время</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAustraliaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+      <source>Tasmania Standard Time</source>
+      <translation>Тасмания, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+      <source>E. Australia Standard Time</source>
+      <translation>Восточная Австралия, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+      <source>AUS Eastern Standard Time</source>
+      <translation>Восточная Австралия, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+      <source>Cen. Australia Standard Time</source>
+      <translation>Центральная Австралия, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+      <source>AUS Central Standard Time</source>
+      <translation>Центральная Австралия, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+      <source>W. Australia Standard Time</source>
+      <translation>Западная Австралия, стандартное время</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEtcData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
+      <source>GMT +12</source>
+      <translation>GMT +12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
+      <source>GMT -02</source>
+      <translation>GMT -02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
+      <source>GMT -11</source>
+      <translation>GMT -11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
+      <source>GMT -13</source>
+      <translation>GMT -13</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
+      <source>GMT -12</source>
+      <translation>GMT -12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
+      <source>GMT -10</source>
+      <translation>GMT -10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
+      <source>GMT -09</source>
+      <translation>GMT -09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
+      <source>GMT -08</source>
+      <translation>GMT -08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
+      <source>GMT -07</source>
+      <translation>GMT -07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
+      <source>GMT -06</source>
+      <translation>GMT -06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
+      <source>GMT -05</source>
+      <translation>GMT -05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
+      <source>GMT -04</source>
+      <translation>GMT -04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
+      <source>GMT -03</source>
+      <translation>GMT -03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
+      <source>GMT -01</source>
+      <translation>GMT -01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
+      <source>GMT</source>
+      <translation>GMT</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
+      <source>GMT +01</source>
+      <translation>GMT +01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
+      <source>GMT +02</source>
+      <translation>GMT +02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
+      <source>GMT +03</source>
+      <translation>GMT +03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
+      <source>GMT +04</source>
+      <translation>GMT +04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
+      <source>GMT +05</source>
+      <translation>GMT +05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
+      <source>GMT +06</source>
+      <translation>GMT +06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
+      <source>GMT +07</source>
+      <translation>GMT +07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
+      <source>GMT +08</source>
+      <translation>GMT +08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
+      <source>GMT +09</source>
+      <translation>GMT +09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
+      <source>GMT +10</source>
+      <translation>GMT +10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
+      <source>GMT +11</source>
+      <translation>GMT +11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
+      <source>UTC</source>
+      <translation>UTC</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEuropeData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
+      <source>GMT Standard Time</source>
+      <translation>GMT, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
+      <source>Central Europe Standard Time</source>
+      <translation>Центральная Европа, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
+      <source>Central European Standard Time</source>
+      <translation>Центрально-европейское стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
+      <source>Romance Standard Time</source>
+      <translation>Романское стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
+      <source>W. Europe Standard Time</source>
+      <translation>Западная Европа, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
+      <source>E. Europe Standard Time</source>
+      <translation>Восточная Европа, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
+      <source>FLE Standard Time</source>
+      <translation>FLE, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
+      <source>GTB Standard Time</source>
+      <translation>GTB, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
+      <source>Belarus Standard Time</source>
+      <translation>Белорусское стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
+      <source>Russian Standard Time</source>
+      <translation>Российское стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
+      <source>Turkey Standard Time</source>
+      <translation>Турция, стандартное время</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzIndianData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
+      <source>Mauritius Standard Time</source>
+      <translation>Мавритания, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
+      <source>Christmas Island Standard Time</source>
+      <translation>Остров Рождества, стандартное время</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzPacificData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
+      <source>Tonga Standard Time</source>
+      <translation>Тонга, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
+      <source>Fiji Standard Time</source>
+      <translation>Фиджи, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
+      <source>New Zealand Standard Time</source>
+      <translation>Новая Зеландия, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>Центральное Тихоокеанское стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
+      <source>West Pacific Standard Time</source>
+      <translation>Западное Тихоокеанское стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
+      <source>Samoa Standard Time</source>
+      <translation>Самоа, стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
+      <source>Hawaiian Standard Time</source>
+      <translation>Гавайское стандартное время</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
+      <source>Easter Island Standard Time</source>
+      <translation>Остров Пасхи, стандартное время</translation>
     </message>
   </context>
   <context>
@@ -12177,838 +11859,6 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
     </message>
   </context>
   <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>Морокко, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>Западная Центральная Африка, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>Южная Африка, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>Намибия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>Египет, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Восточная Африка, стандартное время</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>Аргентина, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>Восточная Южная Америка, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>Гренландия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>Монтевидео, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>Ньюфайндленд, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>Южная Америка, восточное стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Atlantic Standard Time</source>
-      <translation>Атлантика, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>Центральная Бразилия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Южная Америка, Тихий океан, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>Paraguay Standard Time</source>
-      <translation>Парагвай, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>SA Western Standard Time</source>
-      <translation>Южная Америка, западное стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Venezuela Standard Time</source>
-      <translation>Венесуэла, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>Eastern Standard Time</source>
-      <translation>Восточное стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>Южная Америка, Тихий океан, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>US Eastern Standard Time</source>
-      <translation>США, восточное стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Canada Central Standard Time</source>
-      <translation>Центральная Канада, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central America Standard Time</source>
-      <translation>Центральная Америка, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>Центральное стандартное время (Мексика)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Central Standard Time</source>
-      <translation>Центральное стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>Горное стандартное время (Мексика)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>Mountain Standard Time</source>
-      <translation>Горное стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>US Mountain Standard Time</source>
-      <translation>США, горное стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>Тихоокеанское стандартное время (Мексика)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Pacific Standard Time</source>
-      <translation>Тихоокеанское стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Alaskan Standard Time</source>
-      <translation>Аляска, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>Гавайи, Алеуты</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Daylight Time</source>
-      <translation>Атлантическое летнее время</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Новая Зеландия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Центральное Тихоокеанское стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Западное Тихоокеанское стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Западная Австралия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Юго-Восточная Азия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Центральная Азия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>Западная Азия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Восточная Африка, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Южная Америка, Тихий океан, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>Южная Америка, западное стандартное время</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Западная Европа, стандартное время</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>Камчатка, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>Магадан, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>Владивосток, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>Якутск, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>Токио, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>Корея, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>Сингапур, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>Улан-Батор, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>Тайпей, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>Северная Азия, восточное стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>Китай, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Юго-Восточная Азия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>Северная Азия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>Мьянма, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>Северная Центральная Азия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Центральная Азия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>Бангладеш, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>Непал, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>Шри-Ланка, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>Индия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>Западная Азия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>Пакистан, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>Екатеринбург, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>Грузия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>Кавказ, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>Азербайджан, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>Арабское стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>Афганистан, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>Иран, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>Арабское стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>Арабское стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>Сирия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>Средняя Азия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>Иордан, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>Израиль, стандартное время</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>Гринвич, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>Азорские острова, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>Кабо-Верде, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>Средняя Атлантика, стандартное время</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>Тасмания, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>Восточная Австралия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>Восточная Австралия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>Центральная Австралия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>Центральная Австралия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Западная Австралия, стандартное время</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
-      <source>GMT +12</source>
-      <translation>GMT +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
-      <source>GMT -02</source>
-      <translation>GMT -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT -13</source>
-      <translation>GMT -13</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT -12</source>
-      <translation>GMT -12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -10</source>
-      <translation>GMT -10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -09</source>
-      <translation>GMT -09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>GMT -08</source>
-      <translation>GMT -08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
-      <source>GMT -07</source>
-      <translation>GMT -07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
-      <source>GMT -06</source>
-      <translation>GMT -06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
-      <source>GMT -05</source>
-      <translation>GMT -05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
-      <source>GMT -04</source>
-      <translation>GMT -04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
-      <source>GMT -03</source>
-      <translation>GMT -03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
-      <source>GMT -01</source>
-      <translation>GMT -01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
-      <source>GMT</source>
-      <translation>GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
-      <source>GMT +01</source>
-      <translation>GMT +01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
-      <source>GMT +02</source>
-      <translation>GMT +02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
-      <source>GMT +03</source>
-      <translation>GMT +03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
-      <source>GMT +04</source>
-      <translation>GMT +04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
-      <source>GMT +05</source>
-      <translation>GMT +05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
-      <source>GMT +06</source>
-      <translation>GMT +06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
-      <source>GMT +07</source>
-      <translation>GMT +07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
-      <source>GMT +08</source>
-      <translation>GMT +08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
-      <source>GMT +09</source>
-      <translation>GMT +09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
-      <source>GMT +10</source>
-      <translation>GMT +10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
-      <source>GMT +11</source>
-      <translation>GMT +11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
-      <source>UTC</source>
-      <translation>UTC</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>GMT, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>Центральная Европа, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>Центрально-европейское стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>Романское стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Западная Европа, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>Восточная Европа, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>FLE, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>GTB, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>Белорусское стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>Российское стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>Турция, стандартное время</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>Мавритания, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>Остров Рождества, стандартное время</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>Тонга, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>Фиджи, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Новая Зеландия, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Центральное Тихоокеанское стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Западное Тихоокеанское стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>Самоа, стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>Гавайское стандартное время</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>Остров Пасхи, стандартное время</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation type="unfinished">Внутренняя ошибка</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation type="unfinished"/>
-    </message>
-  </context>
-  <context>
     <name>Wakespeed</name>
     <message>
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
@@ -13185,6 +12035,119 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
       <source>DC/DC misconfiguration</source>
       <translation>Неправильная конфигурация DC/DC</translation>
+    </message>
+  </context>
+  <context>
+    <name>VebusError</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+      <source>Device switched off</source>
+      <translation>Устройство выключено</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+      <source>Mixed old/new MK2</source>
+      <translation>Смешанный старый/новый MK2</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+      <source>Expected devices error</source>
+      <translation>Ошибка ожидаемых устройств</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+      <source>No other device detected</source>
+      <translation>Другие устройства не обнаружены</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+      <source>Overvoltage on AC-out</source>
+      <translation>Перенапряжение на выходе AC</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+      <source>DDC program error</source>
+      <translation>Ошибка программы DDC</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+      <source>VE.Bus BMS without assistant</source>
+      <translation>VE.Bus BMS без ассистента</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+      <source>Ground relay test failed</source>
+      <translation>Ошибка теста реле заземления</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+      <source>System time sync error</source>
+      <translation>Ошибка синхронизации системного времени</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+      <source>Grid relay test fault</source>
+      <translation>Ошибка теста сетевого реле</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+      <source>Config mismatch with 2nd mcu</source>
+      <translation>Несоответствие конфигурации со вторым микроконтроллером</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+      <source>Device transmit error</source>
+      <translation>Ошибка передачи устройства</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+      <source>Awaiting configuration or dongle missing</source>
+      <translation>Ожидание конфигурации или отсутствует ключ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+      <source>Phase master missing</source>
+      <translation>Отсутствует главный по фазе</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+      <source>Overvoltage has occurred</source>
+      <translation>Произошло перенапряжение</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+      <source>Slave does not have AC input!</source>
+      <translation>У ведомого устройства нет входа AC!</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+      <source>Device can't be slave</source>
+      <translation>Устройство не может быть ведомым</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+      <source>System protection initiated</source>
+      <translation>Инициирована защита системы</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+      <source>Firmware incompatibiltiy</source>
+      <translation>Несовместимость прошивок</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+      <source>Internal error</source>
+      <translation>Внутренняя ошибка</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+      <source>Failing relay test prevents connection</source>
+      <translation>Неудачный тест реле препятствует подключению</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+      <source>VE.Bus error</source>
+      <translation>Ошибка VE.Bus</translation>
     </message>
   </context>
 </TS>

--- a/i18n/venus-gui-v2_sv.ts
+++ b/i18n/venus-gui-v2_sv.ts
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="sv">
   <context>
-    <name/>
+    <name></name>
     <message id="switchable_output_disabled">
       <location filename="../../src/enums.cpp" line="478"/>
       <source>Disabled</source>
@@ -22,6 +22,7 @@
     <message id="solarchargers_state_off">
       <location filename="../../src/enums.cpp" line="331"/>
       <source>Off</source>
+      <extracomment>Digital input state</extracomment>
       <translation>Av</translation>
     </message>
     <message id="common_words_auto">
@@ -52,18 +53,25 @@
     <message id="settings_startpage_none">
       <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
       <source>None</source>
+      <extracomment>Indicates no phase</extracomment>
       <translation>Ingen</translation>
     </message>
     <message id="common_words_position_ac">
       <location filename="../../components/CommonWords.qml" line="416"/>
       <source>Position</source>
-      <extracomment>AC input or output position</extracomment>
+      <extracomment>EVCS AC input/output position</extracomment>
       <translation>Position</translation>
     </message>
     <message id="settings_minmax_speed">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="193"/>
       <source>Speed</source>
+      <extracomment>A speed measurement value</extracomment>
       <translation>Hastighet</translation>
+    </message>
+    <message id="common_words_state">
+      <location filename="../../components/CommonWords.qml" line="502"/>
+      <source>State</source>
+      <translation>Status</translation>
     </message>
     <message id="settings_firmware_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="67"/>
@@ -101,8 +109,8 @@
       <source>Solar yield</source>
       <translation>Solcellsproduktion</translation>
     </message>
-    <message id="ess_state_external_control">
-      <location filename="../../data/Ess.qml" line="41"/>
+    <message id="inverters_state_externalccontrol">
+      <location filename="../../data/System.qml" line="183"/>
       <source>External control</source>
       <translation>Extern kontroll</translation>
     </message>
@@ -140,6 +148,11 @@
       <location filename="../../components/CommonWords.qml" line="203"/>
       <source>ESS</source>
       <translation>ESS</translation>
+    </message>
+    <message id="pagesettingsconnectivity_ethernet">
+      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
+      <source>Ethernet</source>
+      <translation>Ethernet</translation>
     </message>
     <message id="pagesettingsconnectivity_wifi">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="28"/>
@@ -262,11 +275,6 @@
       <source>Name</source>
       <translation>Namn</translation>
     </message>
-    <message id="settings_deviceinfo_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="38"/>
-      <source>Name</source>
-      <translation type="unfinished">Namn</translation>
-    </message>
     <message id="settings_deviceinfo_product_id">
       <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
       <source>Product ID</source>
@@ -327,15 +335,20 @@
       <source>Daily run time</source>
       <translation>Daglig drift</translation>
     </message>
+    <message id="common_words_value_must_be_greater_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="560"/>
+      <source>Value must be greater than stop value</source>
+      <translation>Värdet måste vara högre än stoppvärdet</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="563"/>
+      <source>Value must be lower than start value</source>
+      <translation>Värdet måste vara lägre än startvärdet</translation>
+    </message>
     <message id="settings_minmax_acout_max_power">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="124"/>
       <source>AC output</source>
       <translation>AC-utgång</translation>
-    </message>
-    <message id="ac_output">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="15"/>
-      <source>AC output</source>
-      <translation type="unfinished">AC-utgång</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
       <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="25"/>
@@ -382,16 +395,6 @@
       <source>Unavailable monitor, set another</source>
       <translation>Övervakare ej tillgänglig, ställ in en annan</translation>
     </message>
-    <message id="page_generator_conditions_battery_monitor">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="42"/>
-      <source>Battery monitor</source>
-      <translation type="unfinished">Batteriövervakare</translation>
-    </message>
-    <message id="page_generator_conditions_unavailable_monitor_set_another">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="44"/>
-      <source>Unavailable monitor, set another</source>
-      <translation type="unfinished">Övervakare ej tillgänglig, ställ in en annan</translation>
-    </message>
     <message id="page_generator_conditions_on_loss_of_communication">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="68"/>
       <source>On loss of communication</source>
@@ -416,11 +419,6 @@
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="105"/>
       <source>Battery SOC</source>
       <translation>Batteri SOC</translation>
-    </message>
-    <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="173"/>
-      <source>Periodic run</source>
-      <translation type="unfinished">Periodisk drift</translation>
     </message>
     <message id="settings_inverter_high_temperature">
       <location filename="../../data/Generators.qml" line="83"/>
@@ -505,7 +503,7 @@
     <message id="settings_gps_speed_kmh">
       <location filename="../../pages/settings/PageGps.qml" line="83"/>
       <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometres per hour</extracomment>
+      <extracomment>GPS speed data, in kilometers per hour</extracomment>
       <translation>%1 km/h</translation>
     </message>
     <message id="settings_gps_speed_mph">
@@ -523,7 +521,7 @@
     <message id="settings_gps_speed_ms">
       <location filename="../../pages/settings/PageGps.qml" line="95"/>
       <source>%1 m/s</source>
-      <extracomment>GPS speed data, in metres per second</extracomment>
+      <extracomment>GPS speed data, in meters per second</extracomment>
       <translation>%1 m/s</translation>
     </message>
     <message id="settings_gps_course">
@@ -580,21 +578,6 @@
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="64"/>
       <source>%1 (Output %2)</source>
       <translation>%1 (Utgång %2)</translation>
-    </message>
-    <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">Aktiv batteriövervakare</translation>
-    </message>
-    <message id="settings_batteries_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="101"/>
-      <source>Name</source>
-      <translation type="unfinished">Namn</translation>
-    </message>
-    <message id="settings_batteries_enter_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="103"/>
-      <source>Enter name</source>
-      <translation type="unfinished">Ange namn</translation>
     </message>
     <message id="settings_briefview_center_active_battery_monitor">
       <location filename="../../components/listitems/ListBriefCenterDetails.qml" line="27"/>
@@ -656,45 +639,25 @@
       <source>CAN-bus profile</source>
       <translation>CAN-busprofil</translation>
     </message>
-    <message id="settings_disabled">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="31"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Inaktiverad</translation>
-    </message>
-    <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</translation>
-    </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
       <location filename="../../pages/settings/CanbusProfile.qml" line="42"/>
       <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
       <translation>VE.Can &amp; CAN-bus BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
       <source>Oceanvolt (250 kbit/s)</source>
       <translation>Oceanvolt (250 kbit/s)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
       <source>RV-C (250 kbit/s)</source>
       <translation>RV-C (250 kbit/s)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
       <source>Up, but no services (250 kbit/s)</source>
       <translation>Aktiv men inga tjänster (250 kbit/s)</translation>
-    </message>
-    <message id="settings_canopen_motordrive_250">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
-      <source>CANopen Motor drive (250 kbit/s)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_canopen_motordrive_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
-      <source>CANopen Motor drive (500 kbit/s)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_devices">
       <location filename="../../components/CommonWords.qml" line="166"/>
@@ -731,11 +694,6 @@
       <source>Check Unique id numbers</source>
       <translation>Kontrollera unika ID-nummer</translation>
     </message>
-    <message id="settings_canbus_unique_id_press_to_check">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Press to check</source>
-      <translation type="unfinished">Tryck för att söka</translation>
-    </message>
     <message id="settings_canbus_unique_id_conflict">
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="125"/>
       <source>There is another device connected with this unique number, please select a new number.</source>
@@ -745,11 +703,6 @@
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="133"/>
       <source>OK: No other device is connected with this unique number.</source>
       <translation>OK: Ingen annan enhet är kopplad till detta unika nummer.</translation>
-    </message>
-    <message id="pagesettingsintegrations_canopenmotordrive">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
-      <source>CANopen motor drives</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_network_status">
       <location filename="../../components/CommonWords.qml" line="349"/>
@@ -884,11 +837,6 @@
       <source>Unavailable sensor, set another</source>
       <translation>Sensor ej tillgänglig, ställ in en annan</translation>
     </message>
-    <message id="settings_system_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="81"/>
-      <source>Unavailable sensor, set another</source>
-      <translation type="unfinished">Sensor ej tillgänglig, ställ in en annan</translation>
-    </message>
     <message id="settings_dvcc_used_sensor">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="120"/>
       <source>Used sensor</source>
@@ -945,12 +893,6 @@
       <source>Auto selected</source>
       <translation>Autovald</translation>
     </message>
-    <message id="settings_dvcc_auto_selected_none">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="208"/>
-      <source>None</source>
-      <extracomment>Indicates no option is selected</extracomment>
-      <translation type="unfinished">Ingen</translation>
-    </message>
     <message id="settings_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
       <source>Build date/time</source>
@@ -986,12 +928,6 @@
       <source>Installing %1</source>
       <extracomment>%1 = firmware version</extracomment>
       <translation>Installerar %1</translation>
-    </message>
-    <message id="settings_firmware_offline_press_to_install">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">Tryck för att uppdatera till %1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="90"/>
@@ -1062,12 +998,6 @@
       <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
       <translation>Installerar %1 %2%</translation>
     </message>
-    <message id="settings_firmware_online_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="86"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">Installerar %1...</translation>
-    </message>
     <message id="settings_firmware_update_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="109"/>
       <source>Update build date/time</source>
@@ -1097,11 +1027,6 @@
       <location filename="../../pages/settings/PageSettingsFronius.qml" line="56"/>
       <source>TCP port</source>
       <translation>TCP port</translation>
-    </message>
-    <message id="page_settings_fronius_modbus_settings">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
-      <source>Modbus port and unit ID settings</source>
-      <translation type="unfinished"/>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
       <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
@@ -1153,16 +1078,6 @@
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="64"/>
       <source>AC-Out MP</source>
       <translation>AC-Out MP</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="52"/>
-      <source>AC-In1 L%1</source>
-      <translation type="unfinished">AC-In1 L%1</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="56"/>
-      <source>AC-In1 --</source>
-      <translation type="unfinished">AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="70"/>
@@ -1330,12 +1245,6 @@
       <source>Reset service timer</source>
       <translation>Återställa servicetimer</translation>
     </message>
-    <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
-      <source>Volume</source>
-      <extracomment>Title for a list of units of volume (e.g. cubic metres, litres, gallons)</extracomment>
-      <translation type="unfinished">Volym</translation>
-    </message>
     <message id="settings_gps_format">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="69"/>
       <source>Format</source>
@@ -1438,42 +1347,6 @@ Om det inte fungerar, testa simkortet i en telefon för att säkerställa att de
       <source>Wrong PIN</source>
       <translation>Fel PIN-kod</translation>
     </message>
-    <message id="page_settings_gsm_ok">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>OK</source>
-      <translation type="unfinished">Ok</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="128"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">Okänt fel</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_state">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="153"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Okänd</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_value">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="182"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Okänd</translation>
-    </message>
-    <message id="page_settings_gsm_offline">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="173"/>
-      <source>Offline</source>
-      <translation type="unfinished">Offline</translation>
-    </message>
-    <message id="page_settings_gsm_connecting">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="176"/>
-      <source>Connecting</source>
-      <translation type="unfinished">Ansluter...</translation>
-    </message>
-    <message id="page_settings_gsm_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="179"/>
-      <source>Connected</source>
-      <translation type="unfinished">Ansluten</translation>
-    </message>
     <message id="page_settings_gsm_pin">
       <location filename="../../pages/settings/PageSettingsGsm.qml" line="191"/>
       <source>PIN</source>
@@ -1530,32 +1403,32 @@ Om det inte fungerar, testa simkortet i en telefon för att säkerställa att de
       <translation>Nätmätning</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
       <source>External meter</source>
       <translation>Extern mätare</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="67"/>
       <source>Inverter/Charger</source>
       <translation>Växelriktare/laddare</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
       <source>Multiphase regulation</source>
       <translation>Flerfasreglering</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="91"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
       <source>Total of all phases</source>
       <translation>Totalt för alla faser</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="95"/>
       <source>Individual phase</source>
       <translation>Individuell fas</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="99"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="101"/>
       <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
@@ -1564,68 +1437,13 @@ CAUTION: Use only if required by the utility provider.</source>
 VARNING: Använd endast om det krävs av elleverantören.</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="104"/>
       <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
       <translation>Summan av alla faser regleras intelligent för att uppnå börvärdet för nätet (systemeffektiviteten optimeras).
 
 Använd såvida det inte är förbjudet av elleverantören.</translation>
-    </message>
-    <message id="settings_ess_min_soc">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation type="unfinished">Lägsta SoC (om inte nätet felar)</translation>
-    </message>
-    <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="129"/>
-      <source>Active SOC limit</source>
-      <translation type="unfinished">Nuvarande SoC-gräns</translation>
-    </message>
-    <message id="settings_ess_battery_life_sustain">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
-      <source>Sustain</source>
-      <translation type="unfinished">Upprätthålla</translation>
-    </message>
-    <message id="settings_ess_battery_life_recharge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="157"/>
-      <source>Recharge</source>
-      <translation type="unfinished">Laddar</translation>
-    </message>
-    <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <source>Scheduled charge levels</source>
-      <translation type="unfinished">Schemalagda laddningsnivåer</translation>
-    </message>
-    <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="257"/>
-      <source>Active (%1)</source>
-      <translation type="unfinished">Aktiv (%1)</translation>
-    </message>
-    <message id="settings_ess_inactive">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="259"/>
-      <source>Inactive</source>
-      <translation type="unfinished">Inaktiv</translation>
-    </message>
-    <message id="settings_ess_dynamic">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="293"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">Dynamiskt ESS</translation>
-    </message>
-    <message id="settings_ess_deprecated">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="319"/>
-      <source>Deprecated settings</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_charge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="326"/>
-      <source>Battery charge limit (% of CCL)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_discharge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="337"/>
-      <source>Battery discharge limit (% of DCL)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_rs_ess_min_soc">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="40"/>
@@ -1637,13 +1455,8 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <source>Active SOC limit</source>
       <translation>Nuvarande SoC-gräns</translation>
     </message>
-    <message id="scheduled_charge_inactive">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
-      <source>Inactive</source>
-      <translation type="unfinished">Inaktiv</translation>
-    </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="245"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="247"/>
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
       <source>Peak shaving</source>
       <translation>Topplastutjämning</translation>
@@ -1659,12 +1472,12 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <translation>Alltid</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="151"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
       <source>Discharge disabled</source>
       <translation>Urladdning inaktiverad</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
       <source>Slow charge</source>
       <translation>Långsam laddning</translation>
     </message>
@@ -1679,32 +1492,32 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <translation>Laddar</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="165"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="167"/>
       <source>Limit charge power</source>
       <translation>Gräns laddningsström</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="183"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="185"/>
       <source>Maximum charge power</source>
       <translation>Maximal laddningsström</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="196"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="198"/>
       <source>Limit inverter power</source>
       <translation>Gräns växelriktareffekt</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="214"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="216"/>
       <source>Maximum inverter power</source>
       <translation>Högsta växelriktareffekt</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="225"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="227"/>
       <source>Grid setpoint</source>
       <translation>Börvärde nät</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="236"/>
       <source>Grid feed-in</source>
       <translation>Nätinmatning</translation>
     </message>
@@ -1743,8 +1556,8 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <source>Door alarm</source>
       <translation>Dörrlarm</translation>
     </message>
-    <message id="digitalinputs_type_bilgepump">
-      <location filename="../../src/enums.cpp" line="201"/>
+    <message id="switchable_output_bilge_pump">
+      <location filename="../../src/enums.cpp" line="424"/>
       <source>Bilge pump</source>
       <translation>Länspump</translation>
     </message>
@@ -1796,11 +1609,6 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <source>Deferred by %1s</source>
       <extracomment>%1 = number of seconds</extracomment>
       <translation>Fördröjd med %1s</translation>
-    </message>
-    <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="75"/>
-      <source>Are you sure?</source>
-      <translation type="unfinished">Är du säker`?</translation>
     </message>
     <message id="settings_vrm_portal_id">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="87"/>
@@ -1939,11 +1747,6 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <source>External storage</source>
       <translation>Extern lagring</translation>
     </message>
-    <message id="settings_vrm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="308"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">Okänt fel</translation>
-    </message>
     <message id="settings_vrm_no_error">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="311"/>
       <source>No Error</source>
@@ -2029,37 +1832,10 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <source>Function</source>
       <translation>Funktion</translation>
     </message>
-    <message id="settings_relay_disabled">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="54"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="98"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Inaktiverad</translation>
-    </message>
     <message id="settings_relay_alarm_relay">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="56"/>
       <source>Alarm relay</source>
       <translation>Larmrelä</translation>
-    </message>
-    <message id="settings_relay_tank_pump">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="62"/>
-      <source>Tank pump</source>
-      <translation type="unfinished">Tankpump</translation>
-    </message>
-    <message id="settings_relay_manual">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="64"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="100"/>
-      <source>Manual</source>
-      <translation type="unfinished">Manual</translation>
-    </message>
-    <message id="settings_relay_polarity_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
-      <source>Polarity (Relay 1)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_relay_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
-      <source>Polarity</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_normally_open">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="83"/>
@@ -2075,11 +1851,6 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="93"/>
       <source>Function (Relay 2)</source>
       <translation>Funktion (Relä 2)</translation>
-    </message>
-    <message id="settings_relay_polarity_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
-      <source>Polarity (Relay 2)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_temp_control_rules">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="119"/>
@@ -2111,12 +1882,6 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
       <source>Press to boot</source>
       <translation>Tryck för att starta</translation>
-    </message>
-    <message id="settings_firmware_backup_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
-      <translation type="unfinished">Fast programvara %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
@@ -2152,6 +1917,7 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
     <message id="nav_boat">
       <location filename="../../pages/boat/BoatPage.qml" line="14"/>
       <source>Boat</source>
+      <extracomment>The 'Boat' page</extracomment>
       <translation>Båt</translation>
     </message>
     <message id="settings_system_name">
@@ -2219,11 +1985,6 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <source>Solar charger current control</source>
       <translation>Solcellsladdare strömkontroll</translation>
     </message>
-    <message id="settings_system_status_bms_params">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
-      <source>BMS control</source>
-      <translation type="unfinished">BMS-kontroll</translation>
-    </message>
     <message id="common_words_bms_control">
       <location filename="../../components/CommonWords.qml" line="101"/>
       <source>BMS control</source>
@@ -2238,11 +1999,6 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
       <source>Pump state</source>
       <translation>Pumpstatus</translation>
-    </message>
-    <message id="settings_pump_auto">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="56"/>
-      <source>Auto</source>
-      <translation type="unfinished">Automatisk</translation>
     </message>
     <message id="settings_tank_sensor">
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
@@ -2271,11 +2027,6 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="35"/>
       <source>Unplugged</source>
       <translation>Urkopplad</translation>
-    </message>
-    <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="16"/>
-      <source>Name</source>
-      <translation type="unfinished">Namn</translation>
     </message>
     <message id="settings_tcpip_hidden">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="21"/>
@@ -2317,16 +2068,6 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="99"/>
       <source>IP configuration</source>
       <translation>IP-konfigurering</translation>
-    </message>
-    <message id="settings_tcpip_manual">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="105"/>
-      <source>Manual</source>
-      <translation type="unfinished">Manual</translation>
-    </message>
-    <message id="settings_tcpip_off">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="107"/>
-      <source>Off</source>
-      <translation type="unfinished">Av</translation>
     </message>
     <message id="settings_tcpip_fixed">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="109"/>
@@ -2382,21 +2123,6 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="30"/>
       <source>Create access point</source>
       <translation>Skapa åtkomstpunkt</translation>
-    </message>
-    <message id="settings_wifi_access_point_enter_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="68"/>
-      <source>Enter password</source>
-      <translation type="unfinished">Ange lösenord</translation>
-    </message>
-    <message id="page_settings_wifi_invalid_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
-      <source>Password length must be either 0 or between 10 and 63 characters long</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_wifi_password_updated">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
-      <source>Password updated</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_wifi_networks">
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="86"/>
@@ -2539,20 +2265,10 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <extracomment>Network status: Standalone</extracomment>
       <translation>Fristående</translation>
     </message>
-    <message id="charger_standalone">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="45"/>
-      <source>Standalone</source>
-      <translation type="unfinished">Fristående</translation>
-    </message>
     <message id="charger_charge">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="48"/>
       <source>Charge</source>
       <translation>Belastning</translation>
-    </message>
-    <message id="charger_external_control">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="51"/>
-      <source>External control</source>
-      <translation type="unfinished">Extern kontroll</translation>
     </message>
     <message id="charger_charge_hub_1">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="54"/>
@@ -2584,16 +2300,6 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <source>Master setting</source>
       <translation>Masterinställning</translation>
     </message>
-    <message id="charger_slave">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="85"/>
-      <source>Slave</source>
-      <translation type="unfinished">Slav</translation>
-    </message>
-    <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation type="unfinished">Laddningsspänning</translation>
-    </message>
     <message id="systemsettings_networkstatus_slave">
       <location filename="../../data/SystemSettings.qml" line="148"/>
       <source>Slave</source>
@@ -2615,14 +2321,15 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <source>Group &amp; Charge master</source>
       <translation>Grupp - &amp; laddningsmaster</translation>
     </message>
-    <message id="genset_charge_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="365"/>
+    <message id="charger_charge_voltage">
+      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
       <source>Charge voltage</source>
       <translation>Laddningsspänning</translation>
     </message>
     <message id="common_words_reset">
       <location filename="../../components/CommonWords.qml" line="448"/>
       <source>Reset</source>
+      <extracomment>Reset the BMS control</extracomment>
       <translation>Återställ</translation>
     </message>
     <message id="solarcharger_load">
@@ -2651,14 +2358,14 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <extracomment>Voltage alarm is at "Warning" level</extracomment>
       <translation>Varning</translation>
     </message>
-    <message id="listitems_alarm_level_alarm">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="25"/>
+    <message id="digitalinputs_state_alarm">
+      <location filename="../../src/enums.cpp" line="270"/>
       <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
+      <extracomment>Relay function is 'alarm'</extracomment>
       <translation>Larm</translation>
     </message>
-    <message id="devicelist_tankshape_volume">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="190"/>
+    <message id="components_volumeunit_volume">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
       <source>Volume</source>
       <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
       <translation>Volym</translation>
@@ -2808,26 +2515,10 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <source>Relay function</source>
       <translation>Reläfunktion</translation>
     </message>
-    <message id="batterysettingrelay_alarm">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation type="unfinished">Larm</translation>
-    </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
       <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
       <source>Charger or generator start/stop</source>
       <translation>Laddare eller generator start/stopp</translation>
-    </message>
-    <message id="batterysettingrelay_manual_control">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
-      <source>Manual control</source>
-      <translation type="unfinished">Manuell styrning</translation>
-    </message>
-    <message id="batterysettingrelay_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">Säkring gått</translation>
     </message>
     <message id="common_words_manual_control">
       <location filename="../../components/CommonWords.qml" line="302"/>
@@ -2853,12 +2544,6 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
       <source>Status LEDs</source>
       <translation>Status LED-lampor</translation>
-    </message>
-    <message id="batterydiagnostics_none">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
-      <source>None</source>
-      <extracomment>Indicates no alarm is set</extracomment>
-      <translation type="unfinished">Ingen</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
@@ -2888,7 +2573,7 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
     <message id="common_words_switch">
       <location filename="../../components/CommonWords.qml" line="525"/>
       <source>Switch</source>
-      <extracomment>Change the mode value</extracomment>
+      <extracomment>Change the battery mode</extracomment>
       <translation>Brytare</translation>
     </message>
     <message id="devicelist_battery_initializing">
@@ -2956,21 +2641,6 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <source>Top section voltage</source>
       <translation>Spänning toppsektion</translation>
     </message>
-    <message id="battery_bank_error_communication">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="96"/>
-      <source>Communication error</source>
-      <translation type="unfinished">Kommunikationsfel</translation>
-    </message>
-    <message id="battery_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="182"/>
-      <source>State of health</source>
-      <translation type="unfinished">Hälsostatus</translation>
-    </message>
-    <message id="battery_bus_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="212"/>
-      <source>Bus voltage</source>
-      <translation type="unfinished">Busspänning</translation>
-    </message>
     <message id="battery_bottom_section_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="228"/>
       <source>Bottom section voltage</source>
@@ -3016,16 +2686,6 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <source>IO</source>
       <translation>IO</translation>
     </message>
-    <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="391"/>
-      <source>System</source>
-      <translation type="unfinished">System</translation>
-    </message>
-    <message id="battery_press_to_redetect">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="433"/>
-      <source>Press to redetect</source>
-      <translation type="unfinished">Tryck för att detektera på nytt</translation>
-    </message>
     <message id="pagesettingsgeneral_system">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="107"/>
       <source>System</source>
@@ -3066,16 +2726,6 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <source>Low SOC</source>
       <translation>Låg SOC</translation>
     </message>
-    <message id="batteryalarms_high_battery_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
-      <source>High battery voltage</source>
-      <translation type="unfinished">Hög batterispänning</translation>
-    </message>
-    <message id="batteryalarms_low_soc">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low SOC</source>
-      <translation type="unfinished">Låg SOC</translation>
-    </message>
     <message id="batteryalarms_low_starter_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="73"/>
       <source>Low starter voltage</source>
@@ -3095,11 +2745,6 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
       <source>Mid-point voltage</source>
       <translation>Spänning mittpunkt</translation>
-    </message>
-    <message id="batteryalarms_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">Säkring gått</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
@@ -3293,11 +2938,6 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <source>Restore factory defaults</source>
       <translation>Återställ fabriksinställningar</translation>
     </message>
-    <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation type="unfinished">Tryck för att återställa</translation>
-    </message>
     <message id="vebus_backup_press_to_restore">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="362"/>
       <source>Press to restore</source>
@@ -3337,11 +2977,6 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="18"/>
       <source>Capacity</source>
       <translation>Kapacitet</translation>
-    </message>
-    <message id="batterysettingsbattery_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
-      <source>Capacity</source>
-      <translation type="unfinished">Kapacitet</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
@@ -3418,11 +3053,6 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <source>No power on busbar</source>
       <translation>Ingen ström på skena</translation>
     </message>
-    <message id="lynxdistributor_connection_lost">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
-      <source>Connection lost</source>
-      <translation type="unfinished">Anslutning förlorad</translation>
-    </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
       <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
       <source>%n fuse(s) blown</source>
@@ -3458,26 +3088,6 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <source>Shutdowns due error</source>
       <translation>Avstängning på grund av fel</translation>
     </message>
-    <message id="lynxiondiagnostics_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
-      <source>Last error</source>
-      <translation type="unfinished">Senaste fel</translation>
-    </message>
-    <message id="lynxiondiagnostics_2nd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
-      <source>2nd last error</source>
-      <translation type="unfinished">2:a senaste fel</translation>
-    </message>
-    <message id="lynxiondiagnostics_3rd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
-      <source>3rd last error</source>
-      <translation type="unfinished">3:e senaste fel</translation>
-    </message>
-    <message id="lynxiondiagnostics_4th_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
-      <source>4th last error</source>
-      <translation type="unfinished">4:e senaste fel</translation>
-    </message>
     <message id="lynxionio_system_switch">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
       <source>System Switch</source>
@@ -3497,11 +3107,6 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <location filename="../../components/CommonWords.qml" line="54"/>
       <source>Batteries</source>
       <translation>Batterier</translation>
-    </message>
-    <message id="lynxionsystem_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
-      <source>Capacity</source>
-      <translation type="unfinished">Kapacitet</translation>
     </message>
     <message id="lynxionsystem_parallel">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="30"/>
@@ -3523,20 +3128,10 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <source>Min/max cell temperature</source>
       <translation>Lägsta/högsta celltemperatur</translation>
     </message>
-    <message id="lynxionsystem_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="92"/>
-      <source>Balancing</source>
-      <translation type="unfinished">Balansering</translation>
-    </message>
     <message id="lynxionsystem_balancer_balancing">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
       <source>Balancing</source>
       <translation>Balansering</translation>
-    </message>
-    <message id="lynxionsystem_balancer_unknown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="117"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Okänd</translation>
     </message>
     <message id="dc_output">
       <location filename="../../components/listitems/ListDcOutputQuantityGroup.qml" line="16"/>
@@ -3644,11 +3239,6 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <source>Remaining</source>
       <translation>Återstående</translation>
     </message>
-    <message id="devicelist_tanksensor_sensor_battery">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="51"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">Sensorbatteri</translation>
-    </message>
     <message id="temperature_sensor_battery">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="112"/>
       <source>Sensor battery</source>
@@ -3677,7 +3267,7 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
     <message id="devicelist_tanksetup_custom">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="53"/>
       <source>Custom</source>
-      <translation type="unfinished">Anpassa</translation>
+      <translation>Anpassa</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="59"/>
@@ -3710,34 +3300,34 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <translation>Sensorvärde</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="75"/>
       <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
       <translation>Ingen kundanpassning definierad. Du kan definiera en med upp till tio punkter. Observera att 0 % och 100 % är implicita.</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="91"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="89"/>
       <source>Point %1</source>
       <extracomment>%1 = the point number</extracomment>
       <translation>Punkt %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="133"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="179"/>
       <source>Add point</source>
       <translation>Lägg till punkt</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="156"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="205"/>
       <source>Sensor level</source>
       <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
       <translation>Sensornivå</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="256"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="311"/>
       <source>Duplicate sensor level values are not allowed.</source>
       <translation>Dubbletter av sensornivåvärden är inte tillåtna.</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="262"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="317"/>
       <source>Volume values must be increasing.</source>
       <translation>Volymvärden måste öka.</translation>
     </message>
@@ -3777,11 +3367,6 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <source>Switch position</source>
       <translation>Brytarläge</translation>
     </message>
-    <message id="ac-in-setup_single_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="142"/>
-      <source>Single phase</source>
-      <translation type="unfinished">Enfas</translation>
-    </message>
     <message id="ac-in-setup_two_phase">
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="144"/>
       <source>2-phase</source>
@@ -3791,11 +3376,6 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="146"/>
       <source>3-phase</source>
       <translation>Trefas</translation>
-    </message>
-    <message id="ac-in-setup_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="161"/>
-      <source>Devices</source>
-      <translation type="unfinished">Enheter</translation>
     </message>
     <message id="ac-in-genset_ac">
       <location filename="../../components/PageGensetModel.qml" line="194"/>
@@ -3889,12 +3469,6 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <extracomment>%1 = CT device number</extracomment>
       <translation>CT %1</translation>
     </message>
-    <message id="smappeect_phase_none">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation type="unfinished">Ingen</translation>
-    </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
       <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
       <source>Flashing LED indicates this CT</source>
@@ -3908,11 +3482,13 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
     <message id="common_words_setting_disabled_when_dmc_connected">
       <location filename="../../components/CommonWords.qml" line="355"/>
       <source>This setting is disabled when a Digital Multi Control is connected.</source>
+      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>Den här inställningen är inaktiv när en Digital Multi Control är ansluten.</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
       <location filename="../../components/CommonWords.qml" line="358"/>
       <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>Den här inställningen är inaktiv när en VE.Bus BMS är ansluten.</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
@@ -3930,16 +3506,6 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="21"/>
       <source>Inverted</source>
       <translation>Omvänd</translation>
-    </message>
-    <message id="digitalinput_enable_alarm">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="48"/>
-      <source>Enable alarm</source>
-      <translation type="unfinished">Aktivera larm</translation>
-    </message>
-    <message id="digitalinput_inverted">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="54"/>
-      <source>Inverted</source>
-      <translation type="unfinished">Omvänd</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
       <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="60"/>
@@ -3976,16 +3542,6 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <source>Wind speed</source>
       <translation>Vindhastighet</translation>
     </message>
-    <message id="page_meteo_battery_voltage">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="99"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">Sensorbatteri</translation>
-    </message>
-    <message id="meteo_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="120"/>
-      <source>Low</source>
-      <translation type="unfinished">Låg</translation>
-    </message>
     <message id="page_meteo_settings_auto_detect">
       <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
       <source>Auto-detect</source>
@@ -4016,16 +3572,6 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <source>Reset counter</source>
       <translation>Återställ räknare</translation>
     </message>
-    <message id="temperature_short_circuited">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="32"/>
-      <source>Short circuited</source>
-      <translation type="unfinished">Kortsluten</translation>
-    </message>
-    <message id="temperature_reverse_polarity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="35"/>
-      <source>Reverse polarity</source>
-      <translation type="unfinished">Omvänd polaritet</translation>
-    </message>
     <message id="temperature_sensor_battery_low">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
       <source>Sensor battery low</source>
@@ -4040,36 +3586,6 @@ Använd såvida det inte är förbjudet av elleverantören.</translation>
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="62"/>
       <source>Pressure</source>
       <translation>Tryck</translation>
-    </message>
-    <message id="temperature_pm25">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
-      <source>PM2.5</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_co2">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>CO₂</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_voc">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
-      <source>VOC index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_nox">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
-      <source>NOx index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_luminosity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
-      <source>Luminosity</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="133"/>
-      <source>Low</source>
-      <translation type="unfinished">Låg</translation>
     </message>
     <message id="temperature_offset">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
@@ -4123,25 +3639,10 @@ OBS: Uppdateringen kan tillfälligt stoppa systemet.</translation>
       <source>Updating the MK3, values will reappear after the update is complete</source>
       <translation>Uppdaterar MK3, värden visar åter efter att uppdateringen har slutförts</translation>
     </message>
-    <message id="vebus_device_charging_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="78"/>
-      <source>Charging the battery to 100%</source>
-      <translation type="unfinished">Laddning av batteriet till 100%</translation>
-    </message>
     <message id="vebus_device_charging_the_battery_to_100">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="93"/>
       <source>Charging the battery to 100%</source>
       <translation>Laddning av batteriet till 100%</translation>
-    </message>
-    <message id="vebus_device_page_microgrid_parameters">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
-      <source>Microgrid parameters</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="vebus_device_page_advanced">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
-      <source>Advanced</source>
-      <translation type="unfinished">Avancerad</translation>
     </message>
     <message id="vebus_device_in_progress">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="80"/>
@@ -4197,15 +3698,15 @@ Vill du fortsätta?</translation>
       <source>DC Current</source>
       <translation>DC-ström</translation>
     </message>
+    <message id="vebus_device_page_advanced">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
+      <source>Advanced</source>
+      <translation>Avancerad</translation>
+    </message>
     <message id="common_words_alarm_setup">
       <location filename="../../components/CommonWords.qml" line="65"/>
       <source>Alarm setup</source>
       <translation>Larminställning</translation>
-    </message>
-    <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
-      <translation type="unfinished">Ett VE.Bus BMS stänger automatiskt av systemet vid behov för att skydda batteriet. Att styra systemet från Color Control är därför inte möjligt.</translation>
     </message>
     <message id="vebus_device_bms_not_found">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="240"/>
@@ -4246,7 +3747,7 @@ Vill du fortsätta?</translation>
     <message id="vebus_device_starting">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="117"/>
       <source>Starting...</source>
-      <translation type="unfinished">Startar...</translation>
+      <translation>Startar...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="120"/>
@@ -4312,16 +3813,6 @@ Vill du fortsätta?</translation>
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="260"/>
       <source>ESS Relay test</source>
       <translation>ESS-relätest</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_completed">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="266"/>
-      <source>Completed</source>
-      <translation type="unfinished">Avslutad</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_pending">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="268"/>
-      <source>Pending</source>
-      <translation type="unfinished">Avvaktar</translation>
     </message>
     <message id="cycle_history_completed">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
@@ -4508,6 +3999,7 @@ Vill du fortsätta?</translation>
     <message id="rssystemalarms_overload">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
       <source>Overload</source>
+      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
       <translation>Överbelastning</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
@@ -4520,11 +4012,6 @@ Vill du fortsätta?</translation>
       <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
       <source>Voltage Sensor</source>
       <translation>Spänningssensor</translation>
-    </message>
-    <message id="vebus_device_phase_rotation">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
-      <source>Phase rotation</source>
-      <translation type="unfinished">Fasrotation</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
@@ -4556,12 +4043,6 @@ Vill du fortsätta?</translation>
       <source>VE.Bus BMS version</source>
       <translation>VE.Bus BMS version</translation>
     </message>
-    <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="15"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="52"/>
-      <source>Minimum SOC</source>
-      <translation type="unfinished">Lägsta SOC</translation>
-    </message>
     <message id="ess_unless_grid_fails">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="32"/>
       <source>Unless grid fails</source>
@@ -4581,7 +4062,7 @@ Vill du fortsätta?</translation>
     <message id="common_words_ac_input_role">
       <location filename="../../components/CommonWords.qml" line="24"/>
       <source>Role</source>
-      <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
       <translation>Roll</translation>
     </message>
     <message id="common_words_ac_load">
@@ -4620,18 +4101,6 @@ Vill du fortsätta?</translation>
       <source>Active</source>
       <extracomment>Status is 'active'</extracomment>
       <translation>Aktiv</translation>
-    </message>
-    <message id="common_words_alarm">
-      <location filename="../../components/CommonWords.qml" line="51"/>
-      <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
-      <translation type="unfinished">Larm</translation>
-    </message>
-    <message id="common_words_alarm_setting_overload">
-      <location filename="../../components/CommonWords.qml" line="58"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation type="unfinished">Överbelastning</translation>
     </message>
     <message id="common_words_alarm_status">
       <location filename="../../components/CommonWords.qml" line="68"/>
@@ -4678,8 +4147,8 @@ Vill du fortsätta?</translation>
       <source>Charge current</source>
       <translation>Laddningsström</translation>
     </message>
-    <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="125"/>
+    <message id="battery_mode_charging">
+      <location filename="../../src/enums.cpp" line="30"/>
       <source>Charging</source>
       <extracomment>"Charging" state</extracomment>
       <translation>Laddar</translation>
@@ -4693,7 +4162,7 @@ Vill du fortsätta?</translation>
     <message id="digitalinputs_state_closed">
       <location filename="../../src/enums.cpp" line="262"/>
       <source>Closed</source>
-      <extracomment>Digital input state</extracomment>
+      <extracomment>Status is 'closed'</extracomment>
       <translation>Stängd</translation>
     </message>
     <message id="evchargers_status_connected">
@@ -4701,8 +4170,8 @@ Vill du fortsätta?</translation>
       <source>Connected</source>
       <translation>Ansluten</translation>
     </message>
-    <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="143"/>
+    <message id="temperature_slider_current">
+      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
       <source>Current</source>
       <extracomment>Electric current, as measured in Amps</extracomment>
       <translation>Ström</translation>
@@ -4729,9 +4198,10 @@ Vill du fortsätta?</translation>
       <extracomment>Title for device information</extracomment>
       <translation>Enhet</translation>
     </message>
-    <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="172"/>
+    <message id="battery_mode_discharging">
+      <location filename="../../src/enums.cpp" line="34"/>
       <source>Discharging</source>
+      <extracomment>Battery mode</extracomment>
       <translation>laddar ur</translation>
     </message>
     <message id="wifimodel_disconnected">
@@ -4817,13 +4287,14 @@ Vill du fortsätta?</translation>
       <source>%1 Hour(s)</source>
       <translation>%1 timme(timmar)</translation>
     </message>
-    <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="251"/>
+    <message id="battery_mode_idle">
+      <location filename="../../src/enums.cpp" line="26"/>
       <source>Idle</source>
+      <extracomment>Battery mode</extracomment>
       <translation>Viloläge</translation>
     </message>
-    <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="258"/>
+    <message id="scheduled_charge_inactive">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
       <source>Inactive</source>
       <extracomment>Status is 'inactive'</extracomment>
       <translation>Inaktiv</translation>
@@ -4925,8 +4396,8 @@ Vill du fortsätta?</translation>
       <source>Offline</source>
       <translation>Offline</translation>
     </message>
-    <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="17"/>
+    <message id="digitalinputs_state_ok">
+      <location filename="../../src/enums.cpp" line="266"/>
       <source>OK</source>
       <extracomment>Voltage alarm is at "OK" level</extracomment>
       <translation>Ok</translation>
@@ -4934,6 +4405,7 @@ Vill du fortsätta?</translation>
     <message id="switchable_output_on">
       <location filename="../../src/enums.cpp" line="471"/>
       <source>On</source>
+      <extracomment>Digital input state</extracomment>
       <translation>På</translation>
     </message>
     <message id="common_words_online">
@@ -4944,7 +4416,7 @@ Vill du fortsätta?</translation>
     <message id="digitalinputs_state_open">
       <location filename="../../src/enums.cpp" line="258"/>
       <source>Open</source>
-      <extracomment>Digital input open</extracomment>
+      <extracomment>Status is 'open'</extracomment>
       <translation>Öppen</translation>
     </message>
     <message id="common_words_password">
@@ -5004,9 +4476,10 @@ Vill du fortsätta?</translation>
       <source>Remove</source>
       <translation>Ta bort</translation>
     </message>
-    <message id="switch_state_running">
-      <location filename="../../src/enums.cpp" line="363"/>
+    <message id="switchable_output_running">
+      <location filename="../../src/enums.cpp" line="468"/>
       <source>Running</source>
+      <extracomment>Status = "running"</extracomment>
       <translation>I drift</translation>
     </message>
     <message id="common_words_scanning">
@@ -5073,7 +4546,7 @@ Vill du fortsätta?</translation>
     <message id="pvinverter_statusCode_startup">
       <location filename="../../src/enums.cpp" line="296"/>
       <source>Startup (%1)</source>
-      <extracomment>PV inverter status code. %1 = the startup status number</extracomment>
+      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
       <translation>Start (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
@@ -5128,8 +4601,10 @@ Vill du fortsätta?</translation>
       <source>Unique Identity Number</source>
       <translation>Unikt identitetsnummer</translation>
     </message>
-    <message id="settings_radio_button_group_unknown">
-      <location filename="../../components/listitems/core/ListRadioButtonGroup.qml" line="44"/>
+    <message id="Unknown">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
       <source>Unknown</source>
       <translation>Okänd</translation>
     </message>
@@ -5284,11 +4759,6 @@ Vill du fortsätta?</translation>
       <source>Error while checking for firmware updates</source>
       <translation>Fel vid sökning av uppdateringar av fast programvara</translation>
     </message>
-    <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation type="unfinished">Fel vid sökning av uppdateringar av fast programvara</translation>
-    </message>
     <message id="settings_firmware_downloading_and_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="63"/>
       <source>Downloading and installing firmware %1...</source>
@@ -5315,6 +4785,66 @@ Vill du fortsätta?</translation>
       <source>No firmware found</source>
       <translation>Ingen programvara hittades</translation>
     </message>
+    <message id="tank_type_fuel">
+      <location filename="../../src/enums.cpp" line="495"/>
+      <source>Fuel</source>
+      <translation>Bränsle</translation>
+    </message>
+    <message id="tank_type_fresh_water">
+      <location filename="../../src/enums.cpp" line="498"/>
+      <source>Fresh water</source>
+      <translation>Färskvatten</translation>
+    </message>
+    <message id="tank_type_waste_water">
+      <location filename="../../src/enums.cpp" line="501"/>
+      <source>Waste water</source>
+      <translation>Spillvatten</translation>
+    </message>
+    <message id="tank_type_live_well">
+      <location filename="../../src/enums.cpp" line="504"/>
+      <source>Live well</source>
+      <translation>Vattentank</translation>
+    </message>
+    <message id="tank_type_oil">
+      <location filename="../../src/enums.cpp" line="507"/>
+      <source>Oil</source>
+      <translation>Olja</translation>
+    </message>
+    <message id="tank_type_black_water">
+      <location filename="../../src/enums.cpp" line="510"/>
+      <source>Black water</source>
+      <translation>SVARTVATTEN</translation>
+    </message>
+    <message id="tank_type_gasoline">
+      <location filename="../../src/enums.cpp" line="513"/>
+      <source>Gasoline</source>
+      <translation>Bensin</translation>
+    </message>
+    <message id="tank_type_diesel">
+      <location filename="../../src/enums.cpp" line="516"/>
+      <source>Diesel</source>
+      <translation>Diesel</translation>
+    </message>
+    <message id="tank_type_lpg">
+      <location filename="../../src/enums.cpp" line="519"/>
+      <source>LPG</source>
+      <translation>LPG</translation>
+    </message>
+    <message id="tank_type_lng">
+      <location filename="../../src/enums.cpp" line="522"/>
+      <source>LNG</source>
+      <translation>LNG</translation>
+    </message>
+    <message id="tank_type_hydraulic_oil">
+      <location filename="../../src/enums.cpp" line="525"/>
+      <source>Hydraulic oil</source>
+      <translation>Hydraulolja</translation>
+    </message>
+    <message id="tank_type_raw_water">
+      <location filename="../../src/enums.cpp" line="528"/>
+      <source>Raw water</source>
+      <translation>Råvatten</translation>
+    </message>
     <message id="listItem_no_access">
       <location filename="../../components/listitems/core/ListItem.qml" line="102"/>
       <source>Setting locked for access level</source>
@@ -5328,6 +4858,7 @@ Vill du fortsätta?</translation>
     <message id="welcome_brief_title">
       <location filename="../../pages/welcome/WelcomeView.qml" line="81"/>
       <source>Brief</source>
+      <extracomment>The 'Brief' page</extracomment>
       <translation>Sammanfattning</translation>
     </message>
     <message id="welcome_overview_title">
@@ -5344,23 +4875,6 @@ Vill du fortsätta?</translation>
       <location filename="../../pages/NotificationsPage.qml" line="13"/>
       <source>Notifications</source>
       <translation>Meddelanden</translation>
-    </message>
-    <message id="notifications_page_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="43"/>
-      <source>Active Notifications</source>
-      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_page_inactive_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="47"/>
-      <source>Inactive Notifications</source>
-      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_no_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="106"/>
-      <source>No active notifications</source>
-      <translation type="unfinished"/>
     </message>
     <message id="utils_formatTimestamp_now">
       <location filename="../../components/Utils.js" line="258"/>
@@ -5465,11 +4979,6 @@ Vill du fortsätta?</translation>
       <source>Self-consumption above limit</source>
       <translation>Egenförbrukning över gräns</translation>
     </message>
-    <message id="cgwacs_battery_schedule_pv">
-      <location filename="../../components/listitems/ListChargeSchedule.qml" line="171"/>
-      <source>PV</source>
-      <translation type="unfinished">PV</translation>
-    </message>
     <message id="settings_multirs_pv">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="185"/>
       <source>PV</source>
@@ -5480,8 +4989,8 @@ Vill du fortsätta?</translation>
       <source>PV &amp; Battery</source>
       <translation>Solceller och batteri</translation>
     </message>
-    <message id="settings_firmware_checking">
-      <location filename="../../components/listitems/ListFirmwareCheckButton.qml" line="16"/>
+    <message id="pagesettingssupportstate_firmware_checking">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
       <source>Checking...</source>
       <translation>Söker...</translation>
     </message>
@@ -5489,12 +4998,6 @@ Vill du fortsätta?</translation>
       <location filename="../../components/listitems/ListAlarmState.qml" line="11"/>
       <source>Alarm state</source>
       <translation>Larmtillstånd</translation>
-    </message>
-    <message id="devicelist_battery_alarm_state">
-      <location filename="../../components/listitems/ListAlarmState.qml" line="19"/>
-      <source>Alarm</source>
-      <extracomment>Alarm state is active</extracomment>
-      <translation type="unfinished">Larm</translation>
     </message>
     <message id="clear_history_button_clear_history">
       <location filename="../../components/listitems/ListClearHistoryButton.qml" line="15"/>
@@ -5646,11 +5149,6 @@ Vill du fortsätta?</translation>
       <source>Max Voltage</source>
       <translation>Högsta spänning</translation>
     </message>
-    <message id="charger_history_box_max_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="64"/>
-      <source>Max Voltage</source>
-      <translation type="unfinished">Högsta spänning</translation>
-    </message>
     <message id="charger_history_box_max_current">
       <location filename="../../components/SolarDetailBox.qml" line="70"/>
       <source>Max Current</source>
@@ -5661,24 +5159,6 @@ Vill du fortsätta?</translation>
       <source>Charge time</source>
       <extracomment>Statistics for battery charging time</extracomment>
       <translation>Laddningstid</translation>
-    </message>
-    <message id="charger_history_box_bulk">
-      <location filename="../../components/SolarDetailBox.qml" line="136"/>
-      <source>Bulk</source>
-      <extracomment>Battery: time spent in 'Bulk' mode</extracomment>
-      <translation type="unfinished">Bulk</translation>
-    </message>
-    <message id="charger_history_box_float">
-      <location filename="../../components/SolarDetailBox.qml" line="148"/>
-      <source>Float</source>
-      <extracomment>Battery: time spent in 'Float' mode</extracomment>
-      <translation type="unfinished">Flytladdning</translation>
-    </message>
-    <message id="charger_history_hr">
-      <location filename="../../components/SolarDetailBox.qml" line="174"/>
-      <source>hr</source>
-      <extracomment>Abbreviation of "hour"</extracomment>
-      <translation type="unfinished">tim</translation>
     </message>
     <message id="solarchargers_state_bulk">
       <location filename="../../src/enums.cpp" line="337"/>
@@ -5750,11 +5230,6 @@ Vill du fortsätta?</translation>
       <source>Connecting</source>
       <translation>Ansluter...</translation>
     </message>
-    <message id="splash_view_connecting">
-      <location filename="../../components/SplashView.qml" line="288"/>
-      <source>Connecting</source>
-      <translation type="unfinished">Ansluter...</translation>
-    </message>
     <message id="splash_view_connected">
       <location filename="../../components/SplashView.qml" line="290"/>
       <source>Connected, awaiting broker messages</source>
@@ -5810,6 +5285,11 @@ Vill du fortsätta?</translation>
       <source>MQTT protocol level 5 error</source>
       <translation>Fel MQTT-protokoll nivå 5</translation>
     </message>
+    <message id="common_words_silence_alarm">
+      <location filename="../../components/CommonWords.qml" line="476"/>
+      <source>Silence alarm</source>
+      <translation>Tysta larm</translation>
+    </message>
     <message id="vebus_device_page_total_power">
       <location filename="../../components/ThreePhaseQuantityTable.qml" line="47"/>
       <source>Total Power</source>
@@ -5860,20 +5340,10 @@ Vill du fortsätta?</translation>
       <source>Retrieving IP address</source>
       <translation>Hämtar IP-adress</translation>
     </message>
-    <message id="utils_connman_connected">
-      <location filename="../../components/Utils.js" line="292"/>
-      <source>Connected</source>
-      <translation type="unfinished">Ansluten</translation>
-    </message>
     <message id="utils_connman_disconnect">
       <location filename="../../components/Utils.js" line="295"/>
       <source>Disconnect</source>
       <translation>Koppla ifrån</translation>
-    </message>
-    <message id="utils_connman_disconnected">
-      <location filename="../../components/Utils.js" line="299"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Frånkopplad</translation>
     </message>
     <message id="overview_widget_acloads_title">
       <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
@@ -5911,11 +5381,6 @@ Vill du fortsätta?</translation>
       <source>Shore current limit</source>
       <translation>Landströmsbegränsning</translation>
     </message>
-    <message id="acInputs_statusCode_stopping">
-      <location filename="../../data/AcInputs.qml" line="170"/>
-      <source>Stopping</source>
-      <translation type="unfinished">Stoppar</translation>
-    </message>
     <message id="page_generator_stopping">
       <location filename="../../data/Generators.qml" line="44"/>
       <source>Stopping</source>
@@ -5931,7 +5396,7 @@ Vill du fortsätta?</translation>
       <location filename="../../data/common/TankDescription.qml" line="24"/>
       <location filename="../../src/device.cpp" line="133"/>
       <source>%1 tank (%2)</source>
-      <extracomment>Tank description. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
       <translation>%1 tank (%2)</translation>
     </message>
     <message id="dcMeter_ac_charger">
@@ -5980,11 +5445,6 @@ Vill du fortsätta?</translation>
       <location filename="../../data/Ess.qml" line="20"/>
       <source>Keep batteries charged</source>
       <translation>Håll batterierna laddade</translation>
-    </message>
-    <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="50"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Frånkopplad</translation>
     </message>
     <message id="evchargers_status_charged">
       <location filename="../../data/EvChargers.qml" line="58"/>
@@ -6045,16 +5505,6 @@ Vill du fortsätta?</translation>
       <location filename="../../data/EvChargers.qml" line="97"/>
       <source>Start charging</source>
       <translation>Starta laddning</translation>
-    </message>
-    <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="113"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Okänd</translation>
-    </message>
-    <message id="evchargers_mode_scheduled">
-      <location filename="../../data/EvChargers.qml" line="126"/>
-      <source>Scheduled</source>
-      <translation type="unfinished">Schemalagd</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
       <location filename="../../data/System.qml" line="195"/>
@@ -6179,11 +5629,6 @@ Vill du fortsätta?</translation>
       <source>Power supply mode</source>
       <translation>Strömförsörjningsläge</translation>
     </message>
-    <message id="inverters_state_sustain">
-      <location filename="../../data/System.qml" line="158"/>
-      <source>Sustain</source>
-      <translation type="unfinished">Upprätthålla</translation>
-    </message>
     <message id="inverters_state_wakeup">
       <location filename="../../data/System.qml" line="162"/>
       <source>Wake up</source>
@@ -6218,16 +5663,6 @@ Vill du fortsätta?</translation>
       <location filename="../../data/System.qml" line="180"/>
       <source>Test</source>
       <translation>Test</translation>
-    </message>
-    <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="183"/>
-      <source>External control</source>
-      <translation type="unfinished">Extern kontroll</translation>
-    </message>
-    <message id="inverters_state_dynamic_ess">
-      <location filename="../../data/System.qml" line="198"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">Dynamiskt ESS</translation>
     </message>
     <message id="settings_rs_ess_dess">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="97"/>
@@ -6306,16 +5741,13 @@ Vill du fortsätta?</translation>
     <message id="ess_recommended">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="73"/>
       <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
       <translation>För litiumbatterier rekommenderas inte en nivå under 10 % laddning. För andra batterityper, kolla databladet för att se tillverkarens rekommenderade lägsta nivå.</translation>
-    </message>
-    <message id="controlcard_generator_label_autostart">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="63"/>
-      <source>Autostart</source>
-      <translation type="unfinished">Autostart</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
       <location filename="../../pages/controlcards/GeneratorCard.qml" line="70"/>
       <source>Start and stop the generator based on the configured autostart conditions.</source>
+      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
       <translation>Starta och stoppa generatorn baserat på de inställda villkoren för autostart.</translation>
     </message>
     <message id="generator_dialog_disabled">
@@ -6338,11 +5770,13 @@ Vill du fortsätta?</translation>
       <location filename="../../pages/controlcards/InverterChargerCard.qml" line="26"/>
       <source>Inverter / Charger (%1)</source>
       <extracomment>%1 = the inverter/charger name</extracomment>
+      <oldsource>Inverter / Charger</oldsource>
       <translation>Växelriktare/ laddare (%1)</translation>
     </message>
     <message id="settings_page_debug_quit_application">
       <location filename="../../pages/settings/debug/PageDebug.qml" line="36"/>
       <source>Quit application</source>
+      <oldsource>Quit Application</oldsource>
       <translation>Lämna applikation</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
@@ -6353,12 +5787,8 @@ Vill du fortsätta?</translation>
     <message id="settings_page_relay_generator_run_time">
       <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
       <source>Current run time</source>
+      <oldsource>Run time</oldsource>
       <translation>Nuvarande drifttid</translation>
-    </message>
-    <message id="settings_page_genset_generator_run_time">
-      <location filename="../../components/PageGensetModel.qml" line="102"/>
-      <source>Current run time</source>
-      <translation type="unfinished">Nuvarande drifttid</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
       <location filename="../../components/PageGensetModel.qml" line="110"/>
@@ -6385,19 +5815,10 @@ Vill du fortsätta?</translation>
       <source>Remote start mode</source>
       <translation>Fjärrstartsläge</translation>
     </message>
-    <message id="ac-in-genset_speed">
-      <location filename="../../components/PageGensetModel.qml" line="245"/>
-      <source>Speed</source>
-      <translation type="unfinished">Hastighet</translation>
-    </message>
-    <message id="ac-in-genset_load">
-      <location filename="../../components/PageGensetModel.qml" line="252"/>
-      <source>Load</source>
-      <translation type="unfinished">Belastning</translation>
-    </message>
     <message id="ac-in-genset_oil_pressure">
       <location filename="../../components/PageGensetModel.qml" line="260"/>
       <source>Oil pressure</source>
+      <oldsource>Oil Pressure</oldsource>
       <translation>Oljetryck</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
@@ -6493,11 +5914,13 @@ Vill du fortsätta?</translation>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
       <source>High starter battery voltage alarms</source>
+      <oldsource>High starter batttery voltage alarms</oldsource>
       <translation>Larm om hög startbatterispänning</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
       <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
       <translation>Observera att om du ändrar miniminivån för "tid kvar urladdning" ändrar du även inställningen för "låg laddningsstatus" i relämenyn</translation>
     </message>
     <message id="lynxionsystem_cells_per_battery">
@@ -6574,6 +5997,7 @@ Vill du fortsätta?</translation>
       <location filename="../../pages/settings/devicelist/delegates/DeviceListDelegate_solarcharger.qml" line="34"/>
       <source>Error: #%1</source>
       <extracomment>%1 = error number</extracomment>
+      <oldsource>Error: %1</oldsource>
       <translation>Fel: #%1</translation>
     </message>
     <message id="devicelistpage_genset">
@@ -6630,17 +6054,14 @@ Vill du fortsätta?</translation>
     <message id="settings_page_relay_generator_auto_start_enabled">
       <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
       <source>Autostart functionality</source>
+      <oldsource>Auto start functionality</oldsource>
       <translation>Autostart-funktion</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="97"/>
       <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
       <translation>Säkerställ att generatorn inte är ansluten till AC-ingång %1 när du använder detta alternativ.</translation>
-    </message>
-    <message id="page_generator_conditions_inverter_high_temperature">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="139"/>
-      <source>Inverter high temperature</source>
-      <translation type="unfinished">Hög temp. växelriktare</translation>
     </message>
     <message id="page_generator_conditions_tank_level">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="159"/>
@@ -6670,30 +6091,34 @@ Vill du fortsätta?</translation>
     <message id="settings_generator_function_not_enabled">
       <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
       <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
+      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
       <translation>Generatorns start/stopp-funktion är inte på, gå till reläinställningarna och ändra funktionen till "Generator start/stopp"</translation>
     </message>
     <message id="settings_batteries_intro">
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="45"/>
       <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
       <translation>Använd den här menyn för att definiera vilken data som ska visas när man klickar på batterisymbolen på översiktssidan. Samma val är även synliga på VRM-portalen.</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
       <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
       <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
       <translation>Kontinuerlig skanning kan störa Wi-Fi-funktionen.</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
       <source>CAN-bus BMS LV (500 kbit/s)</source>
+      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
       <translation>CAN-bus BMS LV (500 kbit/s)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
       <source>CAN-bus BMS HV (500 kbit/s)</source>
       <translation>CAN-bus BMS HV (500 kbit/s)</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
       <source>Up, but no services (500 kbit/s)</source>
       <translation>Aktiv men inga tjänster (500 kbit/s)</translation>
     </message>
@@ -6706,41 +6131,6 @@ Vill du fortsätta?</translation>
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="127"/>
       <source>Brief page</source>
       <translation>Kort sida</translation>
-    </message>
-    <message id="settings_displayoff_1min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="46"/>
-      <source>1 min</source>
-      <translation type="unfinished">1 min</translation>
-    </message>
-    <message id="settings_displayoff_10min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="48"/>
-      <source>10 min</source>
-      <translation type="unfinished">10 min</translation>
-    </message>
-    <message id="settings_displayoff_30min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="50"/>
-      <source>30 min</source>
-      <translation type="unfinished">30 min</translation>
-    </message>
-    <message id="settings_displayoff_never">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="52"/>
-      <source>Never</source>
-      <translation type="unfinished">Aldrig</translation>
-    </message>
-    <message id="settings_remote_console_appearance_auto">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="112"/>
-      <source>Auto</source>
-      <translation type="unfinished">Automatisk</translation>
-    </message>
-    <message id="settings_brief_view_start_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="119"/>
-      <source>Start page</source>
-      <translation type="unfinished">Startsida</translation>
-    </message>
-    <message id="settings_display_boat_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="135"/>
-      <source>Boat page</source>
-      <translation type="unfinished">Båtsida</translation>
     </message>
     <message id="settings_display_minmax">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="148"/>
@@ -6795,21 +6185,6 @@ Vill du fortsätta?</translation>
       <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
       <translation>%1 är inställt på %2</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_unsupported_device">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="50"/>
-      <source>Unsupported GX device</source>
-      <translation type="unfinished">GX-enhet som ej stöds</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_clean">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="55"/>
-      <source>Clean</source>
-      <translation type="unfinished">Rensa</translation>
-    </message>
-    <message id="pagesettingsgeneral_firmware">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="112"/>
-      <source>Firmware</source>
-      <translation type="unfinished">Maskinvara</translation>
-    </message>
     <message id="pagesettingsgeneral_access_and_security">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
       <source>Access &amp; Security</source>
@@ -6843,6 +6218,7 @@ Vill du fortsätta?</translation>
     <message id="settings_language_please_wait">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="209"/>
       <source>Please wait while the language is changed.</source>
+      <oldsource>Please wait while the language is changed</oldsource>
       <translation>Vänta medan språket byts.</translation>
     </message>
     <message id="settings_briefview_totals">
@@ -6859,11 +6235,6 @@ Vill du fortsätta?</translation>
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="71"/>
       <source>Tank is not connected.</source>
       <translation>Tank är ej ansluten</translation>
-    </message>
-    <message id="settings_briefview_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="83"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">Aktiv batteriövervakare</translation>
     </message>
     <message id="settings_briefview_individual_batteries">
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="86"/>
@@ -6914,6 +6285,7 @@ Vill du fortsätta?</translation>
     <message id="settings_dvcc_charge_current_limits">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="30"/>
       <source>Charge current limits</source>
+      <oldsource>Charge Current limits</oldsource>
       <translation>Laddningsströmbegränsningar</translation>
     </message>
     <message id="settings_firmware_official_release">
@@ -6993,11 +6365,6 @@ Vill du fortsätta?</translation>
       <source>No password and the network communication is not encrypted</source>
       <translation>Inget lösenord och nätverkskommunikationen är inte krypterad</translation>
     </message>
-    <message id="settings_logout_now">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
-      <source>Log out now</source>
-      <translation type="unfinished">Logga ut nu</translation>
-    </message>
     <message id="settings_security_profile_password_incorrect_length">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="28"/>
       <source>Password needs to be at least 8 characters long</source>
@@ -7048,25 +6415,10 @@ Vill du fortsätta?</translation>
       <source>Page will automatically reload in 5 seconds</source>
       <translation>Sidan kommer automatiskt att laddas på nytt om 5 sekunder</translation>
     </message>
-    <message id="settings_security_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="159"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">Lösenordet måste innehålla minst 8 tecken</translation>
-    </message>
     <message id="settings_root_password">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="269"/>
       <source>Root password</source>
       <translation>Root-lösenord</translation>
-    </message>
-    <message id="settings_root_enter_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="272"/>
-      <source>Enter password</source>
-      <translation type="unfinished">Ange lösenord</translation>
-    </message>
-    <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="277"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">Lösenordet måste innehålla minst 8 tecken</translation>
     </message>
     <message id="settings_root_password_changed_to">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="283"/>
@@ -7082,6 +6434,11 @@ Vill du fortsätta?</translation>
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="321"/>
       <source>Logout</source>
       <translation>Utloggning</translation>
+    </message>
+    <message id="settings_logout_now">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
+      <source>Log out now</source>
+      <translation>Logga ut nu</translation>
     </message>
     <message id="settings_logout_dialog_title">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="335"/>
@@ -7141,11 +6498,13 @@ Vill du fortsätta?</translation>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="141"/>
       <source>Alarm when generator is not in autostart mode</source>
+      <oldsource>Alarm when generator is not in auto start mode</oldsource>
       <translation>Larm när generatorn inte är i autostart-läge</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="147"/>
       <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
       <translation>Ett larm utlöses när autostart-funktionen har varit inaktiv i över 10 minuter</translation>
     </message>
     <message id="settings_units_amps_exceptions">
@@ -7161,6 +6520,11 @@ Vill du fortsätta?</translation>
     <message id="settings_ess_use_this_option_for_peak_shaving">
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
       <source>Use this option for peak shaving.</source>
+      <oldsource>Use this option for peak shaving.
+
+The peak shaving threshold is set using the AC input current limit setting.
+
+See documentation for further information.</oldsource>
       <translation>Använd detta alternativ för topplastutjämning.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
@@ -7204,17 +6568,17 @@ Vill du fortsätta?</translation>
       <translation>Högsta systemexportström (per fas)</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="71"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="73"/>
       <source>Self-consumption from battery</source>
       <translation>Egen förbrukning från batteri</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="76"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
       <source>All system loads</source>
       <translation>Alla systembelastningar</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="80"/>
       <source>Only critical loads</source>
       <translation>Endast kritiska laster</translation>
     </message>
@@ -7272,26 +6636,6 @@ Vill du fortsätta?</translation>
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="194"/>
       <source>Server Applications</source>
       <translation>Serverapplikationer</translation>
-    </message>
-    <message id="pagesettingsintegrations_venus_os_enable_large_features">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
-      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_large_victron_community">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="274"/>
-      <source>Victron Community</source>
-      <translation type="unfinished">Victron-Community</translation>
-    </message>
-    <message id="pagesettingsintegrations_ui_plugins">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
-      <source>UI Plugins</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
-      <source>Integrates with the device list</source>
-      <translation type="unfinished"/>
     </message>
     <message id="pagesettingssupportstate_modbus_tcp_server">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="453"/>
@@ -7394,25 +6738,10 @@ Vill du fortsätta?</translation>
       <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
       <translation>Det är inte möjligt att byta fast programvaruversion om inte "Nätverkssäkerhetsprofil" har valts i "Inställningar/ Allmänna".</translation>
     </message>
-    <message id="pagesettingsconnectivity_ethernet">
-      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
-      <source>Ethernet</source>
-      <translation type="unfinished">Ethernet</translation>
-    </message>
     <message id="pagesettingsconnectivity_mobile_network">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="53"/>
       <source>Mobile Network</source>
       <translation>Mobilt nätverk</translation>
-    </message>
-    <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Boat</source>
-      <translation type="unfinished">Båt</translation>
-    </message>
-    <message id="settings_system_name_auto">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="32"/>
-      <source>Automatic</source>
-      <translation type="unfinished">Automatisk</translation>
     </message>
     <message id="pagesettingssystem_ac_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
@@ -7443,11 +6772,6 @@ Vill du fortsätta?</translation>
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="89"/>
       <source>Distributed Voltage and Current Control (DVCC)</source>
       <translation>Kontroll av distribuerad spänning och ström (DVCC)</translation>
-    </message>
-    <message id="settings_system_grid">
-      <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="18"/>
-      <source>Grid</source>
-      <translation type="unfinished">Nät</translation>
     </message>
     <message id="settings_system_ac_position">
       <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="58"/>
@@ -7487,16 +6811,19 @@ Vill du fortsätta?</translation>
     <message id="settings_system_has_dc_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="97"/>
       <source>Display DC Loads</source>
+      <oldsource>Has DC system</oldsource>
       <translation>Visa DC-belastningar.</translation>
     </message>
     <message id="settings_system_battery_measurements">
       <location filename="../../pages/settings/PageSettingsBatteries.qml" line="65"/>
       <source>Battery measurements</source>
+      <oldsource>Battery Measurements</oldsource>
       <translation>Batterimätningar</translation>
     </message>
     <message id="settings_system_system_status">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
       <source>System status</source>
+      <oldsource>System Status</oldsource>
       <translation>Systemstatus</translation>
     </message>
     <message id="settings_tcpip_wired">
@@ -7507,11 +6834,13 @@ Vill du fortsätta?</translation>
     <message id="settings_vecan_device_instance">
       <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
       <source>VE.Can Device Instance</source>
+      <oldsource>Device Instance</oldsource>
       <translation>VE.CAN-enhetsinstans</translation>
     </message>
     <message id="settings_vecan_device_number">
       <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="32"/>
       <source>VE.Can Instance# %1</source>
+      <oldsource>Device# %1</oldsource>
       <translation>VE.Can-instans# %1</translation>
     </message>
     <message id="settings_tz_antarctica">
@@ -7542,6 +6871,7 @@ Vill du fortsätta?</translation>
     <message id="settings_vrm">
       <location filename="../../pages/SettingsPage.qml" line="59"/>
       <source>VRM</source>
+      <extracomment>Forced by %2 to dark</extracomment>
       <translation>VRM</translation>
     </message>
     <message id="settings_remote_monitoring_portal">
@@ -7549,20 +6879,10 @@ Vill du fortsätta?</translation>
       <source>Remote monitoring portal</source>
       <translation>Fjärrövervakningsportal</translation>
     </message>
-    <message id="settings_advanced">
-      <location filename="../../pages/SettingsPage.qml" line="68"/>
-      <source>Advanced</source>
-      <translation type="unfinished">Avancerad</translation>
-    </message>
-    <message id="settings_integrations">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
+    <message id="pagesettingssupportstate_integrations">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
       <source>Integrations</source>
       <translation>Integrationer</translation>
-    </message>
-    <message id="settings_relays_sensors_tanks">
-      <location filename="../../pages/SettingsPage.qml" line="75"/>
-      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
-      <translation type="unfinished">Relän, sensorer, tankar, solcellsväxelriktare, Modbus, MQTT ...</translation>
     </message>
     <message id="settings_acdcsystem_ess_dvcc_battery">
       <location filename="../../pages/SettingsPage.qml" line="84"/>
@@ -7582,11 +6902,13 @@ Vill du fortsätta?</translation>
     <message id="settings_system_setup">
       <location filename="../../pages/SettingsPage.qml" line="82"/>
       <source>System Setup</source>
+      <oldsource>System setup</oldsource>
       <translation>Systeminstallation</translation>
     </message>
     <message id="settings_vrm_device_instances">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
       <source>VRM device instances</source>
+      <oldsource>VRM Device Instances</oldsource>
       <translation>VRM enhetsinstanser</translation>
     </message>
     <message id="solarcharger_not_supported">
@@ -7604,28 +6926,10 @@ Vill du fortsätta?</translation>
       <source>The firmware version in the MPPT Solar Charger must be v1.09 or later. Contact Victron Service for update instructions and files.</source>
       <translation>Den fasta programvaruversionen i MPPT-solcellsladdaren måste vara v1.09 eller senare. Kontakta Victrons kundtjänst för uppdateringsinstruktioner och filer.</translation>
     </message>
-    <message id="solarcharger_pv">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="102"/>
-      <source>PV</source>
-      <extracomment>PV power for solar charger</extracomment>
-      <translation type="unfinished">PV</translation>
-    </message>
     <message id="solarcharger_total_power">
       <location filename="../../pages/solar/PageSolarCharger.qml" line="127"/>
       <source>Total PV power</source>
       <translation>Total solcellseffekt</translation>
-    </message>
-    <message id="solarcharger_total_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="211"/>
-      <source>Total yield</source>
-      <extracomment>Solar charger total yield</extracomment>
-      <translation type="unfinished">Totalt utbyte</translation>
-    </message>
-    <message id="solarcharger_system_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="220"/>
-      <source>System yield</source>
-      <extracomment>Solar charger system yield</extracomment>
-      <translation type="unfinished">Systemutbyte</translation>
     </message>
     <message id="settings_multirs_total_yield">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="63"/>
@@ -7661,16 +6965,19 @@ Vill du fortsätta?</translation>
     <message id="vebus_device_update_firmware">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="133"/>
       <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
       <translation>Den här funktionen kräver fasta programvaruversion 400 eller högre. Kontakta din installatör för att uppdatera din Multi/Quattro.</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="139"/>
       <source>Charger not ready, equalization cannot be started</source>
+      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
       <translation>Laddaren är inte redo, utjämning kan inte påbörjas</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="143"/>
       <source>Equalization cannot be triggered during bulk charge state</source>
+      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
       <translation>Utjämning kan inte aktiveras under bulkladdningsläget.</translation>
     </message>
     <message id="vebus_device_restart_vebus_system_restart_confirmation_description">
@@ -7693,78 +7000,20 @@ Vill du fortsätta?</translation>
       <source>Auto-started • %1</source>
       <translation>Autostartade • %1</translation>
     </message>
-    <message id="common_words_battery">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery</source>
-      <translation type="unfinished">Batteri</translation>
-    </message>
-    <message id="common_words_boat_page">
-      <location filename="../../components/CommonWords.qml" line="111"/>
-      <source>Boat</source>
-      <extracomment>The 'Boat' page</extracomment>
-      <translation type="unfinished">Båt</translation>
-    </message>
-    <message id="common_words_brief_page">
-      <location filename="../../components/CommonWords.qml" line="115"/>
-      <source>Brief</source>
-      <extracomment>The 'Brief' page</extracomment>
-      <translation type="unfinished">Sammanfattning</translation>
-    </message>
-    <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation type="unfinished">Stängd</translation>
-    </message>
-    <message id="common_words_color">
-      <location filename="../../components/CommonWords.qml" line="136"/>
-      <source>Color</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_connected">
-      <location filename="../../components/CommonWords.qml" line="139"/>
-      <source>Connected</source>
-      <translation type="unfinished">Ansluten</translation>
-    </message>
     <message id="common_words_daily_history">
       <location filename="../../components/CommonWords.qml" line="152"/>
       <source>Daily history</source>
       <translation>Daglig historik</translation>
-    </message>
-    <message id="common_words_disabled">
-      <location filename="../../components/CommonWords.qml" line="169"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Inaktiverad</translation>
-    </message>
-    <message id="common_words_disconnected">
-      <location filename="../../components/CommonWords.qml" line="175"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Frånkopplad</translation>
-    </message>
-    <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="191"/>
-      <source>Error</source>
-      <translation type="unfinished">Fel</translation>
     </message>
     <message id="common_words_error_not_a_number">
       <location filename="../../components/CommonWords.qml" line="200"/>
       <source>'%1' is not a number.</source>
       <translation>”%1” är inte ett nummer.</translation>
     </message>
-    <message id="common_words_generator">
-      <location filename="../../components/CommonWords.qml" line="217"/>
-      <source>Generator</source>
-      <translation type="unfinished">Generator</translation>
-    </message>
     <message id="common_words_input_current_limit">
       <location filename="../../components/CommonWords.qml" line="261"/>
       <source>Input current limit</source>
       <translation>Gräns ingångsström</translation>
-    </message>
-    <message id="common_words_inverter_charger">
-      <location filename="../../components/CommonWords.qml" line="264"/>
-      <source>Inverter / Charger</source>
-      <translation type="unfinished">Växelriktare/ laddare</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
       <location filename="../../components/CommonWords.qml" line="268"/>
@@ -7777,12 +7026,6 @@ Vill du fortsätta?</translation>
       <source>Manual stop</source>
       <translation>Manuellt stopp</translation>
     </message>
-    <message id="common_words_max">
-      <location filename="../../components/CommonWords.qml" line="315"/>
-      <source>Max</source>
-      <extracomment>Short for Maximum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_maximum_current">
       <location filename="../../components/CommonWords.qml" line="318"/>
       <source>Maximum current</source>
@@ -7793,62 +7036,10 @@ Vill du fortsätta?</translation>
       <source>Maximum power</source>
       <translation>Högsta effekt</translation>
     </message>
-    <message id="common_words_min">
-      <location filename="../../components/CommonWords.qml" line="331"/>
-      <source>Min</source>
-      <extracomment>Short for Minimum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_minimum_current">
       <location filename="../../components/CommonWords.qml" line="334"/>
       <source>Minimum current</source>
       <translation>Lägsta ström</translation>
-    </message>
-    <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="433"/>
-      <source>No</source>
-      <translation type="unfinished">Nej</translation>
-    </message>
-    <message id="common_words_none_option">
-      <location filename="../../components/CommonWords.qml" line="364"/>
-      <source>None</source>
-      <translation type="unfinished">Ingen</translation>
-    </message>
-    <message id="common_words_none_errors">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>None</source>
-      <extracomment>Indicates there are no errors</extracomment>
-      <translation type="unfinished">Ingen</translation>
-    </message>
-    <message id="common_words_not_available">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Not available</source>
-      <translation type="unfinished">Inte tillgänglig</translation>
-    </message>
-    <message id="common_words_off">
-      <location filename="../../components/CommonWords.qml" line="377"/>
-      <source>Off</source>
-      <translation type="unfinished">Av</translation>
-    </message>
-    <message id="common_words_ok">
-      <location filename="../../components/CommonWords.qml" line="383"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="41"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="45"/>
-      <source>OK</source>
-      <translation type="unfinished">Ok</translation>
-    </message>
-    <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="386"/>
-      <source>On</source>
-      <translation type="unfinished">På</translation>
-    </message>
-    <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="393"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation type="unfinished">Öppen</translation>
     </message>
     <message id="common_words_open_circuit">
       <location filename="../../components/CommonWords.qml" line="396"/>
@@ -7860,108 +7051,17 @@ Vill du fortsätta?</translation>
       <source>Overall history</source>
       <translation>Total historik</translation>
     </message>
-    <message id="common_words_press">
-      <location filename="../../components/CommonWords.qml" line="419"/>
-      <source>Press</source>
-      <translation type="unfinished">Press</translation>
-    </message>
-    <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation type="unfinished">I drift</translation>
-    </message>
-    <message id="common_words_settings">
-      <location filename="../../components/CommonWords.qml" line="467"/>
-      <source>Settings</source>
-      <translation type="unfinished">Inställningar</translation>
-    </message>
-    <message id="common_words_silence_alarm">
-      <location filename="../../components/CommonWords.qml" line="476"/>
-      <source>Silence alarm</source>
-      <translation type="unfinished">Tysta larm</translation>
-    </message>
     <message id="common_words_soc">
       <location filename="../../components/CommonWords.qml" line="480"/>
       <source>SOC %1</source>
       <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
       <translation>SoC %1%</translation>
     </message>
-    <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation type="unfinished">Hastighet</translation>
-    </message>
-    <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="487"/>
-      <source>Standby</source>
-      <translation type="unfinished">Standby</translation>
-    </message>
-    <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="502"/>
-      <source>State</source>
-      <translation type="unfinished">Status</translation>
-    </message>
-    <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="512"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation type="unfinished">Start (%1)</translation>
-    </message>
-    <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>Stopped</source>
-      <translation type="unfinished">Stoppad</translation>
-    </message>
-    <message id="common_words_total_power">
-      <location filename="../../components/CommonWords.qml" line="540"/>
-      <source>Total power</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="547"/>
-      <source>Type</source>
-      <translation type="unfinished">Sort</translation>
-    </message>
-    <message id="common_words_unknown_status">
-      <location filename="../../components/CommonWords.qml" line="554"/>
-      <source>Unknown</source>
-      <extracomment>Status = "unknown"</extracomment>
-      <translation type="unfinished">Okänd</translation>
-    </message>
-    <message id="common_words_value_must_be_greater_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="557"/>
-      <source>Value must be greater than start value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_value_must_be_greater_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="560"/>
-      <source>Value must be greater than stop value</source>
-      <translation type="unfinished">Värdet måste vara högre än stoppvärdet</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="563"/>
-      <source>Value must be lower than start value</source>
-      <translation type="unfinished">Värdet måste vara lägre än startvärdet</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="566"/>
-      <source>Value must be lower than stop value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="581"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="431"/>
-      <source>Yes</source>
-      <translation type="unfinished">Ja</translation>
-    </message>
     <message id="common_words_yield_today">
       <location filename="../../components/CommonWords.qml" line="592"/>
       <source>Yield Today</source>
       <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+      <oldsource>Yield today</oldsource>
       <translation>Produktion idag</translation>
     </message>
     <message id="common_words_format_error">
@@ -7988,10 +7088,11 @@ Vill du fortsätta?</translation>
     <message id="settings_firmware_installed_rebooting">
       <location filename="../../components/FirmwareUpdate.qml" line="79"/>
       <source>Firmware installed, device rebooting</source>
+      <oldsource>Firmware installed, rebooting.</oldsource>
       <translation>Fast programvara installerad, enheten startar om.</translation>
     </message>
-    <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/RadioButtonListPage.qml" line="121"/>
+    <message id="modaldialog_confirm">
+      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
       <source>Confirm</source>
       <extracomment>Confirm password, and verify it if possible</extracomment>
       <translation>Bekräfta</translation>
@@ -8009,11 +7110,13 @@ Vill du fortsätta?</translation>
     <message id="cgwacs_battery_schedule_duration">
       <location filename="../../components/listitems/ListChargeSchedule.qml" line="144"/>
       <source>Duration</source>
+      <oldsource>Duration (hh:mm)</oldsource>
       <translation>Varaktighet</translation>
     </message>
     <message id="settings_relay_deactivation_value">
       <location filename="../../components/TemperatureRelaySettings.qml" line="86"/>
       <source>Deactivation value</source>
+      <oldsource>Deativation value</oldsource>
       <translation>Inaktiveringsvärde</translation>
     </message>
     <message id="splash_view_device_disconnected">
@@ -8061,29 +7164,6 @@ Vill du fortsätta?</translation>
       <source>Temperature warning</source>
       <translation>Temperaturvarning</translation>
     </message>
-    <message id="battery_mode_idle">
-      <location filename="../../src/enums.cpp" line="26"/>
-      <source>Idle</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Viloläge</translation>
-    </message>
-    <message id="battery_mode_charging">
-      <location filename="../../src/enums.cpp" line="30"/>
-      <source>Charging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Laddar</translation>
-    </message>
-    <message id="battery_mode_discharging">
-      <location filename="../../src/enums.cpp" line="34"/>
-      <source>Discharging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">laddar ur</translation>
-    </message>
-    <message id="dcMeter_bilge_pump">
-      <location filename="../../src/enums.cpp" line="115"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">Länspump</translation>
-    </message>
     <message id="switch_state_channel_fault">
       <location filename="../../src/enums.cpp" line="372"/>
       <source>Channel Fault</source>
@@ -8114,26 +7194,6 @@ Vill du fortsätta?</translation>
       <source>Slave of %1</source>
       <translation>Slav under %1</translation>
     </message>
-    <message id="switchable_output_numeric_input">
-      <location filename="../../src/enums.cpp" line="418"/>
-      <source>Numeric input</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bilge_pump">
-      <location filename="../../src/enums.cpp" line="424"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">Länspump</translation>
-    </message>
-    <message id="switchable_output_not_running">
-      <location filename="../../src/enums.cpp" line="448"/>
-      <source>Not running</source>
-      <translation type="unfinished">Ej i drift</translation>
-    </message>
-    <message id="switchable_output_off">
-      <location filename="../../src/enums.cpp" line="451"/>
-      <source>Off</source>
-      <translation type="unfinished">Av</translation>
-    </message>
     <message id="switchable_output_powered">
       <location filename="../../src/enums.cpp" line="455"/>
       <source>Powered</source>
@@ -8162,16 +7222,19 @@ Vill du fortsätta?</translation>
     <message id="evchargers_status_welded_contacts_error">
       <location filename="../../data/EvChargers.qml" line="76"/>
       <source>Welded contacts test error (shorted)</source>
+      <oldsource>Welded contacts error</oldsource>
       <translation>Testfel för svetsade kontakter (kortslutna)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
       <location filename="../../data/EvChargers.qml" line="100"/>
       <source>Switching to 3 phase</source>
+      <oldsource>Switching to 3-phase</oldsource>
       <translation>Växlar till trefas</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
       <location filename="../../data/EvChargers.qml" line="103"/>
       <source>Switching to 1 phase</source>
+      <oldsource>Switching to single phase</oldsource>
       <translation>Växlar till enfas</translation>
     </message>
     <message id="evchargers_status_stop_charging">
@@ -8323,17 +7386,6 @@ If the generator is currently running due to a autostart condition, disabling au
       <source>Open link</source>
       <translation>Öppna länk</translation>
     </message>
-    <message id="listlink_show_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="43"/>
-      <source>Show QR code</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="listlink_scan_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="52"/>
-      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
-      <extracomment>%1 = url text</extracomment>
-      <translation type="unfinished">Skanna QR-koden med din bärbara enhet.&lt;br /&gt;Eller ange länken: %1</translation>
-    </message>
     <message id="settings_services_mqtt_access">
       <location filename="../../components/listitems/ListMqttAccessSwitch.qml" line="11"/>
       <source>MQTT Access</source>
@@ -8405,12 +7457,6 @@ If the generator is currently running due to a autostart condition, disabling au
       <extracomment>The 'Brief' page, with the side panel opened</extracomment>
       <translation>Kort (sidopanel öppen)</translation>
     </message>
-    <message id="startpage_option_overview">
-      <location filename="../../data/StartPageConfiguration.qml" line="37"/>
-      <source>Overview</source>
-      <extracomment>The 'Overview' page</extracomment>
-      <translation type="unfinished">Översikt</translation>
-    </message>
     <message id="startpage_option_levels_tanks">
       <location filename="../../data/StartPageConfiguration.qml" line="43"/>
       <source>Levels (Tanks)</source>
@@ -8429,12 +7475,12 @@ If the generator is currently running due to a autostart condition, disabling au
       <translation>Batterilista</translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
+      <location filename="../../pages/DialogLayer.qml" line="56"/>
       <source>GX device has been updated</source>
       <translation>GX-enheten har uppdaterats</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
+      <location filename="../../pages/DialogLayer.qml" line="58"/>
       <source>Page will automatically reload in ten seconds to load the latest version.</source>
       <translation>Sidan laddas automatiskt om igen om 10 sekunder för att ladda den senaste versionen.</translation>
     </message>
@@ -8604,8 +7650,8 @@ Observera att denna meny endast visar Carlo Gavazzi-mätare anslutna över RS485
       <source>Unit</source>
       <translation>Enhet</translation>
     </message>
-    <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="61"/>
+    <message id="page_settings_fronius_unitid_invalid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
       <source>%1 is not a valid unit number. Use a number between 1-247.</source>
       <translation>%1 ä inte ett giltigt nummer. Använd ett nummer mellan 1-247.</translation>
     </message>
@@ -8720,11 +7766,6 @@ Observera att denna meny endast visar Carlo Gavazzi-mätare anslutna över RS485
       <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="66"/>
       <source>Controller Temperature</source>
       <translation>Controllertemperatur</translation>
-    </message>
-    <message id="devicelist_motordrive_motordirectioninverted">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
-      <source>Motor Direction Inverted</source>
-      <translation type="unfinished"/>
     </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
@@ -8916,11 +7957,6 @@ Med strömlinjeformad navigering och en fräsch look blir allting du älskar än
     <message id="welcome_done">
       <location filename="../../pages/welcome/WelcomeView.qml" line="136"/>
       <source>Done</source>
-      <translation type="unfinished">Genomfört</translation>
-    </message>
-    <message id="mk2vsc_state_done">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="20"/>
-      <source>Done</source>
       <translation>Genomfört</translation>
     </message>
     <message id="welcome_next">
@@ -8978,6 +8014,7 @@ GX-enheten kan endast styra en ansluten generator och tar den med det lägsta VR
     <message id="settings_tz_etc">
       <location filename="../../pages/settings/PageTzInfo.qml" line="280"/>
       <source>Other</source>
+      <oldsource>Etc</oldsource>
       <translation>Annat</translation>
     </message>
     <message id="ac-in-modeldefault_energy_reverse_x">
@@ -8995,6 +8032,11 @@ GX-enheten kan endast styra en ansluten generator och tar den med det lägsta VR
       <location filename="../../src/enums.cpp" line="438"/>
       <source>Unsupported type: %1</source>
       <translation>Typ som ej stöds: %1</translation>
+    </message>
+    <message id="common_words_press">
+      <location filename="../../components/CommonWords.qml" line="419"/>
+      <source>Press</source>
+      <translation>Press</translation>
     </message>
     <message id="output_aux_battery_service_changed_dcdc">
       <location filename="../../components/listitems/ListOutputBatteryRadioButtonGroup.qml" line="27"/>
@@ -9135,13 +8177,6 @@ GX-enheten kan endast styra en ansluten generator och tar den med det lägsta VR
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="38"/>
       <source>Resetting VE.Bus products</source>
       <translation>Återställning av VE.Bus-produkter</translation>
-    </message>
-    <message id="Unknown">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Okänd</translation>
     </message>
     <message id="mk2vsc_error_mk2_mk3_comm">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="47"/>
@@ -9447,11 +8482,6 @@ GX-enheten kan endast styra en ansluten generator och tar den med det lägsta VR
       <source>Changing the GX Password</source>
       <translation>Ändrar GX-lösenordet</translation>
     </message>
-    <message id="modaldialog_confirm">
-      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
-      <source>Confirm</source>
-      <translation type="unfinished">Bekräfta</translation>
-    </message>
     <message id="settings_security_profile_change_password_description">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="83"/>
       <source>Please enter a new GX password:</source>
@@ -9544,21 +8574,6 @@ GX-enheten kan endast styra en ansluten generator och tar den med det lägsta VR
       <source>Modifications installed</source>
       <translation>Modifieringar installerade</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_modbus">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="28"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">Modbus TCP-server</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_signalk">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="32"/>
-      <source>Signal K</source>
-      <translation type="unfinished">Signal K</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_nodered">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="36"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">Node-RED</translation>
-    </message>
     <message id="pagesettingsgeneral_modificationchecks_running_integrations">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="43"/>
       <source>%1 running integrations</source>
@@ -9634,16 +8649,6 @@ GX-enheten kan endast styra en ansluten generator och tar den med det lägsta VR
       <source>Installed and enabled, disables at next boot</source>
       <translation>Installerad och aktiverad, inaktiveras vid nästa start</translation>
     </message>
-    <message id="pagesettingssupportstate_firmware_checking">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
-      <source>Checking...</source>
-      <translation type="unfinished">Söker...</translation>
-    </message>
-    <message id="pagesettingssupportstate_firmware_unknown">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="166"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Okänd</translation>
-    </message>
     <message id="pagesettingssupportstate_support_status">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="228"/>
       <source>Support status</source>
@@ -9665,11 +8670,6 @@ GX-enheten kan endast styra en ansluten generator och tar den med det lägsta VR
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="288"/>
       <source>Press 'OK' to disable custom startup scripts and reboot</source>
       <translation>Tryck på 'OK' för att inaktivera anpassade startskript och starta om</translation>
-    </message>
-    <message id="pagesettingssupportstate_re_enable_custom_startup_scripts">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="309"/>
-      <source>Re-enable custom startup scripts</source>
-      <translation type="unfinished">Aktivera anpassade startskript igen</translation>
     </message>
     <message id="pagesettingssupportstate_reenable_and_reboot_now">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="322"/>
@@ -9696,11 +8696,6 @@ GX-enheten kan endast styra en ansluten generator och tar den med det lägsta VR
       <source>Disable also custom startup scripts?</source>
       <translation>Inaktivera även anpassade startskript?</translation>
     </message>
-    <message id="pagesettingssupportstate_integrations">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
-      <source>Integrations</source>
-      <translation type="unfinished">Integrationer</translation>
-    </message>
     <message id="pagesettingssupportstate_orange_items_description">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="494"/>
       <source>Items colored orange are supported and provided by Victron Energy, but using them incorrectly can affect system stability. In case of troubleshooting, disable those first.</source>
@@ -9712,7 +8707,7 @@ GX-enheten kan endast styra en ansluten generator och tar den med det lägsta VR
       <translation>Anslut en kompatibel Bluetooth USB-dongel för att aktivera Bluetooth-anslutning.</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="140"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="142"/>
       <source>BatteryLife state</source>
       <translation>BatteryLife-status</translation>
     </message>
@@ -9720,23 +8715,6 @@ GX-enheten kan endast styra en ansluten generator och tar den med det lägsta VR
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="33"/>
       <source>Device Integrations</source>
       <translation>Enhetsintegrationer</translation>
-    </message>
-    <message id="pagesettingsintegrations_modbus_tcp_server">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="201"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">Modbus TCP-server</translation>
-    </message>
-    <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="226"/>
-      <location filename="../../pages/settings/PageSettingsSignalK.qml" line="18"/>
-      <source>Signal K</source>
-      <translation type="unfinished">Signal K</translation>
-    </message>
-    <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="241"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">Node-RED</translation>
     </message>
     <message id="settings_venusos_large_documentation">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="267"/>
@@ -9746,6 +8724,7 @@ GX-enheten kan endast styra en ansluten generator och tar den med det lägsta VR
     <message id="settings_modbus_enable_modbus_tcp">
       <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
       <source>Enable Modbus TCP Server</source>
+      <oldsource>Enable Modbus/TCP</oldsource>
       <translation>Aktivera Modbus TCP-server</translation>
     </message>
     <message id="pagesettingsconnectivity_bluetooth_for_victronconnect_app">
@@ -9839,11 +8818,13 @@ GX-enheten kan endast styra en ansluten generator och tar den med det lägsta VR
     <message id="settings_gps_format_kmh">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="93"/>
       <source>Kilometres per hour</source>
+      <oldsource>Kilometers per hour</oldsource>
       <translation>Kilometer per timme</translation>
     </message>
     <message id="settings_gps_format_ms">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="95"/>
       <source>Metres per second</source>
+      <oldsource>Meters per second</oldsource>
       <translation>Meter per sekund</translation>
     </message>
     <message id="components_volumeunit_cubic_metres">
@@ -9871,8 +8852,8 @@ GX-enheten kan endast styra en ansluten generator och tar den med det lägsta VR
       <source>The Relay can now be found in the devices list</source>
       <translation>Reläet finns nu i enhetslistan</translation>
     </message>
-    <message id="common_words_gx_device_relays">
-      <location filename="../../components/CommonWords.qml" line="223"/>
+    <message id="gx_device_relays">
+      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
       <source>GX device relays</source>
       <translation>GX-enhetens reläer</translation>
     </message>
@@ -9926,12 +8907,6 @@ GX-enheten kan endast styra en ansluten generator och tar den med det lägsta VR
       <extracomment>Forced by app to %1</extracomment>
       <translation>auto</translation>
     </message>
-    <message id="settings_remote_console_forced_by_vrm">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="94"/>
-      <source>VRM</source>
-      <extracomment>Forced by %2 to dark</extracomment>
-      <translation type="unfinished">VRM</translation>
-    </message>
     <message id="settings_remote_console_forced_by_app">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="97"/>
       <source>app</source>
@@ -9981,6 +8956,7 @@ GX-enheten kan endast styra en ansluten generator och tar den med det lägsta VR
     <message id="settings_large_access_signal_k">
       <location filename="../../pages/settings/PageSettingsSignalK.qml" line="24"/>
       <source>Access Signal K</source>
+      <oldsource>Access Signal K (local network)</oldsource>
       <translation>Åtkomst Signal K</translation>
     </message>
     <message id="pagesettingsintegrations_shelly_devices">
@@ -9991,6 +8967,7 @@ GX-enheten kan endast styra en ansluten generator och tar den med det lägsta VR
     <message id="settings_large_access_node_red">
       <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
       <source>Access Node-RED</source>
+      <oldsource>Access Node-RED (local network)</oldsource>
       <translation>Åtkomst Node-RED</translation>
     </message>
     <message id="settings_wifi_access_point_password">
@@ -10058,57 +9035,6 @@ GX-enheten kan endast styra en ansluten generator och tar den med det lägsta VR
       <source>Wind charger</source>
       <translation>Vindkraftsladdare</translation>
     </message>
-    <message id="digitalinputs_type_disabled">
-      <location filename="../../src/enums.cpp" line="192"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Inaktiverad</translation>
-    </message>
-    <message id="digitalinputs_state_off">
-      <location filename="../../src/enums.cpp" line="242"/>
-      <source>Off</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Av</translation>
-    </message>
-    <message id="digitalinputs_state_on">
-      <location filename="../../src/enums.cpp" line="246"/>
-      <source>On</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">På</translation>
-    </message>
-    <message id="digitalinputs_state_ok">
-      <location filename="../../src/enums.cpp" line="266"/>
-      <source>OK</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Ok</translation>
-    </message>
-    <message id="digitalinputs_state_alarm">
-      <location filename="../../src/enums.cpp" line="270"/>
-      <source>Alarm</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Larm</translation>
-    </message>
-    <message id="digitalinputs_state_running">
-      <location filename="../../src/enums.cpp" line="274"/>
-      <source>Running</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">I drift</translation>
-    </message>
-    <message id="pvinverter_statusCode_running">
-      <location filename="../../src/enums.cpp" line="300"/>
-      <source>Running</source>
-      <extracomment>PV inverter status code</extracomment>
-      <translation type="unfinished">I drift</translation>
-    </message>
-    <message id="solarchargers_state_external control">
-      <location filename="../../src/enums.cpp" line="352"/>
-      <source>External control</source>
-      <translation type="unfinished">Extern kontroll</translation>
-    </message>
-    <message id="switch_state_over_temperature">
-      <location filename="../../src/enums.cpp" line="366"/>
-      <source>Over temperature</source>
-      <translation type="unfinished">Övertemperatur</translation>
-    </message>
     <message id="switchable_output_temperature_setpoint">
       <location filename="../../src/enums.cpp" line="398"/>
       <source>Temperature setpoint</source>
@@ -10118,11 +9044,6 @@ GX-enheten kan endast styra en ansluten generator och tar den med det lägsta VR
       <location filename="../../src/enums.cpp" line="401"/>
       <source>Stepped switch</source>
       <translation>Stegvis omkopplare</translation>
-    </message>
-    <message id="switchable_output_slave">
-      <location filename="../../src/enums.cpp" line="408"/>
-      <source>Slave</source>
-      <translation type="unfinished">Slav</translation>
     </message>
     <message id="switchable_output_dropdown">
       <location filename="../../src/enums.cpp" line="412"/>
@@ -10134,122 +9055,10 @@ GX-enheten kan endast styra en ansluten generator och tar den med det lägsta VR
       <source>Basic slider</source>
       <translation>Grundläggande slider</translation>
     </message>
-    <message id="switchable_output_rgb_color_wheel">
-      <location filename="../../src/enums.cpp" line="427"/>
-      <source>RGB color wheel</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_cct_color_wheel">
-      <location filename="../../src/enums.cpp" line="431"/>
-      <source>CCT color wheel</source>
-      <extracomment>Correlated Color Temperature color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_rgbw_color_wheel">
-      <location filename="../../src/enums.cpp" line="435"/>
-      <source>RGB + W color wheel</source>
-      <extracomment>RGB + white color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bypassed">
-      <location filename="../../src/enums.cpp" line="484"/>
-      <source>Bypassed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="tank_type_fuel">
-      <location filename="../../src/enums.cpp" line="495"/>
-      <source>Fuel</source>
-      <translation type="unfinished">Bränsle</translation>
-    </message>
-    <message id="tank_type_fresh_water">
-      <location filename="../../src/enums.cpp" line="498"/>
-      <source>Fresh water</source>
-      <translation type="unfinished">Färskvatten</translation>
-    </message>
-    <message id="tank_type_waste_water">
-      <location filename="../../src/enums.cpp" line="501"/>
-      <source>Waste water</source>
-      <translation type="unfinished">Spillvatten</translation>
-    </message>
-    <message id="tank_type_live_well">
-      <location filename="../../src/enums.cpp" line="504"/>
-      <source>Live well</source>
-      <translation type="unfinished">Vattentank</translation>
-    </message>
-    <message id="tank_type_oil">
-      <location filename="../../src/enums.cpp" line="507"/>
-      <source>Oil</source>
-      <translation type="unfinished">Olja</translation>
-    </message>
-    <message id="tank_type_black_water">
-      <location filename="../../src/enums.cpp" line="510"/>
-      <source>Black water</source>
-      <translation type="unfinished">SVARTVATTEN</translation>
-    </message>
-    <message id="tank_type_gasoline">
-      <location filename="../../src/enums.cpp" line="513"/>
-      <source>Gasoline</source>
-      <translation type="unfinished">Bensin</translation>
-    </message>
-    <message id="tank_type_diesel">
-      <location filename="../../src/enums.cpp" line="516"/>
-      <source>Diesel</source>
-      <translation type="unfinished">Diesel</translation>
-    </message>
-    <message id="tank_type_lpg">
-      <location filename="../../src/enums.cpp" line="519"/>
-      <source>LPG</source>
-      <translation type="unfinished">LPG</translation>
-    </message>
-    <message id="tank_type_lng">
-      <location filename="../../src/enums.cpp" line="522"/>
-      <source>LNG</source>
-      <translation type="unfinished">LNG</translation>
-    </message>
-    <message id="tank_type_hydraulic_oil">
-      <location filename="../../src/enums.cpp" line="525"/>
-      <source>Hydraulic oil</source>
-      <translation type="unfinished">Hydraulolja</translation>
-    </message>
-    <message id="tank_type_raw_water">
-      <location filename="../../src/enums.cpp" line="528"/>
-      <source>Raw water</source>
-      <translation type="unfinished">Råvatten</translation>
-    </message>
-    <message id="microgrid_mode_hybrid_droop">
-      <location filename="../../src/enums.cpp" line="539"/>
-      <source>Hybrid droop</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_following">
-      <location filename="../../src/enums.cpp" line="542"/>
-      <source>Grid-following</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_forming">
-      <location filename="../../src/enums.cpp" line="545"/>
-      <source>Grid-forming</source>
-      <translation type="unfinished"/>
-    </message>
     <message id="switchable_output_three_state_switch">
       <location filename="../../src/enums.cpp" line="421"/>
       <source>Three-state switch</source>
       <translation>Tre-lägesomkopplare</translation>
-    </message>
-    <message id="switchable_output_fault">
-      <location filename="../../src/enums.cpp" line="464"/>
-      <source>Fault</source>
-      <translation type="unfinished">Fel</translation>
-    </message>
-    <message id="switchable_output_running">
-      <location filename="../../src/enums.cpp" line="468"/>
-      <source>Running</source>
-      <translation type="unfinished">I drift</translation>
-    </message>
-    <message id="switchable_output_trip_low_voltage">
-      <location filename="../../src/enums.cpp" line="481"/>
-      <source>Trip low voltage</source>
-      <translation type="unfinished">Inaktiverad</translation>
     </message>
     <message id="settings_modbus_tcp_unit_id_note">
       <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="41"/>
@@ -10271,281 +9080,1152 @@ GX-enheten kan endast styra en ansluten generator och tar den med det lägsta VR
       <source>Press to refresh</source>
       <translation>Tryck för att uppdatera</translation>
     </message>
-    <message id="temperature_type_unknown">
-      <location filename="../../data/EnvironmentInputs.qml" line="65"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Okänd</translation>
-    </message>
-    <message id="brief_solar_yield">
-      <location filename="../../pages/BriefSidePanel.qml" line="24"/>
-      <source>Solar yield</source>
-      <translation type="unfinished">Solcellsproduktion</translation>
-    </message>
-    <message id="brief_dc_input">
-      <location filename="../../pages/BriefSidePanel.qml" line="214"/>
-      <source>DC input</source>
-      <translation type="unfinished">DC-ingång</translation>
-    </message>
-    <message id="brief_ac_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="257"/>
-      <source>AC Loads</source>
-      <translation type="unfinished">AC-belastningar</translation>
-    </message>
-    <message id="brief_dc_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="284"/>
-      <source>DC Loads</source>
-      <translation type="unfinished">DC-belastningar</translation>
-    </message>
-    <message id="nav_overview">
-      <location filename="../../pages/OverviewPage.qml" line="450"/>
-      <source>Overview</source>
-      <translation type="unfinished">Översikt</translation>
-    </message>
-    <message id="settings_state">
-      <location filename="../../pages/settings/PageCanbusStatus.qml" line="116"/>
-      <source>State</source>
-      <translation type="unfinished">Status</translation>
-    </message>
-    <message id="inverter_pv">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="56"/>
-      <source>PV</source>
-      <translation type="unfinished">PV</translation>
-    </message>
-    <message id="inverter_total_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="76"/>
-      <source>Total yield</source>
-      <translation type="unfinished">Totalt utbyte</translation>
-    </message>
-    <message id="inverter_system_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="84"/>
-      <source>System yield</source>
-      <translation type="unfinished">Systemutbyte</translation>
-    </message>
-    <message id="charger_total_pv_power">
-      <location filename="../../pages/solar/SolarDevicePage.qml" line="61"/>
-      <source>Total PV Power</source>
-      <translation type="unfinished">Total solcellseffekt</translation>
-    </message>
-    <message id="vebus_device_alarm_only">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
-      <source>Alarm only</source>
-      <translation type="unfinished">Enbart larm</translation>
-    </message>
-    <message id="vebus_device_alarms_and_warnings">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
-      <source>Alarms &amp; warnings</source>
-      <translation type="unfinished">Larm &amp; varningar</translation>
-    </message>
-    <message id="vebus_device_alarm_group_warning">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
-      <source>Warning</source>
-      <translation type="unfinished">Varning</translation>
-    </message>
-    <message id="load_delegate_status">
-      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
-      <source>Status: %1</source>
-      <translation type="unfinished"/>
+    <message id="common_words_total_power">
+      <location filename="../../components/CommonWords.qml" line="540"/>
+      <source>Total power</source>
+      <translation>Total effekt</translation>
     </message>
     <message id="venus_os_gui">
       <location filename="../../Main.qml" line="17"/>
       <source>Venus OS GUI</source>
       <extracomment>Application title</extracomment>
-      <translation type="unfinished"/>
       <extra-Context>only shown on desktop systems</extra-Context>
+      <translation>Venus OS GUI</translation>
+    </message>
+    <message id="load_delegate_status">
+      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
+      <source>Status: %1</source>
+      <translation>Status: %1</translation>
+    </message>
+    <message id="settings_relay_polarity_relay1">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
+      <source>Polarity (Relay 1)</source>
+      <translation>Polaritet (Relä 1)</translation>
+    </message>
+    <message id="settings_relay_polarity">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
+      <source>Polarity</source>
+      <translation>Polaritet</translation>
+    </message>
+    <message id="settings_relay_polarity_relay2">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
+      <source>Polarity (Relay 2)</source>
+      <translation>Polaritet (Relä 2)</translation>
+    </message>
+    <message id="page_settings_wifi_invalid_password">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
+      <source>Password length must be either 0 or between 10 and 63 characters long</source>
+      <translation>Lösenordets längd måste vara antingen 0 eller mellan 10 och 63 tecken långt</translation>
+    </message>
+    <message id="page_settings_wifi_password_updated">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
+      <source>Password updated</source>
+      <translation>Lösenord uppdaterat</translation>
+    </message>
+    <message id="common_words_max">
+      <location filename="../../components/CommonWords.qml" line="315"/>
+      <source>Max</source>
+      <extracomment>Short for Maximum</extracomment>
+      <translation>Max</translation>
+    </message>
+    <message id="common_words_min">
+      <location filename="../../components/CommonWords.qml" line="331"/>
+      <source>Min</source>
+      <extracomment>Short for Minimum</extracomment>
+      <translation>Min</translation>
+    </message>
+    <message id="settings_ess_deprecated">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="321"/>
+      <source>Deprecated settings</source>
+      <translation>Föråldrade inställningar</translation>
+    </message>
+    <message id="settings_ess_max_charge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="328"/>
+      <source>Battery charge limit (% of CCL)</source>
+      <translation>Batteriladdningsgräns (% av CCL)</translation>
+    </message>
+    <message id="settings_ess_max_discharge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="339"/>
+      <source>Battery discharge limit (% of DCL)</source>
+      <translation>Batteriurladdningsgräns (% av DCL)</translation>
+    </message>
+    <message id="vebus_device_bms_message">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
+      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
+      <oldsource>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</oldsource>
+      <translation>En VE.Bus BMS stänger automatiskt av systemet vid behov för att skydda batteriet. Det är därför inte möjligt att styra systemet från GX-enheten.</translation>
+    </message>
+    <message id="switchable_output_numeric_input">
+      <location filename="../../src/enums.cpp" line="418"/>
+      <source>Numeric input</source>
+      <translation>Numerisk inmatning</translation>
     </message>
     <message id="autotoggleswitch_disable_auto_mode_info">
       <location filename="../../components/controls/AutoToggleButton.qml" line="34"/>
       <source>Disable Auto mode first</source>
-      <translation type="unfinished"/>
+      <translation>Inaktivera automatiskt läge först</translation>
+    </message>
+    <message id="pagesettingsintegrations_venus_os_enable_large_features">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
+      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
+      <translation>Aktivera Venus OS Large-firmware för att använda Node-RED eller Signal-K</translation>
+    </message>
+    <message id="settings_relays_sensors_tanks">
+      <location filename="../../pages/SettingsPage.qml" line="75"/>
+      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
+      <oldsource>Relays, Sensors, Tanks, PV Inverters, Modbus, MQTT…</oldsource>
+      <translation>Reläer, sensorer, solcellsväxelriktare, Modbus, Node-RED</translation>
+    </message>
+    <message id="vebus_device_page_microgrid_parameters">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
+      <source>Microgrid parameters</source>
+      <translation>Mikronätsparametrar</translation>
+    </message>
+    <message id="microgrid_mode_hybrid_droop">
+      <location filename="../../src/enums.cpp" line="539"/>
+      <source>Hybrid droop</source>
+      <translation>Hybrid droop</translation>
+    </message>
+    <message id="microgrid_mode_grid_following">
+      <location filename="../../src/enums.cpp" line="542"/>
+      <source>Grid-following</source>
+      <translation>Nätföljande</translation>
+    </message>
+    <message id="microgrid_mode_grid_forming">
+      <location filename="../../src/enums.cpp" line="545"/>
+      <source>Grid-forming</source>
+      <translation>Nätbildande</translation>
+    </message>
+    <message id="switchable_output_trip_low_voltage">
+      <location filename="../../src/enums.cpp" line="481"/>
+      <source>Trip low voltage</source>
+      <oldsource>Disabled</oldsource>
+      <translation>Utlös låg spänning</translation>
     </message>
     <message id="microgrid">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="15"/>
       <source>Microgrid</source>
-      <translation type="unfinished"/>
+      <translation>Mikronät</translation>
     </message>
     <message id="page_microgrid_active_mode">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="19"/>
       <source>Active mode</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_microgrid_from_p1_to_p2">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="34"/>
-      <source>%1 %2 to %3 %4</source>
-      <extracomment>Describes a range from one quantity to another, e.g. "30 W to 60 W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
-      <translation type="unfinished"/>
+      <translation>Aktivt läge</translation>
     </message>
     <message id="page_microgrid_hybrid_droop_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="92"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
       <source>Hybrid droop parameters</source>
-      <translation type="unfinished"/>
+      <translation>Hybrid droop-parametrar</translation>
     </message>
     <message id="page_microgrid_reference_active_power_p0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="105"/>
       <source>Reference active power (P&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Referens aktiv effekt (P&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_frequency_f0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="108"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="112"/>
       <source>Reference frequency (f&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Referensfrekvens (f&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_frequency_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="117"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="119"/>
       <source>Frequency droop slope (droop&lt;sub&gt;fP&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Frekvens droop-lutning (droop&lt;sub&gt;fP&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_reactive_power">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="126"/>
       <source>Reference reactive power (Q&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Referens reaktiv effekt (Q&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_voltage">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="135"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="133"/>
       <source>Reference Voltage (U&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Referensspänning (U&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_voltage_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="144"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="140"/>
       <source>Voltage droop slope (droop&lt;sub&gt;UQ&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Spännings droop-lutning (droop&lt;sub&gt;UQ&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_minimum_and_maximum_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="146"/>
       <source>Minimum and maximum parameters</source>
-      <translation type="unfinished"/>
+      <translation>Minimi- och maximiparametrar</translation>
     </message>
     <message id="page_microgrid_allowed_active_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="156"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
       <source>Allowed active power range</source>
-      <translation type="unfinished"/>
+      <translation>Tillåtet aktivt effektområde</translation>
     </message>
     <message id="page_microgrid_allowed_reactive_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="164"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="159"/>
       <source>Allowed reactive power range</source>
-      <translation type="unfinished"/>
+      <translation>Tillåtet reaktivt effektområde</translation>
     </message>
     <message id="page_microgrid_p_q_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="176"/>
       <source>P-Q direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>P-Q direktstyrningsinställningar</translation>
     </message>
     <message id="page_microgrid_active_power_setpoint_p">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="186"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
       <source>Active power setpoint (P)</source>
-      <translation type="unfinished"/>
+      <translation>Börvärde för aktiv effekt (P)</translation>
     </message>
     <message id="page_microgrid_reactive_power_setpoint_q">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="194"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="188"/>
       <source>Reactive power setpoint (Q)</source>
-      <translation type="unfinished"/>
+      <translation>Börvärde för reaktiv effekt (Q)</translation>
     </message>
     <message id="page_microgrid_allowed_frequency_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="202"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="195"/>
       <source>Allowed frequency range</source>
-      <translation type="unfinished"/>
+      <translation>Tillåtet frekvensområde</translation>
     </message>
     <message id="page_microgrid_allowed_voltage_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="210"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="203"/>
       <source>Allowed voltage range</source>
-      <translation type="unfinished"/>
+      <translation>Tillåtet spänningsområde</translation>
     </message>
     <message id="page_microgrid_v_f_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="227"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="220"/>
       <source>V-f direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>V-f direktstyrningsinställningar</translation>
     </message>
     <message id="page_microgrid_voltage_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="225"/>
       <source>Voltage setpoint (U)</source>
-      <translation type="unfinished"/>
+      <translation>Börvärde för spänning (U)</translation>
     </message>
     <message id="page_microgrid_frequency_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="240"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
       <source>Frequency setpoint (f)</source>
-      <translation type="unfinished"/>
+      <translation>Börvärde för frekvens (f)</translation>
     </message>
-    <message id="temperature_slider_current">
-      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
-      <source>Current</source>
-      <extracomment>The current temperature measurement</extracomment>
-      <translation type="unfinished">Ström</translation>
+    <message id="pagesettingsintegrations_canopenmotordrive">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
+      <source>CANopen motor drives</source>
+      <translation>CANopen-motorstyrningar</translation>
+    </message>
+    <message id="pagesettingsintegrations_ui_plugins">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
+      <source>UI Plugins</source>
+      <translation>UI-pluginprogram</translation>
+    </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
+      <source>Motor Direction Inverted</source>
+      <translation>Motorriktning inverterad</translation>
     </message>
     <message id="page_settings_canopenmotordrive_scan_for_motor_drives">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="31"/>
       <source>Scan for motor drives</source>
-      <translation type="unfinished"/>
+      <translation>Sök efter motorstyrningar</translation>
     </message>
     <message id="page_settings_canopenmotordrive_discovered_motor_drive_ids">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="39"/>
       <source>Discovered motor drive IDs</source>
-      <translation type="unfinished"/>
+      <translation>Hittade motorstyrnings-ID:n</translation>
     </message>
-    <message id="switchableoutput_gx_device_relays">
-      <location filename="../../src/switchableoutput.cpp" line="388"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">GX-enhetens reläer</translation>
+    <message id="temperature_pm25">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
+      <source>PM2.5</source>
+      <translation>PM2.5</translation>
     </message>
-    <message id="gx_device_relays">
-      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">GX-enhetens reläer</translation>
+    <message id="temperature_co2">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+      <source>CO₂</source>
+      <translation>CO₂</translation>
     </message>
-    <message id="color_preset">
-      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
-      <source>Preset</source>
-      <translation type="unfinished"/>
+    <message id="temperature_voc">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
+      <source>VOC index</source>
+      <translation>VOC-index</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_location">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
-      <source>Add Modbus port and unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_nox">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
+      <source>NOx index</source>
+      <translation>NOx-index</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_unitid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
-      <source>Unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_luminosity">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
+      <source>Luminosity</source>
+      <translation>Ljusstyrka</translation>
     </message>
-    <message id="page_settings_fronius_unitid_invalid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation type="unfinished">%1 ä inte ett giltigt nummer. Använd ett nummer mellan 1-247.</translation>
-    </message>
-    <message id="page_settings_fronius_add_modbus_location_button">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
-      <source>Add</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_locations_note">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
-      <source>The default modbus port is 502 and the default unit ID is 126.
-Here you can add additional ports and unit IDs to scan for PV inverters.</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_location_number">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
-      <source>Port/Unit ID %1</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location_description">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
-      <source>Port: %1 (Unit %2)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
-      <source>Remove Modbus port and unit ID?</source>
-      <translation type="unfinished"/>
+    <message id="switchable_output_bypassed">
+      <location filename="../../src/enums.cpp" line="484"/>
+      <source>Bypassed</source>
+      <translation>Förbikopplad</translation>
     </message>
     <message id="switchableoutput_list_delegate_auto_status">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="84"/>
       <source>Auto (%1)</source>
       <extracomment>%1 = 'On' or 'Off'</extracomment>
-      <translation type="unfinished"/>
+      <translation>Auto (%1)</translation>
     </message>
     <message id="switchableoutput_list_delegate_state_forced">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="100"/>
       <source>Forced</source>
-      <translation type="unfinished"/>
+      <translation>Tvingad</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_settings">
+      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
+      <source>Modbus port and unit ID settings</source>
+      <translation>Modbus-port och enhets-ID-inställningar</translation>
+    </message>
+    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
+      <source>Integrates with the device list</source>
+      <translation>Integreras med enhetslistan</translation>
+    </message>
+    <message id="common_words_color">
+      <location filename="../../components/CommonWords.qml" line="136"/>
+      <source>Color</source>
+      <translation>Färg</translation>
+    </message>
+    <message id="common_words_value_must_be_greater_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="557"/>
+      <source>Value must be greater than start value</source>
+      <translation>Värdet måste vara större än startvärdet</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="566"/>
+      <source>Value must be lower than stop value</source>
+      <translation>Värdet måste vara lägre än stoppvärdet</translation>
+    </message>
+    <message id="notifications_page_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="43"/>
+      <source>Active Notifications</source>
+      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
+      <translation>Aktiva notifikationer</translation>
+    </message>
+    <message id="notifications_page_inactive_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="47"/>
+      <source>Inactive Notifications</source>
+      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
+      <translation>Inaktiva notifikationer</translation>
+    </message>
+    <message id="notifications_no_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="106"/>
+      <source>No active notifications</source>
+      <translation>Inga aktiva notifikationer</translation>
+    </message>
+    <message id="switchable_output_rgb_color_wheel">
+      <location filename="../../src/enums.cpp" line="427"/>
+      <source>RGB color wheel</source>
+      <translation>RGB-färghjul</translation>
+    </message>
+    <message id="switchable_output_cct_color_wheel">
+      <location filename="../../src/enums.cpp" line="431"/>
+      <source>CCT color wheel</source>
+      <extracomment>Correlated Color Temperature color wheel</extracomment>
+      <translation>CCT-färghjul</translation>
+    </message>
+    <message id="switchable_output_rgbw_color_wheel">
+      <location filename="../../src/enums.cpp" line="435"/>
+      <source>RGB + W color wheel</source>
+      <extracomment>RGB + white color wheel</extracomment>
+      <translation>RGB + W-färghjul</translation>
+    </message>
+    <message id="listlink_show_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="43"/>
+      <source>Show QR code</source>
+      <translation>Visa QR-kod</translation>
+    </message>
+    <message id="listlink_scan_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="52"/>
+      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
+      <extracomment>%1 = url text</extracomment>
+      <oldsource>Scan the QR code with your portable device.&lt;br /&gt;Or insert the link: %1</oldsource>
+      <translation>Öppna QR-koden för att skanna den med din bärbara enhet.&lt;br /&gt;Eller infoga länken: %1</translation>
+    </message>
+    <message id="color_preset">
+      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
+      <source>Preset</source>
+      <translation>Förinställning</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
+      <source>Add Modbus port and unit ID</source>
+      <translation>Lägg till Modbus-port och enhets-ID</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_unitid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
+      <source>Unit ID</source>
+      <translation>Enhets-ID</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location_button">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
+      <source>Add</source>
+      <translation>Lägg till</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_locations_note">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
+      <source>The default modbus port is 502 and the default unit ID is 126.
+Here you can add additional ports and unit IDs to scan for PV inverters.</source>
+      <translation>Standardmodbus-porten är 502 och standardenhets-ID:t är 126.
+Här kan du lägga till ytterligare portar och enhets-ID:n för att söka efter PV-växelriktare.</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_location_number">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
+      <source>Port/Unit ID %1</source>
+      <translation>Port/Enhets-ID %1</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location_description">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
+      <source>Port: %1 (Unit %2)</source>
+      <translation>Port: %1 (Enhet %2)</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
+      <source>Remove Modbus port and unit ID?</source>
+      <translation>Ta bort Modbus-port och enhets-ID?</translation>
+    </message>
+    <message id="devicelist_tankshape_edit_point">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="182"/>
+      <source>Edit point %1</source>
+      <extracomment>%1 = which point is being edited, a number like "1" or "2"</extracomment>
+      <translation></translation>
+    </message>
+    <message id="settings_canbus_vecan">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
+      <source>VE.Can (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_250">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <source>VE.Can &amp; CANopen E-drive (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_500">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
+      <source>CANopen E-drive (500 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="page_microgrid_from_p1_to_p2">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="39"/>
+      <source>%1%2 to %3%4</source>
+      <extracomment>Describes a range from one quantity to another, e.g. "30W to 60W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
+      <translation></translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAfricaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
+      <source>Morocco Standard Time</source>
+      <translation>Normaltid i Marocko</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
+      <source>W. Central Africa Standard Time</source>
+      <translation>Normaltid i V. Centralafrika</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
+      <source>South Africa Standard Time</source>
+      <translation>Normaltid i Sydafrika</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
+      <source>Namibia Standard Time</source>
+      <translation>Normaltid i Namibia</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
+      <source>Egypt Standard Time</source>
+      <translation>Normaltid i Egypten</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
+      <source>E. Africa Standard Time</source>
+      <translation>Normaltid i Östafrika</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAmericaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
+      <source>Argentina Standard Time</source>
+      <translation>Normaltid i Argentina</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
+      <source>E. South America Standard Time</source>
+      <translation>Normaltid i Ö. Sydamerika</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
+      <source>Greenland Standard Time</source>
+      <translation>Normaltid på Grönland</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
+      <source>Montevideo Standard Time</source>
+      <translation>Normaltid i Montevideo</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
+      <source>Newfoundland Standard Time</source>
+      <translation>Normaltid Newfoundland</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
+      <source>SA Eastern Standard Time</source>
+      <translation>Normaltid Ö. Sydamerika</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
+      <source>Atlantic Standard Time</source>
+      <translation>Normaltid Atlanten</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
+      <source>Central Brazilian Standard Time</source>
+      <translation>Normaltid i centrala Brasilien</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>Normaltid Stilla havet - Sydamerika</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
+      <source>Paraguay Standard Time</source>
+      <translation>Normaltid i Paraguay</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
+      <source>SA Western Standard Time</source>
+      <translation>Normaltid i V. Sydamerika</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
+      <source>Venezuela Standard Time</source>
+      <translation>Normaltid i Venezuela</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
+      <source>Eastern Standard Time</source>
+      <translation>Eastern Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
+      <source>SA Pacific Standard Time</source>
+      <translation>Normaltid Stilla havet - Sydamerika</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
+      <source>US Eastern Standard Time</source>
+      <translation>Normaltid i Ö. USA</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
+      <source>Canada Central Standard Time</source>
+      <translation>Normaltid i centrala Kanada</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
+      <source>Central America Standard Time</source>
+      <translation>Normaltid i Centralamerika</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
+      <source>Central Standard Time (Mexico)</source>
+      <translation>Central Standard Time (Mexiko)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
+      <source>Central Standard Time</source>
+      <translation>Central Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
+      <source>Mountain Standard Time (Mexico)</source>
+      <translation>Mountain Standard Time (Mexiko)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
+      <source>Mountain Standard Time</source>
+      <translation>Mountain Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
+      <source>US Mountain Standard Time</source>
+      <translation>Mountain Standard Time USA</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
+      <source>Pacific Standard Time (Mexico)</source>
+      <translation>Pacific Standard Time (Mexiko)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
+      <source>Pacific Standard Time</source>
+      <translation>Pacific Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
+      <source>Alaskan Standard Time</source>
+      <translation>Normaltid i Alaska</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
+      <source>Hawaii-Aleutian</source>
+      <translation>Hawaii-Aleutian</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
+      <source>Atlantic Daylight Time</source>
+      <translation>Atlantisk sommartid</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAntarcticaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+      <source>New Zealand Standard Time</source>
+      <translation>Normaltid på Nya Zeeland</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>Central Pacific Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+      <source>West Pacific Standard Time</source>
+      <translation>West Pacific Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+      <source>W. Australia Standard Time</source>
+      <translation>Normaltid i V. Australien</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+      <source>SE Asia Standard Time</source>
+      <translation>Normaltid SÖ. Asien</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+      <source>Central Asia Standard Time</source>
+      <translation>Normaltid i centrala Asien</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+      <source>West Asia Standard Time</source>
+      <translation>Normaltid V. Asien</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+      <source>E. Africa Standard Time</source>
+      <translation>Normaltid i Östafrika</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>Normaltid Stilla havet - Sydamerika</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+      <source>SA Western Standard Time</source>
+      <translation>Normaltid i V. Sydamerika</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzArcticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
+      <source>W. Europe Standard Time</source>
+      <translation>Normaltid V. Europa</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAsiaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
+      <source>Kamchatka Standard Time</source>
+      <translation>Normaltid i Kamchatka</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
+      <source>Magadan Standard Time</source>
+      <translation>Normaltid i Magadan</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
+      <source>Vladivostok Standard Time</source>
+      <translation>Normaltid i Vladivostok</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
+      <source>Yakutsk Standard Time</source>
+      <translation>Normaltid i Yakutsk</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
+      <source>Tokyo Standard Time</source>
+      <translation>Normaltid i Tokyo</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
+      <source>Korea Standard Time</source>
+      <translation>Normaltid i Korea</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
+      <source>Singapore Standard Time</source>
+      <translation>Normaltid i Singapore</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
+      <source>Ulaanbaatar Standard Time</source>
+      <translation>Normaltid i Ulaanbaatar</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
+      <source>Taipei Standard Time</source>
+      <translation>Normaltid i Taipei</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
+      <source>North Asia East Standard Time</source>
+      <translation>Normaltid i N.Ö. Asien</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
+      <source>China Standard Time</source>
+      <translation>Normaltid i Kina</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
+      <source>SE Asia Standard Time</source>
+      <translation>Normaltid SÖ. Asien</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
+      <source>North Asia Standard Time</source>
+      <translation>Normaltid i N. Asien</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
+      <source>Myanmar Standard Time</source>
+      <translation>Normaltid i Myanmar</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
+      <source>N. Central Asia Standard Time</source>
+      <translation>Normaltid i N. Centralasien</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
+      <source>Central Asia Standard Time</source>
+      <translation>Normaltid i centrala Asien</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
+      <source>Bangladesh Standard Time</source>
+      <translation>Normaltid i Bangladesh</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
+      <source>Nepal Standard Time</source>
+      <translation>Normaltid i Nepal</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
+      <source>Sri Lanka Standard Time</source>
+      <translation>Normaltid på Sri Lanka</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
+      <source>India Standard Time</source>
+      <translation>Normaltid i Indien</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
+      <source>West Asia Standard Time</source>
+      <translation>Normaltid V. Asien</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
+      <source>Pakistan Standard Time</source>
+      <translation>Normaltid i Pakistan</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
+      <source>Ekaterinburg Standard Time</source>
+      <translation>Normaltid i Ekaterinburg</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
+      <source>Georgian Standard Time</source>
+      <translation>Normaltid i Georgien</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
+      <source>Caucasus Standard Time</source>
+      <translation>Normaltid i Kaukasus</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
+      <source>Azerbaijan Standard Time</source>
+      <translation>Normaltid i Azerbajdzan</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
+      <source>Arabian Standard Time</source>
+      <translation>Arabian Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
+      <source>Afghanistan Standard Time</source>
+      <translation>Normaltid i Afghanistan</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
+      <source>Iran Standard Time</source>
+      <translation>Normaltid i Iran</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
+      <source>Arabic Standard Time</source>
+      <translation>Arabic Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
+      <source>Arab Standard Time</source>
+      <translation>Arab Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
+      <source>Syria Standard Time</source>
+      <translation>Normaltid i Syrien</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
+      <source>Middle East Standard Time</source>
+      <translation>Normaltid i Mellanöstern</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
+      <source>Jordan Standard Time</source>
+      <translation>Normaltid i Jordanien</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
+      <source>Israel Standard Time</source>
+      <translation>Normaltid i Israel</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAtlanticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+      <source>Greenwich Standard Time</source>
+      <translation>Greenwich Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+      <source>Azores Standard Time</source>
+      <translation>Normaltid på Azorerna</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+      <source>Cape Verde Standard Time</source>
+      <translation>Normaltid i Kap Verde</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
+      <source>Mid-Atlantic Standard Time</source>
+      <translation>Mid-Atlantic Standard Time</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAustraliaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+      <source>Tasmania Standard Time</source>
+      <translation>Normaltid i Tasmanien</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+      <source>E. Australia Standard Time</source>
+      <translation>Normaltid i Ö. Australien</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+      <source>AUS Eastern Standard Time</source>
+      <translation>Normaltid i Ö. Australien</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+      <source>Cen. Australia Standard Time</source>
+      <translation>Normaltid i centrala Australien</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+      <source>AUS Central Standard Time</source>
+      <translation>Normaltid i centrala Australien</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+      <source>W. Australia Standard Time</source>
+      <translation>Normaltid i V. Australien</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEtcData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
+      <source>GMT +12</source>
+      <translation>GMT +12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
+      <source>GMT -02</source>
+      <translation>GMT -02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
+      <source>GMT -11</source>
+      <translation>GMT -11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
+      <source>GMT -13</source>
+      <translation>GMT -13</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
+      <source>GMT -12</source>
+      <translation>GMT -12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
+      <source>GMT -10</source>
+      <translation>GMT -10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
+      <source>GMT -09</source>
+      <translation>GMT -09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
+      <source>GMT -08</source>
+      <translation>GMT -08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
+      <source>GMT -07</source>
+      <translation>GMT -07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
+      <source>GMT -06</source>
+      <translation>GMT -06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
+      <source>GMT -05</source>
+      <translation>GMT -05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
+      <source>GMT -04</source>
+      <translation>GMT -04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
+      <source>GMT -03</source>
+      <translation>GMT -03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
+      <source>GMT -01</source>
+      <translation>GMT -01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
+      <source>GMT</source>
+      <translation>GMT</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
+      <source>GMT +01</source>
+      <translation>GMT +01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
+      <source>GMT +02</source>
+      <translation>GMT +02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
+      <source>GMT +03</source>
+      <translation>GMT +03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
+      <source>GMT +04</source>
+      <translation>GMT +04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
+      <source>GMT +05</source>
+      <translation>GMT +05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
+      <source>GMT +06</source>
+      <translation>GMT +06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
+      <source>GMT +07</source>
+      <translation>GMT +07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
+      <source>GMT +08</source>
+      <translation>GMT +08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
+      <source>GMT +09</source>
+      <translation>GMT +09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
+      <source>GMT +10</source>
+      <translation>GMT +10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
+      <source>GMT +11</source>
+      <translation>GMT +11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
+      <source>UTC</source>
+      <translation>UTC</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEuropeData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
+      <source>GMT Standard Time</source>
+      <translation>GMT Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
+      <source>Central Europe Standard Time</source>
+      <translation>Normaltid Centraleuropa</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
+      <source>Central European Standard Time</source>
+      <translation>Normaltid Centraleuropa</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
+      <source>Romance Standard Time</source>
+      <translation>Romance Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
+      <source>W. Europe Standard Time</source>
+      <translation>Normaltid V. Europa</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
+      <source>E. Europe Standard Time</source>
+      <translation>Normaltid Östeuropa</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
+      <source>FLE Standard Time</source>
+      <translation>FLE Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
+      <source>GTB Standard Time</source>
+      <translation>GTB Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
+      <source>Belarus Standard Time</source>
+      <translation>Normaltid Belarus</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
+      <source>Russian Standard Time</source>
+      <translation>Normaltid i Ryssland</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
+      <source>Turkey Standard Time</source>
+      <translation>Normaltid Turkiet</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzIndianData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
+      <source>Mauritius Standard Time</source>
+      <translation>Normaltid på Mauritius</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
+      <source>Christmas Island Standard Time</source>
+      <translation>Normaltid på Julön</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzPacificData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
+      <source>Tonga Standard Time</source>
+      <translation>Normaltid på Tonga</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
+      <source>Fiji Standard Time</source>
+      <translation>Normaltid på Fiji</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
+      <source>New Zealand Standard Time</source>
+      <translation>Normaltid på Nya Zeeland</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>Central Pacific Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
+      <source>West Pacific Standard Time</source>
+      <translation>West Pacific Standard Time</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
+      <source>Samoa Standard Time</source>
+      <translation>Normaltid på Samoa</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
+      <source>Hawaiian Standard Time</source>
+      <translation>Normaltid på Hawaii</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
+      <source>Easter Island Standard Time</source>
+      <translation>Normaltid på Påskön</translation>
     </message>
   </context>
   <context>
@@ -12174,838 +11854,6 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
     </message>
   </context>
   <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>Normaltid i Marocko</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>Normaltid i V. Centralafrika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>Normaltid i Sydafrika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>Normaltid i Namibia</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>Normaltid i Egypten</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Normaltid i Östafrika</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>Normaltid i Argentina</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>Normaltid i Ö. Sydamerika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>Normaltid på Grönland</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>Normaltid i Montevideo</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>Normaltid Newfoundland</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>Normaltid Ö. Sydamerika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Atlantic Standard Time</source>
-      <translation>Normaltid Atlanten</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>Normaltid i centrala Brasilien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Normaltid Stilla havet - Sydamerika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>Paraguay Standard Time</source>
-      <translation>Normaltid i Paraguay</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>SA Western Standard Time</source>
-      <translation>Normaltid i V. Sydamerika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Venezuela Standard Time</source>
-      <translation>Normaltid i Venezuela</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>Eastern Standard Time</source>
-      <translation>Eastern Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>Normaltid Stilla havet - Sydamerika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>US Eastern Standard Time</source>
-      <translation>Normaltid i Ö. USA</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Canada Central Standard Time</source>
-      <translation>Normaltid i centrala Kanada</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central America Standard Time</source>
-      <translation>Normaltid i Centralamerika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>Central Standard Time (Mexiko)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Central Standard Time</source>
-      <translation>Central Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>Mountain Standard Time (Mexiko)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>Mountain Standard Time</source>
-      <translation>Mountain Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>US Mountain Standard Time</source>
-      <translation>Mountain Standard Time USA</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>Pacific Standard Time (Mexiko)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Pacific Standard Time</source>
-      <translation>Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Alaskan Standard Time</source>
-      <translation>Normaltid i Alaska</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>Hawaii-Aleutian</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Daylight Time</source>
-      <translation>Atlantisk sommartid</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Normaltid på Nya Zeeland</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Central Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>West Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Normaltid i V. Australien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Normaltid SÖ. Asien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Normaltid i centrala Asien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>Normaltid V. Asien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Normaltid i Östafrika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Normaltid Stilla havet - Sydamerika</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>Normaltid i V. Sydamerika</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Normaltid V. Europa</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>Normaltid i Kamchatka</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>Normaltid i Magadan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>Normaltid i Vladivostok</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>Normaltid i Yakutsk</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>Normaltid i Tokyo</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>Normaltid i Korea</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>Normaltid i Singapore</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>Normaltid i Ulaanbaatar</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>Normaltid i Taipei</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>Normaltid i N.Ö. Asien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>Normaltid i Kina</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Normaltid SÖ. Asien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>Normaltid i N. Asien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>Normaltid i Myanmar</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>Normaltid i N. Centralasien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Normaltid i centrala Asien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>Normaltid i Bangladesh</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>Normaltid i Nepal</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>Normaltid på Sri Lanka</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>Normaltid i Indien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>Normaltid V. Asien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>Normaltid i Pakistan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>Normaltid i Ekaterinburg</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>Normaltid i Georgien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>Normaltid i Kaukasus</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>Normaltid i Azerbajdzan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>Arabian Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>Normaltid i Afghanistan</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>Normaltid i Iran</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>Arabic Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>Arab Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>Normaltid i Syrien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>Normaltid i Mellanöstern</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>Normaltid i Jordanien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>Normaltid i Israel</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>Greenwich Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>Normaltid på Azorerna</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>Normaltid i Kap Verde</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>Mid-Atlantic Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>Normaltid i Tasmanien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>Normaltid i Ö. Australien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>Normaltid i Ö. Australien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>Normaltid i centrala Australien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>Normaltid i centrala Australien</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Normaltid i V. Australien</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
-      <source>GMT +12</source>
-      <translation>GMT +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
-      <source>GMT -02</source>
-      <translation>GMT -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT -13</source>
-      <translation>GMT -13</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT -12</source>
-      <translation>GMT -12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -10</source>
-      <translation>GMT -10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -09</source>
-      <translation>GMT -09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>GMT -08</source>
-      <translation>GMT -08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
-      <source>GMT -07</source>
-      <translation>GMT -07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
-      <source>GMT -06</source>
-      <translation>GMT -06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
-      <source>GMT -05</source>
-      <translation>GMT -05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
-      <source>GMT -04</source>
-      <translation>GMT -04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
-      <source>GMT -03</source>
-      <translation>GMT -03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
-      <source>GMT -01</source>
-      <translation>GMT -01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
-      <source>GMT</source>
-      <translation>GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
-      <source>GMT +01</source>
-      <translation>GMT +01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
-      <source>GMT +02</source>
-      <translation>GMT +02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
-      <source>GMT +03</source>
-      <translation>GMT +03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
-      <source>GMT +04</source>
-      <translation>GMT +04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
-      <source>GMT +05</source>
-      <translation>GMT +05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
-      <source>GMT +06</source>
-      <translation>GMT +06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
-      <source>GMT +07</source>
-      <translation>GMT +07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
-      <source>GMT +08</source>
-      <translation>GMT +08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
-      <source>GMT +09</source>
-      <translation>GMT +09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
-      <source>GMT +10</source>
-      <translation>GMT +10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
-      <source>GMT +11</source>
-      <translation>GMT +11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
-      <source>UTC</source>
-      <translation>UTC</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>GMT Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>Normaltid Centraleuropa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>Normaltid Centraleuropa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>Romance Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Normaltid V. Europa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>Normaltid Östeuropa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>FLE Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>GTB Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>Normaltid Belarus</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>Normaltid i Ryssland</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>Normaltid Turkiet</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>Normaltid på Mauritius</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>Normaltid på Julön</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>Normaltid på Tonga</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>Normaltid på Fiji</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Normaltid på Nya Zeeland</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Central Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>West Pacific Standard Time</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>Normaltid på Samoa</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>Normaltid på Hawaii</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>Normaltid på Påskön</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation type="unfinished">Invändigt fel</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation type="unfinished"/>
-    </message>
-  </context>
-  <context>
     <name>Wakespeed</name>
     <message>
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
@@ -13182,6 +12030,119 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
       <source>DC/DC misconfiguration</source>
       <translation>DC/DC felkonfigurering</translation>
+    </message>
+  </context>
+  <context>
+    <name>VebusError</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+      <source>Device switched off</source>
+      <translation>Enheten är avstängd</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+      <source>Mixed old/new MK2</source>
+      <translation>Blandning av gamla/nya MK2</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+      <source>Expected devices error</source>
+      <translation>Fel förväntade enheter</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+      <source>No other device detected</source>
+      <translation>Ingen annan enhet detekterad</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+      <source>Overvoltage on AC-out</source>
+      <translation>Överspänning på AC-utgång</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+      <source>DDC program error</source>
+      <translation>DDC-programfel</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+      <source>VE.Bus BMS without assistant</source>
+      <translation>VE.Bus BMS utan assistent</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+      <source>Ground relay test failed</source>
+      <translation>Jordrelätest misslyckades</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+      <source>System time sync error</source>
+      <translation>Fel vid synkronisering av systemtid</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+      <source>Grid relay test fault</source>
+      <translation>Fel vid test av nätrelä</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+      <source>Config mismatch with 2nd mcu</source>
+      <translation>Konfigurationsfel med 2:a MCU</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+      <source>Device transmit error</source>
+      <translation>Enheten sänder fel</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+      <source>Awaiting configuration or dongle missing</source>
+      <translation>Väntar på konfiguration eller dongel saknas</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+      <source>Phase master missing</source>
+      <translation>Fas master saknas</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+      <source>Overvoltage has occurred</source>
+      <translation>Överspänning har uppstått</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+      <source>Slave does not have AC input!</source>
+      <translation>Slaven har ingen AC-ingång!</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+      <source>Device can't be slave</source>
+      <translation>Enheten kan inte vara slav</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+      <source>System protection initiated</source>
+      <translation>Systemskydd initierat</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+      <source>Firmware incompatibiltiy</source>
+      <translation>Inkompatibel firmware</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+      <source>Internal error</source>
+      <translation>Internt fel</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+      <source>Failing relay test prevents connection</source>
+      <translation>Misslyckat relätest förhindrar anslutning</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+      <source>VE.Bus error</source>
+      <translation>VE.Bus-fel</translation>
     </message>
   </context>
 </TS>

--- a/i18n/venus-gui-v2_th.ts
+++ b/i18n/venus-gui-v2_th.ts
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="th">
   <context>
-    <name/>
+    <name></name>
     <message id="switchable_output_disabled">
       <location filename="../../src/enums.cpp" line="478"/>
       <source>Disabled</source>
@@ -22,6 +22,7 @@
     <message id="solarchargers_state_off">
       <location filename="../../src/enums.cpp" line="331"/>
       <source>Off</source>
+      <extracomment>Digital input state</extracomment>
       <translation>ปิด</translation>
     </message>
     <message id="common_words_auto">
@@ -52,18 +53,25 @@
     <message id="settings_startpage_none">
       <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
       <source>None</source>
+      <extracomment>Indicates no phase</extracomment>
       <translation>ไม่มี</translation>
     </message>
     <message id="common_words_position_ac">
       <location filename="../../components/CommonWords.qml" line="416"/>
       <source>Position</source>
-      <extracomment>AC input or output position</extracomment>
+      <extracomment>EVCS AC input/output position</extracomment>
       <translation>ตำแหน่ง</translation>
     </message>
     <message id="settings_minmax_speed">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="193"/>
       <source>Speed</source>
+      <extracomment>A speed measurement value</extracomment>
       <translation>ความเร็ว</translation>
+    </message>
+    <message id="common_words_state">
+      <location filename="../../components/CommonWords.qml" line="502"/>
+      <source>State</source>
+      <translation>สถานะ</translation>
     </message>
     <message id="settings_firmware_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="67"/>
@@ -101,8 +109,8 @@
       <source>Solar yield</source>
       <translation>ผลผลิตพลังงานแสงอาทิตย์</translation>
     </message>
-    <message id="ess_state_external_control">
-      <location filename="../../data/Ess.qml" line="41"/>
+    <message id="inverters_state_externalccontrol">
+      <location filename="../../data/System.qml" line="183"/>
       <source>External control</source>
       <translation>การควบคุมภายนอก</translation>
     </message>
@@ -140,6 +148,11 @@
       <location filename="../../components/CommonWords.qml" line="203"/>
       <source>ESS</source>
       <translation>ESS</translation>
+    </message>
+    <message id="pagesettingsconnectivity_ethernet">
+      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
+      <source>Ethernet</source>
+      <translation>อีเธอร์เน็ต</translation>
     </message>
     <message id="pagesettingsconnectivity_wifi">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="28"/>
@@ -262,11 +275,6 @@
       <source>Name</source>
       <translation>ชื่อ</translation>
     </message>
-    <message id="settings_deviceinfo_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="38"/>
-      <source>Name</source>
-      <translation type="unfinished">ชื่อ</translation>
-    </message>
     <message id="settings_deviceinfo_product_id">
       <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
       <source>Product ID</source>
@@ -327,15 +335,20 @@
       <source>Daily run time</source>
       <translation>เวลาทำงานประจำวัน</translation>
     </message>
+    <message id="common_words_value_must_be_greater_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="560"/>
+      <source>Value must be greater than stop value</source>
+      <translation>ค่าต้องมากกว่าค่าสต็อป</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="563"/>
+      <source>Value must be lower than start value</source>
+      <translation>ค่าต้องต่ำกว่าค่าเริ่มต้น</translation>
+    </message>
     <message id="settings_minmax_acout_max_power">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="124"/>
       <source>AC output</source>
       <translation>เอาต์พุต AC</translation>
-    </message>
-    <message id="ac_output">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="15"/>
-      <source>AC output</source>
-      <translation type="unfinished">เอาต์พุต AC</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
       <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="25"/>
@@ -382,16 +395,6 @@
       <source>Unavailable monitor, set another</source>
       <translation>การตรวจสอบไม่พร้อมใช้งาน ตั้งค่าอื่น</translation>
     </message>
-    <message id="page_generator_conditions_battery_monitor">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="42"/>
-      <source>Battery monitor</source>
-      <translation type="unfinished">การตรวจสอบแบตเตอรี่</translation>
-    </message>
-    <message id="page_generator_conditions_unavailable_monitor_set_another">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="44"/>
-      <source>Unavailable monitor, set another</source>
-      <translation type="unfinished">การตรวจสอบไม่พร้อมใช้งาน ตั้งค่าอื่น</translation>
-    </message>
     <message id="page_generator_conditions_on_loss_of_communication">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="68"/>
       <source>On loss of communication</source>
@@ -416,11 +419,6 @@
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="105"/>
       <source>Battery SOC</source>
       <translation>แบตเตอรี่ SOC</translation>
-    </message>
-    <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="173"/>
-      <source>Periodic run</source>
-      <translation type="unfinished">วิ่งเป็นระยะ</translation>
     </message>
     <message id="settings_inverter_high_temperature">
       <location filename="../../data/Generators.qml" line="83"/>
@@ -505,7 +503,7 @@
     <message id="settings_gps_speed_kmh">
       <location filename="../../pages/settings/PageGps.qml" line="83"/>
       <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometres per hour</extracomment>
+      <extracomment>GPS speed data, in kilometers per hour</extracomment>
       <translation>%1 กม./ชม</translation>
     </message>
     <message id="settings_gps_speed_mph">
@@ -523,7 +521,7 @@
     <message id="settings_gps_speed_ms">
       <location filename="../../pages/settings/PageGps.qml" line="95"/>
       <source>%1 m/s</source>
-      <extracomment>GPS speed data, in metres per second</extracomment>
+      <extracomment>GPS speed data, in meters per second</extracomment>
       <translation>%1 เมตร/วินาที</translation>
     </message>
     <message id="settings_gps_course">
@@ -580,21 +578,6 @@
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="64"/>
       <source>%1 (Output %2)</source>
       <translation>%1 (เอาต์พุต %2)</translation>
-    </message>
-    <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">จอภาพแบตเตอรี่ที่ใช้งาน</translation>
-    </message>
-    <message id="settings_batteries_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="101"/>
-      <source>Name</source>
-      <translation type="unfinished">ชื่อ</translation>
-    </message>
-    <message id="settings_batteries_enter_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="103"/>
-      <source>Enter name</source>
-      <translation type="unfinished">ใส่ชื่อ</translation>
     </message>
     <message id="settings_briefview_center_active_battery_monitor">
       <location filename="../../components/listitems/ListBriefCenterDetails.qml" line="27"/>
@@ -656,45 +639,25 @@
       <source>CAN-bus profile</source>
       <translation>โปรไฟล์ CAN บัส</translation>
     </message>
-    <message id="settings_disabled">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="31"/>
-      <source>Disabled</source>
-      <translation type="unfinished">พิการ</translation>
-    </message>
-    <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</translation>
-    </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
       <location filename="../../pages/settings/CanbusProfile.qml" line="42"/>
       <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
       <translation>VE.Can &amp; CAN-bus BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
       <source>Oceanvolt (250 kbit/s)</source>
       <translation>Oceanvolt (250 kbit/s)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
       <source>RV-C (250 kbit/s)</source>
       <translation>RV-C (250 kbit/s)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
       <source>Up, but no services (250 kbit/s)</source>
       <translation>ขึ้น แต่ไม่มีบริการ (250 kbit/s)</translation>
-    </message>
-    <message id="settings_canopen_motordrive_250">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
-      <source>CANopen Motor drive (250 kbit/s)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_canopen_motordrive_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
-      <source>CANopen Motor drive (500 kbit/s)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_devices">
       <location filename="../../components/CommonWords.qml" line="166"/>
@@ -731,11 +694,6 @@
       <source>Check Unique id numbers</source>
       <translation>ตรวจสอบหมายเลขประจำตัวที่ไม่ซ้ำ</translation>
     </message>
-    <message id="settings_canbus_unique_id_press_to_check">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Press to check</source>
-      <translation type="unfinished">กดเพื่อตรวจสอบ</translation>
-    </message>
     <message id="settings_canbus_unique_id_conflict">
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="125"/>
       <source>There is another device connected with this unique number, please select a new number.</source>
@@ -745,11 +703,6 @@
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="133"/>
       <source>OK: No other device is connected with this unique number.</source>
       <translation>ตกลง: ไม่มีอุปกรณ์อื่นเชื่อมต่อกับหมายเลขเฉพาะนี้</translation>
-    </message>
-    <message id="pagesettingsintegrations_canopenmotordrive">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
-      <source>CANopen motor drives</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_network_status">
       <location filename="../../components/CommonWords.qml" line="349"/>
@@ -884,11 +837,6 @@
       <source>Unavailable sensor, set another</source>
       <translation>เซ็นเซอร์ไม่พร้อมใช้งาน ตั้งค่าอื่น</translation>
     </message>
-    <message id="settings_system_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="81"/>
-      <source>Unavailable sensor, set another</source>
-      <translation type="unfinished">เซ็นเซอร์ไม่พร้อมใช้งาน ตั้งค่าอื่น</translation>
-    </message>
     <message id="settings_dvcc_used_sensor">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="120"/>
       <source>Used sensor</source>
@@ -945,12 +893,6 @@
       <source>Auto selected</source>
       <translation>เลือกอัตโนมัติ</translation>
     </message>
-    <message id="settings_dvcc_auto_selected_none">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="208"/>
-      <source>None</source>
-      <extracomment>Indicates no option is selected</extracomment>
-      <translation type="unfinished">ไม่มี</translation>
-    </message>
     <message id="settings_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
       <source>Build date/time</source>
@@ -986,12 +928,6 @@
       <source>Installing %1</source>
       <extracomment>%1 = firmware version</extracomment>
       <translation>กำลังติดตั้ง %1</translation>
-    </message>
-    <message id="settings_firmware_offline_press_to_install">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">กดเพื่ออัปเดตเป็น %1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="90"/>
@@ -1062,12 +998,6 @@
       <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
       <translation>กำลังติดตั้ง %1 %2%</translation>
     </message>
-    <message id="settings_firmware_online_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="86"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">กำลังติดตั้ง %1...</translation>
-    </message>
     <message id="settings_firmware_update_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="109"/>
       <source>Update build date/time</source>
@@ -1097,11 +1027,6 @@
       <location filename="../../pages/settings/PageSettingsFronius.qml" line="56"/>
       <source>TCP port</source>
       <translation>พอร์ต TCP</translation>
-    </message>
-    <message id="page_settings_fronius_modbus_settings">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
-      <source>Modbus port and unit ID settings</source>
-      <translation type="unfinished"/>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
       <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
@@ -1153,16 +1078,6 @@
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="64"/>
       <source>AC-Out MP</source>
       <translation>AC-Out ส.ส</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="52"/>
-      <source>AC-In1 L%1</source>
-      <translation type="unfinished">เอซีอิน1 L%1</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="56"/>
-      <source>AC-In1 --</source>
-      <translation type="unfinished">เอซี-อิน1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="70"/>
@@ -1330,12 +1245,6 @@
       <source>Reset service timer</source>
       <translation>รีเซ็ตตัวจับเวลาบริการ</translation>
     </message>
-    <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
-      <source>Volume</source>
-      <extracomment>Title for a list of units of volume (e.g. cubic metres, litres, gallons)</extracomment>
-      <translation type="unfinished">ปริมาณ</translation>
-    </message>
     <message id="settings_gps_format">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="69"/>
       <source>Format</source>
@@ -1438,42 +1347,6 @@ If that doesn't work, check sim-card in a phone to make sure that there is credi
       <source>Wrong PIN</source>
       <translation>PIN ผิด</translation>
     </message>
-    <message id="page_settings_gsm_ok">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>OK</source>
-      <translation type="unfinished">ตกลง</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="128"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">ข้อผิดพลาดที่ไม่รู้จัก</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_state">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="153"/>
-      <source>Unknown</source>
-      <translation type="unfinished">ไม่รู้จัก</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_value">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="182"/>
-      <source>Unknown</source>
-      <translation type="unfinished">ไม่รู้จัก</translation>
-    </message>
-    <message id="page_settings_gsm_offline">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="173"/>
-      <source>Offline</source>
-      <translation type="unfinished">ออฟไลน์</translation>
-    </message>
-    <message id="page_settings_gsm_connecting">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="176"/>
-      <source>Connecting</source>
-      <translation type="unfinished">กำลังเชื่อมต่อ</translation>
-    </message>
-    <message id="page_settings_gsm_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="179"/>
-      <source>Connected</source>
-      <translation type="unfinished">เชื่อมต่อแล้ว</translation>
-    </message>
     <message id="page_settings_gsm_pin">
       <location filename="../../pages/settings/PageSettingsGsm.qml" line="191"/>
       <source>PIN</source>
@@ -1530,32 +1403,32 @@ If that doesn't work, check sim-card in a phone to make sure that there is credi
       <translation>วัดแสงกริด</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
       <source>External meter</source>
       <translation>เครื่องวัดภายนอก</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="67"/>
       <source>Inverter/Charger</source>
       <translation>อินเวอร์เตอร์/เครื่องชาร์จ</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
       <source>Multiphase regulation</source>
       <translation>การควบคุมหลายเฟส</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="91"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
       <source>Total of all phases</source>
       <translation>รวมทุกขั้นตอน</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="95"/>
       <source>Individual phase</source>
       <translation>เฟสส่วนตัว</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="99"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="101"/>
       <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
@@ -1564,68 +1437,13 @@ CAUTION: Use only if required by the utility provider.</source>
 ข้อควรระวัง: ใช้เฉพาะในกรณีที่ผู้ให้บริการสาธารณูปโภคต้องการเท่านั้น</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="104"/>
       <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
       <translation>ผลรวมของทุกเฟสได้รับการควบคุมอย่างชาญฉลาดเพื่อให้บรรลุจุดกำหนดของกริด (เพิ่มประสิทธิภาพของระบบ)
 
 ใช้เว้นแต่จะได้รับอนุญาตจากผู้ให้บริการสาธารณูปโภค</translation>
-    </message>
-    <message id="settings_ess_min_soc">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation type="unfinished">SOC ขั้นต่ำ (เว้นแต่กริดจะล้มเหลว)</translation>
-    </message>
-    <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="129"/>
-      <source>Active SOC limit</source>
-      <translation type="unfinished">ขีด จำกัด SOC ที่ใช้งานอยู่</translation>
-    </message>
-    <message id="settings_ess_battery_life_sustain">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
-      <source>Sustain</source>
-      <translation type="unfinished">ยังชีพประคับประคอง</translation>
-    </message>
-    <message id="settings_ess_battery_life_recharge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="157"/>
-      <source>Recharge</source>
-      <translation type="unfinished">เติมเงิน</translation>
-    </message>
-    <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <source>Scheduled charge levels</source>
-      <translation type="unfinished">ระดับการชาร์จตามกำหนดเวลา</translation>
-    </message>
-    <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="257"/>
-      <source>Active (%1)</source>
-      <translation type="unfinished">ใช้งานอยู่ (%1)</translation>
-    </message>
-    <message id="settings_ess_inactive">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="259"/>
-      <source>Inactive</source>
-      <translation type="unfinished">ไม่ใช้งาน</translation>
-    </message>
-    <message id="settings_ess_dynamic">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="293"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">ไดนามิก ESS</translation>
-    </message>
-    <message id="settings_ess_deprecated">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="319"/>
-      <source>Deprecated settings</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_charge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="326"/>
-      <source>Battery charge limit (% of CCL)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_discharge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="337"/>
-      <source>Battery discharge limit (% of DCL)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_rs_ess_min_soc">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="40"/>
@@ -1637,13 +1455,8 @@ Use unless prohibited by the utility provider.</source>
       <source>Active SOC limit</source>
       <translation>ขีด จำกัด SOC ที่ใช้งานอยู่</translation>
     </message>
-    <message id="scheduled_charge_inactive">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
-      <source>Inactive</source>
-      <translation type="unfinished">ไม่ใช้งาน</translation>
-    </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="245"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="247"/>
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
       <source>Peak shaving</source>
       <translation>การใช้สูงสุด</translation>
@@ -1659,12 +1472,12 @@ Use unless prohibited by the utility provider.</source>
       <translation>ตลอดเวลา</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="151"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
       <source>Discharge disabled</source>
       <translation>ปลดประจำการ</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
       <source>Slow charge</source>
       <translation>ชาร์จช้า</translation>
     </message>
@@ -1679,32 +1492,32 @@ Use unless prohibited by the utility provider.</source>
       <translation>เติมเงิน</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="165"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="167"/>
       <source>Limit charge power</source>
       <translation>ขีด จำกัด กำลังการชาร์จ</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="183"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="185"/>
       <source>Maximum charge power</source>
       <translation>กำลังชาร์จสูงสุด</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="196"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="198"/>
       <source>Limit inverter power</source>
       <translation>จำกัดกำลังของอินเวอร์เตอร์</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="214"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="216"/>
       <source>Maximum inverter power</source>
       <translation>กำลังสูงสุดของอินเวอร์เตอร์</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="225"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="227"/>
       <source>Grid setpoint</source>
       <translation>จุดตั้งค่ากริด</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="236"/>
       <source>Grid feed-in</source>
       <translation>กริดป้อนเข้า</translation>
     </message>
@@ -1743,8 +1556,8 @@ Use unless prohibited by the utility provider.</source>
       <source>Door alarm</source>
       <translation>สัญญาณเตือนประตู</translation>
     </message>
-    <message id="digitalinputs_type_bilgepump">
-      <location filename="../../src/enums.cpp" line="201"/>
+    <message id="switchable_output_bilge_pump">
+      <location filename="../../src/enums.cpp" line="424"/>
       <source>Bilge pump</source>
       <translation>ปั๊มน้ำท้องเรือ</translation>
     </message>
@@ -1796,11 +1609,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Deferred by %1s</source>
       <extracomment>%1 = number of seconds</extracomment>
       <translation>เลื่อนออกไป %1s</translation>
-    </message>
-    <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="75"/>
-      <source>Are you sure?</source>
-      <translation type="unfinished">คุณแน่ใจมั้ย?</translation>
     </message>
     <message id="settings_vrm_portal_id">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="87"/>
@@ -1939,11 +1747,6 @@ Use unless prohibited by the utility provider.</source>
       <source>External storage</source>
       <translation>จัดเก็บข้อมูลภายนอก</translation>
     </message>
-    <message id="settings_vrm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="308"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">ข้อผิดพลาดที่ไม่รู้จัก</translation>
-    </message>
     <message id="settings_vrm_no_error">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="311"/>
       <source>No Error</source>
@@ -2029,37 +1832,10 @@ Use unless prohibited by the utility provider.</source>
       <source>Function</source>
       <translation>ฟังก์ชั่น</translation>
     </message>
-    <message id="settings_relay_disabled">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="54"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="98"/>
-      <source>Disabled</source>
-      <translation type="unfinished">พิการ</translation>
-    </message>
     <message id="settings_relay_alarm_relay">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="56"/>
       <source>Alarm relay</source>
       <translation>รีเลย์ปลุก</translation>
-    </message>
-    <message id="settings_relay_tank_pump">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="62"/>
-      <source>Tank pump</source>
-      <translation type="unfinished">ปั๊มถัง</translation>
-    </message>
-    <message id="settings_relay_manual">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="64"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="100"/>
-      <source>Manual</source>
-      <translation type="unfinished">คู่มือ</translation>
-    </message>
-    <message id="settings_relay_polarity_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
-      <source>Polarity (Relay 1)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_relay_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
-      <source>Polarity</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_normally_open">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="83"/>
@@ -2075,11 +1851,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="93"/>
       <source>Function (Relay 2)</source>
       <translation>ฟังก์ชั่น (รีเลย์ 2)</translation>
-    </message>
-    <message id="settings_relay_polarity_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
-      <source>Polarity (Relay 2)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_temp_control_rules">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="119"/>
@@ -2111,12 +1882,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
       <source>Press to boot</source>
       <translation>กดเพื่อบูต</translation>
-    </message>
-    <message id="settings_firmware_backup_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
-      <translation type="unfinished">เฟิร์มแวร์ %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
@@ -2152,6 +1917,7 @@ Use unless prohibited by the utility provider.</source>
     <message id="nav_boat">
       <location filename="../../pages/boat/BoatPage.qml" line="14"/>
       <source>Boat</source>
+      <extracomment>The 'Boat' page</extracomment>
       <translation>เรือ</translation>
     </message>
     <message id="settings_system_name">
@@ -2219,11 +1985,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Solar charger current control</source>
       <translation>ตัวควบคุมกระแสไฟชาร์จพลังงานแสงอาทิตย์</translation>
     </message>
-    <message id="settings_system_status_bms_params">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
-      <source>BMS control</source>
-      <translation type="unfinished">ตัวควบคุม BMS</translation>
-    </message>
     <message id="common_words_bms_control">
       <location filename="../../components/CommonWords.qml" line="101"/>
       <source>BMS control</source>
@@ -2238,11 +1999,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
       <source>Pump state</source>
       <translation>สถานะปั๊ม</translation>
-    </message>
-    <message id="settings_pump_auto">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="56"/>
-      <source>Auto</source>
-      <translation type="unfinished">อัตโนมัติ</translation>
     </message>
     <message id="settings_tank_sensor">
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
@@ -2271,11 +2027,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="35"/>
       <source>Unplugged</source>
       <translation>ถอดปลั๊ก</translation>
-    </message>
-    <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="16"/>
-      <source>Name</source>
-      <translation type="unfinished">ชื่อ</translation>
     </message>
     <message id="settings_tcpip_hidden">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="21"/>
@@ -2317,16 +2068,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="99"/>
       <source>IP configuration</source>
       <translation>การกำหนดค่า IP</translation>
-    </message>
-    <message id="settings_tcpip_manual">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="105"/>
-      <source>Manual</source>
-      <translation type="unfinished">คู่มือ</translation>
-    </message>
-    <message id="settings_tcpip_off">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="107"/>
-      <source>Off</source>
-      <translation type="unfinished">ปิด</translation>
     </message>
     <message id="settings_tcpip_fixed">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="109"/>
@@ -2382,21 +2123,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="30"/>
       <source>Create access point</source>
       <translation>สร้างจุดเชื่อมต่อ</translation>
-    </message>
-    <message id="settings_wifi_access_point_enter_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="68"/>
-      <source>Enter password</source>
-      <translation type="unfinished">ใส่รหัสผ่าน</translation>
-    </message>
-    <message id="page_settings_wifi_invalid_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
-      <source>Password length must be either 0 or between 10 and 63 characters long</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_wifi_password_updated">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
-      <source>Password updated</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_wifi_networks">
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="86"/>
@@ -2539,20 +2265,10 @@ Use unless prohibited by the utility provider.</source>
       <extracomment>Network status: Standalone</extracomment>
       <translation>สแตนด์อโลน</translation>
     </message>
-    <message id="charger_standalone">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="45"/>
-      <source>Standalone</source>
-      <translation type="unfinished">สแตนด์อโลน</translation>
-    </message>
     <message id="charger_charge">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="48"/>
       <source>Charge</source>
       <translation>โหลด</translation>
-    </message>
-    <message id="charger_external_control">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="51"/>
-      <source>External control</source>
-      <translation type="unfinished">การควบคุมภายนอก</translation>
     </message>
     <message id="charger_charge_hub_1">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="54"/>
@@ -2584,16 +2300,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Master setting</source>
       <translation>การตั้งค่าหลัก</translation>
     </message>
-    <message id="charger_slave">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="85"/>
-      <source>Slave</source>
-      <translation type="unfinished">ตัวรอง</translation>
-    </message>
-    <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation type="unfinished">แรงดันไฟชาร์จ</translation>
-    </message>
     <message id="systemsettings_networkstatus_slave">
       <location filename="../../data/SystemSettings.qml" line="148"/>
       <source>Slave</source>
@@ -2615,14 +2321,15 @@ Use unless prohibited by the utility provider.</source>
       <source>Group &amp; Charge master</source>
       <translation>หัวหน้ากลุ่ม &amp; การชาร์จ</translation>
     </message>
-    <message id="genset_charge_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="365"/>
+    <message id="charger_charge_voltage">
+      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
       <source>Charge voltage</source>
       <translation>แรงดันไฟชาร์จ</translation>
     </message>
     <message id="common_words_reset">
       <location filename="../../components/CommonWords.qml" line="448"/>
       <source>Reset</source>
+      <extracomment>Reset the BMS control</extracomment>
       <translation>รีเซ็ต</translation>
     </message>
     <message id="solarcharger_load">
@@ -2651,14 +2358,14 @@ Use unless prohibited by the utility provider.</source>
       <extracomment>Voltage alarm is at "Warning" level</extracomment>
       <translation>คำเตือน</translation>
     </message>
-    <message id="listitems_alarm_level_alarm">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="25"/>
+    <message id="digitalinputs_state_alarm">
+      <location filename="../../src/enums.cpp" line="270"/>
       <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
+      <extracomment>Relay function is 'alarm'</extracomment>
       <translation>เตือน</translation>
     </message>
-    <message id="devicelist_tankshape_volume">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="190"/>
+    <message id="components_volumeunit_volume">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
       <source>Volume</source>
       <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
       <translation>ปริมาณ</translation>
@@ -2808,26 +2515,10 @@ Use unless prohibited by the utility provider.</source>
       <source>Relay function</source>
       <translation>ฟังก์ชั่นรีเลย์</translation>
     </message>
-    <message id="batterysettingrelay_alarm">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation type="unfinished">เตือน</translation>
-    </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
       <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
       <source>Charger or generator start/stop</source>
       <translation>ชาร์จเจอร์หรือเครื่องกำเนิดไฟฟ้า เริ่ม/หยุด</translation>
-    </message>
-    <message id="batterysettingrelay_manual_control">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
-      <source>Manual control</source>
-      <translation type="unfinished">ควบคุมด้วยมือ</translation>
-    </message>
-    <message id="batterysettingrelay_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">ฟิวส์ขาด</translation>
     </message>
     <message id="common_words_manual_control">
       <location filename="../../components/CommonWords.qml" line="302"/>
@@ -2853,12 +2544,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
       <source>Status LEDs</source>
       <translation>ไฟ LED แสดงสถานะ</translation>
-    </message>
-    <message id="batterydiagnostics_none">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
-      <source>None</source>
-      <extracomment>Indicates no alarm is set</extracomment>
-      <translation type="unfinished">ไม่มี</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
@@ -2888,7 +2573,7 @@ Use unless prohibited by the utility provider.</source>
     <message id="common_words_switch">
       <location filename="../../components/CommonWords.qml" line="525"/>
       <source>Switch</source>
-      <extracomment>Change the mode value</extracomment>
+      <extracomment>Change the battery mode</extracomment>
       <translation>สวิตช์</translation>
     </message>
     <message id="devicelist_battery_initializing">
@@ -2956,21 +2641,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Top section voltage</source>
       <translation>แรงดันไฟฟ้าส่วนบน</translation>
     </message>
-    <message id="battery_bank_error_communication">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="96"/>
-      <source>Communication error</source>
-      <translation type="unfinished">ข้อผิดพลาดในการสื่อสาร</translation>
-    </message>
-    <message id="battery_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="182"/>
-      <source>State of health</source>
-      <translation type="unfinished">สถานะของสุขภาพ</translation>
-    </message>
-    <message id="battery_bus_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="212"/>
-      <source>Bus voltage</source>
-      <translation type="unfinished">แรงดันบัส</translation>
-    </message>
     <message id="battery_bottom_section_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="228"/>
       <source>Bottom section voltage</source>
@@ -3016,16 +2686,6 @@ Use unless prohibited by the utility provider.</source>
       <source>IO</source>
       <translation>IO</translation>
     </message>
-    <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="391"/>
-      <source>System</source>
-      <translation type="unfinished">ระบบ</translation>
-    </message>
-    <message id="battery_press_to_redetect">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="433"/>
-      <source>Press to redetect</source>
-      <translation type="unfinished">กดเพื่อตรวจหาอีกครั้ง</translation>
-    </message>
     <message id="pagesettingsgeneral_system">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="107"/>
       <source>System</source>
@@ -3066,16 +2726,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Low SOC</source>
       <translation>SOC ต่ำ</translation>
     </message>
-    <message id="batteryalarms_high_battery_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
-      <source>High battery voltage</source>
-      <translation type="unfinished">แรงดันแบตเตอรี่สูง</translation>
-    </message>
-    <message id="batteryalarms_low_soc">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low SOC</source>
-      <translation type="unfinished">SOC ต่ำ</translation>
-    </message>
     <message id="batteryalarms_low_starter_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="73"/>
       <source>Low starter voltage</source>
@@ -3095,11 +2745,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
       <source>Mid-point voltage</source>
       <translation>แรงดันไฟฟ้าจุดกึ่งกลาง</translation>
-    </message>
-    <message id="batteryalarms_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">ฟิวส์ขาด</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
@@ -3293,11 +2938,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Restore factory defaults</source>
       <translation>เรียกคืนค่าเริ่มต้นจากโรงงาน</translation>
     </message>
-    <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation type="unfinished">กดเพื่อคืนค่า</translation>
-    </message>
     <message id="vebus_backup_press_to_restore">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="362"/>
       <source>Press to restore</source>
@@ -3337,11 +2977,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="18"/>
       <source>Capacity</source>
       <translation>ความจุ</translation>
-    </message>
-    <message id="batterysettingsbattery_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
-      <source>Capacity</source>
-      <translation type="unfinished">ความจุ</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
@@ -3418,11 +3053,6 @@ Use unless prohibited by the utility provider.</source>
       <source>No power on busbar</source>
       <translation>ไม่มีไฟบนบัสบาร์</translation>
     </message>
-    <message id="lynxdistributor_connection_lost">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
-      <source>Connection lost</source>
-      <translation type="unfinished">ขาดการเชื่อมต่อ</translation>
-    </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
       <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
       <source>%n fuse(s) blown</source>
@@ -3457,26 +3087,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Shutdowns due error</source>
       <translation>ปิดระบบเนื่องจากข้อผิดพลาด</translation>
     </message>
-    <message id="lynxiondiagnostics_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
-      <source>Last error</source>
-      <translation type="unfinished">ข้อผิดพลาดล่าสุด</translation>
-    </message>
-    <message id="lynxiondiagnostics_2nd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
-      <source>2nd last error</source>
-      <translation type="unfinished">ผิดพลาดครั้งที่ 2</translation>
-    </message>
-    <message id="lynxiondiagnostics_3rd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
-      <source>3rd last error</source>
-      <translation type="unfinished">ผิดพลาดครั้งที่ 3</translation>
-    </message>
-    <message id="lynxiondiagnostics_4th_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
-      <source>4th last error</source>
-      <translation type="unfinished">ผิดพลาดครั้งที่ 4</translation>
-    </message>
     <message id="lynxionio_system_switch">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
       <source>System Switch</source>
@@ -3496,11 +3106,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../components/CommonWords.qml" line="54"/>
       <source>Batteries</source>
       <translation>แบตเตอรี่</translation>
-    </message>
-    <message id="lynxionsystem_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
-      <source>Capacity</source>
-      <translation type="unfinished">ความจุ</translation>
     </message>
     <message id="lynxionsystem_parallel">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="30"/>
@@ -3522,20 +3127,10 @@ Use unless prohibited by the utility provider.</source>
       <source>Min/max cell temperature</source>
       <translation>อุณหภูมิเซลล์ต่ำสุด/สูงสุด</translation>
     </message>
-    <message id="lynxionsystem_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="92"/>
-      <source>Balancing</source>
-      <translation type="unfinished">การทรงตัว</translation>
-    </message>
     <message id="lynxionsystem_balancer_balancing">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
       <source>Balancing</source>
       <translation>การทรงตัว</translation>
-    </message>
-    <message id="lynxionsystem_balancer_unknown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="117"/>
-      <source>Unknown</source>
-      <translation type="unfinished">ไม่รู้จัก</translation>
     </message>
     <message id="dc_output">
       <location filename="../../components/listitems/ListDcOutputQuantityGroup.qml" line="16"/>
@@ -3643,11 +3238,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Remaining</source>
       <translation>ที่เหลืออยู่</translation>
     </message>
-    <message id="devicelist_tanksensor_sensor_battery">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="51"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">แบตเตอรี่เซนเซอร์</translation>
-    </message>
     <message id="temperature_sensor_battery">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="112"/>
       <source>Sensor battery</source>
@@ -3676,7 +3266,7 @@ Use unless prohibited by the utility provider.</source>
     <message id="devicelist_tanksetup_custom">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="53"/>
       <source>Custom</source>
-      <translation type="unfinished">กำหนดเอง</translation>
+      <translation>กำหนดเอง</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="59"/>
@@ -3709,34 +3299,34 @@ Use unless prohibited by the utility provider.</source>
       <translation>ค่าเซ็นเซอร์</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="75"/>
       <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
       <translation>ไม่มีการกำหนดรูปร่างที่กำหนดเอง คุณอาจกำหนดหนึ่งรายการได้มากถึงสิบคะแนน โปรดทราบว่า 0% และ 100% เป็นนัย</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="91"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="89"/>
       <source>Point %1</source>
       <extracomment>%1 = the point number</extracomment>
       <translation>จุด %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="133"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="179"/>
       <source>Add point</source>
       <translation>เพิ่มจุด</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="156"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="205"/>
       <source>Sensor level</source>
       <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
       <translation>ระดับเซนเซอร์</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="256"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="311"/>
       <source>Duplicate sensor level values are not allowed.</source>
       <translation>ไม่อนุญาตให้ใช้ค่าระดับเซ็นเซอร์ซ้ำกัน</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="262"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="317"/>
       <source>Volume values must be increasing.</source>
       <translation>ค่าปริมาณจะต้องเพิ่มขึ้น</translation>
     </message>
@@ -3776,11 +3366,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Switch position</source>
       <translation>สลับตำแหน่ง</translation>
     </message>
-    <message id="ac-in-setup_single_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="142"/>
-      <source>Single phase</source>
-      <translation type="unfinished">เฟสเดียว</translation>
-    </message>
     <message id="ac-in-setup_two_phase">
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="144"/>
       <source>2-phase</source>
@@ -3790,11 +3375,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="146"/>
       <source>3-phase</source>
       <translation>3 เฟส</translation>
-    </message>
-    <message id="ac-in-setup_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="161"/>
-      <source>Devices</source>
-      <translation type="unfinished">อุปกรณ์</translation>
     </message>
     <message id="ac-in-genset_ac">
       <location filename="../../components/PageGensetModel.qml" line="194"/>
@@ -3888,12 +3468,6 @@ Use unless prohibited by the utility provider.</source>
       <extracomment>%1 = CT device number</extracomment>
       <translation>กะรัต %1</translation>
     </message>
-    <message id="smappeect_phase_none">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation type="unfinished">ไม่มี</translation>
-    </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
       <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
       <source>Flashing LED indicates this CT</source>
@@ -3907,11 +3481,13 @@ Use unless prohibited by the utility provider.</source>
     <message id="common_words_setting_disabled_when_dmc_connected">
       <location filename="../../components/CommonWords.qml" line="355"/>
       <source>This setting is disabled when a Digital Multi Control is connected.</source>
+      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>การตั้งค่านี้จะถูกปิดใช้งานเมื่อเชื่อมต่อ Digital Multi Control</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
       <location filename="../../components/CommonWords.qml" line="358"/>
       <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>การตั้งค่านี้ถูกปิดใช้งานเมื่อมีการเชื่อมต่อ VE.Bus BMS</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
@@ -3929,16 +3505,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="21"/>
       <source>Inverted</source>
       <translation>คว่ำ</translation>
-    </message>
-    <message id="digitalinput_enable_alarm">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="48"/>
-      <source>Enable alarm</source>
-      <translation type="unfinished">เปิดใช้งานการเตือน</translation>
-    </message>
-    <message id="digitalinput_inverted">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="54"/>
-      <source>Inverted</source>
-      <translation type="unfinished">คว่ำ</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
       <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="60"/>
@@ -3975,16 +3541,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Wind speed</source>
       <translation>ความเร็วลม</translation>
     </message>
-    <message id="page_meteo_battery_voltage">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="99"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">แบตเตอรี่เซนเซอร์</translation>
-    </message>
-    <message id="meteo_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="120"/>
-      <source>Low</source>
-      <translation type="unfinished">ต่ำ</translation>
-    </message>
     <message id="page_meteo_settings_auto_detect">
       <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
       <source>Auto-detect</source>
@@ -4015,16 +3571,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Reset counter</source>
       <translation>รีเซ็ตตัวนับ</translation>
     </message>
-    <message id="temperature_short_circuited">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="32"/>
-      <source>Short circuited</source>
-      <translation type="unfinished">ลัดวงจร</translation>
-    </message>
-    <message id="temperature_reverse_polarity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="35"/>
-      <source>Reverse polarity</source>
-      <translation type="unfinished">ขั้วย้อนกลับ</translation>
-    </message>
     <message id="temperature_sensor_battery_low">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
       <source>Sensor battery low</source>
@@ -4039,36 +3585,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="62"/>
       <source>Pressure</source>
       <translation>ความกดดัน</translation>
-    </message>
-    <message id="temperature_pm25">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
-      <source>PM2.5</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_co2">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>CO₂</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_voc">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
-      <source>VOC index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_nox">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
-      <source>NOx index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_luminosity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
-      <source>Luminosity</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="133"/>
-      <source>Low</source>
-      <translation type="unfinished">ต่ำ</translation>
     </message>
     <message id="temperature_offset">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
@@ -4122,25 +3638,10 @@ NOTE: The update might temporarily stop the system.</source>
       <source>Updating the MK3, values will reappear after the update is complete</source>
       <translation>การอัปเดต MK3 ค่าต่างๆ จะปรากฏขึ้นอีกครั้งหลังจากการอัปเดตเสร็จสิ้น</translation>
     </message>
-    <message id="vebus_device_charging_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="78"/>
-      <source>Charging the battery to 100%</source>
-      <translation type="unfinished">ชาร์จแบตเตอรี่ให้เต็ม 100%</translation>
-    </message>
     <message id="vebus_device_charging_the_battery_to_100">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="93"/>
       <source>Charging the battery to 100%</source>
       <translation>ชาร์จแบตเตอรี่ให้เต็ม 100%</translation>
-    </message>
-    <message id="vebus_device_page_microgrid_parameters">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
-      <source>Microgrid parameters</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="vebus_device_page_advanced">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
-      <source>Advanced</source>
-      <translation type="unfinished">ขั้นสูง</translation>
     </message>
     <message id="vebus_device_in_progress">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="80"/>
@@ -4196,15 +3697,15 @@ Do you want to continue?</source>
       <source>DC Current</source>
       <translation>กระแสตรง</translation>
     </message>
+    <message id="vebus_device_page_advanced">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
+      <source>Advanced</source>
+      <translation>ขั้นสูง</translation>
+    </message>
     <message id="common_words_alarm_setup">
       <location filename="../../components/CommonWords.qml" line="65"/>
       <source>Alarm setup</source>
       <translation>ตั้งปลุก</translation>
-    </message>
-    <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
-      <translation type="unfinished">VE.Bus BMS จะปิดระบบโดยอัตโนมัติเมื่อจำเป็นเพื่อปกป้องแบตเตอรี่ จึงไม่สามารถควบคุมระบบของตัวควบคุมได้</translation>
     </message>
     <message id="vebus_device_bms_not_found">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="240"/>
@@ -4245,7 +3746,7 @@ Do you want to continue?</source>
     <message id="vebus_device_starting">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="117"/>
       <source>Starting...</source>
-      <translation type="unfinished">เริ่ม...</translation>
+      <translation>เริ่ม...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="120"/>
@@ -4311,16 +3812,6 @@ Do you want to continue?</source>
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="260"/>
       <source>ESS Relay test</source>
       <translation>การทดสอบรีเลย์ ESS</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_completed">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="266"/>
-      <source>Completed</source>
-      <translation type="unfinished">สมบูรณ์</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_pending">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="268"/>
-      <source>Pending</source>
-      <translation type="unfinished">รอดำเนินการ</translation>
     </message>
     <message id="cycle_history_completed">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
@@ -4507,6 +3998,7 @@ Do you want to continue?</source>
     <message id="rssystemalarms_overload">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
       <source>Overload</source>
+      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
       <translation>โอเวอร์โหลด</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
@@ -4519,11 +4011,6 @@ Do you want to continue?</source>
       <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
       <source>Voltage Sensor</source>
       <translation>เซ็นเซอร์แรงดันไฟฟ้า</translation>
-    </message>
-    <message id="vebus_device_phase_rotation">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
-      <source>Phase rotation</source>
-      <translation type="unfinished">การหมุนเฟส</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
@@ -4555,12 +4042,6 @@ Do you want to continue?</source>
       <source>VE.Bus BMS version</source>
       <translation>เวอร์ชัน VE.Bus BMS</translation>
     </message>
-    <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="15"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="52"/>
-      <source>Minimum SOC</source>
-      <translation type="unfinished">SOC ขั้นต่ำ</translation>
-    </message>
     <message id="ess_unless_grid_fails">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="32"/>
       <source>Unless grid fails</source>
@@ -4580,7 +4061,7 @@ Do you want to continue?</source>
     <message id="common_words_ac_input_role">
       <location filename="../../components/CommonWords.qml" line="24"/>
       <source>Role</source>
-      <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
       <translation>หน้าที่</translation>
     </message>
     <message id="common_words_ac_load">
@@ -4619,18 +4100,6 @@ Do you want to continue?</source>
       <source>Active</source>
       <extracomment>Status is 'active'</extracomment>
       <translation>คล่องแคล่ว</translation>
-    </message>
-    <message id="common_words_alarm">
-      <location filename="../../components/CommonWords.qml" line="51"/>
-      <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
-      <translation type="unfinished">เตือน</translation>
-    </message>
-    <message id="common_words_alarm_setting_overload">
-      <location filename="../../components/CommonWords.qml" line="58"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation type="unfinished">โอเวอร์โหลด</translation>
     </message>
     <message id="common_words_alarm_status">
       <location filename="../../components/CommonWords.qml" line="68"/>
@@ -4677,8 +4146,8 @@ Do you want to continue?</source>
       <source>Charge current</source>
       <translation>กระแสไฟชาร์จ</translation>
     </message>
-    <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="125"/>
+    <message id="battery_mode_charging">
+      <location filename="../../src/enums.cpp" line="30"/>
       <source>Charging</source>
       <extracomment>"Charging" state</extracomment>
       <translation>กำลังชาร์จ</translation>
@@ -4692,7 +4161,7 @@ Do you want to continue?</source>
     <message id="digitalinputs_state_closed">
       <location filename="../../src/enums.cpp" line="262"/>
       <source>Closed</source>
-      <extracomment>Digital input state</extracomment>
+      <extracomment>Status is 'closed'</extracomment>
       <translation>ปิด</translation>
     </message>
     <message id="evchargers_status_connected">
@@ -4700,8 +4169,8 @@ Do you want to continue?</source>
       <source>Connected</source>
       <translation>เชื่อมต่อแล้ว</translation>
     </message>
-    <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="143"/>
+    <message id="temperature_slider_current">
+      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
       <source>Current</source>
       <extracomment>Electric current, as measured in Amps</extracomment>
       <translation>หมุนเวียน</translation>
@@ -4728,9 +4197,10 @@ Do you want to continue?</source>
       <extracomment>Title for device information</extracomment>
       <translation>อุปกรณ์</translation>
     </message>
-    <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="172"/>
+    <message id="battery_mode_discharging">
+      <location filename="../../src/enums.cpp" line="34"/>
       <source>Discharging</source>
+      <extracomment>Battery mode</extracomment>
       <translation>การคายประจุ</translation>
     </message>
     <message id="wifimodel_disconnected">
@@ -4816,13 +4286,14 @@ Do you want to continue?</source>
       <source>%1 Hour(s)</source>
       <translation>%1 ชั่วโมง</translation>
     </message>
-    <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="251"/>
+    <message id="battery_mode_idle">
+      <location filename="../../src/enums.cpp" line="26"/>
       <source>Idle</source>
+      <extracomment>Battery mode</extracomment>
       <translation>ว่าง</translation>
     </message>
-    <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="258"/>
+    <message id="scheduled_charge_inactive">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
       <source>Inactive</source>
       <extracomment>Status is 'inactive'</extracomment>
       <translation>ไม่ใช้งาน</translation>
@@ -4924,8 +4395,8 @@ Do you want to continue?</source>
       <source>Offline</source>
       <translation>ออฟไลน์</translation>
     </message>
-    <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="17"/>
+    <message id="digitalinputs_state_ok">
+      <location filename="../../src/enums.cpp" line="266"/>
       <source>OK</source>
       <extracomment>Voltage alarm is at "OK" level</extracomment>
       <translation>ตกลง</translation>
@@ -4933,6 +4404,7 @@ Do you want to continue?</source>
     <message id="switchable_output_on">
       <location filename="../../src/enums.cpp" line="471"/>
       <source>On</source>
+      <extracomment>Digital input state</extracomment>
       <translation>เปิด</translation>
     </message>
     <message id="common_words_online">
@@ -4943,7 +4415,7 @@ Do you want to continue?</source>
     <message id="digitalinputs_state_open">
       <location filename="../../src/enums.cpp" line="258"/>
       <source>Open</source>
-      <extracomment>Digital input open</extracomment>
+      <extracomment>Status is 'open'</extracomment>
       <translation>เปิด</translation>
     </message>
     <message id="common_words_password">
@@ -5003,9 +4475,10 @@ Do you want to continue?</source>
       <source>Remove</source>
       <translation>ลบ</translation>
     </message>
-    <message id="switch_state_running">
-      <location filename="../../src/enums.cpp" line="363"/>
+    <message id="switchable_output_running">
+      <location filename="../../src/enums.cpp" line="468"/>
       <source>Running</source>
+      <extracomment>Status = "running"</extracomment>
       <translation>ทำงาน</translation>
     </message>
     <message id="common_words_scanning">
@@ -5072,7 +4545,7 @@ Do you want to continue?</source>
     <message id="pvinverter_statusCode_startup">
       <location filename="../../src/enums.cpp" line="296"/>
       <source>Startup (%1)</source>
-      <extracomment>PV inverter status code. %1 = the startup status number</extracomment>
+      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
       <translation>การเริ่มต้น (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
@@ -5127,8 +4600,10 @@ Do you want to continue?</source>
       <source>Unique Identity Number</source>
       <translation>หมายเลขประจำตัวที่ไม่ซ้ำกัน</translation>
     </message>
-    <message id="settings_radio_button_group_unknown">
-      <location filename="../../components/listitems/core/ListRadioButtonGroup.qml" line="44"/>
+    <message id="Unknown">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
       <source>Unknown</source>
       <translation>ไม่รู้จัก</translation>
     </message>
@@ -5283,11 +4758,6 @@ Do you want to continue?</source>
       <source>Error while checking for firmware updates</source>
       <translation>เกิดข้อผิดพลาดขณะตรวจสอบการอัปเดตเฟิร์มแวร์</translation>
     </message>
-    <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation type="unfinished">เกิดข้อผิดพลาดขณะตรวจสอบการอัปเดตเฟิร์มแวร์</translation>
-    </message>
     <message id="settings_firmware_downloading_and_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="63"/>
       <source>Downloading and installing firmware %1...</source>
@@ -5314,6 +4784,66 @@ Do you want to continue?</source>
       <source>No firmware found</source>
       <translation>ไม่พบเฟิร์มแวร์</translation>
     </message>
+    <message id="tank_type_fuel">
+      <location filename="../../src/enums.cpp" line="495"/>
+      <source>Fuel</source>
+      <translation>เชื้อเพลิง</translation>
+    </message>
+    <message id="tank_type_fresh_water">
+      <location filename="../../src/enums.cpp" line="498"/>
+      <source>Fresh water</source>
+      <translation>น้ำจืด</translation>
+    </message>
+    <message id="tank_type_waste_water">
+      <location filename="../../src/enums.cpp" line="501"/>
+      <source>Waste water</source>
+      <translation>น้ำเสีย</translation>
+    </message>
+    <message id="tank_type_live_well">
+      <location filename="../../src/enums.cpp" line="504"/>
+      <source>Live well</source>
+      <translation>อยู่ดีมีสุข</translation>
+    </message>
+    <message id="tank_type_oil">
+      <location filename="../../src/enums.cpp" line="507"/>
+      <source>Oil</source>
+      <translation>น้ำมัน</translation>
+    </message>
+    <message id="tank_type_black_water">
+      <location filename="../../src/enums.cpp" line="510"/>
+      <source>Black water</source>
+      <translation>น้ำดำ</translation>
+    </message>
+    <message id="tank_type_gasoline">
+      <location filename="../../src/enums.cpp" line="513"/>
+      <source>Gasoline</source>
+      <translation>น้ำมันเบนซิน</translation>
+    </message>
+    <message id="tank_type_diesel">
+      <location filename="../../src/enums.cpp" line="516"/>
+      <source>Diesel</source>
+      <translation>ดีเซล</translation>
+    </message>
+    <message id="tank_type_lpg">
+      <location filename="../../src/enums.cpp" line="519"/>
+      <source>LPG</source>
+      <translation>แอลพีจี</translation>
+    </message>
+    <message id="tank_type_lng">
+      <location filename="../../src/enums.cpp" line="522"/>
+      <source>LNG</source>
+      <translation>LNG</translation>
+    </message>
+    <message id="tank_type_hydraulic_oil">
+      <location filename="../../src/enums.cpp" line="525"/>
+      <source>Hydraulic oil</source>
+      <translation>น้ำมันไฮดรอลิก</translation>
+    </message>
+    <message id="tank_type_raw_water">
+      <location filename="../../src/enums.cpp" line="528"/>
+      <source>Raw water</source>
+      <translation>น้ำดิบ</translation>
+    </message>
     <message id="listItem_no_access">
       <location filename="../../components/listitems/core/ListItem.qml" line="102"/>
       <source>Setting locked for access level</source>
@@ -5327,6 +4857,7 @@ Do you want to continue?</source>
     <message id="welcome_brief_title">
       <location filename="../../pages/welcome/WelcomeView.qml" line="81"/>
       <source>Brief</source>
+      <extracomment>The 'Brief' page</extracomment>
       <translation>รวบรัด</translation>
     </message>
     <message id="welcome_overview_title">
@@ -5343,23 +4874,6 @@ Do you want to continue?</source>
       <location filename="../../pages/NotificationsPage.qml" line="13"/>
       <source>Notifications</source>
       <translation>การแจ้งเตือน</translation>
-    </message>
-    <message id="notifications_page_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="43"/>
-      <source>Active Notifications</source>
-      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_page_inactive_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="47"/>
-      <source>Inactive Notifications</source>
-      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_no_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="106"/>
-      <source>No active notifications</source>
-      <translation type="unfinished"/>
     </message>
     <message id="utils_formatTimestamp_now">
       <location filename="../../components/Utils.js" line="258"/>
@@ -5464,11 +4978,6 @@ Do you want to continue?</source>
       <source>Self-consumption above limit</source>
       <translation>การใช้งานเกินขีดจำกัด</translation>
     </message>
-    <message id="cgwacs_battery_schedule_pv">
-      <location filename="../../components/listitems/ListChargeSchedule.qml" line="171"/>
-      <source>PV</source>
-      <translation type="unfinished">PV</translation>
-    </message>
     <message id="settings_multirs_pv">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="185"/>
       <source>PV</source>
@@ -5479,8 +4988,8 @@ Do you want to continue?</source>
       <source>PV &amp; Battery</source>
       <translation>เซลล์แสงอาทิตย์และแบตเตอรี่</translation>
     </message>
-    <message id="settings_firmware_checking">
-      <location filename="../../components/listitems/ListFirmwareCheckButton.qml" line="16"/>
+    <message id="pagesettingssupportstate_firmware_checking">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
       <source>Checking...</source>
       <translation>กำลังตรวจสอบ...</translation>
     </message>
@@ -5488,12 +4997,6 @@ Do you want to continue?</source>
       <location filename="../../components/listitems/ListAlarmState.qml" line="11"/>
       <source>Alarm state</source>
       <translation>สถานะปลุก</translation>
-    </message>
-    <message id="devicelist_battery_alarm_state">
-      <location filename="../../components/listitems/ListAlarmState.qml" line="19"/>
-      <source>Alarm</source>
-      <extracomment>Alarm state is active</extracomment>
-      <translation type="unfinished">เตือน</translation>
     </message>
     <message id="clear_history_button_clear_history">
       <location filename="../../components/listitems/ListClearHistoryButton.qml" line="15"/>
@@ -5645,11 +5148,6 @@ Do you want to continue?</source>
       <source>Max Voltage</source>
       <translation>แรงดันไฟฟ้าสูงสุด</translation>
     </message>
-    <message id="charger_history_box_max_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="64"/>
-      <source>Max Voltage</source>
-      <translation type="unfinished">แรงดันไฟฟ้าสูงสุด</translation>
-    </message>
     <message id="charger_history_box_max_current">
       <location filename="../../components/SolarDetailBox.qml" line="70"/>
       <source>Max Current</source>
@@ -5660,24 +5158,6 @@ Do you want to continue?</source>
       <source>Charge time</source>
       <extracomment>Statistics for battery charging time</extracomment>
       <translation>เวลาชาร์จ</translation>
-    </message>
-    <message id="charger_history_box_bulk">
-      <location filename="../../components/SolarDetailBox.qml" line="136"/>
-      <source>Bulk</source>
-      <extracomment>Battery: time spent in 'Bulk' mode</extracomment>
-      <translation type="unfinished">จำนวนมาก</translation>
-    </message>
-    <message id="charger_history_box_float">
-      <location filename="../../components/SolarDetailBox.qml" line="148"/>
-      <source>Float</source>
-      <extracomment>Battery: time spent in 'Float' mode</extracomment>
-      <translation type="unfinished">ลอย</translation>
-    </message>
-    <message id="charger_history_hr">
-      <location filename="../../components/SolarDetailBox.qml" line="174"/>
-      <source>hr</source>
-      <extracomment>Abbreviation of "hour"</extracomment>
-      <translation type="unfinished">ชม</translation>
     </message>
     <message id="solarchargers_state_bulk">
       <location filename="../../src/enums.cpp" line="337"/>
@@ -5749,11 +5229,6 @@ Do you want to continue?</source>
       <source>Connecting</source>
       <translation>กำลังเชื่อมต่อ</translation>
     </message>
-    <message id="splash_view_connecting">
-      <location filename="../../components/SplashView.qml" line="288"/>
-      <source>Connecting</source>
-      <translation type="unfinished">กำลังเชื่อมต่อ</translation>
-    </message>
     <message id="splash_view_connected">
       <location filename="../../components/SplashView.qml" line="290"/>
       <source>Connected, awaiting broker messages</source>
@@ -5809,6 +5284,11 @@ Do you want to continue?</source>
       <source>MQTT protocol level 5 error</source>
       <translation>ข้อผิดพลาดของโปรโตคอล MQTT ระดับ 5</translation>
     </message>
+    <message id="common_words_silence_alarm">
+      <location filename="../../components/CommonWords.qml" line="476"/>
+      <source>Silence alarm</source>
+      <translation>ปลุกเงียบ</translation>
+    </message>
     <message id="vebus_device_page_total_power">
       <location filename="../../components/ThreePhaseQuantityTable.qml" line="47"/>
       <source>Total Power</source>
@@ -5859,20 +5339,10 @@ Do you want to continue?</source>
       <source>Retrieving IP address</source>
       <translation>กำลังเรียกที่อยู่ IP</translation>
     </message>
-    <message id="utils_connman_connected">
-      <location filename="../../components/Utils.js" line="292"/>
-      <source>Connected</source>
-      <translation type="unfinished">เชื่อมต่อแล้ว</translation>
-    </message>
     <message id="utils_connman_disconnect">
       <location filename="../../components/Utils.js" line="295"/>
       <source>Disconnect</source>
       <translation>ตัดการเชื่อมต่อ</translation>
-    </message>
-    <message id="utils_connman_disconnected">
-      <location filename="../../components/Utils.js" line="299"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">ตัดการเชื่อมต่อ</translation>
     </message>
     <message id="overview_widget_acloads_title">
       <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
@@ -5910,11 +5380,6 @@ Do you want to continue?</source>
       <source>Shore current limit</source>
       <translation>ขีดจำกัดกระแสฝั่ง</translation>
     </message>
-    <message id="acInputs_statusCode_stopping">
-      <location filename="../../data/AcInputs.qml" line="170"/>
-      <source>Stopping</source>
-      <translation type="unfinished">หยุด</translation>
-    </message>
     <message id="page_generator_stopping">
       <location filename="../../data/Generators.qml" line="44"/>
       <source>Stopping</source>
@@ -5930,7 +5395,7 @@ Do you want to continue?</source>
       <location filename="../../data/common/TankDescription.qml" line="24"/>
       <location filename="../../src/device.cpp" line="133"/>
       <source>%1 tank (%2)</source>
-      <extracomment>Tank description. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
       <translation>%1 รถถัง (%2)</translation>
     </message>
     <message id="dcMeter_ac_charger">
@@ -5979,11 +5444,6 @@ Do you want to continue?</source>
       <location filename="../../data/Ess.qml" line="20"/>
       <source>Keep batteries charged</source>
       <translation>เก็บแบตเตอรี่ไว้</translation>
-    </message>
-    <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="50"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">ตัดการเชื่อมต่อ</translation>
     </message>
     <message id="evchargers_status_charged">
       <location filename="../../data/EvChargers.qml" line="58"/>
@@ -6044,16 +5504,6 @@ Do you want to continue?</source>
       <location filename="../../data/EvChargers.qml" line="97"/>
       <source>Start charging</source>
       <translation>เริ่มการชาร์จ</translation>
-    </message>
-    <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="113"/>
-      <source>Unknown</source>
-      <translation type="unfinished">ไม่รู้จัก</translation>
-    </message>
-    <message id="evchargers_mode_scheduled">
-      <location filename="../../data/EvChargers.qml" line="126"/>
-      <source>Scheduled</source>
-      <translation type="unfinished">กำหนดการ</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
       <location filename="../../data/System.qml" line="195"/>
@@ -6178,11 +5628,6 @@ Do you want to continue?</source>
       <source>Power supply mode</source>
       <translation>โหมดพาวเวอร์ซัพพลาย</translation>
     </message>
-    <message id="inverters_state_sustain">
-      <location filename="../../data/System.qml" line="158"/>
-      <source>Sustain</source>
-      <translation type="unfinished">ยังชีพประคับประคอง</translation>
-    </message>
     <message id="inverters_state_wakeup">
       <location filename="../../data/System.qml" line="162"/>
       <source>Wake up</source>
@@ -6217,16 +5662,6 @@ Do you want to continue?</source>
       <location filename="../../data/System.qml" line="180"/>
       <source>Test</source>
       <translation>ทดสอบ</translation>
-    </message>
-    <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="183"/>
-      <source>External control</source>
-      <translation type="unfinished">การควบคุมภายนอก</translation>
-    </message>
-    <message id="inverters_state_dynamic_ess">
-      <location filename="../../data/System.qml" line="198"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">ไดนามิก ESS</translation>
     </message>
     <message id="settings_rs_ess_dess">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="97"/>
@@ -6305,16 +5740,13 @@ Do you want to continue?</source>
     <message id="ess_recommended">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="73"/>
       <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
       <translation>สำหรับแบตเตอรี่ลิเธียม ไม่แนะนำให้ชาร์จต่ำกว่า 10% สำหรับแบตเตอรี่ประเภทอื่นๆ ให้ตรวจสอบเอกสารข้อมูลเพื่อดูระดับขั้นต่ำที่แนะนำโดยผู้ผลิต</translation>
-    </message>
-    <message id="controlcard_generator_label_autostart">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="63"/>
-      <source>Autostart</source>
-      <translation type="unfinished">เริ่มอัตโนมัติ</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
       <location filename="../../pages/controlcards/GeneratorCard.qml" line="70"/>
       <source>Start and stop the generator based on the configured autostart conditions.</source>
+      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
       <translation>เริ่มต้นและหยุดเครื่องกำเนิดไฟฟ้าตามเงื่อนไขการเริ่มอัตโนมัติที่กำหนดค่าไว้</translation>
     </message>
     <message id="generator_dialog_disabled">
@@ -6337,11 +5769,13 @@ Do you want to continue?</source>
       <location filename="../../pages/controlcards/InverterChargerCard.qml" line="26"/>
       <source>Inverter / Charger (%1)</source>
       <extracomment>%1 = the inverter/charger name</extracomment>
+      <oldsource>Inverter / Charger</oldsource>
       <translation>อินเวอร์เตอร์ / เครื่องชาร์จ (%1)</translation>
     </message>
     <message id="settings_page_debug_quit_application">
       <location filename="../../pages/settings/debug/PageDebug.qml" line="36"/>
       <source>Quit application</source>
+      <oldsource>Quit Application</oldsource>
       <translation>ออกจากการสมัคร</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
@@ -6352,12 +5786,8 @@ Do you want to continue?</source>
     <message id="settings_page_relay_generator_run_time">
       <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
       <source>Current run time</source>
+      <oldsource>Run time</oldsource>
       <translation>เวลาการทำงานปัจจุบัน</translation>
-    </message>
-    <message id="settings_page_genset_generator_run_time">
-      <location filename="../../components/PageGensetModel.qml" line="102"/>
-      <source>Current run time</source>
-      <translation type="unfinished">เวลาการทำงานปัจจุบัน</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
       <location filename="../../components/PageGensetModel.qml" line="110"/>
@@ -6384,19 +5814,10 @@ Do you want to continue?</source>
       <source>Remote start mode</source>
       <translation>โหมดเริ่มต้นระยะไกล</translation>
     </message>
-    <message id="ac-in-genset_speed">
-      <location filename="../../components/PageGensetModel.qml" line="245"/>
-      <source>Speed</source>
-      <translation type="unfinished">ความเร็ว</translation>
-    </message>
-    <message id="ac-in-genset_load">
-      <location filename="../../components/PageGensetModel.qml" line="252"/>
-      <source>Load</source>
-      <translation type="unfinished">โหลด</translation>
-    </message>
     <message id="ac-in-genset_oil_pressure">
       <location filename="../../components/PageGensetModel.qml" line="260"/>
       <source>Oil pressure</source>
+      <oldsource>Oil Pressure</oldsource>
       <translation>แรงดันน้ำมัน</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
@@ -6492,11 +5913,13 @@ Do you want to continue?</source>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
       <source>High starter battery voltage alarms</source>
+      <oldsource>High starter batttery voltage alarms</oldsource>
       <translation>สัญญาณเตือนแรงดันแบตเตอรี่สตาร์ทสูง</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
       <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
       <translation>โปรดทราบว่าการเปลี่ยนการตั้งค่าชั้นจำหน่าย Time-to-go จะเปลี่ยนการตั้งค่าสถานะการชาร์จต่ำในเมนูรีเลย์ด้วย</translation>
     </message>
     <message id="lynxionsystem_cells_per_battery">
@@ -6573,6 +5996,7 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/devicelist/delegates/DeviceListDelegate_solarcharger.qml" line="34"/>
       <source>Error: #%1</source>
       <extracomment>%1 = error number</extracomment>
+      <oldsource>Error: %1</oldsource>
       <translation>ข้อผิดพลาด: #%1</translation>
     </message>
     <message id="devicelistpage_genset">
@@ -6629,17 +6053,14 @@ Do you want to continue?</source>
     <message id="settings_page_relay_generator_auto_start_enabled">
       <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
       <source>Autostart functionality</source>
+      <oldsource>Auto start functionality</oldsource>
       <translation>ฟังก์ชั่นเริ่มต้นอัตโนมัติ</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="97"/>
       <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
       <translation>ตรวจสอบให้แน่ใจว่าเครื่องกำเนิดไฟฟ้าไม่ได้เชื่อมต่อกับอินพุต AC %1 เมื่อใช้ตัวเลือกนี้</translation>
-    </message>
-    <message id="page_generator_conditions_inverter_high_temperature">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="139"/>
-      <source>Inverter high temperature</source>
-      <translation type="unfinished">อินเวอร์เตอร์อุณหภูมิสูง</translation>
     </message>
     <message id="page_generator_conditions_tank_level">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="159"/>
@@ -6669,30 +6090,34 @@ Do you want to continue?</source>
     <message id="settings_generator_function_not_enabled">
       <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
       <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
+      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
       <translation>ไม่สามารถเปิดใช้งานฟังก์ชันการสตาร์ท/หยุดเครื่องกำเนิดไฟฟ้าได้ ให้ไปที่การตั้งค่ารีเลย์และตั้งค่าฟังก์ชันเป็น "การสตาร์ท/หยุดเครื่องกำเนิดไฟฟ้า"</translation>
     </message>
     <message id="settings_batteries_intro">
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="45"/>
       <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
       <translation>ใช้เมนูนี้เพื่อกำหนดข้อมูลแบตเตอรี่ที่แสดงเมื่อคลิกไอคอนแบตเตอรี่ในหน้าภาพรวม ตัวเลือกเดียวกันนี้จะปรากฏบน VRM Portal เช่นกัน</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
       <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
       <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
       <translation>การสแกนอย่างต่อเนื่องอาจรบกวนการทำงานของ Wi-Fi</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
       <source>CAN-bus BMS LV (500 kbit/s)</source>
+      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
       <translation>CAN-bus BMS LV (500 กิโลบิต/วินาที)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
       <source>CAN-bus BMS HV (500 kbit/s)</source>
       <translation>CAN-bus BMS HV (500 กิโลบิต/วินาที)</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
       <source>Up, but no services (500 kbit/s)</source>
       <translation>ขึ้นแต่ไม่มีบริการ (500 kbit/s)</translation>
     </message>
@@ -6705,41 +6130,6 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="127"/>
       <source>Brief page</source>
       <translation>หน้าสั้นๆ</translation>
-    </message>
-    <message id="settings_displayoff_1min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="46"/>
-      <source>1 min</source>
-      <translation type="unfinished">1 นาที</translation>
-    </message>
-    <message id="settings_displayoff_10min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="48"/>
-      <source>10 min</source>
-      <translation type="unfinished">10 นาที</translation>
-    </message>
-    <message id="settings_displayoff_30min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="50"/>
-      <source>30 min</source>
-      <translation type="unfinished">30 นาที</translation>
-    </message>
-    <message id="settings_displayoff_never">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="52"/>
-      <source>Never</source>
-      <translation type="unfinished">ไม่เคย</translation>
-    </message>
-    <message id="settings_remote_console_appearance_auto">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="112"/>
-      <source>Auto</source>
-      <translation type="unfinished">อัตโนมัติ</translation>
-    </message>
-    <message id="settings_brief_view_start_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="119"/>
-      <source>Start page</source>
-      <translation type="unfinished">หน้าแรก</translation>
-    </message>
-    <message id="settings_display_boat_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="135"/>
-      <source>Boat page</source>
-      <translation type="unfinished">หน้าเรือ</translation>
     </message>
     <message id="settings_display_minmax">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="148"/>
@@ -6794,21 +6184,6 @@ Do you want to continue?</source>
       <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
       <translation>%1 ถูกตั้งค่าเป็น %2</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_unsupported_device">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="50"/>
-      <source>Unsupported GX device</source>
-      <translation type="unfinished">อุปกรณ์ GX ที่ไม่รองรับ</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_clean">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="55"/>
-      <source>Clean</source>
-      <translation type="unfinished">ล้าง</translation>
-    </message>
-    <message id="pagesettingsgeneral_firmware">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="112"/>
-      <source>Firmware</source>
-      <translation type="unfinished">เฟิร์มแวร์</translation>
-    </message>
     <message id="pagesettingsgeneral_access_and_security">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
       <source>Access &amp; Security</source>
@@ -6842,6 +6217,7 @@ Do you want to continue?</source>
     <message id="settings_language_please_wait">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="209"/>
       <source>Please wait while the language is changed.</source>
+      <oldsource>Please wait while the language is changed</oldsource>
       <translation>กรุณารอสักครู่ในขณะที่ภาษามีการเปลี่ยนแปลง</translation>
     </message>
     <message id="settings_briefview_totals">
@@ -6858,11 +6234,6 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="71"/>
       <source>Tank is not connected.</source>
       <translation>ถังไม่ได้เชื่อมต่อ</translation>
-    </message>
-    <message id="settings_briefview_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="83"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">จอภาพแบตเตอรี่ที่ใช้งาน</translation>
     </message>
     <message id="settings_briefview_individual_batteries">
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="86"/>
@@ -6913,6 +6284,7 @@ Do you want to continue?</source>
     <message id="settings_dvcc_charge_current_limits">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="30"/>
       <source>Charge current limits</source>
+      <oldsource>Charge Current limits</oldsource>
       <translation>ชาร์จขีดจำกัดปัจจุบัน</translation>
     </message>
     <message id="settings_firmware_official_release">
@@ -6992,11 +6364,6 @@ Do you want to continue?</source>
       <source>No password and the network communication is not encrypted</source>
       <translation>ไม่มีรหัสผ่านและการสื่อสารเครือข่ายไม่ได้เข้ารหัส</translation>
     </message>
-    <message id="settings_logout_now">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
-      <source>Log out now</source>
-      <translation type="unfinished">ออกจากระบบตอนนี้</translation>
-    </message>
     <message id="settings_security_profile_password_incorrect_length">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="28"/>
       <source>Password needs to be at least 8 characters long</source>
@@ -7047,25 +6414,10 @@ Do you want to continue?</source>
       <source>Page will automatically reload in 5 seconds</source>
       <translation>หน้าจะโหลดซ้ำอัตโนมัติภายใน 5 วินาที</translation>
     </message>
-    <message id="settings_security_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="159"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">รหัสผ่านต้องมีความยาวอย่างน้อย 8 ตัวอักษร</translation>
-    </message>
     <message id="settings_root_password">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="269"/>
       <source>Root password</source>
       <translation>รหัสผ่านรูท</translation>
-    </message>
-    <message id="settings_root_enter_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="272"/>
-      <source>Enter password</source>
-      <translation type="unfinished">ใส่รหัสผ่าน</translation>
-    </message>
-    <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="277"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">รหัสผ่านต้องมีความยาวอย่างน้อย 8 ตัวอักษร</translation>
     </message>
     <message id="settings_root_password_changed_to">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="283"/>
@@ -7081,6 +6433,11 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="321"/>
       <source>Logout</source>
       <translation>ออกจากระบบ</translation>
+    </message>
+    <message id="settings_logout_now">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
+      <source>Log out now</source>
+      <translation>ออกจากระบบตอนนี้</translation>
     </message>
     <message id="settings_logout_dialog_title">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="335"/>
@@ -7140,11 +6497,13 @@ Do you want to continue?</source>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="141"/>
       <source>Alarm when generator is not in autostart mode</source>
+      <oldsource>Alarm when generator is not in auto start mode</oldsource>
       <translation>แจ้งเตือนเมื่อเครื่องกำเนิดไฟฟ้าไม่อยู่ในโหมดสตาร์ทอัตโนมัติ</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="147"/>
       <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
       <translation>สัญญาณเตือนจะถูกกระตุ้นเมื่อฟังก์ชันสตาร์ทอัตโนมัติถูกปิดใช้งานเป็นเวลานานกว่า 10 นาที</translation>
     </message>
     <message id="settings_units_amps_exceptions">
@@ -7160,6 +6519,11 @@ Do you want to continue?</source>
     <message id="settings_ess_use_this_option_for_peak_shaving">
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
       <source>Use this option for peak shaving.</source>
+      <oldsource>Use this option for peak shaving.
+
+The peak shaving threshold is set using the AC input current limit setting.
+
+See documentation for further information.</oldsource>
       <translation>ใช้ตัวเลือกนี้เพื่อการโกนสูงสุด</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
@@ -7203,17 +6567,17 @@ Do you want to continue?</source>
       <translation>กระแสส่งออกระบบสูงสุด (ต่อเฟส)</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="71"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="73"/>
       <source>Self-consumption from battery</source>
       <translation>การบริโภคเองจากแบตเตอรี่</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="76"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
       <source>All system loads</source>
       <translation>โหลดระบบทั้งหมด</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="80"/>
       <source>Only critical loads</source>
       <translation>โหลดวิกฤติเท่านั้น</translation>
     </message>
@@ -7271,26 +6635,6 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="194"/>
       <source>Server Applications</source>
       <translation>แอปพลิเคชันเซิร์ฟเวอร์</translation>
-    </message>
-    <message id="pagesettingsintegrations_venus_os_enable_large_features">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
-      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_large_victron_community">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="274"/>
-      <source>Victron Community</source>
-      <translation type="unfinished">ชุมชนวิคตรอน</translation>
-    </message>
-    <message id="pagesettingsintegrations_ui_plugins">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
-      <source>UI Plugins</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
-      <source>Integrates with the device list</source>
-      <translation type="unfinished"/>
     </message>
     <message id="pagesettingssupportstate_modbus_tcp_server">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="453"/>
@@ -7393,25 +6737,10 @@ Do you want to continue?</source>
       <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
       <translation>การสลับเวอร์ชันเฟิร์มแวร์ไม่สามารถทำได้หากไม่ได้เลือก "โปรไฟล์ความปลอดภัยของเครือข่าย" ใน "การตั้งค่า/ทั่วไป"</translation>
     </message>
-    <message id="pagesettingsconnectivity_ethernet">
-      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
-      <source>Ethernet</source>
-      <translation type="unfinished">อีเธอร์เน็ต</translation>
-    </message>
     <message id="pagesettingsconnectivity_mobile_network">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="53"/>
       <source>Mobile Network</source>
       <translation>เครือข่ายมือถือ</translation>
-    </message>
-    <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Boat</source>
-      <translation type="unfinished">เรือ</translation>
-    </message>
-    <message id="settings_system_name_auto">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="32"/>
-      <source>Automatic</source>
-      <translation type="unfinished">อัตโนมัติ</translation>
     </message>
     <message id="pagesettingssystem_ac_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
@@ -7442,11 +6771,6 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="89"/>
       <source>Distributed Voltage and Current Control (DVCC)</source>
       <translation>การควบคุมแรงดันและกระแสไฟฟ้าแบบกระจาย (DVCC)</translation>
-    </message>
-    <message id="settings_system_grid">
-      <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="18"/>
-      <source>Grid</source>
-      <translation type="unfinished">กริด</translation>
     </message>
     <message id="settings_system_ac_position">
       <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="58"/>
@@ -7486,16 +6810,19 @@ Do you want to continue?</source>
     <message id="settings_system_has_dc_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="97"/>
       <source>Display DC Loads</source>
+      <oldsource>Has DC system</oldsource>
       <translation>แสดงโหลด DC</translation>
     </message>
     <message id="settings_system_battery_measurements">
       <location filename="../../pages/settings/PageSettingsBatteries.qml" line="65"/>
       <source>Battery measurements</source>
+      <oldsource>Battery Measurements</oldsource>
       <translation>การวัดแบตเตอรี่</translation>
     </message>
     <message id="settings_system_system_status">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
       <source>System status</source>
+      <oldsource>System Status</oldsource>
       <translation>สถานะของระบบ</translation>
     </message>
     <message id="settings_tcpip_wired">
@@ -7506,11 +6833,13 @@ Do you want to continue?</source>
     <message id="settings_vecan_device_instance">
       <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
       <source>VE.Can Device Instance</source>
+      <oldsource>Device Instance</oldsource>
       <translation>อินสแตนซ์อุปกรณ์ VE.Can</translation>
     </message>
     <message id="settings_vecan_device_number">
       <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="32"/>
       <source>VE.Can Instance# %1</source>
+      <oldsource>Device# %1</oldsource>
       <translation>VE.Can อินสแตนซ์# %1</translation>
     </message>
     <message id="settings_tz_antarctica">
@@ -7541,6 +6870,7 @@ Do you want to continue?</source>
     <message id="settings_vrm">
       <location filename="../../pages/SettingsPage.qml" line="59"/>
       <source>VRM</source>
+      <extracomment>Forced by %2 to dark</extracomment>
       <translation>วีอาร์เอ็ม</translation>
     </message>
     <message id="settings_remote_monitoring_portal">
@@ -7548,20 +6878,10 @@ Do you want to continue?</source>
       <source>Remote monitoring portal</source>
       <translation>พอร์ทัลการตรวจสอบระยะไกล</translation>
     </message>
-    <message id="settings_advanced">
-      <location filename="../../pages/SettingsPage.qml" line="68"/>
-      <source>Advanced</source>
-      <translation type="unfinished">ขั้นสูง</translation>
-    </message>
-    <message id="settings_integrations">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
+    <message id="pagesettingssupportstate_integrations">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
       <source>Integrations</source>
       <translation>การบูรณาการ</translation>
-    </message>
-    <message id="settings_relays_sensors_tanks">
-      <location filename="../../pages/SettingsPage.qml" line="75"/>
-      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
-      <translation type="unfinished">รีเลย์, เซ็นเซอร์, ถัง, อินเวอร์เตอร์ PV, Modbus, MQTT…</translation>
     </message>
     <message id="settings_acdcsystem_ess_dvcc_battery">
       <location filename="../../pages/SettingsPage.qml" line="84"/>
@@ -7581,11 +6901,13 @@ Do you want to continue?</source>
     <message id="settings_system_setup">
       <location filename="../../pages/SettingsPage.qml" line="82"/>
       <source>System Setup</source>
+      <oldsource>System setup</oldsource>
       <translation>ติดตั้งระบบ</translation>
     </message>
     <message id="settings_vrm_device_instances">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
       <source>VRM device instances</source>
+      <oldsource>VRM Device Instances</oldsource>
       <translation>อินสแตนซ์อุปกรณ์ VRM</translation>
     </message>
     <message id="solarcharger_not_supported">
@@ -7603,28 +6925,10 @@ Do you want to continue?</source>
       <source>The firmware version in the MPPT Solar Charger must be v1.09 or later. Contact Victron Service for update instructions and files.</source>
       <translation>เฟิร์มแวร์ใน MPPT Solar Charger ต้องเป็นเวอร์ชัน 1.09 ขึ้นไป ติดต่อ Victron Service เพื่อรับคำแนะนำและไฟล์สำหรับการอัปเดต</translation>
     </message>
-    <message id="solarcharger_pv">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="102"/>
-      <source>PV</source>
-      <extracomment>PV power for solar charger</extracomment>
-      <translation type="unfinished">PV</translation>
-    </message>
     <message id="solarcharger_total_power">
       <location filename="../../pages/solar/PageSolarCharger.qml" line="127"/>
       <source>Total PV power</source>
       <translation>พลัง PV ทั้งหมด</translation>
-    </message>
-    <message id="solarcharger_total_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="211"/>
-      <source>Total yield</source>
-      <extracomment>Solar charger total yield</extracomment>
-      <translation type="unfinished">ผลตอบแทนรวม</translation>
-    </message>
-    <message id="solarcharger_system_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="220"/>
-      <source>System yield</source>
-      <extracomment>Solar charger system yield</extracomment>
-      <translation type="unfinished">ผลตอบแทนของระบบ</translation>
     </message>
     <message id="settings_multirs_total_yield">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="63"/>
@@ -7660,16 +6964,19 @@ Do you want to continue?</source>
     <message id="vebus_device_update_firmware">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="133"/>
       <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
       <translation>คุณสมบัตินี้ต้องใช้เฟิร์มแวร์เวอร์ชัน 400 ขึ้นไป ติดต่อผู้ติดตั้งเพื่ออัปเดต Multi/Quattro ของคุณ</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="139"/>
       <source>Charger not ready, equalization cannot be started</source>
+      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
       <translation>ที่ชาร์จไม่พร้อม ไม่สามารถเริ่มการปรับสมดุลได้</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="143"/>
       <source>Equalization cannot be triggered during bulk charge state</source>
+      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
       <translation>ไม่สามารถทริกเกอร์การปรับสมดุลระหว่างสถานะการชาร์จจำนวนมาก</translation>
     </message>
     <message id="vebus_device_restart_vebus_system_restart_confirmation_description">
@@ -7692,78 +6999,20 @@ Do you want to continue?</source>
       <source>Auto-started • %1</source>
       <translation>เริ่มอัตโนมัติ • %1</translation>
     </message>
-    <message id="common_words_battery">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery</source>
-      <translation type="unfinished">แบตเตอรี่</translation>
-    </message>
-    <message id="common_words_boat_page">
-      <location filename="../../components/CommonWords.qml" line="111"/>
-      <source>Boat</source>
-      <extracomment>The 'Boat' page</extracomment>
-      <translation type="unfinished">เรือ</translation>
-    </message>
-    <message id="common_words_brief_page">
-      <location filename="../../components/CommonWords.qml" line="115"/>
-      <source>Brief</source>
-      <extracomment>The 'Brief' page</extracomment>
-      <translation type="unfinished">รวบรัด</translation>
-    </message>
-    <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation type="unfinished">ปิด</translation>
-    </message>
-    <message id="common_words_color">
-      <location filename="../../components/CommonWords.qml" line="136"/>
-      <source>Color</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_connected">
-      <location filename="../../components/CommonWords.qml" line="139"/>
-      <source>Connected</source>
-      <translation type="unfinished">เชื่อมต่อแล้ว</translation>
-    </message>
     <message id="common_words_daily_history">
       <location filename="../../components/CommonWords.qml" line="152"/>
       <source>Daily history</source>
       <translation>ประวัติประจำวัน</translation>
-    </message>
-    <message id="common_words_disabled">
-      <location filename="../../components/CommonWords.qml" line="169"/>
-      <source>Disabled</source>
-      <translation type="unfinished">พิการ</translation>
-    </message>
-    <message id="common_words_disconnected">
-      <location filename="../../components/CommonWords.qml" line="175"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">ตัดการเชื่อมต่อ</translation>
-    </message>
-    <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="191"/>
-      <source>Error</source>
-      <translation type="unfinished">ข้อผิดพลาด</translation>
     </message>
     <message id="common_words_error_not_a_number">
       <location filename="../../components/CommonWords.qml" line="200"/>
       <source>'%1' is not a number.</source>
       <translation>'%1' ไม่ใช่ตัวเลข</translation>
     </message>
-    <message id="common_words_generator">
-      <location filename="../../components/CommonWords.qml" line="217"/>
-      <source>Generator</source>
-      <translation type="unfinished">เครื่องกำเนิดไฟฟ้า</translation>
-    </message>
     <message id="common_words_input_current_limit">
       <location filename="../../components/CommonWords.qml" line="261"/>
       <source>Input current limit</source>
       <translation>อินพุตขีดจำกัดปัจจุบัน</translation>
-    </message>
-    <message id="common_words_inverter_charger">
-      <location filename="../../components/CommonWords.qml" line="264"/>
-      <source>Inverter / Charger</source>
-      <translation type="unfinished">อินเวอร์เตอร์/เครื่องชาร์จ</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
       <location filename="../../components/CommonWords.qml" line="268"/>
@@ -7776,12 +7025,6 @@ Do you want to continue?</source>
       <source>Manual stop</source>
       <translation>หยุดด้วยตนเอง</translation>
     </message>
-    <message id="common_words_max">
-      <location filename="../../components/CommonWords.qml" line="315"/>
-      <source>Max</source>
-      <extracomment>Short for Maximum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_maximum_current">
       <location filename="../../components/CommonWords.qml" line="318"/>
       <source>Maximum current</source>
@@ -7792,62 +7035,10 @@ Do you want to continue?</source>
       <source>Maximum power</source>
       <translation>กำลังสูงสุด</translation>
     </message>
-    <message id="common_words_min">
-      <location filename="../../components/CommonWords.qml" line="331"/>
-      <source>Min</source>
-      <extracomment>Short for Minimum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_minimum_current">
       <location filename="../../components/CommonWords.qml" line="334"/>
       <source>Minimum current</source>
       <translation>กระแสไฟฟ้าขั้นต่ำ</translation>
-    </message>
-    <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="433"/>
-      <source>No</source>
-      <translation type="unfinished">ไม่</translation>
-    </message>
-    <message id="common_words_none_option">
-      <location filename="../../components/CommonWords.qml" line="364"/>
-      <source>None</source>
-      <translation type="unfinished">ไม่มี</translation>
-    </message>
-    <message id="common_words_none_errors">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>None</source>
-      <extracomment>Indicates there are no errors</extracomment>
-      <translation type="unfinished">ไม่มี</translation>
-    </message>
-    <message id="common_words_not_available">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Not available</source>
-      <translation type="unfinished">ไม่ว่าง</translation>
-    </message>
-    <message id="common_words_off">
-      <location filename="../../components/CommonWords.qml" line="377"/>
-      <source>Off</source>
-      <translation type="unfinished">ปิด</translation>
-    </message>
-    <message id="common_words_ok">
-      <location filename="../../components/CommonWords.qml" line="383"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="41"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="45"/>
-      <source>OK</source>
-      <translation type="unfinished">ตกลง</translation>
-    </message>
-    <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="386"/>
-      <source>On</source>
-      <translation type="unfinished">เปิด</translation>
-    </message>
-    <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="393"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation type="unfinished">เปิด</translation>
     </message>
     <message id="common_words_open_circuit">
       <location filename="../../components/CommonWords.qml" line="396"/>
@@ -7859,108 +7050,17 @@ Do you want to continue?</source>
       <source>Overall history</source>
       <translation>ประวัติโดยรวม</translation>
     </message>
-    <message id="common_words_press">
-      <location filename="../../components/CommonWords.qml" line="419"/>
-      <source>Press</source>
-      <translation type="unfinished">กด</translation>
-    </message>
-    <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation type="unfinished">ทำงาน</translation>
-    </message>
-    <message id="common_words_settings">
-      <location filename="../../components/CommonWords.qml" line="467"/>
-      <source>Settings</source>
-      <translation type="unfinished">การตั้งค่า</translation>
-    </message>
-    <message id="common_words_silence_alarm">
-      <location filename="../../components/CommonWords.qml" line="476"/>
-      <source>Silence alarm</source>
-      <translation type="unfinished">ปลุกเงียบ</translation>
-    </message>
     <message id="common_words_soc">
       <location filename="../../components/CommonWords.qml" line="480"/>
       <source>SOC %1</source>
       <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
       <translation>เอสโอซี %1%</translation>
     </message>
-    <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation type="unfinished">ความเร็ว</translation>
-    </message>
-    <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="487"/>
-      <source>Standby</source>
-      <translation type="unfinished">สแตนด์บาย</translation>
-    </message>
-    <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="502"/>
-      <source>State</source>
-      <translation type="unfinished">สถานะ</translation>
-    </message>
-    <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="512"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation type="unfinished">การเริ่มต้น (%1)</translation>
-    </message>
-    <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>Stopped</source>
-      <translation type="unfinished">หยุด</translation>
-    </message>
-    <message id="common_words_total_power">
-      <location filename="../../components/CommonWords.qml" line="540"/>
-      <source>Total power</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="547"/>
-      <source>Type</source>
-      <translation type="unfinished">พิมพ์</translation>
-    </message>
-    <message id="common_words_unknown_status">
-      <location filename="../../components/CommonWords.qml" line="554"/>
-      <source>Unknown</source>
-      <extracomment>Status = "unknown"</extracomment>
-      <translation type="unfinished">ไม่รู้จัก</translation>
-    </message>
-    <message id="common_words_value_must_be_greater_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="557"/>
-      <source>Value must be greater than start value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_value_must_be_greater_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="560"/>
-      <source>Value must be greater than stop value</source>
-      <translation type="unfinished">ค่าต้องมากกว่าค่าสต็อป</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="563"/>
-      <source>Value must be lower than start value</source>
-      <translation type="unfinished">ค่าต้องต่ำกว่าค่าเริ่มต้น</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="566"/>
-      <source>Value must be lower than stop value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="581"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="431"/>
-      <source>Yes</source>
-      <translation type="unfinished">ใช่</translation>
-    </message>
     <message id="common_words_yield_today">
       <location filename="../../components/CommonWords.qml" line="592"/>
       <source>Yield Today</source>
       <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+      <oldsource>Yield today</oldsource>
       <translation>ผลผลิตวันนี้</translation>
     </message>
     <message id="common_words_format_error">
@@ -7987,10 +7087,11 @@ Do you want to continue?</source>
     <message id="settings_firmware_installed_rebooting">
       <location filename="../../components/FirmwareUpdate.qml" line="79"/>
       <source>Firmware installed, device rebooting</source>
+      <oldsource>Firmware installed, rebooting.</oldsource>
       <translation>ติดตั้งเฟิร์มแวร์แล้ว กำลังรีบูตอุปกรณ์</translation>
     </message>
-    <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/RadioButtonListPage.qml" line="121"/>
+    <message id="modaldialog_confirm">
+      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
       <source>Confirm</source>
       <extracomment>Confirm password, and verify it if possible</extracomment>
       <translation>ยืนยัน</translation>
@@ -8008,11 +7109,13 @@ Do you want to continue?</source>
     <message id="cgwacs_battery_schedule_duration">
       <location filename="../../components/listitems/ListChargeSchedule.qml" line="144"/>
       <source>Duration</source>
+      <oldsource>Duration (hh:mm)</oldsource>
       <translation>ระยะเวลา</translation>
     </message>
     <message id="settings_relay_deactivation_value">
       <location filename="../../components/TemperatureRelaySettings.qml" line="86"/>
       <source>Deactivation value</source>
+      <oldsource>Deativation value</oldsource>
       <translation>ค่าปิดการใช้งาน</translation>
     </message>
     <message id="splash_view_device_disconnected">
@@ -8060,29 +7163,6 @@ Do you want to continue?</source>
       <source>Temperature warning</source>
       <translation>การเตือนอุณหภูมิ</translation>
     </message>
-    <message id="battery_mode_idle">
-      <location filename="../../src/enums.cpp" line="26"/>
-      <source>Idle</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">ว่าง</translation>
-    </message>
-    <message id="battery_mode_charging">
-      <location filename="../../src/enums.cpp" line="30"/>
-      <source>Charging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">กำลังชาร์จ</translation>
-    </message>
-    <message id="battery_mode_discharging">
-      <location filename="../../src/enums.cpp" line="34"/>
-      <source>Discharging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">การคายประจุ</translation>
-    </message>
-    <message id="dcMeter_bilge_pump">
-      <location filename="../../src/enums.cpp" line="115"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">ปั๊มน้ำท้องเรือ</translation>
-    </message>
     <message id="switch_state_channel_fault">
       <location filename="../../src/enums.cpp" line="372"/>
       <source>Channel Fault</source>
@@ -8113,26 +7193,6 @@ Do you want to continue?</source>
       <source>Slave of %1</source>
       <translation>ทาสของ %1</translation>
     </message>
-    <message id="switchable_output_numeric_input">
-      <location filename="../../src/enums.cpp" line="418"/>
-      <source>Numeric input</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bilge_pump">
-      <location filename="../../src/enums.cpp" line="424"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">ปั๊มน้ำท้องเรือ</translation>
-    </message>
-    <message id="switchable_output_not_running">
-      <location filename="../../src/enums.cpp" line="448"/>
-      <source>Not running</source>
-      <translation type="unfinished">ไม่ได้ทำงาน</translation>
-    </message>
-    <message id="switchable_output_off">
-      <location filename="../../src/enums.cpp" line="451"/>
-      <source>Off</source>
-      <translation type="unfinished">ปิด</translation>
-    </message>
     <message id="switchable_output_powered">
       <location filename="../../src/enums.cpp" line="455"/>
       <source>Powered</source>
@@ -8161,16 +7221,19 @@ Do you want to continue?</source>
     <message id="evchargers_status_welded_contacts_error">
       <location filename="../../data/EvChargers.qml" line="76"/>
       <source>Welded contacts test error (shorted)</source>
+      <oldsource>Welded contacts error</oldsource>
       <translation>ข้อผิดพลาดในการทดสอบหน้าสัมผัสรอยเชื่อม (ลัดวงจร)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
       <location filename="../../data/EvChargers.qml" line="100"/>
       <source>Switching to 3 phase</source>
+      <oldsource>Switching to 3-phase</oldsource>
       <translation>กำลังเปลี่ยนเป็น 3 เฟส</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
       <location filename="../../data/EvChargers.qml" line="103"/>
       <source>Switching to 1 phase</source>
+      <oldsource>Switching to single phase</oldsource>
       <translation>กำลังเปลี่ยนเป็น 1 เฟส</translation>
     </message>
     <message id="evchargers_status_stop_charging">
@@ -8323,17 +7386,6 @@ If the generator is currently running due to a autostart condition, disabling au
       <source>Open link</source>
       <translation>เปิดลิงค์</translation>
     </message>
-    <message id="listlink_show_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="43"/>
-      <source>Show QR code</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="listlink_scan_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="52"/>
-      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
-      <extracomment>%1 = url text</extracomment>
-      <translation type="unfinished">สแกนรหัส QR ด้วยอุปกรณ์พกพาของคุณ&lt;br /&gt;หรือแทรกลิงก์: %1</translation>
-    </message>
     <message id="settings_services_mqtt_access">
       <location filename="../../components/listitems/ListMqttAccessSwitch.qml" line="11"/>
       <source>MQTT Access</source>
@@ -8405,12 +7457,6 @@ If the generator is currently running due to a autostart condition, disabling au
       <extracomment>The 'Brief' page, with the side panel opened</extracomment>
       <translation>กางเกงชั้นใน (แผงด้านข้างเปิด)</translation>
     </message>
-    <message id="startpage_option_overview">
-      <location filename="../../data/StartPageConfiguration.qml" line="37"/>
-      <source>Overview</source>
-      <extracomment>The 'Overview' page</extracomment>
-      <translation type="unfinished">ภาพรวม</translation>
-    </message>
     <message id="startpage_option_levels_tanks">
       <location filename="../../data/StartPageConfiguration.qml" line="43"/>
       <source>Levels (Tanks)</source>
@@ -8429,12 +7475,12 @@ If the generator is currently running due to a autostart condition, disabling au
       <translation>รายการแบตเตอรี่</translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
+      <location filename="../../pages/DialogLayer.qml" line="56"/>
       <source>GX device has been updated</source>
       <translation>อุปกรณ์ GX ได้รับการอัปเดตแล้ว</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
+      <location filename="../../pages/DialogLayer.qml" line="58"/>
       <source>Page will automatically reload in ten seconds to load the latest version.</source>
       <translation>หน้าจะโหลดซ้ำโดยอัตโนมัติในสิบวินาทีเพื่อโหลดเวอร์ชันล่าสุด</translation>
     </message>
@@ -8603,8 +7649,8 @@ Note that this menu only shows Carlo Gavazzi meters connected over RS485. For an
       <source>Unit</source>
       <translation>หน่วย</translation>
     </message>
-    <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="61"/>
+    <message id="page_settings_fronius_unitid_invalid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
       <source>%1 is not a valid unit number. Use a number between 1-247.</source>
       <translation>%1 ไม่ใช่หมายเลขหน่วยที่ถูกต้อง ให้ใช้ตัวเลขระหว่าง 1-247</translation>
     </message>
@@ -8719,11 +7765,6 @@ Note that this menu only shows Carlo Gavazzi meters connected over RS485. For an
       <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="66"/>
       <source>Controller Temperature</source>
       <translation>อุณหภูมิตัวควบคุม</translation>
-    </message>
-    <message id="devicelist_motordrive_motordirectioninverted">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
-      <source>Motor Direction Inverted</source>
-      <translation type="unfinished"/>
     </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
@@ -8915,11 +7956,6 @@ With streamlined navigation and a fresh look, everything you love is now even ea
     <message id="welcome_done">
       <location filename="../../pages/welcome/WelcomeView.qml" line="136"/>
       <source>Done</source>
-      <translation type="unfinished">เสร็จแล้ว</translation>
-    </message>
-    <message id="mk2vsc_state_done">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="20"/>
-      <source>Done</source>
       <translation>เสร็จแล้ว</translation>
     </message>
     <message id="welcome_next">
@@ -8977,6 +8013,7 @@ The GX device can only control one connected genset and takes the one with the l
     <message id="settings_tz_etc">
       <location filename="../../pages/settings/PageTzInfo.qml" line="280"/>
       <source>Other</source>
+      <oldsource>Etc</oldsource>
       <translation>อื่น</translation>
     </message>
     <message id="ac-in-modeldefault_energy_reverse_x">
@@ -8994,6 +8031,11 @@ The GX device can only control one connected genset and takes the one with the l
       <location filename="../../src/enums.cpp" line="438"/>
       <source>Unsupported type: %1</source>
       <translation>ประเภทที่ไม่รองรับ: %1</translation>
+    </message>
+    <message id="common_words_press">
+      <location filename="../../components/CommonWords.qml" line="419"/>
+      <source>Press</source>
+      <translation>กด</translation>
     </message>
     <message id="output_aux_battery_service_changed_dcdc">
       <location filename="../../components/listitems/ListOutputBatteryRadioButtonGroup.qml" line="27"/>
@@ -9134,13 +8176,6 @@ The GX device can only control one connected genset and takes the one with the l
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="38"/>
       <source>Resetting VE.Bus products</source>
       <translation>การรีเซ็ตผลิตภัณฑ์ VE.Bus</translation>
-    </message>
-    <message id="Unknown">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
-      <source>Unknown</source>
-      <translation type="unfinished">ไม่รู้จัก</translation>
     </message>
     <message id="mk2vsc_error_mk2_mk3_comm">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="47"/>
@@ -9446,11 +8481,6 @@ The GX device can only control one connected genset and takes the one with the l
       <source>Changing the GX Password</source>
       <translation>การเปลี่ยนรหัสผ่าน GX</translation>
     </message>
-    <message id="modaldialog_confirm">
-      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
-      <source>Confirm</source>
-      <translation type="unfinished">ยืนยัน</translation>
-    </message>
     <message id="settings_security_profile_change_password_description">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="83"/>
       <source>Please enter a new GX password:</source>
@@ -9543,21 +8573,6 @@ The GX device can only control one connected genset and takes the one with the l
       <source>Modifications installed</source>
       <translation>การปรับปรุงที่ติดตั้ง</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_modbus">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="28"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">เซิร์ฟเวอร์ Modbus TCP</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_signalk">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="32"/>
-      <source>Signal K</source>
-      <translation type="unfinished">สัญญาณ K</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_nodered">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="36"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">โหนด-RED</translation>
-    </message>
     <message id="pagesettingsgeneral_modificationchecks_running_integrations">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="43"/>
       <source>%1 running integrations</source>
@@ -9633,16 +8648,6 @@ The GX device can only control one connected genset and takes the one with the l
       <source>Installed and enabled, disables at next boot</source>
       <translation>ติดตั้งและเปิดใช้งาน จะปิดใช้งานในการบูตครั้งถัดไป</translation>
     </message>
-    <message id="pagesettingssupportstate_firmware_checking">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
-      <source>Checking...</source>
-      <translation type="unfinished">กำลังตรวจสอบ...</translation>
-    </message>
-    <message id="pagesettingssupportstate_firmware_unknown">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="166"/>
-      <source>Unknown</source>
-      <translation type="unfinished">ไม่รู้จัก</translation>
-    </message>
     <message id="pagesettingssupportstate_support_status">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="228"/>
       <source>Support status</source>
@@ -9664,11 +8669,6 @@ The GX device can only control one connected genset and takes the one with the l
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="288"/>
       <source>Press 'OK' to disable custom startup scripts and reboot</source>
       <translation>กด 'OK' เพื่อปิดใช้งานสคริปต์เริ่มต้นระบบแบบกำหนดเองและรีบูต</translation>
-    </message>
-    <message id="pagesettingssupportstate_re_enable_custom_startup_scripts">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="309"/>
-      <source>Re-enable custom startup scripts</source>
-      <translation type="unfinished">เปิดใช้งานสคริปต์เริ่มต้นระบบแบบกำหนดเองอีกครั้ง</translation>
     </message>
     <message id="pagesettingssupportstate_reenable_and_reboot_now">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="322"/>
@@ -9695,11 +8695,6 @@ The GX device can only control one connected genset and takes the one with the l
       <source>Disable also custom startup scripts?</source>
       <translation>ปิดใช้งานสคริปต์เริ่มต้นระบบแบบกำหนดเองด้วยหรือไม่</translation>
     </message>
-    <message id="pagesettingssupportstate_integrations">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
-      <source>Integrations</source>
-      <translation type="unfinished">การบูรณาการ</translation>
-    </message>
     <message id="pagesettingssupportstate_orange_items_description">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="494"/>
       <source>Items colored orange are supported and provided by Victron Energy, but using them incorrectly can affect system stability. In case of troubleshooting, disable those first.</source>
@@ -9711,7 +8706,7 @@ The GX device can only control one connected genset and takes the one with the l
       <translation>เชื่อมต่อดองเกิล USB Bluetooth ที่ใช้งานร่วมกันได้เพื่อเปิดใช้งานการเชื่อมต่อ Bluetooth</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="140"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="142"/>
       <source>BatteryLife state</source>
       <translation>สถานะ BatteryLife</translation>
     </message>
@@ -9719,23 +8714,6 @@ The GX device can only control one connected genset and takes the one with the l
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="33"/>
       <source>Device Integrations</source>
       <translation>การรวมอุปกรณ์</translation>
-    </message>
-    <message id="pagesettingsintegrations_modbus_tcp_server">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="201"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">เซิร์ฟเวอร์ Modbus TCP</translation>
-    </message>
-    <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="226"/>
-      <location filename="../../pages/settings/PageSettingsSignalK.qml" line="18"/>
-      <source>Signal K</source>
-      <translation type="unfinished">สัญญาณ K</translation>
-    </message>
-    <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="241"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">โหนด-RED</translation>
     </message>
     <message id="settings_venusos_large_documentation">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="267"/>
@@ -9745,6 +8723,7 @@ The GX device can only control one connected genset and takes the one with the l
     <message id="settings_modbus_enable_modbus_tcp">
       <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
       <source>Enable Modbus TCP Server</source>
+      <oldsource>Enable Modbus/TCP</oldsource>
       <translation>เปิดใช้งาน Modbus TCP Server</translation>
     </message>
     <message id="pagesettingsconnectivity_bluetooth_for_victronconnect_app">
@@ -9838,11 +8817,13 @@ The GX device can only control one connected genset and takes the one with the l
     <message id="settings_gps_format_kmh">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="93"/>
       <source>Kilometres per hour</source>
+      <oldsource>Kilometers per hour</oldsource>
       <translation>กิโลเมตรต่อชั่วโมง</translation>
     </message>
     <message id="settings_gps_format_ms">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="95"/>
       <source>Metres per second</source>
+      <oldsource>Meters per second</oldsource>
       <translation>เมตรต่อวินาที</translation>
     </message>
     <message id="components_volumeunit_cubic_metres">
@@ -9870,8 +8851,8 @@ The GX device can only control one connected genset and takes the one with the l
       <source>The Relay can now be found in the devices list</source>
       <translation>ขณะนี้สามารถพบ Relay ได้ในรายการอุปกรณ์</translation>
     </message>
-    <message id="common_words_gx_device_relays">
-      <location filename="../../components/CommonWords.qml" line="223"/>
+    <message id="gx_device_relays">
+      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
       <source>GX device relays</source>
       <translation>รีเลย์ของอุปกรณ์ GX</translation>
     </message>
@@ -9925,12 +8906,6 @@ The GX device can only control one connected genset and takes the one with the l
       <extracomment>Forced by app to %1</extracomment>
       <translation>อัตโนมัติ</translation>
     </message>
-    <message id="settings_remote_console_forced_by_vrm">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="94"/>
-      <source>VRM</source>
-      <extracomment>Forced by %2 to dark</extracomment>
-      <translation type="unfinished">วีอาร์เอ็ม</translation>
-    </message>
     <message id="settings_remote_console_forced_by_app">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="97"/>
       <source>app</source>
@@ -9980,6 +8955,7 @@ The GX device can only control one connected genset and takes the one with the l
     <message id="settings_large_access_signal_k">
       <location filename="../../pages/settings/PageSettingsSignalK.qml" line="24"/>
       <source>Access Signal K</source>
+      <oldsource>Access Signal K (local network)</oldsource>
       <translation>เข้าถึง Signal K</translation>
     </message>
     <message id="pagesettingsintegrations_shelly_devices">
@@ -9990,6 +8966,7 @@ The GX device can only control one connected genset and takes the one with the l
     <message id="settings_large_access_node_red">
       <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
       <source>Access Node-RED</source>
+      <oldsource>Access Node-RED (local network)</oldsource>
       <translation>เข้าถึง Node-RED</translation>
     </message>
     <message id="settings_wifi_access_point_password">
@@ -10057,57 +9034,6 @@ The GX device can only control one connected genset and takes the one with the l
       <source>Wind charger</source>
       <translation>เครื่องชาร์จพลังงานลม</translation>
     </message>
-    <message id="digitalinputs_type_disabled">
-      <location filename="../../src/enums.cpp" line="192"/>
-      <source>Disabled</source>
-      <translation type="unfinished">พิการ</translation>
-    </message>
-    <message id="digitalinputs_state_off">
-      <location filename="../../src/enums.cpp" line="242"/>
-      <source>Off</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">ปิด</translation>
-    </message>
-    <message id="digitalinputs_state_on">
-      <location filename="../../src/enums.cpp" line="246"/>
-      <source>On</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">เปิด</translation>
-    </message>
-    <message id="digitalinputs_state_ok">
-      <location filename="../../src/enums.cpp" line="266"/>
-      <source>OK</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">ตกลง</translation>
-    </message>
-    <message id="digitalinputs_state_alarm">
-      <location filename="../../src/enums.cpp" line="270"/>
-      <source>Alarm</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">เตือน</translation>
-    </message>
-    <message id="digitalinputs_state_running">
-      <location filename="../../src/enums.cpp" line="274"/>
-      <source>Running</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">ทำงาน</translation>
-    </message>
-    <message id="pvinverter_statusCode_running">
-      <location filename="../../src/enums.cpp" line="300"/>
-      <source>Running</source>
-      <extracomment>PV inverter status code</extracomment>
-      <translation type="unfinished">ทำงาน</translation>
-    </message>
-    <message id="solarchargers_state_external control">
-      <location filename="../../src/enums.cpp" line="352"/>
-      <source>External control</source>
-      <translation type="unfinished">การควบคุมภายนอก</translation>
-    </message>
-    <message id="switch_state_over_temperature">
-      <location filename="../../src/enums.cpp" line="366"/>
-      <source>Over temperature</source>
-      <translation type="unfinished">อุณหภูมิสูง</translation>
-    </message>
     <message id="switchable_output_temperature_setpoint">
       <location filename="../../src/enums.cpp" line="398"/>
       <source>Temperature setpoint</source>
@@ -10117,11 +9043,6 @@ The GX device can only control one connected genset and takes the one with the l
       <location filename="../../src/enums.cpp" line="401"/>
       <source>Stepped switch</source>
       <translation>สวิตช์แบบขั้น</translation>
-    </message>
-    <message id="switchable_output_slave">
-      <location filename="../../src/enums.cpp" line="408"/>
-      <source>Slave</source>
-      <translation type="unfinished">ตัวรอง</translation>
     </message>
     <message id="switchable_output_dropdown">
       <location filename="../../src/enums.cpp" line="412"/>
@@ -10133,122 +9054,10 @@ The GX device can only control one connected genset and takes the one with the l
       <source>Basic slider</source>
       <translation>แถบเลื่อนพื้นฐาน</translation>
     </message>
-    <message id="switchable_output_rgb_color_wheel">
-      <location filename="../../src/enums.cpp" line="427"/>
-      <source>RGB color wheel</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_cct_color_wheel">
-      <location filename="../../src/enums.cpp" line="431"/>
-      <source>CCT color wheel</source>
-      <extracomment>Correlated Color Temperature color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_rgbw_color_wheel">
-      <location filename="../../src/enums.cpp" line="435"/>
-      <source>RGB + W color wheel</source>
-      <extracomment>RGB + white color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bypassed">
-      <location filename="../../src/enums.cpp" line="484"/>
-      <source>Bypassed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="tank_type_fuel">
-      <location filename="../../src/enums.cpp" line="495"/>
-      <source>Fuel</source>
-      <translation type="unfinished">เชื้อเพลิง</translation>
-    </message>
-    <message id="tank_type_fresh_water">
-      <location filename="../../src/enums.cpp" line="498"/>
-      <source>Fresh water</source>
-      <translation type="unfinished">น้ำจืด</translation>
-    </message>
-    <message id="tank_type_waste_water">
-      <location filename="../../src/enums.cpp" line="501"/>
-      <source>Waste water</source>
-      <translation type="unfinished">น้ำเสีย</translation>
-    </message>
-    <message id="tank_type_live_well">
-      <location filename="../../src/enums.cpp" line="504"/>
-      <source>Live well</source>
-      <translation type="unfinished">อยู่ดีมีสุข</translation>
-    </message>
-    <message id="tank_type_oil">
-      <location filename="../../src/enums.cpp" line="507"/>
-      <source>Oil</source>
-      <translation type="unfinished">น้ำมัน</translation>
-    </message>
-    <message id="tank_type_black_water">
-      <location filename="../../src/enums.cpp" line="510"/>
-      <source>Black water</source>
-      <translation type="unfinished">น้ำดำ</translation>
-    </message>
-    <message id="tank_type_gasoline">
-      <location filename="../../src/enums.cpp" line="513"/>
-      <source>Gasoline</source>
-      <translation type="unfinished">น้ำมันเบนซิน</translation>
-    </message>
-    <message id="tank_type_diesel">
-      <location filename="../../src/enums.cpp" line="516"/>
-      <source>Diesel</source>
-      <translation type="unfinished">ดีเซล</translation>
-    </message>
-    <message id="tank_type_lpg">
-      <location filename="../../src/enums.cpp" line="519"/>
-      <source>LPG</source>
-      <translation type="unfinished">แอลพีจี</translation>
-    </message>
-    <message id="tank_type_lng">
-      <location filename="../../src/enums.cpp" line="522"/>
-      <source>LNG</source>
-      <translation type="unfinished">LNG</translation>
-    </message>
-    <message id="tank_type_hydraulic_oil">
-      <location filename="../../src/enums.cpp" line="525"/>
-      <source>Hydraulic oil</source>
-      <translation type="unfinished">น้ำมันไฮดรอลิก</translation>
-    </message>
-    <message id="tank_type_raw_water">
-      <location filename="../../src/enums.cpp" line="528"/>
-      <source>Raw water</source>
-      <translation type="unfinished">น้ำดิบ</translation>
-    </message>
-    <message id="microgrid_mode_hybrid_droop">
-      <location filename="../../src/enums.cpp" line="539"/>
-      <source>Hybrid droop</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_following">
-      <location filename="../../src/enums.cpp" line="542"/>
-      <source>Grid-following</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_forming">
-      <location filename="../../src/enums.cpp" line="545"/>
-      <source>Grid-forming</source>
-      <translation type="unfinished"/>
-    </message>
     <message id="switchable_output_three_state_switch">
       <location filename="../../src/enums.cpp" line="421"/>
       <source>Three-state switch</source>
       <translation>สวิตช์สามสถานะ</translation>
-    </message>
-    <message id="switchable_output_fault">
-      <location filename="../../src/enums.cpp" line="464"/>
-      <source>Fault</source>
-      <translation type="unfinished">ความผิดพลาด</translation>
-    </message>
-    <message id="switchable_output_running">
-      <location filename="../../src/enums.cpp" line="468"/>
-      <source>Running</source>
-      <translation type="unfinished">ทำงาน</translation>
-    </message>
-    <message id="switchable_output_trip_low_voltage">
-      <location filename="../../src/enums.cpp" line="481"/>
-      <source>Trip low voltage</source>
-      <translation type="unfinished">พิการ</translation>
     </message>
     <message id="settings_modbus_tcp_unit_id_note">
       <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="41"/>
@@ -10270,281 +9079,1152 @@ The GX device can only control one connected genset and takes the one with the l
       <source>Press to refresh</source>
       <translation>กดเพื่อรีเฟรช</translation>
     </message>
-    <message id="temperature_type_unknown">
-      <location filename="../../data/EnvironmentInputs.qml" line="65"/>
-      <source>Unknown</source>
-      <translation type="unfinished">ไม่รู้จัก</translation>
-    </message>
-    <message id="brief_solar_yield">
-      <location filename="../../pages/BriefSidePanel.qml" line="24"/>
-      <source>Solar yield</source>
-      <translation type="unfinished">ผลผลิตพลังงานแสงอาทิตย์</translation>
-    </message>
-    <message id="brief_dc_input">
-      <location filename="../../pages/BriefSidePanel.qml" line="214"/>
-      <source>DC input</source>
-      <translation type="unfinished">อินพุตกระแสตรง</translation>
-    </message>
-    <message id="brief_ac_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="257"/>
-      <source>AC Loads</source>
-      <translation type="unfinished">โหลด AC</translation>
-    </message>
-    <message id="brief_dc_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="284"/>
-      <source>DC Loads</source>
-      <translation type="unfinished">โหลดไฟฟ้ากระแสตรง</translation>
-    </message>
-    <message id="nav_overview">
-      <location filename="../../pages/OverviewPage.qml" line="450"/>
-      <source>Overview</source>
-      <translation type="unfinished">ภาพรวม</translation>
-    </message>
-    <message id="settings_state">
-      <location filename="../../pages/settings/PageCanbusStatus.qml" line="116"/>
-      <source>State</source>
-      <translation type="unfinished">สถานะ</translation>
-    </message>
-    <message id="inverter_pv">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="56"/>
-      <source>PV</source>
-      <translation type="unfinished">PV</translation>
-    </message>
-    <message id="inverter_total_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="76"/>
-      <source>Total yield</source>
-      <translation type="unfinished">ผลตอบแทนรวม</translation>
-    </message>
-    <message id="inverter_system_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="84"/>
-      <source>System yield</source>
-      <translation type="unfinished">ผลตอบแทนของระบบ</translation>
-    </message>
-    <message id="charger_total_pv_power">
-      <location filename="../../pages/solar/SolarDevicePage.qml" line="61"/>
-      <source>Total PV Power</source>
-      <translation type="unfinished">พลัง PV ทั้งหมด</translation>
-    </message>
-    <message id="vebus_device_alarm_only">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
-      <source>Alarm only</source>
-      <translation type="unfinished">การแจ้งเตือนเท่านั้น</translation>
-    </message>
-    <message id="vebus_device_alarms_and_warnings">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
-      <source>Alarms &amp; warnings</source>
-      <translation type="unfinished">การแจ้งเตือนและคำเตือน</translation>
-    </message>
-    <message id="vebus_device_alarm_group_warning">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
-      <source>Warning</source>
-      <translation type="unfinished">คำเตือน</translation>
-    </message>
-    <message id="load_delegate_status">
-      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
-      <source>Status: %1</source>
-      <translation type="unfinished"/>
+    <message id="common_words_total_power">
+      <location filename="../../components/CommonWords.qml" line="540"/>
+      <source>Total power</source>
+      <translation>กำลังไฟรวม</translation>
     </message>
     <message id="venus_os_gui">
       <location filename="../../Main.qml" line="17"/>
       <source>Venus OS GUI</source>
       <extracomment>Application title</extracomment>
-      <translation type="unfinished"/>
       <extra-Context>only shown on desktop systems</extra-Context>
+      <translation>Venus OS GUI</translation>
+    </message>
+    <message id="load_delegate_status">
+      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
+      <source>Status: %1</source>
+      <translation>สถานะ: %1</translation>
+    </message>
+    <message id="settings_relay_polarity_relay1">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
+      <source>Polarity (Relay 1)</source>
+      <translation>ขั้ว (รีเลย์ 1)</translation>
+    </message>
+    <message id="settings_relay_polarity">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
+      <source>Polarity</source>
+      <translation>ขั้ว</translation>
+    </message>
+    <message id="settings_relay_polarity_relay2">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
+      <source>Polarity (Relay 2)</source>
+      <translation>ขั้ว (รีเลย์ 2)</translation>
+    </message>
+    <message id="page_settings_wifi_invalid_password">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
+      <source>Password length must be either 0 or between 10 and 63 characters long</source>
+      <translation>ความยาวรหัสผ่านต้องเป็น 0 หรือระหว่าง 10 ถึง 63 ตัวอักษร</translation>
+    </message>
+    <message id="page_settings_wifi_password_updated">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
+      <source>Password updated</source>
+      <translation>อัปเดตรหัสผ่านแล้ว</translation>
+    </message>
+    <message id="common_words_max">
+      <location filename="../../components/CommonWords.qml" line="315"/>
+      <source>Max</source>
+      <extracomment>Short for Maximum</extracomment>
+      <translation>สูงสุด</translation>
+    </message>
+    <message id="common_words_min">
+      <location filename="../../components/CommonWords.qml" line="331"/>
+      <source>Min</source>
+      <extracomment>Short for Minimum</extracomment>
+      <translation>ต่ำสุด</translation>
+    </message>
+    <message id="settings_ess_deprecated">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="321"/>
+      <source>Deprecated settings</source>
+      <translation>การตั้งค่าที่เลิกใช้แล้ว</translation>
+    </message>
+    <message id="settings_ess_max_charge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="328"/>
+      <source>Battery charge limit (% of CCL)</source>
+      <translation>ขีดจำกัดการชาร์จแบตเตอรี่ (% ของ CCL)</translation>
+    </message>
+    <message id="settings_ess_max_discharge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="339"/>
+      <source>Battery discharge limit (% of DCL)</source>
+      <translation>ขีดจำกัดการคายประจุแบตเตอรี่ (% ของ DCL)</translation>
+    </message>
+    <message id="vebus_device_bms_message">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
+      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
+      <oldsource>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</oldsource>
+      <translation>VE.Bus BMS จะปิดระบบโดยอัตโนมัติเมื่อจำเป็นเพื่อป้องกันแบตเตอรี่ ดังนั้นจึงไม่สามารถควบคุมระบบจากอุปกรณ์ GX ได้</translation>
+    </message>
+    <message id="switchable_output_numeric_input">
+      <location filename="../../src/enums.cpp" line="418"/>
+      <source>Numeric input</source>
+      <translation>ป้อนข้อมูลตัวเลข</translation>
     </message>
     <message id="autotoggleswitch_disable_auto_mode_info">
       <location filename="../../components/controls/AutoToggleButton.qml" line="34"/>
       <source>Disable Auto mode first</source>
-      <translation type="unfinished"/>
+      <translation>ปิดใช้งานโหมดอัตโนมัติก่อน</translation>
+    </message>
+    <message id="pagesettingsintegrations_venus_os_enable_large_features">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
+      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
+      <translation>เปิดใช้งานเฟิร์มแวร์ Venus OS Large เพื่อใช้งาน Node-RED หรือ Signal-K</translation>
+    </message>
+    <message id="settings_relays_sensors_tanks">
+      <location filename="../../pages/SettingsPage.qml" line="75"/>
+      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
+      <oldsource>Relays, Sensors, Tanks, PV Inverters, Modbus, MQTT…</oldsource>
+      <translation>รีเลย์, เซ็นเซอร์, อินเวอร์เตอร์ PV, Modbus, Node-RED</translation>
+    </message>
+    <message id="vebus_device_page_microgrid_parameters">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
+      <source>Microgrid parameters</source>
+      <translation>พารามิเตอร์ Microgrid</translation>
+    </message>
+    <message id="microgrid_mode_hybrid_droop">
+      <location filename="../../src/enums.cpp" line="539"/>
+      <source>Hybrid droop</source>
+      <translation>Hybrid droop</translation>
+    </message>
+    <message id="microgrid_mode_grid_following">
+      <location filename="../../src/enums.cpp" line="542"/>
+      <source>Grid-following</source>
+      <translation>Grid-following</translation>
+    </message>
+    <message id="microgrid_mode_grid_forming">
+      <location filename="../../src/enums.cpp" line="545"/>
+      <source>Grid-forming</source>
+      <translation>Grid-forming</translation>
+    </message>
+    <message id="switchable_output_trip_low_voltage">
+      <location filename="../../src/enums.cpp" line="481"/>
+      <source>Trip low voltage</source>
+      <oldsource>Disabled</oldsource>
+      <translation>ตัดการทำงานเมื่อแรงดันไฟฟ้าต่ำ</translation>
     </message>
     <message id="microgrid">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="15"/>
       <source>Microgrid</source>
-      <translation type="unfinished"/>
+      <translation>Microgrid</translation>
     </message>
     <message id="page_microgrid_active_mode">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="19"/>
       <source>Active mode</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_microgrid_from_p1_to_p2">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="34"/>
-      <source>%1 %2 to %3 %4</source>
-      <extracomment>Describes a range from one quantity to another, e.g. "30 W to 60 W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
-      <translation type="unfinished"/>
+      <translation>โหมด Active</translation>
     </message>
     <message id="page_microgrid_hybrid_droop_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="92"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
       <source>Hybrid droop parameters</source>
-      <translation type="unfinished"/>
+      <translation>พารามิเตอร์ Hybrid droop</translation>
     </message>
     <message id="page_microgrid_reference_active_power_p0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="105"/>
       <source>Reference active power (P&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>กำลังไฟฟ้าแอคทีฟอ้างอิง (P&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_frequency_f0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="108"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="112"/>
       <source>Reference frequency (f&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>ความถี่อ้างอิง (f&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_frequency_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="117"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="119"/>
       <source>Frequency droop slope (droop&lt;sub&gt;fP&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>ความชัน Frequency droop (droop&lt;sub&gt;fP&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_reactive_power">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="126"/>
       <source>Reference reactive power (Q&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>กำลังไฟฟ้ารีแอกทีฟอ้างอิง (Q&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_voltage">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="135"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="133"/>
       <source>Reference Voltage (U&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>แรงดันไฟฟ้าอ้างอิง (U&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_voltage_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="144"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="140"/>
       <source>Voltage droop slope (droop&lt;sub&gt;UQ&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>ความชัน Voltage droop (droop&lt;sub&gt;UQ&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_minimum_and_maximum_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="146"/>
       <source>Minimum and maximum parameters</source>
-      <translation type="unfinished"/>
+      <translation>พารามิเตอร์ต่ำสุดและสูงสุด</translation>
     </message>
     <message id="page_microgrid_allowed_active_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="156"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
       <source>Allowed active power range</source>
-      <translation type="unfinished"/>
+      <translation>ช่วงกำลังไฟฟ้าแอคทีฟที่อนุญาต</translation>
     </message>
     <message id="page_microgrid_allowed_reactive_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="164"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="159"/>
       <source>Allowed reactive power range</source>
-      <translation type="unfinished"/>
+      <translation>ช่วงกำลังไฟฟ้ารีแอกทีฟที่อนุญาต</translation>
     </message>
     <message id="page_microgrid_p_q_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="176"/>
       <source>P-Q direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>การตั้งค่า P-Q direct drive</translation>
     </message>
     <message id="page_microgrid_active_power_setpoint_p">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="186"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
       <source>Active power setpoint (P)</source>
-      <translation type="unfinished"/>
+      <translation>จุดตั้งค่ากำลังไฟฟ้าแอคทีฟ (P)</translation>
     </message>
     <message id="page_microgrid_reactive_power_setpoint_q">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="194"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="188"/>
       <source>Reactive power setpoint (Q)</source>
-      <translation type="unfinished"/>
+      <translation>จุดตั้งค่ากำลังไฟฟ้ารีแอกทีฟ (Q)</translation>
     </message>
     <message id="page_microgrid_allowed_frequency_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="202"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="195"/>
       <source>Allowed frequency range</source>
-      <translation type="unfinished"/>
+      <translation>ช่วงความถี่ที่อนุญาต</translation>
     </message>
     <message id="page_microgrid_allowed_voltage_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="210"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="203"/>
       <source>Allowed voltage range</source>
-      <translation type="unfinished"/>
+      <translation>ช่วงแรงดันไฟฟ้าที่อนุญาต</translation>
     </message>
     <message id="page_microgrid_v_f_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="227"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="220"/>
       <source>V-f direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>การตั้งค่า V-f direct drive</translation>
     </message>
     <message id="page_microgrid_voltage_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="225"/>
       <source>Voltage setpoint (U)</source>
-      <translation type="unfinished"/>
+      <translation>จุดตั้งค่าแรงดันไฟฟ้า (U)</translation>
     </message>
     <message id="page_microgrid_frequency_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="240"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
       <source>Frequency setpoint (f)</source>
-      <translation type="unfinished"/>
+      <translation>จุดตั้งค่าความถี่ (f)</translation>
     </message>
-    <message id="temperature_slider_current">
-      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
-      <source>Current</source>
-      <extracomment>The current temperature measurement</extracomment>
-      <translation type="unfinished">หมุนเวียน</translation>
+    <message id="pagesettingsintegrations_canopenmotordrive">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
+      <source>CANopen motor drives</source>
+      <translation>CANopen motor drives</translation>
+    </message>
+    <message id="pagesettingsintegrations_ui_plugins">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
+      <source>UI Plugins</source>
+      <translation>UI Plugins</translation>
+    </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
+      <source>Motor Direction Inverted</source>
+      <translation>ทิศทางมอเตอร์กลับด้าน</translation>
     </message>
     <message id="page_settings_canopenmotordrive_scan_for_motor_drives">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="31"/>
       <source>Scan for motor drives</source>
-      <translation type="unfinished"/>
+      <translation>สแกนหา Motor drive</translation>
     </message>
     <message id="page_settings_canopenmotordrive_discovered_motor_drive_ids">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="39"/>
       <source>Discovered motor drive IDs</source>
-      <translation type="unfinished"/>
+      <translation>ค้นพบ ID Motor drive</translation>
     </message>
-    <message id="switchableoutput_gx_device_relays">
-      <location filename="../../src/switchableoutput.cpp" line="388"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">รีเลย์ของอุปกรณ์ GX</translation>
+    <message id="temperature_pm25">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
+      <source>PM2.5</source>
+      <translation>PM2.5</translation>
     </message>
-    <message id="gx_device_relays">
-      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">รีเลย์ของอุปกรณ์ GX</translation>
+    <message id="temperature_co2">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+      <source>CO₂</source>
+      <translation>CO₂</translation>
     </message>
-    <message id="color_preset">
-      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
-      <source>Preset</source>
-      <translation type="unfinished"/>
+    <message id="temperature_voc">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
+      <source>VOC index</source>
+      <translation>ดัชนี VOC</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_location">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
-      <source>Add Modbus port and unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_nox">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
+      <source>NOx index</source>
+      <translation>ดัชนี NOx</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_unitid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
-      <source>Unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_luminosity">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
+      <source>Luminosity</source>
+      <translation>ความสว่าง</translation>
     </message>
-    <message id="page_settings_fronius_unitid_invalid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation type="unfinished">%1 ไม่ใช่หมายเลขหน่วยที่ถูกต้อง ให้ใช้ตัวเลขระหว่าง 1-247</translation>
-    </message>
-    <message id="page_settings_fronius_add_modbus_location_button">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
-      <source>Add</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_locations_note">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
-      <source>The default modbus port is 502 and the default unit ID is 126.
-Here you can add additional ports and unit IDs to scan for PV inverters.</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_location_number">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
-      <source>Port/Unit ID %1</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location_description">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
-      <source>Port: %1 (Unit %2)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
-      <source>Remove Modbus port and unit ID?</source>
-      <translation type="unfinished"/>
+    <message id="switchable_output_bypassed">
+      <location filename="../../src/enums.cpp" line="484"/>
+      <source>Bypassed</source>
+      <translation>ข้าม</translation>
     </message>
     <message id="switchableoutput_list_delegate_auto_status">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="84"/>
       <source>Auto (%1)</source>
       <extracomment>%1 = 'On' or 'Off'</extracomment>
-      <translation type="unfinished"/>
+      <translation>อัตโนมัติ (%1)</translation>
     </message>
     <message id="switchableoutput_list_delegate_state_forced">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="100"/>
       <source>Forced</source>
-      <translation type="unfinished"/>
+      <translation>บังคับ</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_settings">
+      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
+      <source>Modbus port and unit ID settings</source>
+      <translation>การตั้งค่าพอร์ต Modbus และ Unit ID</translation>
+    </message>
+    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
+      <source>Integrates with the device list</source>
+      <translation>รวมเข้ากับรายการอุปกรณ์</translation>
+    </message>
+    <message id="common_words_color">
+      <location filename="../../components/CommonWords.qml" line="136"/>
+      <source>Color</source>
+      <translation>สี</translation>
+    </message>
+    <message id="common_words_value_must_be_greater_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="557"/>
+      <source>Value must be greater than start value</source>
+      <translation>ค่าต้องมากกว่าค่าเริ่มต้น</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="566"/>
+      <source>Value must be lower than stop value</source>
+      <translation>ค่าต้องน้อยกว่าค่าสิ้นสุด</translation>
+    </message>
+    <message id="notifications_page_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="43"/>
+      <source>Active Notifications</source>
+      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
+      <translation>การแจ้งเตือนที่เปิดใช้งาน</translation>
+    </message>
+    <message id="notifications_page_inactive_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="47"/>
+      <source>Inactive Notifications</source>
+      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
+      <translation>การแจ้งเตือนที่ไม่ได้เปิดใช้งาน</translation>
+    </message>
+    <message id="notifications_no_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="106"/>
+      <source>No active notifications</source>
+      <translation>ไม่มีการแจ้งเตือนที่เปิดใช้งาน</translation>
+    </message>
+    <message id="switchable_output_rgb_color_wheel">
+      <location filename="../../src/enums.cpp" line="427"/>
+      <source>RGB color wheel</source>
+      <translation>วงล้อสี RGB</translation>
+    </message>
+    <message id="switchable_output_cct_color_wheel">
+      <location filename="../../src/enums.cpp" line="431"/>
+      <source>CCT color wheel</source>
+      <extracomment>Correlated Color Temperature color wheel</extracomment>
+      <translation>วงล้อสี CCT</translation>
+    </message>
+    <message id="switchable_output_rgbw_color_wheel">
+      <location filename="../../src/enums.cpp" line="435"/>
+      <source>RGB + W color wheel</source>
+      <extracomment>RGB + white color wheel</extracomment>
+      <translation>วงล้อสี RGB + W</translation>
+    </message>
+    <message id="listlink_show_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="43"/>
+      <source>Show QR code</source>
+      <translation>แสดงรหัส QR</translation>
+    </message>
+    <message id="listlink_scan_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="52"/>
+      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
+      <extracomment>%1 = url text</extracomment>
+      <oldsource>Scan the QR code with your portable device.&lt;br /&gt;Or insert the link: %1</oldsource>
+      <translation>เปิดรหัส QR เพื่อสแกนด้วยอุปกรณ์พกพาของคุณ&lt;br /&gt;หรือใส่ลิงก์: %1</translation>
+    </message>
+    <message id="color_preset">
+      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
+      <source>Preset</source>
+      <translation>ตั้งค่าล่วงหน้า</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
+      <source>Add Modbus port and unit ID</source>
+      <translation>เพิ่มพอร์ต Modbus และ Unit ID</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_unitid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
+      <source>Unit ID</source>
+      <translation>Unit ID</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location_button">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
+      <source>Add</source>
+      <translation>เพิ่ม</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_locations_note">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
+      <source>The default modbus port is 502 and the default unit ID is 126.
+Here you can add additional ports and unit IDs to scan for PV inverters.</source>
+      <translation>พอร์ต Modbus เริ่มต้นคือ 502 และ Unit ID เริ่มต้นคือ 126
+ที่นี่คุณสามารถเพิ่มพอร์ตและ Unit ID เพิ่มเติมเพื่อสแกนหาอินเวอร์เตอร์ PV ได้</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_location_number">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
+      <source>Port/Unit ID %1</source>
+      <translation>พอร์ต/Unit ID %1</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location_description">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
+      <source>Port: %1 (Unit %2)</source>
+      <translation>พอร์ต: %1 (Unit %2)</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
+      <source>Remove Modbus port and unit ID?</source>
+      <translation>ลบพอร์ต Modbus และ Unit ID?</translation>
+    </message>
+    <message id="devicelist_tankshape_edit_point">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="182"/>
+      <source>Edit point %1</source>
+      <extracomment>%1 = which point is being edited, a number like "1" or "2"</extracomment>
+      <translation></translation>
+    </message>
+    <message id="settings_canbus_vecan">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
+      <source>VE.Can (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_250">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <source>VE.Can &amp; CANopen E-drive (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_500">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
+      <source>CANopen E-drive (500 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="page_microgrid_from_p1_to_p2">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="39"/>
+      <source>%1%2 to %3%4</source>
+      <extracomment>Describes a range from one quantity to another, e.g. "30W to 60W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
+      <translation></translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAfricaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
+      <source>Morocco Standard Time</source>
+      <translation>เวลามาตรฐานโมร็อกโก</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
+      <source>W. Central Africa Standard Time</source>
+      <translation>W. เวลามาตรฐานแอฟริกากลาง</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
+      <source>South Africa Standard Time</source>
+      <translation>เวลามาตรฐานของแอฟริกาใต้</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
+      <source>Namibia Standard Time</source>
+      <translation>เวลามาตรฐานนามิเบีย</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
+      <source>Egypt Standard Time</source>
+      <translation>เวลามาตรฐานอียิปต์</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
+      <source>E. Africa Standard Time</source>
+      <translation>E. เวลามาตรฐานแอฟริกา</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAmericaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
+      <source>Argentina Standard Time</source>
+      <translation>เวลามาตรฐานอาร์เจนตินา</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
+      <source>E. South America Standard Time</source>
+      <translation>E. เวลามาตรฐานของอเมริกาใต้</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
+      <source>Greenland Standard Time</source>
+      <translation>เวลามาตรฐานกรีนแลนด์</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
+      <source>Montevideo Standard Time</source>
+      <translation>เวลามาตรฐานมอนเตวิเดโอ</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
+      <source>Newfoundland Standard Time</source>
+      <translation>เวลามาตรฐานนิวฟันด์แลนด์</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
+      <source>SA Eastern Standard Time</source>
+      <translation>SA เวลามาตรฐานตะวันออก</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
+      <source>Atlantic Standard Time</source>
+      <translation>เวลามาตรฐานแอตแลนติก</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
+      <source>Central Brazilian Standard Time</source>
+      <translation>เวลามาตรฐานของบราซิลตอนกลาง</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>เวลามาตรฐานแปซิฟิก SA</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
+      <source>Paraguay Standard Time</source>
+      <translation>เวลามาตรฐานปารากวัย</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
+      <source>SA Western Standard Time</source>
+      <translation>SA เวลามาตรฐานตะวันตก</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
+      <source>Venezuela Standard Time</source>
+      <translation>เวลามาตรฐานของเวเนซุเอลา</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
+      <source>Eastern Standard Time</source>
+      <translation>เวลามาตรฐานตะวันออก</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
+      <source>SA Pacific Standard Time</source>
+      <translation>เวลามาตรฐานแปซิฟิกของ SA</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
+      <source>US Eastern Standard Time</source>
+      <translation>เวลามาตรฐานตะวันออกของสหรัฐอเมริกา</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
+      <source>Canada Central Standard Time</source>
+      <translation>เวลามาตรฐานกลางของแคนาดา</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
+      <source>Central America Standard Time</source>
+      <translation>เวลามาตรฐานของอเมริกากลาง</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
+      <source>Central Standard Time (Mexico)</source>
+      <translation>เวลามาตรฐานตอนกลาง (เม็กซิโก)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
+      <source>Central Standard Time</source>
+      <translation>เวลามาตรฐานตอนกลาง</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
+      <source>Mountain Standard Time (Mexico)</source>
+      <translation>เวลามาตรฐานแถบภูเขาสูง (เม็กซิโก)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
+      <source>Mountain Standard Time</source>
+      <translation>เวลามาตรฐานบนภูเขา</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
+      <source>US Mountain Standard Time</source>
+      <translation>เวลามาตรฐานภูเขาของสหรัฐอเมริกา</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
+      <source>Pacific Standard Time (Mexico)</source>
+      <translation>เวลามาตรฐานแปซิฟิก (เม็กซิโก)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
+      <source>Pacific Standard Time</source>
+      <translation>เวลามาตรฐานแปซิฟิก</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
+      <source>Alaskan Standard Time</source>
+      <translation>เวลามาตรฐานอลาสก้า</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
+      <source>Hawaii-Aleutian</source>
+      <translation>ฮาวาย-Aleutian</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
+      <source>Atlantic Daylight Time</source>
+      <translation>เวลาออมแสงของมหาสมุทรแอตแลนติก</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAntarcticaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+      <source>New Zealand Standard Time</source>
+      <translation>เวลามาตรฐานของนิวซีแลนด์</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>เวลามาตรฐานแปซิฟิกกลาง</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+      <source>West Pacific Standard Time</source>
+      <translation>เวลามาตรฐานแปซิฟิกตะวันตก</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+      <source>W. Australia Standard Time</source>
+      <translation>เวลามาตรฐานของออสเตรเลียตะวันตก</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+      <source>SE Asia Standard Time</source>
+      <translation>เวลามาตรฐานเอเชียตะวันออกเฉียงใต้</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+      <source>Central Asia Standard Time</source>
+      <translation>เวลามาตรฐานเอเชียกลาง</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+      <source>West Asia Standard Time</source>
+      <translation>เวลามาตรฐานเอเชียตะวันตก</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+      <source>E. Africa Standard Time</source>
+      <translation>E. เวลามาตรฐานแอฟริกา</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>เวลามาตรฐานแปซิฟิก SA</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+      <source>SA Western Standard Time</source>
+      <translation>SA เวลามาตรฐานตะวันตก</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzArcticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
+      <source>W. Europe Standard Time</source>
+      <translation>เวลามาตรฐานยุโรปตะวันตก</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAsiaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
+      <source>Kamchatka Standard Time</source>
+      <translation>เวลามาตรฐานคัมชัตกา</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
+      <source>Magadan Standard Time</source>
+      <translation>เวลามาตรฐานมากาดาน</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
+      <source>Vladivostok Standard Time</source>
+      <translation>เวลามาตรฐานวลาดีวอสตอค</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
+      <source>Yakutsk Standard Time</source>
+      <translation>เวลามาตรฐานยาคุตสค์</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
+      <source>Tokyo Standard Time</source>
+      <translation>เวลามาตรฐานโตเกียว</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
+      <source>Korea Standard Time</source>
+      <translation>เวลามาตรฐานเกาหลี</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
+      <source>Singapore Standard Time</source>
+      <translation>เวลามาตรฐานสิงคโปร์</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
+      <source>Ulaanbaatar Standard Time</source>
+      <translation>เวลามาตรฐานอูลานบาตอร์</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
+      <source>Taipei Standard Time</source>
+      <translation>เวลามาตรฐานไทเป</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
+      <source>North Asia East Standard Time</source>
+      <translation>เวลามาตรฐานเอเชียเหนือตะวันออก</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
+      <source>China Standard Time</source>
+      <translation>เวลามาตรฐานของจีน</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
+      <source>SE Asia Standard Time</source>
+      <translation>เวลามาตรฐานเอเชียตะวันออกเฉียงใต้</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
+      <source>North Asia Standard Time</source>
+      <translation>เวลามาตรฐานเอเชียเหนือ</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
+      <source>Myanmar Standard Time</source>
+      <translation>เวลามาตรฐานของเมียนมาร์</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
+      <source>N. Central Asia Standard Time</source>
+      <translation>เวลามาตรฐานเอเชียกลางเหนือ</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
+      <source>Central Asia Standard Time</source>
+      <translation>เวลามาตรฐานเอเชียกลาง</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
+      <source>Bangladesh Standard Time</source>
+      <translation>เวลามาตรฐานบังกลาเทศ</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
+      <source>Nepal Standard Time</source>
+      <translation>เวลามาตรฐานเนปาล</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
+      <source>Sri Lanka Standard Time</source>
+      <translation>เวลามาตรฐานศรีลังกา</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
+      <source>India Standard Time</source>
+      <translation>เวลามาตรฐานอินเดีย</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
+      <source>West Asia Standard Time</source>
+      <translation>เวลามาตรฐานเอเชียตะวันตก</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
+      <source>Pakistan Standard Time</source>
+      <translation>เวลามาตรฐานของปากีสถาน</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
+      <source>Ekaterinburg Standard Time</source>
+      <translation>เวลามาตรฐานเอคาเตรินเบิร์ก</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
+      <source>Georgian Standard Time</source>
+      <translation>เวลามาตรฐานจอร์เจีย</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
+      <source>Caucasus Standard Time</source>
+      <translation>เวลามาตรฐานคอเคซัส</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
+      <source>Azerbaijan Standard Time</source>
+      <translation>เวลามาตรฐานอาเซอร์ไบจาน</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
+      <source>Arabian Standard Time</source>
+      <translation>เวลามาตรฐานอาหรับ</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
+      <source>Afghanistan Standard Time</source>
+      <translation>เวลามาตรฐานอัฟกานิสถาน</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
+      <source>Iran Standard Time</source>
+      <translation>เวลามาตรฐานอิหร่าน</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
+      <source>Arabic Standard Time</source>
+      <translation>เวลามาตรฐานภาษาอาหรับ</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
+      <source>Arab Standard Time</source>
+      <translation>เวลามาตรฐานอาหรับ</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
+      <source>Syria Standard Time</source>
+      <translation>เวลามาตรฐานซีเรีย</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
+      <source>Middle East Standard Time</source>
+      <translation>เวลามาตรฐานตะวันออกกลาง</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
+      <source>Jordan Standard Time</source>
+      <translation>เวลามาตรฐานจอร์แดน</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
+      <source>Israel Standard Time</source>
+      <translation>เวลามาตรฐานของอิสราเอล</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAtlanticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+      <source>Greenwich Standard Time</source>
+      <translation>เวลามาตรฐานกรีนิช</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+      <source>Azores Standard Time</source>
+      <translation>เวลามาตรฐานอะซอเรส</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+      <source>Cape Verde Standard Time</source>
+      <translation>เวลามาตรฐานเคปเวิร์ด</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
+      <source>Mid-Atlantic Standard Time</source>
+      <translation>เวลามาตรฐานกลางมหาสมุทรแอตแลนติก</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAustraliaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+      <source>Tasmania Standard Time</source>
+      <translation>เวลามาตรฐานแทสเมเนีย</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+      <source>E. Australia Standard Time</source>
+      <translation>E. เวลามาตรฐานของออสเตรเลีย</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+      <source>AUS Eastern Standard Time</source>
+      <translation>เวลามาตรฐานตะวันออกของ AUS</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+      <source>Cen. Australia Standard Time</source>
+      <translation>เซน เวลามาตรฐานของออสเตรเลีย</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+      <source>AUS Central Standard Time</source>
+      <translation>เวลามาตรฐานกลาง AUS</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+      <source>W. Australia Standard Time</source>
+      <translation>เวลามาตรฐานของออสเตรเลียตะวันตก</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEtcData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
+      <source>GMT +12</source>
+      <translation>GMT +12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
+      <source>GMT -02</source>
+      <translation>GMT -02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
+      <source>GMT -11</source>
+      <translation>GMT -11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
+      <source>GMT -13</source>
+      <translation>จีเอ็มที-13</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
+      <source>GMT -12</source>
+      <translation>จีเอ็มที-12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
+      <source>GMT -10</source>
+      <translation>จีเอ็มที-10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
+      <source>GMT -09</source>
+      <translation>จีเอ็มที-09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
+      <source>GMT -08</source>
+      <translation>จีเอ็มที-08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
+      <source>GMT -07</source>
+      <translation>จีเอ็มที-07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
+      <source>GMT -06</source>
+      <translation>จีเอ็มที-06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
+      <source>GMT -05</source>
+      <translation>จีเอ็มที-05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
+      <source>GMT -04</source>
+      <translation>จีเอ็มที-04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
+      <source>GMT -03</source>
+      <translation>จีเอ็มที-03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
+      <source>GMT -01</source>
+      <translation>จีเอ็มที-01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
+      <source>GMT</source>
+      <translation>GMT</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
+      <source>GMT +01</source>
+      <translation>เวลามาตรฐานสากล (GMT+01)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
+      <source>GMT +02</source>
+      <translation>เวลามาตรฐานสากล (GMT+02)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
+      <source>GMT +03</source>
+      <translation>เวลามาตรฐานสากล (GMT+03)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
+      <source>GMT +04</source>
+      <translation>เวลามาตรฐานสากล (GMT+04)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
+      <source>GMT +05</source>
+      <translation>จีเอ็มที +05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
+      <source>GMT +06</source>
+      <translation>เวลามาตรฐานสากล (GMT+06)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
+      <source>GMT +07</source>
+      <translation>เวลามาตรฐานสากล (GMT+07)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
+      <source>GMT +08</source>
+      <translation>จีเอ็มที +08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
+      <source>GMT +09</source>
+      <translation>จีเอ็มที +09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
+      <source>GMT +10</source>
+      <translation>เวลามาตรฐานสากล +10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
+      <source>GMT +11</source>
+      <translation>เวลามาตรฐานสากล +11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
+      <source>UTC</source>
+      <translation>UTC</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEuropeData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
+      <source>GMT Standard Time</source>
+      <translation>เวลามาตรฐาน GMT</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
+      <source>Central Europe Standard Time</source>
+      <translation>เวลามาตรฐานยุโรปกลาง</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
+      <source>Central European Standard Time</source>
+      <translation>เวลามาตรฐานยุโรปกลาง</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
+      <source>Romance Standard Time</source>
+      <translation>เวลามาตรฐานโรแมนติก</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
+      <source>W. Europe Standard Time</source>
+      <translation>เวลามาตรฐานยุโรปตะวันตก</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
+      <source>E. Europe Standard Time</source>
+      <translation>เวลามาตรฐานยุโรปตะวันออก</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
+      <source>FLE Standard Time</source>
+      <translation>เวลามาตรฐาน FLE</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
+      <source>GTB Standard Time</source>
+      <translation>เวลามาตรฐาน GTB</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
+      <source>Belarus Standard Time</source>
+      <translation>เวลามาตรฐานเบลารุส</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
+      <source>Russian Standard Time</source>
+      <translation>เวลามาตรฐานรัสเซีย</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
+      <source>Turkey Standard Time</source>
+      <translation>เวลามาตรฐานของตุรกี</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzIndianData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
+      <source>Mauritius Standard Time</source>
+      <translation>เวลามาตรฐานมอริเชียส</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
+      <source>Christmas Island Standard Time</source>
+      <translation>เวลามาตรฐานของเกาะคริสต์มาส</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzPacificData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
+      <source>Tonga Standard Time</source>
+      <translation>เวลามาตรฐานตองกา</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
+      <source>Fiji Standard Time</source>
+      <translation>เวลามาตรฐานฟิจิ</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
+      <source>New Zealand Standard Time</source>
+      <translation>เวลามาตรฐานของนิวซีแลนด์</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>เวลามาตรฐานแปซิฟิกกลาง</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
+      <source>West Pacific Standard Time</source>
+      <translation>เวลามาตรฐานแปซิฟิกตะวันตก</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
+      <source>Samoa Standard Time</source>
+      <translation>เวลามาตรฐานซามัว</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
+      <source>Hawaiian Standard Time</source>
+      <translation>เวลามาตรฐานฮาวาย</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
+      <source>Easter Island Standard Time</source>
+      <translation>เวลามาตรฐานของเกาะอีสเตอร์</translation>
     </message>
   </context>
   <context>
@@ -12173,838 +11853,6 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
     </message>
   </context>
   <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>เวลามาตรฐานโมร็อกโก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>W. เวลามาตรฐานแอฟริกากลาง</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>เวลามาตรฐานของแอฟริกาใต้</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>เวลามาตรฐานนามิเบีย</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>เวลามาตรฐานอียิปต์</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>E. เวลามาตรฐานแอฟริกา</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>เวลามาตรฐานอาร์เจนตินา</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>E. เวลามาตรฐานของอเมริกาใต้</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>เวลามาตรฐานกรีนแลนด์</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>เวลามาตรฐานมอนเตวิเดโอ</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>เวลามาตรฐานนิวฟันด์แลนด์</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>SA เวลามาตรฐานตะวันออก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Atlantic Standard Time</source>
-      <translation>เวลามาตรฐานแอตแลนติก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>เวลามาตรฐานของบราซิลตอนกลาง</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>เวลามาตรฐานแปซิฟิก SA</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>Paraguay Standard Time</source>
-      <translation>เวลามาตรฐานปารากวัย</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>SA Western Standard Time</source>
-      <translation>SA เวลามาตรฐานตะวันตก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Venezuela Standard Time</source>
-      <translation>เวลามาตรฐานของเวเนซุเอลา</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>Eastern Standard Time</source>
-      <translation>เวลามาตรฐานตะวันออก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>เวลามาตรฐานแปซิฟิกของ SA</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>US Eastern Standard Time</source>
-      <translation>เวลามาตรฐานตะวันออกของสหรัฐอเมริกา</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Canada Central Standard Time</source>
-      <translation>เวลามาตรฐานกลางของแคนาดา</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central America Standard Time</source>
-      <translation>เวลามาตรฐานของอเมริกากลาง</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>เวลามาตรฐานตอนกลาง (เม็กซิโก)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Central Standard Time</source>
-      <translation>เวลามาตรฐานตอนกลาง</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>เวลามาตรฐานแถบภูเขาสูง (เม็กซิโก)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>Mountain Standard Time</source>
-      <translation>เวลามาตรฐานบนภูเขา</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>US Mountain Standard Time</source>
-      <translation>เวลามาตรฐานภูเขาของสหรัฐอเมริกา</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>เวลามาตรฐานแปซิฟิก (เม็กซิโก)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Pacific Standard Time</source>
-      <translation>เวลามาตรฐานแปซิฟิก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Alaskan Standard Time</source>
-      <translation>เวลามาตรฐานอลาสก้า</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>ฮาวาย-Aleutian</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Daylight Time</source>
-      <translation>เวลาออมแสงของมหาสมุทรแอตแลนติก</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>เวลามาตรฐานของนิวซีแลนด์</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>เวลามาตรฐานแปซิฟิกกลาง</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>เวลามาตรฐานแปซิฟิกตะวันตก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>เวลามาตรฐานของออสเตรเลียตะวันตก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>เวลามาตรฐานเอเชียตะวันออกเฉียงใต้</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>เวลามาตรฐานเอเชียกลาง</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>เวลามาตรฐานเอเชียตะวันตก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>E. เวลามาตรฐานแอฟริกา</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>เวลามาตรฐานแปซิฟิก SA</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>SA เวลามาตรฐานตะวันตก</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>เวลามาตรฐานยุโรปตะวันตก</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>เวลามาตรฐานคัมชัตกา</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>เวลามาตรฐานมากาดาน</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>เวลามาตรฐานวลาดีวอสตอค</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>เวลามาตรฐานยาคุตสค์</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>เวลามาตรฐานโตเกียว</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>เวลามาตรฐานเกาหลี</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>เวลามาตรฐานสิงคโปร์</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>เวลามาตรฐานอูลานบาตอร์</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>เวลามาตรฐานไทเป</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>เวลามาตรฐานเอเชียเหนือตะวันออก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>เวลามาตรฐานของจีน</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>เวลามาตรฐานเอเชียตะวันออกเฉียงใต้</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>เวลามาตรฐานเอเชียเหนือ</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>เวลามาตรฐานของเมียนมาร์</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>เวลามาตรฐานเอเชียกลางเหนือ</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>เวลามาตรฐานเอเชียกลาง</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>เวลามาตรฐานบังกลาเทศ</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>เวลามาตรฐานเนปาล</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>เวลามาตรฐานศรีลังกา</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>เวลามาตรฐานอินเดีย</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>เวลามาตรฐานเอเชียตะวันตก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>เวลามาตรฐานของปากีสถาน</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>เวลามาตรฐานเอคาเตรินเบิร์ก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>เวลามาตรฐานจอร์เจีย</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>เวลามาตรฐานคอเคซัส</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>เวลามาตรฐานอาเซอร์ไบจาน</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>เวลามาตรฐานอาหรับ</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>เวลามาตรฐานอัฟกานิสถาน</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>เวลามาตรฐานอิหร่าน</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>เวลามาตรฐานภาษาอาหรับ</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>เวลามาตรฐานอาหรับ</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>เวลามาตรฐานซีเรีย</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>เวลามาตรฐานตะวันออกกลาง</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>เวลามาตรฐานจอร์แดน</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>เวลามาตรฐานของอิสราเอล</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>เวลามาตรฐานกรีนิช</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>เวลามาตรฐานอะซอเรส</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>เวลามาตรฐานเคปเวิร์ด</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>เวลามาตรฐานกลางมหาสมุทรแอตแลนติก</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>เวลามาตรฐานแทสเมเนีย</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>E. เวลามาตรฐานของออสเตรเลีย</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>เวลามาตรฐานตะวันออกของ AUS</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>เซน เวลามาตรฐานของออสเตรเลีย</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>เวลามาตรฐานกลาง AUS</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>เวลามาตรฐานของออสเตรเลียตะวันตก</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
-      <source>GMT +12</source>
-      <translation>GMT +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
-      <source>GMT -02</source>
-      <translation>GMT -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT -13</source>
-      <translation>จีเอ็มที-13</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT -12</source>
-      <translation>จีเอ็มที-12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -10</source>
-      <translation>จีเอ็มที-10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -09</source>
-      <translation>จีเอ็มที-09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>GMT -08</source>
-      <translation>จีเอ็มที-08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
-      <source>GMT -07</source>
-      <translation>จีเอ็มที-07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
-      <source>GMT -06</source>
-      <translation>จีเอ็มที-06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
-      <source>GMT -05</source>
-      <translation>จีเอ็มที-05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
-      <source>GMT -04</source>
-      <translation>จีเอ็มที-04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
-      <source>GMT -03</source>
-      <translation>จีเอ็มที-03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
-      <source>GMT -01</source>
-      <translation>จีเอ็มที-01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
-      <source>GMT</source>
-      <translation>GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
-      <source>GMT +01</source>
-      <translation>เวลามาตรฐานสากล (GMT+01)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
-      <source>GMT +02</source>
-      <translation>เวลามาตรฐานสากล (GMT+02)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
-      <source>GMT +03</source>
-      <translation>เวลามาตรฐานสากล (GMT+03)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
-      <source>GMT +04</source>
-      <translation>เวลามาตรฐานสากล (GMT+04)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
-      <source>GMT +05</source>
-      <translation>จีเอ็มที +05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
-      <source>GMT +06</source>
-      <translation>เวลามาตรฐานสากล (GMT+06)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
-      <source>GMT +07</source>
-      <translation>เวลามาตรฐานสากล (GMT+07)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
-      <source>GMT +08</source>
-      <translation>จีเอ็มที +08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
-      <source>GMT +09</source>
-      <translation>จีเอ็มที +09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
-      <source>GMT +10</source>
-      <translation>เวลามาตรฐานสากล +10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
-      <source>GMT +11</source>
-      <translation>เวลามาตรฐานสากล +11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
-      <source>UTC</source>
-      <translation>UTC</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>เวลามาตรฐาน GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>เวลามาตรฐานยุโรปกลาง</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>เวลามาตรฐานยุโรปกลาง</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>เวลามาตรฐานโรแมนติก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>เวลามาตรฐานยุโรปตะวันตก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>เวลามาตรฐานยุโรปตะวันออก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>เวลามาตรฐาน FLE</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>เวลามาตรฐาน GTB</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>เวลามาตรฐานเบลารุส</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>เวลามาตรฐานรัสเซีย</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>เวลามาตรฐานของตุรกี</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>เวลามาตรฐานมอริเชียส</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>เวลามาตรฐานของเกาะคริสต์มาส</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>เวลามาตรฐานตองกา</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>เวลามาตรฐานฟิจิ</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>เวลามาตรฐานของนิวซีแลนด์</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>เวลามาตรฐานแปซิฟิกกลาง</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>เวลามาตรฐานแปซิฟิกตะวันตก</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>เวลามาตรฐานซามัว</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>เวลามาตรฐานฮาวาย</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>เวลามาตรฐานของเกาะอีสเตอร์</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation type="unfinished">ข้อผิดพลาดภายใน</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation type="unfinished"/>
-    </message>
-  </context>
-  <context>
     <name>Wakespeed</name>
     <message>
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
@@ -13181,6 +12029,119 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
       <source>DC/DC misconfiguration</source>
       <translation>การกำหนดค่า DC/DC ผิดพลาด</translation>
+    </message>
+  </context>
+  <context>
+    <name>VebusError</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+      <source>Device switched off</source>
+      <translation>อุปกรณ์ปิดอยู่</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+      <source>Mixed old/new MK2</source>
+      <translation>MK2 รุ่นเก่า/ใหม่ ผสมกัน</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+      <source>Expected devices error</source>
+      <translation>ข้อผิดพลาดอุปกรณ์ที่คาดไว้</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+      <source>No other device detected</source>
+      <translation>ไม่พบอุปกรณ์อื่น</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+      <source>Overvoltage on AC-out</source>
+      <translation>แรงดันไฟฟ้าเกินบน AC-out</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+      <source>DDC program error</source>
+      <translation>ข้อผิดพลาดโปรแกรม DDC</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+      <source>VE.Bus BMS without assistant</source>
+      <translation>VE.Bus BMS ไม่มีผู้ช่วย</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+      <source>Ground relay test failed</source>
+      <translation>การทดสอบกราวด์รีเลย์ล้มเหลว</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+      <source>System time sync error</source>
+      <translation>ข้อผิดพลาดในการซิงค์เวลาของระบบ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+      <source>Grid relay test fault</source>
+      <translation>ความผิดพลาดในการทดสอบกริดรีเลย์</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+      <source>Config mismatch with 2nd mcu</source>
+      <translation>การกำหนดค่าไม่ตรงกับ mcu ตัวที่ 2</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+      <source>Device transmit error</source>
+      <translation>ข้อผิดพลาดในการส่งข้อมูลอุปกรณ์</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+      <source>Awaiting configuration or dongle missing</source>
+      <translation>กำลังรอการกำหนดค่าหรือไม่มีดองเกิล</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+      <source>Phase master missing</source>
+      <translation>เฟสมาสเตอร์หายไป</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+      <source>Overvoltage has occurred</source>
+      <translation>เกิดแรงดันไฟฟ้าเกิน</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+      <source>Slave does not have AC input!</source>
+      <translation>อุปกรณ์ Slave ไม่มีอินพุต AC!</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+      <source>Device can't be slave</source>
+      <translation>อุปกรณ์ไม่สามารถเป็น Slave ได้</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+      <source>System protection initiated</source>
+      <translation>ระบบป้องกันเริ่มทำงาน</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+      <source>Firmware incompatibiltiy</source>
+      <translation>ความไม่เข้ากันของเฟิร์มแวร์</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+      <source>Internal error</source>
+      <translation>ข้อผิดพลาดภายใน</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+      <source>Failing relay test prevents connection</source>
+      <translation>การทดสอบรีเลย์ล้มเหลวขัดขวางการเชื่อมต่อ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+      <source>VE.Bus error</source>
+      <translation>ข้อผิดพลาด VE.Bus</translation>
     </message>
   </context>
 </TS>

--- a/i18n/venus-gui-v2_tr.ts
+++ b/i18n/venus-gui-v2_tr.ts
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="tr">
   <context>
-    <name/>
+    <name></name>
     <message id="switchable_output_disabled">
       <location filename="../../src/enums.cpp" line="478"/>
       <source>Disabled</source>
@@ -22,6 +22,7 @@
     <message id="solarchargers_state_off">
       <location filename="../../src/enums.cpp" line="331"/>
       <source>Off</source>
+      <extracomment>Digital input state</extracomment>
       <translation>Kapalı</translation>
     </message>
     <message id="common_words_auto">
@@ -52,18 +53,25 @@
     <message id="settings_startpage_none">
       <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
       <source>None</source>
+      <extracomment>Indicates no phase</extracomment>
       <translation>Yok</translation>
     </message>
     <message id="common_words_position_ac">
       <location filename="../../components/CommonWords.qml" line="416"/>
       <source>Position</source>
-      <extracomment>AC input or output position</extracomment>
+      <extracomment>EVCS AC input/output position</extracomment>
       <translation>Konum</translation>
     </message>
     <message id="settings_minmax_speed">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="193"/>
       <source>Speed</source>
+      <extracomment>A speed measurement value</extracomment>
       <translation>Hız</translation>
+    </message>
+    <message id="common_words_state">
+      <location filename="../../components/CommonWords.qml" line="502"/>
+      <source>State</source>
+      <translation>Durum</translation>
     </message>
     <message id="settings_firmware_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="67"/>
@@ -101,8 +109,8 @@
       <source>Solar yield</source>
       <translation>Güneş enerjisi verimi</translation>
     </message>
-    <message id="ess_state_external_control">
-      <location filename="../../data/Ess.qml" line="41"/>
+    <message id="inverters_state_externalccontrol">
+      <location filename="../../data/System.qml" line="183"/>
       <source>External control</source>
       <translation>Extern kontrol</translation>
     </message>
@@ -140,6 +148,11 @@
       <location filename="../../components/CommonWords.qml" line="203"/>
       <source>ESS</source>
       <translation>ESS</translation>
+    </message>
+    <message id="pagesettingsconnectivity_ethernet">
+      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
+      <source>Ethernet</source>
+      <translation>Eternet</translation>
     </message>
     <message id="pagesettingsconnectivity_wifi">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="28"/>
@@ -262,11 +275,6 @@
       <source>Name</source>
       <translation>İsim</translation>
     </message>
-    <message id="settings_deviceinfo_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="38"/>
-      <source>Name</source>
-      <translation type="unfinished">İsim</translation>
-    </message>
     <message id="settings_deviceinfo_product_id">
       <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
       <source>Product ID</source>
@@ -327,15 +335,20 @@
       <source>Daily run time</source>
       <translation>Günlük çalışma süresi</translation>
     </message>
+    <message id="common_words_value_must_be_greater_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="560"/>
+      <source>Value must be greater than stop value</source>
+      <translation>Değer, durdurma değerinden yüksek olmalıdır</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="563"/>
+      <source>Value must be lower than start value</source>
+      <translation>Değer, başlangıç değerinden düşük olmalıdır</translation>
+    </message>
     <message id="settings_minmax_acout_max_power">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="124"/>
       <source>AC output</source>
       <translation>AC Çıkışı</translation>
-    </message>
-    <message id="ac_output">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="15"/>
-      <source>AC output</source>
-      <translation type="unfinished">AC Çıkışı</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
       <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="25"/>
@@ -382,16 +395,6 @@
       <source>Unavailable monitor, set another</source>
       <translation>Monitör kullanılamıyor, yenisini ayarlayın</translation>
     </message>
-    <message id="page_generator_conditions_battery_monitor">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="42"/>
-      <source>Battery monitor</source>
-      <translation type="unfinished">Akü Monitör</translation>
-    </message>
-    <message id="page_generator_conditions_unavailable_monitor_set_another">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="44"/>
-      <source>Unavailable monitor, set another</source>
-      <translation type="unfinished">Monitör kullanılamıyor, yenisini ayarlayın</translation>
-    </message>
     <message id="page_generator_conditions_on_loss_of_communication">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="68"/>
       <source>On loss of communication</source>
@@ -416,11 +419,6 @@
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="105"/>
       <source>Battery SOC</source>
       <translation>Akü SOC</translation>
-    </message>
-    <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="173"/>
-      <source>Periodic run</source>
-      <translation type="unfinished">Periyodik çalıştırma</translation>
     </message>
     <message id="settings_inverter_high_temperature">
       <location filename="../../data/Generators.qml" line="83"/>
@@ -505,7 +503,7 @@
     <message id="settings_gps_speed_kmh">
       <location filename="../../pages/settings/PageGps.qml" line="83"/>
       <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometres per hour</extracomment>
+      <extracomment>GPS speed data, in kilometers per hour</extracomment>
       <translation>1 km/saat</translation>
     </message>
     <message id="settings_gps_speed_mph">
@@ -523,7 +521,7 @@
     <message id="settings_gps_speed_ms">
       <location filename="../../pages/settings/PageGps.qml" line="95"/>
       <source>%1 m/s</source>
-      <extracomment>GPS speed data, in metres per second</extracomment>
+      <extracomment>GPS speed data, in meters per second</extracomment>
       <translation>1 m/s</translation>
     </message>
     <message id="settings_gps_course">
@@ -580,21 +578,6 @@
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="64"/>
       <source>%1 (Output %2)</source>
       <translation>%1 (Çıkış %2)</translation>
-    </message>
-    <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">Aktif akü monitör</translation>
-    </message>
-    <message id="settings_batteries_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="101"/>
-      <source>Name</source>
-      <translation type="unfinished">İsim</translation>
-    </message>
-    <message id="settings_batteries_enter_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="103"/>
-      <source>Enter name</source>
-      <translation type="unfinished">İsim girin</translation>
     </message>
     <message id="settings_briefview_center_active_battery_monitor">
       <location filename="../../components/listitems/ListBriefCenterDetails.qml" line="27"/>
@@ -656,45 +639,25 @@
       <source>CAN-bus profile</source>
       <translation>CAN-bus profili</translation>
     </message>
-    <message id="settings_disabled">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="31"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Devre dışı</translation>
-    </message>
-    <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</translation>
-    </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
       <location filename="../../pages/settings/CanbusProfile.qml" line="42"/>
       <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
       <translation>VE.Can &amp; CAN-bus BMS (250 kbit/s)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
       <source>Oceanvolt (250 kbit/s)</source>
       <translation>Oceanvolt (250 kbit/s)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
       <source>RV-C (250 kbit/s)</source>
       <translation>RV-C (250 kbit/s)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
       <source>Up, but no services (250 kbit/s)</source>
       <translation>Açık, ancak hizmet yok (250 kbit/s)</translation>
-    </message>
-    <message id="settings_canopen_motordrive_250">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
-      <source>CANopen Motor drive (250 kbit/s)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_canopen_motordrive_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
-      <source>CANopen Motor drive (500 kbit/s)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_devices">
       <location filename="../../components/CommonWords.qml" line="166"/>
@@ -731,11 +694,6 @@
       <source>Check Unique id numbers</source>
       <translation>Benzersiz kimlik numaralarını kontrol et</translation>
     </message>
-    <message id="settings_canbus_unique_id_press_to_check">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Press to check</source>
-      <translation type="unfinished">Kontrol etmek için basın</translation>
-    </message>
     <message id="settings_canbus_unique_id_conflict">
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="125"/>
       <source>There is another device connected with this unique number, please select a new number.</source>
@@ -745,11 +703,6 @@
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="133"/>
       <source>OK: No other device is connected with this unique number.</source>
       <translation>TAMAM: Bu benzersiz numaraya bağlı başka bir cihaz yok.</translation>
-    </message>
-    <message id="pagesettingsintegrations_canopenmotordrive">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
-      <source>CANopen motor drives</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_network_status">
       <location filename="../../components/CommonWords.qml" line="349"/>
@@ -884,11 +837,6 @@
       <source>Unavailable sensor, set another</source>
       <translation>Sensör kullanılamıyor, başka birini ayarlayın</translation>
     </message>
-    <message id="settings_system_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="81"/>
-      <source>Unavailable sensor, set another</source>
-      <translation type="unfinished">Sensör kullanılamıyor, başka birini ayarlayın</translation>
-    </message>
     <message id="settings_dvcc_used_sensor">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="120"/>
       <source>Used sensor</source>
@@ -945,12 +893,6 @@
       <source>Auto selected</source>
       <translation>Otomatik seçili</translation>
     </message>
-    <message id="settings_dvcc_auto_selected_none">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="208"/>
-      <source>None</source>
-      <extracomment>Indicates no option is selected</extracomment>
-      <translation type="unfinished">Yok</translation>
-    </message>
     <message id="settings_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
       <source>Build date/time</source>
@@ -986,12 +928,6 @@
       <source>Installing %1</source>
       <extracomment>%1 = firmware version</extracomment>
       <translation>1 Yükleniyor</translation>
-    </message>
-    <message id="settings_firmware_offline_press_to_install">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">%1 Güncellemesi için basın</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="90"/>
@@ -1062,12 +998,6 @@
       <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
       <translation>Installing %1 %2%</translation>
     </message>
-    <message id="settings_firmware_online_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="86"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">Yükleniyor %1...</translation>
-    </message>
     <message id="settings_firmware_update_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="109"/>
       <source>Update build date/time</source>
@@ -1097,11 +1027,6 @@
       <location filename="../../pages/settings/PageSettingsFronius.qml" line="56"/>
       <source>TCP port</source>
       <translation>TCP bağlantı noktası</translation>
-    </message>
-    <message id="page_settings_fronius_modbus_settings">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
-      <source>Modbus port and unit ID settings</source>
-      <translation type="unfinished"/>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
       <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
@@ -1153,16 +1078,6 @@
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="64"/>
       <source>AC-Out MP</source>
       <translation>AC-Çıkış MP</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="52"/>
-      <source>AC-In1 L%1</source>
-      <translation type="unfinished">AC-Giriş1 L%1</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="56"/>
-      <source>AC-In1 --</source>
-      <translation type="unfinished">AC-Giriş1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="70"/>
@@ -1330,12 +1245,6 @@
       <source>Reset service timer</source>
       <translation>Servis zamanlayıcısını sıfırla</translation>
     </message>
-    <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
-      <source>Volume</source>
-      <extracomment>Title for a list of units of volume (e.g. cubic metres, litres, gallons)</extracomment>
-      <translation type="unfinished">Hacim</translation>
-    </message>
     <message id="settings_gps_format">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="69"/>
       <source>Format</source>
@@ -1438,42 +1347,6 @@ Bu işlem işe yaramazsa sim kartı bir telefona takarak veri indirmek için yet
       <source>Wrong PIN</source>
       <translation>Yanlış PIN</translation>
     </message>
-    <message id="page_settings_gsm_ok">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>OK</source>
-      <translation type="unfinished">OK</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="128"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">Bilinmeyen hata</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_state">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="153"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Bilinmiyor</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_value">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="182"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Bilinmiyor</translation>
-    </message>
-    <message id="page_settings_gsm_offline">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="173"/>
-      <source>Offline</source>
-      <translation type="unfinished">Çevrimdışı</translation>
-    </message>
-    <message id="page_settings_gsm_connecting">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="176"/>
-      <source>Connecting</source>
-      <translation type="unfinished">Bağlanıyor</translation>
-    </message>
-    <message id="page_settings_gsm_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="179"/>
-      <source>Connected</source>
-      <translation type="unfinished">Bağlandı</translation>
-    </message>
     <message id="page_settings_gsm_pin">
       <location filename="../../pages/settings/PageSettingsGsm.qml" line="191"/>
       <source>PIN</source>
@@ -1530,32 +1403,32 @@ Bu işlem işe yaramazsa sim kartı bir telefona takarak veri indirmek için yet
       <translation>Şebeke Meter</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
       <source>External meter</source>
       <translation>Harici Meter</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="67"/>
       <source>Inverter/Charger</source>
       <translation>İnvertör/Şarj cihazı</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
       <source>Multiphase regulation</source>
       <translation>Çok fazlı düzenleme</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="91"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
       <source>Total of all phases</source>
       <translation>Tüm fazların toplamı</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="95"/>
       <source>Individual phase</source>
       <translation>Tek faz</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="99"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="101"/>
       <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
@@ -1564,68 +1437,13 @@ CAUTION: Use only if required by the utility provider.</source>
 DİKKAT: Yalnızca hizmet sağlayıcı tarafından isteniyorsa kullanın.</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="104"/>
       <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
       <translation>Tüm fazların toplamı, şebeke ayar noktasına ulaşmak için akıllı bir şekilde düzenlenir (sistem verimliliği optimize edilir).
 
 Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translation>
-    </message>
-    <message id="settings_ess_min_soc">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation type="unfinished">Minimum Deşarj SoC (şebeke kesintisi olmadıkça)</translation>
-    </message>
-    <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="129"/>
-      <source>Active SOC limit</source>
-      <translation type="unfinished">Aktif SOC (aku deşarj seviye) limiti</translation>
-    </message>
-    <message id="settings_ess_battery_life_sustain">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
-      <source>Sustain</source>
-      <translation type="unfinished">Sürdür</translation>
-    </message>
-    <message id="settings_ess_battery_life_recharge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="157"/>
-      <source>Recharge</source>
-      <translation type="unfinished">Re-Şarj</translation>
-    </message>
-    <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <source>Scheduled charge levels</source>
-      <translation type="unfinished">Planlanmış şarj seviyeleri</translation>
-    </message>
-    <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="257"/>
-      <source>Active (%1)</source>
-      <translation type="unfinished">Active (%1)</translation>
-    </message>
-    <message id="settings_ess_inactive">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="259"/>
-      <source>Inactive</source>
-      <translation type="unfinished">Aktif değil</translation>
-    </message>
-    <message id="settings_ess_dynamic">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="293"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">Dinamik ESS</translation>
-    </message>
-    <message id="settings_ess_deprecated">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="319"/>
-      <source>Deprecated settings</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_charge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="326"/>
-      <source>Battery charge limit (% of CCL)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_discharge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="337"/>
-      <source>Battery discharge limit (% of DCL)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_rs_ess_min_soc">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="40"/>
@@ -1637,13 +1455,8 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <source>Active SOC limit</source>
       <translation>Aktif SOC (aku deşarj seviye) limiti</translation>
     </message>
-    <message id="scheduled_charge_inactive">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
-      <source>Inactive</source>
-      <translation type="unfinished">Aktif değil</translation>
-    </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="245"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="247"/>
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
       <source>Peak shaving</source>
       <translation>Peak shaving</translation>
@@ -1659,12 +1472,12 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <translation>Herzaman</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="151"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
       <source>Discharge disabled</source>
       <translation>Deşarj devre dışı</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
       <source>Slow charge</source>
       <translation>Yavaş şarj</translation>
     </message>
@@ -1679,32 +1492,32 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <translation>Re-Şarj</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="165"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="167"/>
       <source>Limit charge power</source>
       <translation>Şarj akımı sınırla</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="183"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="185"/>
       <source>Maximum charge power</source>
       <translation>Maksimum şarj gücü</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="196"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="198"/>
       <source>Limit inverter power</source>
       <translation>İnvertör gücünü sınırla</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="214"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="216"/>
       <source>Maximum inverter power</source>
       <translation>Maksimum invertör gücü</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="225"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="227"/>
       <source>Grid setpoint</source>
       <translation>Grid Setpoint</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="236"/>
       <source>Grid feed-in</source>
       <translation>Şebeke'ye Satış</translation>
     </message>
@@ -1743,8 +1556,8 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <source>Door alarm</source>
       <translation>Kapı Alarmı</translation>
     </message>
-    <message id="digitalinputs_type_bilgepump">
-      <location filename="../../src/enums.cpp" line="201"/>
+    <message id="switchable_output_bilge_pump">
+      <location filename="../../src/enums.cpp" line="424"/>
       <source>Bilge pump</source>
       <translation>Tahliye pompası</translation>
     </message>
@@ -1796,11 +1609,6 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <source>Deferred by %1s</source>
       <extracomment>%1 = number of seconds</extracomment>
       <translation>Deferred by %1s</translation>
-    </message>
-    <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="75"/>
-      <source>Are you sure?</source>
-      <translation type="unfinished">Emin misin?</translation>
     </message>
     <message id="settings_vrm_portal_id">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="87"/>
@@ -1939,11 +1747,6 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <source>External storage</source>
       <translation>Extern bellek</translation>
     </message>
-    <message id="settings_vrm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="308"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">Bilinmeyen hata</translation>
-    </message>
     <message id="settings_vrm_no_error">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="311"/>
       <source>No Error</source>
@@ -2029,37 +1832,10 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <source>Function</source>
       <translation>Fonksiyon</translation>
     </message>
-    <message id="settings_relay_disabled">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="54"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="98"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Devre dışı</translation>
-    </message>
     <message id="settings_relay_alarm_relay">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="56"/>
       <source>Alarm relay</source>
       <translation>Alarm rölesi</translation>
-    </message>
-    <message id="settings_relay_tank_pump">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="62"/>
-      <source>Tank pump</source>
-      <translation type="unfinished">Tank pompası</translation>
-    </message>
-    <message id="settings_relay_manual">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="64"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="100"/>
-      <source>Manual</source>
-      <translation type="unfinished">Manuel</translation>
-    </message>
-    <message id="settings_relay_polarity_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
-      <source>Polarity (Relay 1)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_relay_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
-      <source>Polarity</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_normally_open">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="83"/>
@@ -2075,11 +1851,6 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="93"/>
       <source>Function (Relay 2)</source>
       <translation>Fonksiyon (Röle 2)</translation>
-    </message>
-    <message id="settings_relay_polarity_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
-      <source>Polarity (Relay 2)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_temp_control_rules">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="119"/>
@@ -2111,12 +1882,6 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
       <source>Press to boot</source>
       <translation>Önyükleme için basın</translation>
-    </message>
-    <message id="settings_firmware_backup_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
-      <translation type="unfinished">Donanım yazılımı %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
@@ -2152,6 +1917,7 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
     <message id="nav_boat">
       <location filename="../../pages/boat/BoatPage.qml" line="14"/>
       <source>Boat</source>
+      <extracomment>The 'Boat' page</extracomment>
       <translation>Tekne</translation>
     </message>
     <message id="settings_system_name">
@@ -2219,11 +1985,6 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <source>Solar charger current control</source>
       <translation>Solar şarj cihazı akım kontrolü</translation>
     </message>
-    <message id="settings_system_status_bms_params">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
-      <source>BMS control</source>
-      <translation type="unfinished">BMS kontrolü</translation>
-    </message>
     <message id="common_words_bms_control">
       <location filename="../../components/CommonWords.qml" line="101"/>
       <source>BMS control</source>
@@ -2238,11 +1999,6 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
       <source>Pump state</source>
       <translation>Pompa durumu</translation>
-    </message>
-    <message id="settings_pump_auto">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="56"/>
-      <source>Auto</source>
-      <translation type="unfinished">Otomatik</translation>
     </message>
     <message id="settings_tank_sensor">
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
@@ -2271,11 +2027,6 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="35"/>
       <source>Unplugged</source>
       <translation>Fiş takılı değil</translation>
-    </message>
-    <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="16"/>
-      <source>Name</source>
-      <translation type="unfinished">İsim</translation>
     </message>
     <message id="settings_tcpip_hidden">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="21"/>
@@ -2317,16 +2068,6 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="99"/>
       <source>IP configuration</source>
       <translation>IP yapılandırması</translation>
-    </message>
-    <message id="settings_tcpip_manual">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="105"/>
-      <source>Manual</source>
-      <translation type="unfinished">Manuel</translation>
-    </message>
-    <message id="settings_tcpip_off">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="107"/>
-      <source>Off</source>
-      <translation type="unfinished">Kapalı</translation>
     </message>
     <message id="settings_tcpip_fixed">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="109"/>
@@ -2382,21 +2123,6 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="30"/>
       <source>Create access point</source>
       <translation>Access noktası oluştur</translation>
-    </message>
-    <message id="settings_wifi_access_point_enter_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="68"/>
-      <source>Enter password</source>
-      <translation type="unfinished">Parola Gir</translation>
-    </message>
-    <message id="page_settings_wifi_invalid_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
-      <source>Password length must be either 0 or between 10 and 63 characters long</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_wifi_password_updated">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
-      <source>Password updated</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_wifi_networks">
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="86"/>
@@ -2539,20 +2265,10 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <extracomment>Network status: Standalone</extracomment>
       <translation>Standalone</translation>
     </message>
-    <message id="charger_standalone">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="45"/>
-      <source>Standalone</source>
-      <translation type="unfinished">Standalone</translation>
-    </message>
     <message id="charger_charge">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="48"/>
       <source>Charge</source>
       <translation>Şarj</translation>
-    </message>
-    <message id="charger_external_control">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="51"/>
-      <source>External control</source>
-      <translation type="unfinished">Extern kontrol</translation>
     </message>
     <message id="charger_charge_hub_1">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="54"/>
@@ -2584,16 +2300,6 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <source>Master setting</source>
       <translation>Master Ayarı</translation>
     </message>
-    <message id="charger_slave">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="85"/>
-      <source>Slave</source>
-      <translation type="unfinished">Slave</translation>
-    </message>
-    <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation type="unfinished">Şarj voltajı</translation>
-    </message>
     <message id="systemsettings_networkstatus_slave">
       <location filename="../../data/SystemSettings.qml" line="148"/>
       <source>Slave</source>
@@ -2615,14 +2321,15 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <source>Group &amp; Charge master</source>
       <translation>Grup ve Şarj ana birimi</translation>
     </message>
-    <message id="genset_charge_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="365"/>
+    <message id="charger_charge_voltage">
+      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
       <source>Charge voltage</source>
       <translation>Şarj voltajı</translation>
     </message>
     <message id="common_words_reset">
       <location filename="../../components/CommonWords.qml" line="448"/>
       <source>Reset</source>
+      <extracomment>Reset the BMS control</extracomment>
       <translation>Sıfırla</translation>
     </message>
     <message id="solarcharger_load">
@@ -2651,14 +2358,14 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <extracomment>Voltage alarm is at "Warning" level</extracomment>
       <translation>Uyarı</translation>
     </message>
-    <message id="listitems_alarm_level_alarm">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="25"/>
+    <message id="digitalinputs_state_alarm">
+      <location filename="../../src/enums.cpp" line="270"/>
       <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
+      <extracomment>Relay function is 'alarm'</extracomment>
       <translation>Alarm</translation>
     </message>
-    <message id="devicelist_tankshape_volume">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="190"/>
+    <message id="components_volumeunit_volume">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
       <source>Volume</source>
       <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
       <translation>Hacim</translation>
@@ -2808,26 +2515,10 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <source>Relay function</source>
       <translation>Röle fonksiyonu</translation>
     </message>
-    <message id="batterysettingrelay_alarm">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation type="unfinished">Alarm</translation>
-    </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
       <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
       <source>Charger or generator start/stop</source>
       <translation>Şarj cihazını ya da jeneratörü başlat/durdur</translation>
-    </message>
-    <message id="batterysettingrelay_manual_control">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
-      <source>Manual control</source>
-      <translation type="unfinished">Manuel kontrol</translation>
-    </message>
-    <message id="batterysettingrelay_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">Sigorta atmış</translation>
     </message>
     <message id="common_words_manual_control">
       <location filename="../../components/CommonWords.qml" line="302"/>
@@ -2853,12 +2544,6 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
       <source>Status LEDs</source>
       <translation>Durum LED'leri</translation>
-    </message>
-    <message id="batterydiagnostics_none">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
-      <source>None</source>
-      <extracomment>Indicates no alarm is set</extracomment>
-      <translation type="unfinished">Yok</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
@@ -2888,7 +2573,7 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
     <message id="common_words_switch">
       <location filename="../../components/CommonWords.qml" line="525"/>
       <source>Switch</source>
-      <extracomment>Change the mode value</extracomment>
+      <extracomment>Change the battery mode</extracomment>
       <translation>Anahtar</translation>
     </message>
     <message id="devicelist_battery_initializing">
@@ -2956,21 +2641,6 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <source>Top section voltage</source>
       <translation>Üst bölge voltaj</translation>
     </message>
-    <message id="battery_bank_error_communication">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="96"/>
-      <source>Communication error</source>
-      <translation type="unfinished">İletişim hatası</translation>
-    </message>
-    <message id="battery_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="182"/>
-      <source>State of health</source>
-      <translation type="unfinished">Sağlık durumu</translation>
-    </message>
-    <message id="battery_bus_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="212"/>
-      <source>Bus voltage</source>
-      <translation type="unfinished">Bara voltaj</translation>
-    </message>
     <message id="battery_bottom_section_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="228"/>
       <source>Bottom section voltage</source>
@@ -3016,16 +2686,6 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <source>IO</source>
       <translation>IO</translation>
     </message>
-    <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="391"/>
-      <source>System</source>
-      <translation type="unfinished">Sistem</translation>
-    </message>
-    <message id="battery_press_to_redetect">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="433"/>
-      <source>Press to redetect</source>
-      <translation type="unfinished">Yeniden algılamak için basın</translation>
-    </message>
     <message id="pagesettingsgeneral_system">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="107"/>
       <source>System</source>
@@ -3066,16 +2726,6 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <source>Low SOC</source>
       <translation>Düşük SOC</translation>
     </message>
-    <message id="batteryalarms_high_battery_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
-      <source>High battery voltage</source>
-      <translation type="unfinished">Yüksek akü gerilimi</translation>
-    </message>
-    <message id="batteryalarms_low_soc">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low SOC</source>
-      <translation type="unfinished">Düşük SOC</translation>
-    </message>
     <message id="batteryalarms_low_starter_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="73"/>
       <source>Low starter voltage</source>
@@ -3095,11 +2745,6 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
       <source>Mid-point voltage</source>
       <translation>Orta nokta voltaj</translation>
-    </message>
-    <message id="batteryalarms_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">Sigorta atmış</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
@@ -3293,11 +2938,6 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <source>Restore factory defaults</source>
       <translation>Fabrika ayarlarına dön</translation>
     </message>
-    <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation type="unfinished">Dönmek için basın</translation>
-    </message>
     <message id="vebus_backup_press_to_restore">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="362"/>
       <source>Press to restore</source>
@@ -3337,11 +2977,6 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="18"/>
       <source>Capacity</source>
       <translation>Kapasite</translation>
-    </message>
-    <message id="batterysettingsbattery_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
-      <source>Capacity</source>
-      <translation type="unfinished">Kapasite</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
@@ -3418,16 +3053,13 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <source>No power on busbar</source>
       <translation>Busbarda güç yok</translation>
     </message>
-    <message id="lynxdistributor_connection_lost">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
-      <source>Connection lost</source>
-      <translation type="unfinished">Bağlantı kaybedildi</translation>
-    </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
       <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
       <source>%n fuse(s) blown</source>
       <extracomment>%n = number of fuses that have blown</extracomment>
       <translation>
+        <numerusform>%n sigorta atmış
+Çoğul: %n sigorta atmış</numerusform>
         <numerusform>%n sigorta atmış
 Çoğul: %n sigorta atmış</numerusform>
       </translation>
@@ -3458,26 +3090,6 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <source>Shutdowns due error</source>
       <translation>Hataya bağlı kapanmalar</translation>
     </message>
-    <message id="lynxiondiagnostics_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
-      <source>Last error</source>
-      <translation type="unfinished">Son hata</translation>
-    </message>
-    <message id="lynxiondiagnostics_2nd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
-      <source>2nd last error</source>
-      <translation type="unfinished">İkinci son hata</translation>
-    </message>
-    <message id="lynxiondiagnostics_3rd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
-      <source>3rd last error</source>
-      <translation type="unfinished">Üçüncü son hata</translation>
-    </message>
-    <message id="lynxiondiagnostics_4th_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
-      <source>4th last error</source>
-      <translation type="unfinished">Dördüncü son hata</translation>
-    </message>
     <message id="lynxionio_system_switch">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
       <source>System Switch</source>
@@ -3497,11 +3109,6 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <location filename="../../components/CommonWords.qml" line="54"/>
       <source>Batteries</source>
       <translation>Aküler</translation>
-    </message>
-    <message id="lynxionsystem_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
-      <source>Capacity</source>
-      <translation type="unfinished">Kapasite</translation>
     </message>
     <message id="lynxionsystem_parallel">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="30"/>
@@ -3523,20 +3130,10 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <source>Min/max cell temperature</source>
       <translation>Min/maks. hücre sıcaklığı</translation>
     </message>
-    <message id="lynxionsystem_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="92"/>
-      <source>Balancing</source>
-      <translation type="unfinished">Balanslama</translation>
-    </message>
     <message id="lynxionsystem_balancer_balancing">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
       <source>Balancing</source>
       <translation>Balanslama</translation>
-    </message>
-    <message id="lynxionsystem_balancer_unknown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="117"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Bilinmiyor</translation>
     </message>
     <message id="dc_output">
       <location filename="../../components/listitems/ListDcOutputQuantityGroup.qml" line="16"/>
@@ -3644,11 +3241,6 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <source>Remaining</source>
       <translation>Kalan</translation>
     </message>
-    <message id="devicelist_tanksensor_sensor_battery">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="51"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">Sensör akü</translation>
-    </message>
     <message id="temperature_sensor_battery">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="112"/>
       <source>Sensor battery</source>
@@ -3677,7 +3269,7 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
     <message id="devicelist_tanksetup_custom">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="53"/>
       <source>Custom</source>
-      <translation type="unfinished">Özel</translation>
+      <translation>Özel</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="59"/>
@@ -3710,34 +3302,34 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <translation>Sensör değeri</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="75"/>
       <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
       <translation>Tanımlanmış özel şekil yok. On noktaya kadar bir tane tanımlayabilirsiniz. 0 ve %100'ün ima edildiğini unutmayın.</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="91"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="89"/>
       <source>Point %1</source>
       <extracomment>%1 = the point number</extracomment>
       <translation>Nokta %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="133"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="179"/>
       <source>Add point</source>
       <translation>Puan ekle</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="156"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="205"/>
       <source>Sensor level</source>
       <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
       <translation>Sensör Düzeyi</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="256"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="311"/>
       <source>Duplicate sensor level values are not allowed.</source>
       <translation>Yinelenen sensör seviyesi değerlerine izin verilmez.</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="262"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="317"/>
       <source>Volume values must be increasing.</source>
       <translation>Hacim değerleri artıyor olmalıdır.</translation>
     </message>
@@ -3777,11 +3369,6 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <source>Switch position</source>
       <translation>Switch position</translation>
     </message>
-    <message id="ac-in-setup_single_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="142"/>
-      <source>Single phase</source>
-      <translation type="unfinished">Tek faz</translation>
-    </message>
     <message id="ac-in-setup_two_phase">
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="144"/>
       <source>2-phase</source>
@@ -3791,11 +3378,6 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="146"/>
       <source>3-phase</source>
       <translation>3 fazlı</translation>
-    </message>
-    <message id="ac-in-setup_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="161"/>
-      <source>Devices</source>
-      <translation type="unfinished">Cihazlar</translation>
     </message>
     <message id="ac-in-genset_ac">
       <location filename="../../components/PageGensetModel.qml" line="194"/>
@@ -3889,12 +3471,6 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <extracomment>%1 = CT device number</extracomment>
       <translation>CT %1</translation>
     </message>
-    <message id="smappeect_phase_none">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation type="unfinished">Yok</translation>
-    </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
       <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
       <source>Flashing LED indicates this CT</source>
@@ -3908,11 +3484,13 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
     <message id="common_words_setting_disabled_when_dmc_connected">
       <location filename="../../components/CommonWords.qml" line="355"/>
       <source>This setting is disabled when a Digital Multi Control is connected.</source>
+      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>Bir Dijital Multi Kontrol bağlandığında bu ayar devre dışı bırakılır.</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
       <location filename="../../components/CommonWords.qml" line="358"/>
       <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>Bir VE.Bus BMS bağlandığında bu ayar devre dışı bırakılır.</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
@@ -3930,16 +3508,6 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="21"/>
       <source>Inverted</source>
       <translation>Ters Çevrilmiş</translation>
-    </message>
-    <message id="digitalinput_enable_alarm">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="48"/>
-      <source>Enable alarm</source>
-      <translation type="unfinished">Alarmı etkinleştir</translation>
-    </message>
-    <message id="digitalinput_inverted">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="54"/>
-      <source>Inverted</source>
-      <translation type="unfinished">Ters Çevrilmiş</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
       <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="60"/>
@@ -3976,16 +3544,6 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <source>Wind speed</source>
       <translation>Rüzgar hızı</translation>
     </message>
-    <message id="page_meteo_battery_voltage">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="99"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">Sensör akü</translation>
-    </message>
-    <message id="meteo_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="120"/>
-      <source>Low</source>
-      <translation type="unfinished">Düşük</translation>
-    </message>
     <message id="page_meteo_settings_auto_detect">
       <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
       <source>Auto-detect</source>
@@ -4016,16 +3574,6 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <source>Reset counter</source>
       <translation>Sayacı sıfırla</translation>
     </message>
-    <message id="temperature_short_circuited">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="32"/>
-      <source>Short circuited</source>
-      <translation type="unfinished">Kısa devreli</translation>
-    </message>
-    <message id="temperature_reverse_polarity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="35"/>
-      <source>Reverse polarity</source>
-      <translation type="unfinished">Ters polarite</translation>
-    </message>
     <message id="temperature_sensor_battery_low">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
       <source>Sensor battery low</source>
@@ -4040,36 +3588,6 @@ Hizmet sağlayıcı tarafından yasaklanmadığı sürece kullanın.</translatio
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="62"/>
       <source>Pressure</source>
       <translation>Basınç</translation>
-    </message>
-    <message id="temperature_pm25">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
-      <source>PM2.5</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_co2">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>CO₂</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_voc">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
-      <source>VOC index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_nox">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
-      <source>NOx index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_luminosity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
-      <source>Luminosity</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="133"/>
-      <source>Low</source>
-      <translation type="unfinished">Düşük</translation>
     </message>
     <message id="temperature_offset">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
@@ -4123,25 +3641,10 @@ NOT: Güncelleme sistemi geçici olarak durdurabilir.</translation>
       <source>Updating the MK3, values will reappear after the update is complete</source>
       <translation>MK3 güncelleniyor, güncelleme tamamlandıktan sonra değerler yeniden görünecek</translation>
     </message>
-    <message id="vebus_device_charging_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="78"/>
-      <source>Charging the battery to 100%</source>
-      <translation type="unfinished">Akü %100'e kadar şarj et</translation>
-    </message>
     <message id="vebus_device_charging_the_battery_to_100">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="93"/>
       <source>Charging the battery to 100%</source>
       <translation>Akü %100'e kadar şarj et</translation>
-    </message>
-    <message id="vebus_device_page_microgrid_parameters">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
-      <source>Microgrid parameters</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="vebus_device_page_advanced">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
-      <source>Advanced</source>
-      <translation type="unfinished">Gelişmiş</translation>
     </message>
     <message id="vebus_device_in_progress">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="80"/>
@@ -4197,15 +3700,15 @@ Devam etmek istiyor musunuz?</translation>
       <source>DC Current</source>
       <translation>DC Akımı</translation>
     </message>
+    <message id="vebus_device_page_advanced">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
+      <source>Advanced</source>
+      <translation>Gelişmiş</translation>
+    </message>
     <message id="common_words_alarm_setup">
       <location filename="../../components/CommonWords.qml" line="65"/>
       <source>Alarm setup</source>
       <translation>Alarm ayarı</translation>
-    </message>
-    <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
-      <translation type="unfinished">VE.Bus BMS, aküyü korumak için gerektiğinde sistemi otomatik olarak kapatır. Bu nedenle, sistemi Color Control üzerinden kontrol etmek mümkün olmaz.</translation>
     </message>
     <message id="vebus_device_bms_not_found">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="240"/>
@@ -4246,7 +3749,7 @@ Devam etmek istiyor musunuz?</translation>
     <message id="vebus_device_starting">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="117"/>
       <source>Starting...</source>
-      <translation type="unfinished">Başlatılıyor...</translation>
+      <translation>Başlatılıyor...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="120"/>
@@ -4312,16 +3815,6 @@ Devam etmek istiyor musunuz?</translation>
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="260"/>
       <source>ESS Relay test</source>
       <translation>ESS Röle testi</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_completed">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="266"/>
-      <source>Completed</source>
-      <translation type="unfinished">Tamamlandı</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_pending">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="268"/>
-      <source>Pending</source>
-      <translation type="unfinished">Askıda olması...</translation>
     </message>
     <message id="cycle_history_completed">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
@@ -4508,6 +4001,7 @@ Devam etmek istiyor musunuz?</translation>
     <message id="rssystemalarms_overload">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
       <source>Overload</source>
+      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
       <translation>Aşırı Yük</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
@@ -4520,11 +4014,6 @@ Devam etmek istiyor musunuz?</translation>
       <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
       <source>Voltage Sensor</source>
       <translation>Voltaj Sensörü</translation>
-    </message>
-    <message id="vebus_device_phase_rotation">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
-      <source>Phase rotation</source>
-      <translation type="unfinished">Faz rotasyon</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
@@ -4556,12 +4045,6 @@ Devam etmek istiyor musunuz?</translation>
       <source>VE.Bus BMS version</source>
       <translation>VE.Bus BMS sürümü</translation>
     </message>
-    <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="15"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="52"/>
-      <source>Minimum SOC</source>
-      <translation type="unfinished">Minimüm SoC</translation>
-    </message>
     <message id="ess_unless_grid_fails">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="32"/>
       <source>Unless grid fails</source>
@@ -4581,7 +4064,7 @@ Devam etmek istiyor musunuz?</translation>
     <message id="common_words_ac_input_role">
       <location filename="../../components/CommonWords.qml" line="24"/>
       <source>Role</source>
-      <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
       <translation>Rol</translation>
     </message>
     <message id="common_words_ac_load">
@@ -4620,18 +4103,6 @@ Devam etmek istiyor musunuz?</translation>
       <source>Active</source>
       <extracomment>Status is 'active'</extracomment>
       <translation>Aktif</translation>
-    </message>
-    <message id="common_words_alarm">
-      <location filename="../../components/CommonWords.qml" line="51"/>
-      <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
-      <translation type="unfinished">Alarm</translation>
-    </message>
-    <message id="common_words_alarm_setting_overload">
-      <location filename="../../components/CommonWords.qml" line="58"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation type="unfinished">Aşırı Yük</translation>
     </message>
     <message id="common_words_alarm_status">
       <location filename="../../components/CommonWords.qml" line="68"/>
@@ -4678,8 +4149,8 @@ Devam etmek istiyor musunuz?</translation>
       <source>Charge current</source>
       <translation>Şarj akımı</translation>
     </message>
-    <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="125"/>
+    <message id="battery_mode_charging">
+      <location filename="../../src/enums.cpp" line="30"/>
       <source>Charging</source>
       <extracomment>"Charging" state</extracomment>
       <translation>Şarj</translation>
@@ -4693,7 +4164,7 @@ Devam etmek istiyor musunuz?</translation>
     <message id="digitalinputs_state_closed">
       <location filename="../../src/enums.cpp" line="262"/>
       <source>Closed</source>
-      <extracomment>Digital input state</extracomment>
+      <extracomment>Status is 'closed'</extracomment>
       <translation>Kapalı</translation>
     </message>
     <message id="evchargers_status_connected">
@@ -4701,8 +4172,8 @@ Devam etmek istiyor musunuz?</translation>
       <source>Connected</source>
       <translation>Bağlandı</translation>
     </message>
-    <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="143"/>
+    <message id="temperature_slider_current">
+      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
       <source>Current</source>
       <extracomment>Electric current, as measured in Amps</extracomment>
       <translation>Akım</translation>
@@ -4729,9 +4200,10 @@ Devam etmek istiyor musunuz?</translation>
       <extracomment>Title for device information</extracomment>
       <translation>Cihaz</translation>
     </message>
-    <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="172"/>
+    <message id="battery_mode_discharging">
+      <location filename="../../src/enums.cpp" line="34"/>
       <source>Discharging</source>
+      <extracomment>Battery mode</extracomment>
       <translation>Deşarj </translation>
     </message>
     <message id="wifimodel_disconnected">
@@ -4817,13 +4289,14 @@ Devam etmek istiyor musunuz?</translation>
       <source>%1 Hour(s)</source>
       <translation>1 Saat(ler)</translation>
     </message>
-    <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="251"/>
+    <message id="battery_mode_idle">
+      <location filename="../../src/enums.cpp" line="26"/>
       <source>Idle</source>
+      <extracomment>Battery mode</extracomment>
       <translation>Atıl</translation>
     </message>
-    <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="258"/>
+    <message id="scheduled_charge_inactive">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
       <source>Inactive</source>
       <extracomment>Status is 'inactive'</extracomment>
       <translation>Aktif değil</translation>
@@ -4925,8 +4398,8 @@ Devam etmek istiyor musunuz?</translation>
       <source>Offline</source>
       <translation>Çevrimdışı</translation>
     </message>
-    <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="17"/>
+    <message id="digitalinputs_state_ok">
+      <location filename="../../src/enums.cpp" line="266"/>
       <source>OK</source>
       <extracomment>Voltage alarm is at "OK" level</extracomment>
       <translation>OK</translation>
@@ -4934,6 +4407,7 @@ Devam etmek istiyor musunuz?</translation>
     <message id="switchable_output_on">
       <location filename="../../src/enums.cpp" line="471"/>
       <source>On</source>
+      <extracomment>Digital input state</extracomment>
       <translation>Açık</translation>
     </message>
     <message id="common_words_online">
@@ -4944,7 +4418,7 @@ Devam etmek istiyor musunuz?</translation>
     <message id="digitalinputs_state_open">
       <location filename="../../src/enums.cpp" line="258"/>
       <source>Open</source>
-      <extracomment>Digital input open</extracomment>
+      <extracomment>Status is 'open'</extracomment>
       <translation>Açık</translation>
     </message>
     <message id="common_words_password">
@@ -5004,9 +4478,10 @@ Devam etmek istiyor musunuz?</translation>
       <source>Remove</source>
       <translation>Çıkar</translation>
     </message>
-    <message id="switch_state_running">
-      <location filename="../../src/enums.cpp" line="363"/>
+    <message id="switchable_output_running">
+      <location filename="../../src/enums.cpp" line="468"/>
       <source>Running</source>
+      <extracomment>Status = "running"</extracomment>
       <translation>Çalışıyor</translation>
     </message>
     <message id="common_words_scanning">
@@ -5073,7 +4548,7 @@ Devam etmek istiyor musunuz?</translation>
     <message id="pvinverter_statusCode_startup">
       <location filename="../../src/enums.cpp" line="296"/>
       <source>Startup (%1)</source>
-      <extracomment>PV inverter status code. %1 = the startup status number</extracomment>
+      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
       <translation>Başlangıç (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
@@ -5128,8 +4603,10 @@ Devam etmek istiyor musunuz?</translation>
       <source>Unique Identity Number</source>
       <translation>Benzersiz Kimlik Numarası</translation>
     </message>
-    <message id="settings_radio_button_group_unknown">
-      <location filename="../../components/listitems/core/ListRadioButtonGroup.qml" line="44"/>
+    <message id="Unknown">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
       <source>Unknown</source>
       <translation>Bilinmiyor</translation>
     </message>
@@ -5284,11 +4761,6 @@ Devam etmek istiyor musunuz?</translation>
       <source>Error while checking for firmware updates</source>
       <translation>Ürün firmware güncellemeleri kontrol edilirken hata oluştu</translation>
     </message>
-    <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation type="unfinished">Ürün firmware güncellemeleri kontrol edilirken hata oluştu</translation>
-    </message>
     <message id="settings_firmware_downloading_and_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="63"/>
       <source>Downloading and installing firmware %1...</source>
@@ -5315,6 +4787,66 @@ Devam etmek istiyor musunuz?</translation>
       <source>No firmware found</source>
       <translation>Firmware bulunamadı</translation>
     </message>
+    <message id="tank_type_fuel">
+      <location filename="../../src/enums.cpp" line="495"/>
+      <source>Fuel</source>
+      <translation>Yakıt</translation>
+    </message>
+    <message id="tank_type_fresh_water">
+      <location filename="../../src/enums.cpp" line="498"/>
+      <source>Fresh water</source>
+      <translation>Temiz su</translation>
+    </message>
+    <message id="tank_type_waste_water">
+      <location filename="../../src/enums.cpp" line="501"/>
+      <source>Waste water</source>
+      <translation>Atık su</translation>
+    </message>
+    <message id="tank_type_live_well">
+      <location filename="../../src/enums.cpp" line="504"/>
+      <source>Live well</source>
+      <translation>Faal kuyu</translation>
+    </message>
+    <message id="tank_type_oil">
+      <location filename="../../src/enums.cpp" line="507"/>
+      <source>Oil</source>
+      <translation>Yağ</translation>
+    </message>
+    <message id="tank_type_black_water">
+      <location filename="../../src/enums.cpp" line="510"/>
+      <source>Black water</source>
+      <translation>Atık Su</translation>
+    </message>
+    <message id="tank_type_gasoline">
+      <location filename="../../src/enums.cpp" line="513"/>
+      <source>Gasoline</source>
+      <translation>Benzin</translation>
+    </message>
+    <message id="tank_type_diesel">
+      <location filename="../../src/enums.cpp" line="516"/>
+      <source>Diesel</source>
+      <translation>Dizel</translation>
+    </message>
+    <message id="tank_type_lpg">
+      <location filename="../../src/enums.cpp" line="519"/>
+      <source>LPG</source>
+      <translation>LPG</translation>
+    </message>
+    <message id="tank_type_lng">
+      <location filename="../../src/enums.cpp" line="522"/>
+      <source>LNG</source>
+      <translation>LNG</translation>
+    </message>
+    <message id="tank_type_hydraulic_oil">
+      <location filename="../../src/enums.cpp" line="525"/>
+      <source>Hydraulic oil</source>
+      <translation>Hidrolik yağ</translation>
+    </message>
+    <message id="tank_type_raw_water">
+      <location filename="../../src/enums.cpp" line="528"/>
+      <source>Raw water</source>
+      <translation>Ham Su</translation>
+    </message>
     <message id="listItem_no_access">
       <location filename="../../components/listitems/core/ListItem.qml" line="102"/>
       <source>Setting locked for access level</source>
@@ -5328,6 +4860,7 @@ Devam etmek istiyor musunuz?</translation>
     <message id="welcome_brief_title">
       <location filename="../../pages/welcome/WelcomeView.qml" line="81"/>
       <source>Brief</source>
+      <extracomment>The 'Brief' page</extracomment>
       <translation>Kısa</translation>
     </message>
     <message id="welcome_overview_title">
@@ -5344,23 +4877,6 @@ Devam etmek istiyor musunuz?</translation>
       <location filename="../../pages/NotificationsPage.qml" line="13"/>
       <source>Notifications</source>
       <translation>Bildirimler</translation>
-    </message>
-    <message id="notifications_page_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="43"/>
-      <source>Active Notifications</source>
-      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_page_inactive_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="47"/>
-      <source>Inactive Notifications</source>
-      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_no_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="106"/>
-      <source>No active notifications</source>
-      <translation type="unfinished"/>
     </message>
     <message id="utils_formatTimestamp_now">
       <location filename="../../components/Utils.js" line="258"/>
@@ -5465,11 +4981,6 @@ Devam etmek istiyor musunuz?</translation>
       <source>Self-consumption above limit</source>
       <translation>Limitin üzerinde öz-tüketim</translation>
     </message>
-    <message id="cgwacs_battery_schedule_pv">
-      <location filename="../../components/listitems/ListChargeSchedule.qml" line="171"/>
-      <source>PV</source>
-      <translation type="unfinished">PV</translation>
-    </message>
     <message id="settings_multirs_pv">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="185"/>
       <source>PV</source>
@@ -5480,8 +4991,8 @@ Devam etmek istiyor musunuz?</translation>
       <source>PV &amp; Battery</source>
       <translation>PV &amp; Akü</translation>
     </message>
-    <message id="settings_firmware_checking">
-      <location filename="../../components/listitems/ListFirmwareCheckButton.qml" line="16"/>
+    <message id="pagesettingssupportstate_firmware_checking">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
       <source>Checking...</source>
       <translation>Kontrol ediliyor...</translation>
     </message>
@@ -5489,12 +5000,6 @@ Devam etmek istiyor musunuz?</translation>
       <location filename="../../components/listitems/ListAlarmState.qml" line="11"/>
       <source>Alarm state</source>
       <translation>Alarm durumu</translation>
-    </message>
-    <message id="devicelist_battery_alarm_state">
-      <location filename="../../components/listitems/ListAlarmState.qml" line="19"/>
-      <source>Alarm</source>
-      <extracomment>Alarm state is active</extracomment>
-      <translation type="unfinished">Alarm</translation>
     </message>
     <message id="clear_history_button_clear_history">
       <location filename="../../components/listitems/ListClearHistoryButton.qml" line="15"/>
@@ -5646,11 +5151,6 @@ Devam etmek istiyor musunuz?</translation>
       <source>Max Voltage</source>
       <translation>Max voltaj</translation>
     </message>
-    <message id="charger_history_box_max_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="64"/>
-      <source>Max Voltage</source>
-      <translation type="unfinished">Max voltaj</translation>
-    </message>
     <message id="charger_history_box_max_current">
       <location filename="../../components/SolarDetailBox.qml" line="70"/>
       <source>Max Current</source>
@@ -5661,24 +5161,6 @@ Devam etmek istiyor musunuz?</translation>
       <source>Charge time</source>
       <extracomment>Statistics for battery charging time</extracomment>
       <translation>Şarj süresi</translation>
-    </message>
-    <message id="charger_history_box_bulk">
-      <location filename="../../components/SolarDetailBox.qml" line="136"/>
-      <source>Bulk</source>
-      <extracomment>Battery: time spent in 'Bulk' mode</extracomment>
-      <translation type="unfinished">Bulk</translation>
-    </message>
-    <message id="charger_history_box_float">
-      <location filename="../../components/SolarDetailBox.qml" line="148"/>
-      <source>Float</source>
-      <extracomment>Battery: time spent in 'Float' mode</extracomment>
-      <translation type="unfinished">Float</translation>
-    </message>
-    <message id="charger_history_hr">
-      <location filename="../../components/SolarDetailBox.qml" line="174"/>
-      <source>hr</source>
-      <extracomment>Abbreviation of "hour"</extracomment>
-      <translation type="unfinished">saat</translation>
     </message>
     <message id="solarchargers_state_bulk">
       <location filename="../../src/enums.cpp" line="337"/>
@@ -5750,11 +5232,6 @@ Devam etmek istiyor musunuz?</translation>
       <source>Connecting</source>
       <translation>Bağlanıyor</translation>
     </message>
-    <message id="splash_view_connecting">
-      <location filename="../../components/SplashView.qml" line="288"/>
-      <source>Connecting</source>
-      <translation type="unfinished">Bağlanıyor</translation>
-    </message>
     <message id="splash_view_connected">
       <location filename="../../components/SplashView.qml" line="290"/>
       <source>Connected, awaiting broker messages</source>
@@ -5810,6 +5287,11 @@ Devam etmek istiyor musunuz?</translation>
       <source>MQTT protocol level 5 error</source>
       <translation>MQTT protokolü seviye 5 hatası</translation>
     </message>
+    <message id="common_words_silence_alarm">
+      <location filename="../../components/CommonWords.qml" line="476"/>
+      <source>Silence alarm</source>
+      <translation>Sessiz alarm</translation>
+    </message>
     <message id="vebus_device_page_total_power">
       <location filename="../../components/ThreePhaseQuantityTable.qml" line="47"/>
       <source>Total Power</source>
@@ -5860,20 +5342,10 @@ Devam etmek istiyor musunuz?</translation>
       <source>Retrieving IP address</source>
       <translation>IP adresi alınıyor</translation>
     </message>
-    <message id="utils_connman_connected">
-      <location filename="../../components/Utils.js" line="292"/>
-      <source>Connected</source>
-      <translation type="unfinished">Bağlandı</translation>
-    </message>
     <message id="utils_connman_disconnect">
       <location filename="../../components/Utils.js" line="295"/>
       <source>Disconnect</source>
       <translation>Bağlantıyı kes</translation>
-    </message>
-    <message id="utils_connman_disconnected">
-      <location filename="../../components/Utils.js" line="299"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Bağlantı kesildi</translation>
     </message>
     <message id="overview_widget_acloads_title">
       <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
@@ -5911,11 +5383,6 @@ Devam etmek istiyor musunuz?</translation>
       <source>Shore current limit</source>
       <translation>Sahil Akım Limiti</translation>
     </message>
-    <message id="acInputs_statusCode_stopping">
-      <location filename="../../data/AcInputs.qml" line="170"/>
-      <source>Stopping</source>
-      <translation type="unfinished">Duruyor</translation>
-    </message>
     <message id="page_generator_stopping">
       <location filename="../../data/Generators.qml" line="44"/>
       <source>Stopping</source>
@@ -5931,7 +5398,7 @@ Devam etmek istiyor musunuz?</translation>
       <location filename="../../data/common/TankDescription.qml" line="24"/>
       <location filename="../../src/device.cpp" line="133"/>
       <source>%1 tank (%2)</source>
-      <extracomment>Tank description. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
       <translation>1 tank (%2)</translation>
     </message>
     <message id="dcMeter_ac_charger">
@@ -5980,11 +5447,6 @@ Devam etmek istiyor musunuz?</translation>
       <location filename="../../data/Ess.qml" line="20"/>
       <source>Keep batteries charged</source>
       <translation>Aküleri Dolu Tut</translation>
-    </message>
-    <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="50"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Bağlantı kesildi</translation>
     </message>
     <message id="evchargers_status_charged">
       <location filename="../../data/EvChargers.qml" line="58"/>
@@ -6045,16 +5507,6 @@ Devam etmek istiyor musunuz?</translation>
       <location filename="../../data/EvChargers.qml" line="97"/>
       <source>Start charging</source>
       <translation>Şarjı Başlat</translation>
-    </message>
-    <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="113"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Bilinmiyor</translation>
-    </message>
-    <message id="evchargers_mode_scheduled">
-      <location filename="../../data/EvChargers.qml" line="126"/>
-      <source>Scheduled</source>
-      <translation type="unfinished">Planlanmış</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
       <location filename="../../data/System.qml" line="195"/>
@@ -6179,11 +5631,6 @@ Devam etmek istiyor musunuz?</translation>
       <source>Power supply mode</source>
       <translation>Güç Kaynağı Modu</translation>
     </message>
-    <message id="inverters_state_sustain">
-      <location filename="../../data/System.qml" line="158"/>
-      <source>Sustain</source>
-      <translation type="unfinished">Sürdür</translation>
-    </message>
     <message id="inverters_state_wakeup">
       <location filename="../../data/System.qml" line="162"/>
       <source>Wake up</source>
@@ -6218,16 +5665,6 @@ Devam etmek istiyor musunuz?</translation>
       <location filename="../../data/System.qml" line="180"/>
       <source>Test</source>
       <translation>Test</translation>
-    </message>
-    <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="183"/>
-      <source>External control</source>
-      <translation type="unfinished">Extern kontrol</translation>
-    </message>
-    <message id="inverters_state_dynamic_ess">
-      <location filename="../../data/System.qml" line="198"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">Dinamik ESS</translation>
     </message>
     <message id="settings_rs_ess_dess">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="97"/>
@@ -6306,16 +5743,13 @@ Devam etmek istiyor musunuz?</translation>
     <message id="ess_recommended">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="73"/>
       <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
       <translation>Lityum aküler için %10'un altında şarj önerilmez. Diğer pil türleri için, üretici tarafından önerilen minimum seviye için veri sayfasını kontrol edin.</translation>
-    </message>
-    <message id="controlcard_generator_label_autostart">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="63"/>
-      <source>Autostart</source>
-      <translation type="unfinished">Autostart</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
       <location filename="../../pages/controlcards/GeneratorCard.qml" line="70"/>
       <source>Start and stop the generator based on the configured autostart conditions.</source>
+      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
       <translation>Yapılandırılmış otomatik başlatma koşullarına göre jeneratörü başlatın ve durdurun.</translation>
     </message>
     <message id="generator_dialog_disabled">
@@ -6338,11 +5772,13 @@ Devam etmek istiyor musunuz?</translation>
       <location filename="../../pages/controlcards/InverterChargerCard.qml" line="26"/>
       <source>Inverter / Charger (%1)</source>
       <extracomment>%1 = the inverter/charger name</extracomment>
+      <oldsource>Inverter / Charger</oldsource>
       <translation>İnvertör / Şarj Cihazı (%1)</translation>
     </message>
     <message id="settings_page_debug_quit_application">
       <location filename="../../pages/settings/debug/PageDebug.qml" line="36"/>
       <source>Quit application</source>
+      <oldsource>Quit Application</oldsource>
       <translation>Uygulamadan Çık</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
@@ -6353,12 +5789,8 @@ Devam etmek istiyor musunuz?</translation>
     <message id="settings_page_relay_generator_run_time">
       <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
       <source>Current run time</source>
+      <oldsource>Run time</oldsource>
       <translation>Geçerli çalışma süresi</translation>
-    </message>
-    <message id="settings_page_genset_generator_run_time">
-      <location filename="../../components/PageGensetModel.qml" line="102"/>
-      <source>Current run time</source>
-      <translation type="unfinished">Geçerli çalışma süresi</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
       <location filename="../../components/PageGensetModel.qml" line="110"/>
@@ -6385,19 +5817,10 @@ Devam etmek istiyor musunuz?</translation>
       <source>Remote start mode</source>
       <translation>Uzaktan çalıştırma modu</translation>
     </message>
-    <message id="ac-in-genset_speed">
-      <location filename="../../components/PageGensetModel.qml" line="245"/>
-      <source>Speed</source>
-      <translation type="unfinished">Hız</translation>
-    </message>
-    <message id="ac-in-genset_load">
-      <location filename="../../components/PageGensetModel.qml" line="252"/>
-      <source>Load</source>
-      <translation type="unfinished">Yük</translation>
-    </message>
     <message id="ac-in-genset_oil_pressure">
       <location filename="../../components/PageGensetModel.qml" line="260"/>
       <source>Oil pressure</source>
+      <oldsource>Oil Pressure</oldsource>
       <translation>Yağ Basıncı</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
@@ -6493,11 +5916,13 @@ Devam etmek istiyor musunuz?</translation>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
       <source>High starter battery voltage alarms</source>
+      <oldsource>High starter batttery voltage alarms</oldsource>
       <translation>Yüksek marş aküsü voltajı alarmları</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
       <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
       <translation>Boşaltma katına gitme süresi ayarının değiştirilmesinin röle menüsündeki Düşük şarj durumu ayarını da değiştirdiğini unutmayın.</translation>
     </message>
     <message id="lynxionsystem_cells_per_battery">
@@ -6574,6 +5999,7 @@ Devam etmek istiyor musunuz?</translation>
       <location filename="../../pages/settings/devicelist/delegates/DeviceListDelegate_solarcharger.qml" line="34"/>
       <source>Error: #%1</source>
       <extracomment>%1 = error number</extracomment>
+      <oldsource>Error: %1</oldsource>
       <translation>Hata: #%1</translation>
     </message>
     <message id="devicelistpage_genset">
@@ -6630,17 +6056,14 @@ Devam etmek istiyor musunuz?</translation>
     <message id="settings_page_relay_generator_auto_start_enabled">
       <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
       <source>Autostart functionality</source>
+      <oldsource>Auto start functionality</oldsource>
       <translation>Otomatik başlatma işlevi</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="97"/>
       <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
       <translation>Bu seçeneği kullanırken jeneratörün AC giriş %1'e bağlı olmadığından emin olun</translation>
-    </message>
-    <message id="page_generator_conditions_inverter_high_temperature">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="139"/>
-      <source>Inverter high temperature</source>
-      <translation type="unfinished">İnvertör yüksek sıcaklık</translation>
     </message>
     <message id="page_generator_conditions_tank_level">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="159"/>
@@ -6670,30 +6093,34 @@ Devam etmek istiyor musunuz?</translation>
     <message id="settings_generator_function_not_enabled">
       <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
       <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
+      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
       <translation>Jeneratör başlat/durdur işlevi etkin değil, röle ayarlarına gidin ve işlevi "Jeneratör başlat/durdur" olarak ayarlayın</translation>
     </message>
     <message id="settings_batteries_intro">
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="45"/>
       <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
       <translation>Genel Bakış sayfasında Pil simgesine tıklandığında gösterilen pil verilerini tanımlamak için bu menüyü kullanın. Aynı seçim VRM Portalında da görülebilir.</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
       <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
       <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
       <translation>Sürekli tarama Wi-Fi çalışmasını engelleyebilir.</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
       <source>CAN-bus BMS LV (500 kbit/s)</source>
+      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
       <translation>CAN-bus BMS LV (500 kbit/s)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
       <source>CAN-bus BMS HV (500 kbit/s)</source>
       <translation>CAN-bus BMS HV (500 kbit/s)</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
       <source>Up, but no services (500 kbit/s)</source>
       <translation>Açık, ancak hizmet yok (500 kbit/s)</translation>
     </message>
@@ -6706,41 +6133,6 @@ Devam etmek istiyor musunuz?</translation>
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="127"/>
       <source>Brief page</source>
       <translation>Özet sayfası</translation>
-    </message>
-    <message id="settings_displayoff_1min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="46"/>
-      <source>1 min</source>
-      <translation type="unfinished">1 dak</translation>
-    </message>
-    <message id="settings_displayoff_10min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="48"/>
-      <source>10 min</source>
-      <translation type="unfinished">10 dak</translation>
-    </message>
-    <message id="settings_displayoff_30min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="50"/>
-      <source>30 min</source>
-      <translation type="unfinished">30 dak</translation>
-    </message>
-    <message id="settings_displayoff_never">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="52"/>
-      <source>Never</source>
-      <translation type="unfinished">Hiçbir zaman</translation>
-    </message>
-    <message id="settings_remote_console_appearance_auto">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="112"/>
-      <source>Auto</source>
-      <translation type="unfinished">Otomatik</translation>
-    </message>
-    <message id="settings_brief_view_start_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="119"/>
-      <source>Start page</source>
-      <translation type="unfinished">Başlangıç sayfası</translation>
-    </message>
-    <message id="settings_display_boat_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="135"/>
-      <source>Boat page</source>
-      <translation type="unfinished">Tekne sayfası</translation>
     </message>
     <message id="settings_display_minmax">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="148"/>
@@ -6795,21 +6187,6 @@ Devam etmek istiyor musunuz?</translation>
       <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
       <translation>1, %2 olarak ayarlanmıştır</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_unsupported_device">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="50"/>
-      <source>Unsupported GX device</source>
-      <translation type="unfinished">Desteklenmeyen GX cihazı</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_clean">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="55"/>
-      <source>Clean</source>
-      <translation type="unfinished">Temiz</translation>
-    </message>
-    <message id="pagesettingsgeneral_firmware">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="112"/>
-      <source>Firmware</source>
-      <translation type="unfinished">Firmware</translation>
-    </message>
     <message id="pagesettingsgeneral_access_and_security">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
       <source>Access &amp; Security</source>
@@ -6843,6 +6220,7 @@ Devam etmek istiyor musunuz?</translation>
     <message id="settings_language_please_wait">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="209"/>
       <source>Please wait while the language is changed.</source>
+      <oldsource>Please wait while the language is changed</oldsource>
       <translation>Dil değiştirilirken lütfen bekleyin.</translation>
     </message>
     <message id="settings_briefview_totals">
@@ -6859,11 +6237,6 @@ Devam etmek istiyor musunuz?</translation>
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="71"/>
       <source>Tank is not connected.</source>
       <translation>Tank bağlı değil.</translation>
-    </message>
-    <message id="settings_briefview_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="83"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">Aktif akü monitör</translation>
     </message>
     <message id="settings_briefview_individual_batteries">
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="86"/>
@@ -6914,6 +6287,7 @@ Devam etmek istiyor musunuz?</translation>
     <message id="settings_dvcc_charge_current_limits">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="30"/>
       <source>Charge current limits</source>
+      <oldsource>Charge Current limits</oldsource>
       <translation>Şarj Akımı limitleri</translation>
     </message>
     <message id="settings_firmware_official_release">
@@ -6993,11 +6367,6 @@ Devam etmek istiyor musunuz?</translation>
       <source>No password and the network communication is not encrypted</source>
       <translation>Şifre yok ve ağ iletişimi şifrelenmemiş</translation>
     </message>
-    <message id="settings_logout_now">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
-      <source>Log out now</source>
-      <translation type="unfinished">Şimdi çıkış yap</translation>
-    </message>
     <message id="settings_security_profile_password_incorrect_length">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="28"/>
       <source>Password needs to be at least 8 characters long</source>
@@ -7048,25 +6417,10 @@ Devam etmek istiyor musunuz?</translation>
       <source>Page will automatically reload in 5 seconds</source>
       <translation>Sayfa 5 saniye içinde otomatik olarak yeniden yüklenecektir</translation>
     </message>
-    <message id="settings_security_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="159"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">Şifrenin en az 8 karakter uzunluğunda olması gerekir</translation>
-    </message>
     <message id="settings_root_password">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="269"/>
       <source>Root password</source>
       <translation>Kök parola</translation>
-    </message>
-    <message id="settings_root_enter_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="272"/>
-      <source>Enter password</source>
-      <translation type="unfinished">Parola Gir</translation>
-    </message>
-    <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="277"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">Şifrenin en az 8 karakter uzunluğunda olması gerekir</translation>
     </message>
     <message id="settings_root_password_changed_to">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="283"/>
@@ -7082,6 +6436,11 @@ Devam etmek istiyor musunuz?</translation>
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="321"/>
       <source>Logout</source>
       <translation>Çıkış Yap</translation>
+    </message>
+    <message id="settings_logout_now">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
+      <source>Log out now</source>
+      <translation>Şimdi çıkış yap</translation>
     </message>
     <message id="settings_logout_dialog_title">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="335"/>
@@ -7141,11 +6500,13 @@ Devam etmek istiyor musunuz?</translation>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="141"/>
       <source>Alarm when generator is not in autostart mode</source>
+      <oldsource>Alarm when generator is not in auto start mode</oldsource>
       <translation>Jeneratör otomatik başlatma modunda olmadığında alarm</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="147"/>
       <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
       <translation>Otomatik başlatma işlevi 10 dakikadan uzun süre devre dışı bırakıldığında bir alarm tetiklenecektir</translation>
     </message>
     <message id="settings_units_amps_exceptions">
@@ -7161,6 +6522,11 @@ Devam etmek istiyor musunuz?</translation>
     <message id="settings_ess_use_this_option_for_peak_shaving">
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
       <source>Use this option for peak shaving.</source>
+      <oldsource>Use this option for peak shaving.
+
+The peak shaving threshold is set using the AC input current limit setting.
+
+See documentation for further information.</oldsource>
       <translation>Yoğun tıraş için bu seçeneği kullanın.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
@@ -7204,17 +6570,17 @@ Devam etmek istiyor musunuz?</translation>
       <translation>Maksimum sistem ihracat akımı (faz başına)</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="71"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="73"/>
       <source>Self-consumption from battery</source>
       <translation>Aküden öz tüketim</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="76"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
       <source>All system loads</source>
       <translation>Tüm sistem yükleri</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="80"/>
       <source>Only critical loads</source>
       <translation>Sadece kritik yükler</translation>
     </message>
@@ -7261,7 +6627,7 @@ Devam etmek istiyor musunuz?</translation>
     <message id="pagesettingsintegrations_relays">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="118"/>
       <source>Relays</source>
-      <translation>&lt;b&gt;{isOn}{relayNumber} &lt;/b&gt; rölesini açmak üzeresiniz. Devam etmek istediğinizden emin misiniz?</translation>
+      <translation>Röleler</translation>
     </message>
     <message id="pagesettingsintegrations_digital_io">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="132"/>
@@ -7272,26 +6638,6 @@ Devam etmek istiyor musunuz?</translation>
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="194"/>
       <source>Server Applications</source>
       <translation>Sunucu Uygulamaları</translation>
-    </message>
-    <message id="pagesettingsintegrations_venus_os_enable_large_features">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
-      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_large_victron_community">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="274"/>
-      <source>Victron Community</source>
-      <translation type="unfinished">Victron community</translation>
-    </message>
-    <message id="pagesettingsintegrations_ui_plugins">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
-      <source>UI Plugins</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
-      <source>Integrates with the device list</source>
-      <translation type="unfinished"/>
     </message>
     <message id="pagesettingssupportstate_modbus_tcp_server">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="453"/>
@@ -7394,25 +6740,10 @@ Devam etmek istiyor musunuz?</translation>
       <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
       <translation>"Ayarlar / Genel" bölümündeki "Ağ Güvenlik Profili" seçilmeden ürün yazılımı sürümünü değiştirmek mümkün değildir.</translation>
     </message>
-    <message id="pagesettingsconnectivity_ethernet">
-      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
-      <source>Ethernet</source>
-      <translation type="unfinished">Eternet</translation>
-    </message>
     <message id="pagesettingsconnectivity_mobile_network">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="53"/>
       <source>Mobile Network</source>
       <translation>Mobil Ağ</translation>
-    </message>
-    <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Boat</source>
-      <translation type="unfinished">Tekne</translation>
-    </message>
-    <message id="settings_system_name_auto">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="32"/>
-      <source>Automatic</source>
-      <translation type="unfinished">Otomatik</translation>
     </message>
     <message id="pagesettingssystem_ac_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
@@ -7443,11 +6774,6 @@ Devam etmek istiyor musunuz?</translation>
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="89"/>
       <source>Distributed Voltage and Current Control (DVCC)</source>
       <translation>Dağıtılmış Gerilim ve Akım Kontrolü (DVCC)</translation>
-    </message>
-    <message id="settings_system_grid">
-      <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="18"/>
-      <source>Grid</source>
-      <translation type="unfinished">Şebeke</translation>
     </message>
     <message id="settings_system_ac_position">
       <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="58"/>
@@ -7487,16 +6813,19 @@ Devam etmek istiyor musunuz?</translation>
     <message id="settings_system_has_dc_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="97"/>
       <source>Display DC Loads</source>
+      <oldsource>Has DC system</oldsource>
       <translation>Ekran DC Yükleri</translation>
     </message>
     <message id="settings_system_battery_measurements">
       <location filename="../../pages/settings/PageSettingsBatteries.qml" line="65"/>
       <source>Battery measurements</source>
+      <oldsource>Battery Measurements</oldsource>
       <translation>Akü ölçümleri</translation>
     </message>
     <message id="settings_system_system_status">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
       <source>System status</source>
+      <oldsource>System Status</oldsource>
       <translation>Sistem Durumu</translation>
     </message>
     <message id="settings_tcpip_wired">
@@ -7507,11 +6836,13 @@ Devam etmek istiyor musunuz?</translation>
     <message id="settings_vecan_device_instance">
       <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
       <source>VE.Can Device Instance</source>
+      <oldsource>Device Instance</oldsource>
       <translation>Ve.CAN Örneği</translation>
     </message>
     <message id="settings_vecan_device_number">
       <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="32"/>
       <source>VE.Can Instance# %1</source>
+      <oldsource>Device# %1</oldsource>
       <translation>VE.Can Örneği# %1</translation>
     </message>
     <message id="settings_tz_antarctica">
@@ -7542,6 +6873,7 @@ Devam etmek istiyor musunuz?</translation>
     <message id="settings_vrm">
       <location filename="../../pages/SettingsPage.qml" line="59"/>
       <source>VRM</source>
+      <extracomment>Forced by %2 to dark</extracomment>
       <translation>VRM</translation>
     </message>
     <message id="settings_remote_monitoring_portal">
@@ -7549,20 +6881,10 @@ Devam etmek istiyor musunuz?</translation>
       <source>Remote monitoring portal</source>
       <translation>Uzaktan izleme portalı</translation>
     </message>
-    <message id="settings_advanced">
-      <location filename="../../pages/SettingsPage.qml" line="68"/>
-      <source>Advanced</source>
-      <translation type="unfinished">Gelişmiş</translation>
-    </message>
-    <message id="settings_integrations">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
+    <message id="pagesettingssupportstate_integrations">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
       <source>Integrations</source>
       <translation>Entegrasyonlar</translation>
-    </message>
-    <message id="settings_relays_sensors_tanks">
-      <location filename="../../pages/SettingsPage.qml" line="75"/>
-      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
-      <translation type="unfinished">Röleler, Sensörler, Tanklar, PV İnvertörler, Modbus, MQTT...</translation>
     </message>
     <message id="settings_acdcsystem_ess_dvcc_battery">
       <location filename="../../pages/SettingsPage.qml" line="84"/>
@@ -7582,11 +6904,13 @@ Devam etmek istiyor musunuz?</translation>
     <message id="settings_system_setup">
       <location filename="../../pages/SettingsPage.qml" line="82"/>
       <source>System Setup</source>
+      <oldsource>System setup</oldsource>
       <translation>Sistem kurulumu</translation>
     </message>
     <message id="settings_vrm_device_instances">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
       <source>VRM device instances</source>
+      <oldsource>VRM Device Instances</oldsource>
       <translation>VRM Cihaz Örnekleri</translation>
     </message>
     <message id="solarcharger_not_supported">
@@ -7604,28 +6928,10 @@ Devam etmek istiyor musunuz?</translation>
       <source>The firmware version in the MPPT Solar Charger must be v1.09 or later. Contact Victron Service for update instructions and files.</source>
       <translation>MPPT Güneş Enerjili Şarj Cihazındaki aygıt yazılımı sürümü v1.09 veya üstü olmalıdır. Güncelleme talimatları ve dosyaları için Victron Servisi ile iletişime geçin.</translation>
     </message>
-    <message id="solarcharger_pv">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="102"/>
-      <source>PV</source>
-      <extracomment>PV power for solar charger</extracomment>
-      <translation type="unfinished">PV</translation>
-    </message>
     <message id="solarcharger_total_power">
       <location filename="../../pages/solar/PageSolarCharger.qml" line="127"/>
       <source>Total PV power</source>
       <translation>Toplam pv gücü</translation>
-    </message>
-    <message id="solarcharger_total_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="211"/>
-      <source>Total yield</source>
-      <extracomment>Solar charger total yield</extracomment>
-      <translation type="unfinished">Toplam verim</translation>
-    </message>
-    <message id="solarcharger_system_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="220"/>
-      <source>System yield</source>
-      <extracomment>Solar charger system yield</extracomment>
-      <translation type="unfinished">Sistem verimi</translation>
     </message>
     <message id="settings_multirs_total_yield">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="63"/>
@@ -7661,16 +6967,19 @@ Devam etmek istiyor musunuz?</translation>
     <message id="vebus_device_update_firmware">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="133"/>
       <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
       <translation>fBu özellik için ürün firmware sürümü 400 veya üstü gerekir. Multi/Quattro'nuzu güncellemek için kurulumcunuzla iletişime geçin.</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="139"/>
       <source>Charger not ready, equalization cannot be started</source>
+      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
       <translation>Şarj cihazı hazır değil, dengeleme başlatılamıyor</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="143"/>
       <source>Equalization cannot be triggered during bulk charge state</source>
+      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
       <translation>Eşitleme, toplu şarj durumu sırasında tetiklenemez</translation>
     </message>
     <message id="vebus_device_restart_vebus_system_restart_confirmation_description">
@@ -7693,78 +7002,20 @@ Devam etmek istiyor musunuz?</translation>
       <source>Auto-started • %1</source>
       <translation>Otomatik başlatıldı - %1</translation>
     </message>
-    <message id="common_words_battery">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery</source>
-      <translation type="unfinished">Akü</translation>
-    </message>
-    <message id="common_words_boat_page">
-      <location filename="../../components/CommonWords.qml" line="111"/>
-      <source>Boat</source>
-      <extracomment>The 'Boat' page</extracomment>
-      <translation type="unfinished">Tekne</translation>
-    </message>
-    <message id="common_words_brief_page">
-      <location filename="../../components/CommonWords.qml" line="115"/>
-      <source>Brief</source>
-      <extracomment>The 'Brief' page</extracomment>
-      <translation type="unfinished">Kısa</translation>
-    </message>
-    <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation type="unfinished">Kapalı</translation>
-    </message>
-    <message id="common_words_color">
-      <location filename="../../components/CommonWords.qml" line="136"/>
-      <source>Color</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_connected">
-      <location filename="../../components/CommonWords.qml" line="139"/>
-      <source>Connected</source>
-      <translation type="unfinished">Bağlandı</translation>
-    </message>
     <message id="common_words_daily_history">
       <location filename="../../components/CommonWords.qml" line="152"/>
       <source>Daily history</source>
       <translation>Günlük geçmiş</translation>
-    </message>
-    <message id="common_words_disabled">
-      <location filename="../../components/CommonWords.qml" line="169"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Devre dışı</translation>
-    </message>
-    <message id="common_words_disconnected">
-      <location filename="../../components/CommonWords.qml" line="175"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Bağlantı kesildi</translation>
-    </message>
-    <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="191"/>
-      <source>Error</source>
-      <translation type="unfinished">Hata</translation>
     </message>
     <message id="common_words_error_not_a_number">
       <location filename="../../components/CommonWords.qml" line="200"/>
       <source>'%1' is not a number.</source>
       <translation>'%1' bir sayı değil.</translation>
     </message>
-    <message id="common_words_generator">
-      <location filename="../../components/CommonWords.qml" line="217"/>
-      <source>Generator</source>
-      <translation type="unfinished">Jeneratör</translation>
-    </message>
     <message id="common_words_input_current_limit">
       <location filename="../../components/CommonWords.qml" line="261"/>
       <source>Input current limit</source>
       <translation>Giriş akımı limiti</translation>
-    </message>
-    <message id="common_words_inverter_charger">
-      <location filename="../../components/CommonWords.qml" line="264"/>
-      <source>Inverter / Charger</source>
-      <translation type="unfinished">İnvertör / Şarj Cihazı</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
       <location filename="../../components/CommonWords.qml" line="268"/>
@@ -7777,12 +7028,6 @@ Devam etmek istiyor musunuz?</translation>
       <source>Manual stop</source>
       <translation>Manuel Durdurma</translation>
     </message>
-    <message id="common_words_max">
-      <location filename="../../components/CommonWords.qml" line="315"/>
-      <source>Max</source>
-      <extracomment>Short for Maximum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_maximum_current">
       <location filename="../../components/CommonWords.qml" line="318"/>
       <source>Maximum current</source>
@@ -7793,62 +7038,10 @@ Devam etmek istiyor musunuz?</translation>
       <source>Maximum power</source>
       <translation>Maksimum güç</translation>
     </message>
-    <message id="common_words_min">
-      <location filename="../../components/CommonWords.qml" line="331"/>
-      <source>Min</source>
-      <extracomment>Short for Minimum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_minimum_current">
       <location filename="../../components/CommonWords.qml" line="334"/>
       <source>Minimum current</source>
       <translation>Minimum akım</translation>
-    </message>
-    <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="433"/>
-      <source>No</source>
-      <translation type="unfinished">Hayır</translation>
-    </message>
-    <message id="common_words_none_option">
-      <location filename="../../components/CommonWords.qml" line="364"/>
-      <source>None</source>
-      <translation type="unfinished">Yok</translation>
-    </message>
-    <message id="common_words_none_errors">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>None</source>
-      <extracomment>Indicates there are no errors</extracomment>
-      <translation type="unfinished">Yok</translation>
-    </message>
-    <message id="common_words_not_available">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Not available</source>
-      <translation type="unfinished">Kullanılamıyor</translation>
-    </message>
-    <message id="common_words_off">
-      <location filename="../../components/CommonWords.qml" line="377"/>
-      <source>Off</source>
-      <translation type="unfinished">Kapalı</translation>
-    </message>
-    <message id="common_words_ok">
-      <location filename="../../components/CommonWords.qml" line="383"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="41"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="45"/>
-      <source>OK</source>
-      <translation type="unfinished">OK</translation>
-    </message>
-    <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="386"/>
-      <source>On</source>
-      <translation type="unfinished">Açık</translation>
-    </message>
-    <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="393"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation type="unfinished">Açık</translation>
     </message>
     <message id="common_words_open_circuit">
       <location filename="../../components/CommonWords.qml" line="396"/>
@@ -7860,108 +7053,17 @@ Devam etmek istiyor musunuz?</translation>
       <source>Overall history</source>
       <translation>Genel geçmiş</translation>
     </message>
-    <message id="common_words_press">
-      <location filename="../../components/CommonWords.qml" line="419"/>
-      <source>Press</source>
-      <translation type="unfinished">Basın</translation>
-    </message>
-    <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation type="unfinished">Çalışıyor</translation>
-    </message>
-    <message id="common_words_settings">
-      <location filename="../../components/CommonWords.qml" line="467"/>
-      <source>Settings</source>
-      <translation type="unfinished">Ayarlar</translation>
-    </message>
-    <message id="common_words_silence_alarm">
-      <location filename="../../components/CommonWords.qml" line="476"/>
-      <source>Silence alarm</source>
-      <translation type="unfinished">Sessiz alarm</translation>
-    </message>
     <message id="common_words_soc">
       <location filename="../../components/CommonWords.qml" line="480"/>
       <source>SOC %1</source>
       <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
       <translation>SOC %1</translation>
     </message>
-    <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation type="unfinished">Hız</translation>
-    </message>
-    <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="487"/>
-      <source>Standby</source>
-      <translation type="unfinished">Bekleme</translation>
-    </message>
-    <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="502"/>
-      <source>State</source>
-      <translation type="unfinished">Durum</translation>
-    </message>
-    <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="512"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation type="unfinished">Başlangıç (%1)</translation>
-    </message>
-    <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>Stopped</source>
-      <translation type="unfinished">Durduruldu</translation>
-    </message>
-    <message id="common_words_total_power">
-      <location filename="../../components/CommonWords.qml" line="540"/>
-      <source>Total power</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="547"/>
-      <source>Type</source>
-      <translation type="unfinished">Tip</translation>
-    </message>
-    <message id="common_words_unknown_status">
-      <location filename="../../components/CommonWords.qml" line="554"/>
-      <source>Unknown</source>
-      <extracomment>Status = "unknown"</extracomment>
-      <translation type="unfinished">Bilinmiyor</translation>
-    </message>
-    <message id="common_words_value_must_be_greater_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="557"/>
-      <source>Value must be greater than start value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_value_must_be_greater_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="560"/>
-      <source>Value must be greater than stop value</source>
-      <translation type="unfinished">Değer, durdurma değerinden yüksek olmalıdır</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="563"/>
-      <source>Value must be lower than start value</source>
-      <translation type="unfinished">Değer, başlangıç değerinden düşük olmalıdır</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="566"/>
-      <source>Value must be lower than stop value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="581"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="431"/>
-      <source>Yes</source>
-      <translation type="unfinished">Evet</translation>
-    </message>
     <message id="common_words_yield_today">
       <location filename="../../components/CommonWords.qml" line="592"/>
       <source>Yield Today</source>
       <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+      <oldsource>Yield today</oldsource>
       <translation>Verim bugün</translation>
     </message>
     <message id="common_words_format_error">
@@ -7988,10 +7090,11 @@ Devam etmek istiyor musunuz?</translation>
     <message id="settings_firmware_installed_rebooting">
       <location filename="../../components/FirmwareUpdate.qml" line="79"/>
       <source>Firmware installed, device rebooting</source>
+      <oldsource>Firmware installed, rebooting.</oldsource>
       <translation>Ürün Firmware yüklendi, cihaz yeniden başlatılıyor</translation>
     </message>
-    <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/RadioButtonListPage.qml" line="121"/>
+    <message id="modaldialog_confirm">
+      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
       <source>Confirm</source>
       <extracomment>Confirm password, and verify it if possible</extracomment>
       <translation>Evet, aboneliğimi iptal et</translation>
@@ -8009,11 +7112,13 @@ Devam etmek istiyor musunuz?</translation>
     <message id="cgwacs_battery_schedule_duration">
       <location filename="../../components/listitems/ListChargeSchedule.qml" line="144"/>
       <source>Duration</source>
+      <oldsource>Duration (hh:mm)</oldsource>
       <translation>Süre</translation>
     </message>
     <message id="settings_relay_deactivation_value">
       <location filename="../../components/TemperatureRelaySettings.qml" line="86"/>
       <source>Deactivation value</source>
+      <oldsource>Deativation value</oldsource>
       <translation>Devre dışı bırakma değeri</translation>
     </message>
     <message id="splash_view_device_disconnected">
@@ -8061,29 +7166,6 @@ Devam etmek istiyor musunuz?</translation>
       <source>Temperature warning</source>
       <translation>Sıcaklık uyarısı</translation>
     </message>
-    <message id="battery_mode_idle">
-      <location filename="../../src/enums.cpp" line="26"/>
-      <source>Idle</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Atıl</translation>
-    </message>
-    <message id="battery_mode_charging">
-      <location filename="../../src/enums.cpp" line="30"/>
-      <source>Charging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Şarj</translation>
-    </message>
-    <message id="battery_mode_discharging">
-      <location filename="../../src/enums.cpp" line="34"/>
-      <source>Discharging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Deşarj </translation>
-    </message>
-    <message id="dcMeter_bilge_pump">
-      <location filename="../../src/enums.cpp" line="115"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">Tahliye pompası</translation>
-    </message>
     <message id="switch_state_channel_fault">
       <location filename="../../src/enums.cpp" line="372"/>
       <source>Channel Fault</source>
@@ -8114,26 +7196,6 @@ Devam etmek istiyor musunuz?</translation>
       <source>Slave of %1</source>
       <translation>Bağımlı ünite %1</translation>
     </message>
-    <message id="switchable_output_numeric_input">
-      <location filename="../../src/enums.cpp" line="418"/>
-      <source>Numeric input</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bilge_pump">
-      <location filename="../../src/enums.cpp" line="424"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">Tahliye pompası</translation>
-    </message>
-    <message id="switchable_output_not_running">
-      <location filename="../../src/enums.cpp" line="448"/>
-      <source>Not running</source>
-      <translation type="unfinished">Çalışmıyor</translation>
-    </message>
-    <message id="switchable_output_off">
-      <location filename="../../src/enums.cpp" line="451"/>
-      <source>Off</source>
-      <translation type="unfinished">Kapalı</translation>
-    </message>
     <message id="switchable_output_powered">
       <location filename="../../src/enums.cpp" line="455"/>
       <source>Powered</source>
@@ -8162,16 +7224,19 @@ Devam etmek istiyor musunuz?</translation>
     <message id="evchargers_status_welded_contacts_error">
       <location filename="../../data/EvChargers.qml" line="76"/>
       <source>Welded contacts test error (shorted)</source>
+      <oldsource>Welded contacts error</oldsource>
       <translation>Kaynaklı kontaklar test hatası (kısa devre)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
       <location filename="../../data/EvChargers.qml" line="100"/>
       <source>Switching to 3 phase</source>
+      <oldsource>Switching to 3-phase</oldsource>
       <translation>3 faza geçiş</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
       <location filename="../../data/EvChargers.qml" line="103"/>
       <source>Switching to 1 phase</source>
+      <oldsource>Switching to single phase</oldsource>
       <translation>1 faza geçiş</translation>
     </message>
     <message id="evchargers_status_stop_charging">
@@ -8324,17 +7389,6 @@ Jeneratör otomatik başlatma koşulu nedeniyle çalışıyorsa otomatik başlat
       <source>Open link</source>
       <translation>Bağlantıyı aç</translation>
     </message>
-    <message id="listlink_show_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="43"/>
-      <source>Show QR code</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="listlink_scan_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="52"/>
-      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
-      <extracomment>%1 = url text</extracomment>
-      <translation type="unfinished">QR kodunu taşınabilir cihazınızla tarayın.&lt;br /&gt;Veya bağlantıyı girin: %1</translation>
-    </message>
     <message id="settings_services_mqtt_access">
       <location filename="../../components/listitems/ListMqttAccessSwitch.qml" line="11"/>
       <source>MQTT Access</source>
@@ -8406,12 +7460,6 @@ Jeneratör otomatik başlatma koşulu nedeniyle çalışıyorsa otomatik başlat
       <extracomment>The 'Brief' page, with the side panel opened</extracomment>
       <translation>Brief (yan panel açık)</translation>
     </message>
-    <message id="startpage_option_overview">
-      <location filename="../../data/StartPageConfiguration.qml" line="37"/>
-      <source>Overview</source>
-      <extracomment>The 'Overview' page</extracomment>
-      <translation type="unfinished">Görünüm</translation>
-    </message>
     <message id="startpage_option_levels_tanks">
       <location filename="../../data/StartPageConfiguration.qml" line="43"/>
       <source>Levels (Tanks)</source>
@@ -8430,12 +7478,12 @@ Jeneratör otomatik başlatma koşulu nedeniyle çalışıyorsa otomatik başlat
       <translation>Pil listesi</translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
+      <location filename="../../pages/DialogLayer.qml" line="56"/>
       <source>GX device has been updated</source>
       <translation>GX cihazı güncellendi</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
+      <location filename="../../pages/DialogLayer.qml" line="58"/>
       <source>Page will automatically reload in ten seconds to load the latest version.</source>
       <translation>Sayfa, en son sürümü yüklemek için on saniye içinde otomatik olarak yeniden yüklenecektir.</translation>
     </message>
@@ -8527,6 +7575,7 @@ Bu menünün sadece RS485 üzerinden bağlı Carlo Gavazzi sayaçlarını göste
       <source>After %n minute(s)</source>
       <translation>
         <numerusform>%n dakika sonra</numerusform>
+        <numerusform>%n dakika sonra</numerusform>
       </translation>
     </message>
     <message id="settings_startpage_description">
@@ -8604,8 +7653,8 @@ Bu menünün sadece RS485 üzerinden bağlı Carlo Gavazzi sayaçlarını göste
       <source>Unit</source>
       <translation>Birim</translation>
     </message>
-    <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="61"/>
+    <message id="page_settings_fronius_unitid_invalid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
       <source>%1 is not a valid unit number. Use a number between 1-247.</source>
       <translation>1 geçerli bir birim numarası değil. 1-247 arasında bir sayı kullanın.</translation>
     </message>
@@ -8720,11 +7769,6 @@ Bu menünün sadece RS485 üzerinden bağlı Carlo Gavazzi sayaçlarını göste
       <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="66"/>
       <source>Controller Temperature</source>
       <translation>Kontrolör sıcaklığı</translation>
-    </message>
-    <message id="devicelist_motordrive_motordirectioninverted">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
-      <source>Motor Direction Inverted</source>
-      <translation type="unfinished"/>
     </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
@@ -8916,11 +7960,6 @@ Kolaylaştırılmış navigasyon ve yeni bir görünümle, sevdiğiniz her şeye
     <message id="welcome_done">
       <location filename="../../pages/welcome/WelcomeView.qml" line="136"/>
       <source>Done</source>
-      <translation type="unfinished">Tamamlandı</translation>
-    </message>
-    <message id="mk2vsc_state_done">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="20"/>
-      <source>Done</source>
       <translation>Tamamlandı</translation>
     </message>
     <message id="welcome_next">
@@ -8978,6 +8017,7 @@ GX cihazı yalnızca bir bağlı jeneratörü kontrol edebilir ve en düşük VR
     <message id="settings_tz_etc">
       <location filename="../../pages/settings/PageTzInfo.qml" line="280"/>
       <source>Other</source>
+      <oldsource>Etc</oldsource>
       <translation>Diğer</translation>
     </message>
     <message id="ac-in-modeldefault_energy_reverse_x">
@@ -8995,6 +8035,11 @@ GX cihazı yalnızca bir bağlı jeneratörü kontrol edebilir ve en düşük VR
       <location filename="../../src/enums.cpp" line="438"/>
       <source>Unsupported type: %1</source>
       <translation>Desteklenmeyen tip: %1</translation>
+    </message>
+    <message id="common_words_press">
+      <location filename="../../components/CommonWords.qml" line="419"/>
+      <source>Press</source>
+      <translation>Basın</translation>
     </message>
     <message id="output_aux_battery_service_changed_dcdc">
       <location filename="../../components/listitems/ListOutputBatteryRadioButtonGroup.qml" line="27"/>
@@ -9135,13 +8180,6 @@ GX cihazı yalnızca bir bağlı jeneratörü kontrol edebilir ve en düşük VR
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="38"/>
       <source>Resetting VE.Bus products</source>
       <translation>VE.Bus ürünlerini sıfırlama</translation>
-    </message>
-    <message id="Unknown">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Bilinmiyor</translation>
     </message>
     <message id="mk2vsc_error_mk2_mk3_comm">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="47"/>
@@ -9447,11 +8485,6 @@ GX cihazı yalnızca bir bağlı jeneratörü kontrol edebilir ve en düşük VR
       <source>Changing the GX Password</source>
       <translation>GX Parolasını Değiştirme</translation>
     </message>
-    <message id="modaldialog_confirm">
-      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
-      <source>Confirm</source>
-      <translation type="unfinished">Evet, aboneliğimi iptal et</translation>
-    </message>
     <message id="settings_security_profile_change_password_description">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="83"/>
       <source>Please enter a new GX password:</source>
@@ -9544,21 +8577,6 @@ GX cihazı yalnızca bir bağlı jeneratörü kontrol edebilir ve en düşük VR
       <source>Modifications installed</source>
       <translation>Yüklenmiş değişiklikler</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_modbus">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="28"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">Modbus TCP Sunucusu</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_signalk">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="32"/>
-      <source>Signal K</source>
-      <translation type="unfinished">Signal K</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_nodered">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="36"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">Node-RED</translation>
-    </message>
     <message id="pagesettingsgeneral_modificationchecks_running_integrations">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="43"/>
       <source>%1 running integrations</source>
@@ -9634,16 +8652,6 @@ GX cihazı yalnızca bir bağlı jeneratörü kontrol edebilir ve en düşük VR
       <source>Installed and enabled, disables at next boot</source>
       <translation>Yüklü ve etkin, sonraki başlatmada devre dışı bırakılır</translation>
     </message>
-    <message id="pagesettingssupportstate_firmware_checking">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
-      <source>Checking...</source>
-      <translation type="unfinished">Kontrol ediliyor...</translation>
-    </message>
-    <message id="pagesettingssupportstate_firmware_unknown">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="166"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Bilinmiyor</translation>
-    </message>
     <message id="pagesettingssupportstate_support_status">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="228"/>
       <source>Support status</source>
@@ -9665,11 +8673,6 @@ GX cihazı yalnızca bir bağlı jeneratörü kontrol edebilir ve en düşük VR
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="288"/>
       <source>Press 'OK' to disable custom startup scripts and reboot</source>
       <translation>Özel başlangıç komut dosyalarını devre dışı bırakmak ve yeniden başlatmak için 'Tamam'a basın</translation>
-    </message>
-    <message id="pagesettingssupportstate_re_enable_custom_startup_scripts">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="309"/>
-      <source>Re-enable custom startup scripts</source>
-      <translation type="unfinished">Özel başlangıç komut dosyalarını yeniden etkinleştir</translation>
     </message>
     <message id="pagesettingssupportstate_reenable_and_reboot_now">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="322"/>
@@ -9696,11 +8699,6 @@ GX cihazı yalnızca bir bağlı jeneratörü kontrol edebilir ve en düşük VR
       <source>Disable also custom startup scripts?</source>
       <translation>Özel başlangıç komut dosyaları da devre dışı bırakılsın mı?</translation>
     </message>
-    <message id="pagesettingssupportstate_integrations">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
-      <source>Integrations</source>
-      <translation type="unfinished">Entegrasyonlar</translation>
-    </message>
     <message id="pagesettingssupportstate_orange_items_description">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="494"/>
       <source>Items colored orange are supported and provided by Victron Energy, but using them incorrectly can affect system stability. In case of troubleshooting, disable those first.</source>
@@ -9712,7 +8710,7 @@ GX cihazı yalnızca bir bağlı jeneratörü kontrol edebilir ve en düşük VR
       <translation>Bluetooth bağlantısını etkinleştirmek için uyumlu bir Bluetooth USB dongle'ı bağlayın.</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="140"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="142"/>
       <source>BatteryLife state</source>
       <translation>BatteryLife durumu</translation>
     </message>
@@ -9720,23 +8718,6 @@ GX cihazı yalnızca bir bağlı jeneratörü kontrol edebilir ve en düşük VR
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="33"/>
       <source>Device Integrations</source>
       <translation>Cihaz Entegrasyonları</translation>
-    </message>
-    <message id="pagesettingsintegrations_modbus_tcp_server">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="201"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">Modbus TCP Sunucusu</translation>
-    </message>
-    <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="226"/>
-      <location filename="../../pages/settings/PageSettingsSignalK.qml" line="18"/>
-      <source>Signal K</source>
-      <translation type="unfinished">Signal K</translation>
-    </message>
-    <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="241"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">Node-RED</translation>
     </message>
     <message id="settings_venusos_large_documentation">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="267"/>
@@ -9746,6 +8727,7 @@ GX cihazı yalnızca bir bağlı jeneratörü kontrol edebilir ve en düşük VR
     <message id="settings_modbus_enable_modbus_tcp">
       <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
       <source>Enable Modbus TCP Server</source>
+      <oldsource>Enable Modbus/TCP</oldsource>
       <translation>Modbus TCP Sunucusunu Etkinleştir</translation>
     </message>
     <message id="pagesettingsconnectivity_bluetooth_for_victronconnect_app">
@@ -9839,11 +8821,13 @@ GX cihazı yalnızca bir bağlı jeneratörü kontrol edebilir ve en düşük VR
     <message id="settings_gps_format_kmh">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="93"/>
       <source>Kilometres per hour</source>
+      <oldsource>Kilometers per hour</oldsource>
       <translation>Kilometre/saat</translation>
     </message>
     <message id="settings_gps_format_ms">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="95"/>
       <source>Metres per second</source>
+      <oldsource>Meters per second</oldsource>
       <translation>Metre/saniye</translation>
     </message>
     <message id="components_volumeunit_cubic_metres">
@@ -9871,8 +8855,8 @@ GX cihazı yalnızca bir bağlı jeneratörü kontrol edebilir ve en düşük VR
       <source>The Relay can now be found in the devices list</source>
       <translation>Röle artık cihazlar listesinde bulunabilir</translation>
     </message>
-    <message id="common_words_gx_device_relays">
-      <location filename="../../components/CommonWords.qml" line="223"/>
+    <message id="gx_device_relays">
+      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
       <source>GX device relays</source>
       <translation>GX cihazı röleleri</translation>
     </message>
@@ -9926,12 +8910,6 @@ GX cihazı yalnızca bir bağlı jeneratörü kontrol edebilir ve en düşük VR
       <extracomment>Forced by app to %1</extracomment>
       <translation>otomatik</translation>
     </message>
-    <message id="settings_remote_console_forced_by_vrm">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="94"/>
-      <source>VRM</source>
-      <extracomment>Forced by %2 to dark</extracomment>
-      <translation type="unfinished">VRM</translation>
-    </message>
     <message id="settings_remote_console_forced_by_app">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="97"/>
       <source>app</source>
@@ -9981,6 +8959,7 @@ GX cihazı yalnızca bir bağlı jeneratörü kontrol edebilir ve en düşük VR
     <message id="settings_large_access_signal_k">
       <location filename="../../pages/settings/PageSettingsSignalK.qml" line="24"/>
       <source>Access Signal K</source>
+      <oldsource>Access Signal K (local network)</oldsource>
       <translation>Signal K'ye eriş</translation>
     </message>
     <message id="pagesettingsintegrations_shelly_devices">
@@ -9991,6 +8970,7 @@ GX cihazı yalnızca bir bağlı jeneratörü kontrol edebilir ve en düşük VR
     <message id="settings_large_access_node_red">
       <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
       <source>Access Node-RED</source>
+      <oldsource>Access Node-RED (local network)</oldsource>
       <translation>Node-RED'e eriş</translation>
     </message>
     <message id="settings_wifi_access_point_password">
@@ -10058,57 +9038,6 @@ GX cihazı yalnızca bir bağlı jeneratörü kontrol edebilir ve en düşük VR
       <source>Wind charger</source>
       <translation>Rüzgar şarj cihazı</translation>
     </message>
-    <message id="digitalinputs_type_disabled">
-      <location filename="../../src/enums.cpp" line="192"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Devre dışı</translation>
-    </message>
-    <message id="digitalinputs_state_off">
-      <location filename="../../src/enums.cpp" line="242"/>
-      <source>Off</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Kapalı</translation>
-    </message>
-    <message id="digitalinputs_state_on">
-      <location filename="../../src/enums.cpp" line="246"/>
-      <source>On</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Açık</translation>
-    </message>
-    <message id="digitalinputs_state_ok">
-      <location filename="../../src/enums.cpp" line="266"/>
-      <source>OK</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">OK</translation>
-    </message>
-    <message id="digitalinputs_state_alarm">
-      <location filename="../../src/enums.cpp" line="270"/>
-      <source>Alarm</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Alarm</translation>
-    </message>
-    <message id="digitalinputs_state_running">
-      <location filename="../../src/enums.cpp" line="274"/>
-      <source>Running</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Çalışıyor</translation>
-    </message>
-    <message id="pvinverter_statusCode_running">
-      <location filename="../../src/enums.cpp" line="300"/>
-      <source>Running</source>
-      <extracomment>PV inverter status code</extracomment>
-      <translation type="unfinished">Çalışıyor</translation>
-    </message>
-    <message id="solarchargers_state_external control">
-      <location filename="../../src/enums.cpp" line="352"/>
-      <source>External control</source>
-      <translation type="unfinished">Extern kontrol</translation>
-    </message>
-    <message id="switch_state_over_temperature">
-      <location filename="../../src/enums.cpp" line="366"/>
-      <source>Over temperature</source>
-      <translation type="unfinished">Aşırı sıcaklık</translation>
-    </message>
     <message id="switchable_output_temperature_setpoint">
       <location filename="../../src/enums.cpp" line="398"/>
       <source>Temperature setpoint</source>
@@ -10118,11 +9047,6 @@ GX cihazı yalnızca bir bağlı jeneratörü kontrol edebilir ve en düşük VR
       <location filename="../../src/enums.cpp" line="401"/>
       <source>Stepped switch</source>
       <translation>Kademeli anahtar</translation>
-    </message>
-    <message id="switchable_output_slave">
-      <location filename="../../src/enums.cpp" line="408"/>
-      <source>Slave</source>
-      <translation type="unfinished">Slave</translation>
     </message>
     <message id="switchable_output_dropdown">
       <location filename="../../src/enums.cpp" line="412"/>
@@ -10134,122 +9058,10 @@ GX cihazı yalnızca bir bağlı jeneratörü kontrol edebilir ve en düşük VR
       <source>Basic slider</source>
       <translation>Temel kaydırıcı</translation>
     </message>
-    <message id="switchable_output_rgb_color_wheel">
-      <location filename="../../src/enums.cpp" line="427"/>
-      <source>RGB color wheel</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_cct_color_wheel">
-      <location filename="../../src/enums.cpp" line="431"/>
-      <source>CCT color wheel</source>
-      <extracomment>Correlated Color Temperature color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_rgbw_color_wheel">
-      <location filename="../../src/enums.cpp" line="435"/>
-      <source>RGB + W color wheel</source>
-      <extracomment>RGB + white color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bypassed">
-      <location filename="../../src/enums.cpp" line="484"/>
-      <source>Bypassed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="tank_type_fuel">
-      <location filename="../../src/enums.cpp" line="495"/>
-      <source>Fuel</source>
-      <translation type="unfinished">Yakıt</translation>
-    </message>
-    <message id="tank_type_fresh_water">
-      <location filename="../../src/enums.cpp" line="498"/>
-      <source>Fresh water</source>
-      <translation type="unfinished">Temiz su</translation>
-    </message>
-    <message id="tank_type_waste_water">
-      <location filename="../../src/enums.cpp" line="501"/>
-      <source>Waste water</source>
-      <translation type="unfinished">Atık su</translation>
-    </message>
-    <message id="tank_type_live_well">
-      <location filename="../../src/enums.cpp" line="504"/>
-      <source>Live well</source>
-      <translation type="unfinished">Faal kuyu</translation>
-    </message>
-    <message id="tank_type_oil">
-      <location filename="../../src/enums.cpp" line="507"/>
-      <source>Oil</source>
-      <translation type="unfinished">Yağ</translation>
-    </message>
-    <message id="tank_type_black_water">
-      <location filename="../../src/enums.cpp" line="510"/>
-      <source>Black water</source>
-      <translation type="unfinished">Atık Su</translation>
-    </message>
-    <message id="tank_type_gasoline">
-      <location filename="../../src/enums.cpp" line="513"/>
-      <source>Gasoline</source>
-      <translation type="unfinished">Benzin</translation>
-    </message>
-    <message id="tank_type_diesel">
-      <location filename="../../src/enums.cpp" line="516"/>
-      <source>Diesel</source>
-      <translation type="unfinished">Dizel</translation>
-    </message>
-    <message id="tank_type_lpg">
-      <location filename="../../src/enums.cpp" line="519"/>
-      <source>LPG</source>
-      <translation type="unfinished">LPG</translation>
-    </message>
-    <message id="tank_type_lng">
-      <location filename="../../src/enums.cpp" line="522"/>
-      <source>LNG</source>
-      <translation type="unfinished">LNG</translation>
-    </message>
-    <message id="tank_type_hydraulic_oil">
-      <location filename="../../src/enums.cpp" line="525"/>
-      <source>Hydraulic oil</source>
-      <translation type="unfinished">Hidrolik yağ</translation>
-    </message>
-    <message id="tank_type_raw_water">
-      <location filename="../../src/enums.cpp" line="528"/>
-      <source>Raw water</source>
-      <translation type="unfinished">Ham Su</translation>
-    </message>
-    <message id="microgrid_mode_hybrid_droop">
-      <location filename="../../src/enums.cpp" line="539"/>
-      <source>Hybrid droop</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_following">
-      <location filename="../../src/enums.cpp" line="542"/>
-      <source>Grid-following</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_forming">
-      <location filename="../../src/enums.cpp" line="545"/>
-      <source>Grid-forming</source>
-      <translation type="unfinished"/>
-    </message>
     <message id="switchable_output_three_state_switch">
       <location filename="../../src/enums.cpp" line="421"/>
       <source>Three-state switch</source>
       <translation>Üç konumlu anahtar</translation>
-    </message>
-    <message id="switchable_output_fault">
-      <location filename="../../src/enums.cpp" line="464"/>
-      <source>Fault</source>
-      <translation type="unfinished">Hata</translation>
-    </message>
-    <message id="switchable_output_running">
-      <location filename="../../src/enums.cpp" line="468"/>
-      <source>Running</source>
-      <translation type="unfinished">Çalışıyor</translation>
-    </message>
-    <message id="switchable_output_trip_low_voltage">
-      <location filename="../../src/enums.cpp" line="481"/>
-      <source>Trip low voltage</source>
-      <translation type="unfinished">Devre dışı</translation>
     </message>
     <message id="settings_modbus_tcp_unit_id_note">
       <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="41"/>
@@ -10271,281 +9083,1152 @@ GX cihazı yalnızca bir bağlı jeneratörü kontrol edebilir ve en düşük VR
       <source>Press to refresh</source>
       <translation>Yenilemek için basın</translation>
     </message>
-    <message id="temperature_type_unknown">
-      <location filename="../../data/EnvironmentInputs.qml" line="65"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Bilinmiyor</translation>
-    </message>
-    <message id="brief_solar_yield">
-      <location filename="../../pages/BriefSidePanel.qml" line="24"/>
-      <source>Solar yield</source>
-      <translation type="unfinished">Güneş enerjisi verimi</translation>
-    </message>
-    <message id="brief_dc_input">
-      <location filename="../../pages/BriefSidePanel.qml" line="214"/>
-      <source>DC input</source>
-      <translation type="unfinished">DC Giriş</translation>
-    </message>
-    <message id="brief_ac_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="257"/>
-      <source>AC Loads</source>
-      <translation type="unfinished">AC Yükleri</translation>
-    </message>
-    <message id="brief_dc_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="284"/>
-      <source>DC Loads</source>
-      <translation type="unfinished">dcLoads</translation>
-    </message>
-    <message id="nav_overview">
-      <location filename="../../pages/OverviewPage.qml" line="450"/>
-      <source>Overview</source>
-      <translation type="unfinished">Görünüm</translation>
-    </message>
-    <message id="settings_state">
-      <location filename="../../pages/settings/PageCanbusStatus.qml" line="116"/>
-      <source>State</source>
-      <translation type="unfinished">Durum</translation>
-    </message>
-    <message id="inverter_pv">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="56"/>
-      <source>PV</source>
-      <translation type="unfinished">PV</translation>
-    </message>
-    <message id="inverter_total_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="76"/>
-      <source>Total yield</source>
-      <translation type="unfinished">Toplam verim</translation>
-    </message>
-    <message id="inverter_system_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="84"/>
-      <source>System yield</source>
-      <translation type="unfinished">Sistem verimi</translation>
-    </message>
-    <message id="charger_total_pv_power">
-      <location filename="../../pages/solar/SolarDevicePage.qml" line="61"/>
-      <source>Total PV Power</source>
-      <translation type="unfinished">Toplam PV gücü</translation>
-    </message>
-    <message id="vebus_device_alarm_only">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
-      <source>Alarm only</source>
-      <translation type="unfinished">Sadece alarm</translation>
-    </message>
-    <message id="vebus_device_alarms_and_warnings">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
-      <source>Alarms &amp; warnings</source>
-      <translation type="unfinished">Alarm ve uyarılar</translation>
-    </message>
-    <message id="vebus_device_alarm_group_warning">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
-      <source>Warning</source>
-      <translation type="unfinished">Uyarı</translation>
-    </message>
-    <message id="load_delegate_status">
-      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
-      <source>Status: %1</source>
-      <translation type="unfinished"/>
+    <message id="common_words_total_power">
+      <location filename="../../components/CommonWords.qml" line="540"/>
+      <source>Total power</source>
+      <translation>Toplam güç</translation>
     </message>
     <message id="venus_os_gui">
       <location filename="../../Main.qml" line="17"/>
       <source>Venus OS GUI</source>
       <extracomment>Application title</extracomment>
-      <translation type="unfinished"/>
       <extra-Context>only shown on desktop systems</extra-Context>
+      <translation>Venus OS GUI</translation>
+    </message>
+    <message id="load_delegate_status">
+      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
+      <source>Status: %1</source>
+      <translation>Durum: %1</translation>
+    </message>
+    <message id="settings_relay_polarity_relay1">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
+      <source>Polarity (Relay 1)</source>
+      <translation>Polarite (Röle 1)</translation>
+    </message>
+    <message id="settings_relay_polarity">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
+      <source>Polarity</source>
+      <translation>Polarite</translation>
+    </message>
+    <message id="settings_relay_polarity_relay2">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
+      <source>Polarity (Relay 2)</source>
+      <translation>Polarite (Röle 2)</translation>
+    </message>
+    <message id="page_settings_wifi_invalid_password">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
+      <source>Password length must be either 0 or between 10 and 63 characters long</source>
+      <translation>Parola uzunluğu 0 veya 10 ile 63 karakter arasında olmalıdır</translation>
+    </message>
+    <message id="page_settings_wifi_password_updated">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
+      <source>Password updated</source>
+      <translation>Parola güncellendi</translation>
+    </message>
+    <message id="common_words_max">
+      <location filename="../../components/CommonWords.qml" line="315"/>
+      <source>Max</source>
+      <extracomment>Short for Maximum</extracomment>
+      <translation>Maks</translation>
+    </message>
+    <message id="common_words_min">
+      <location filename="../../components/CommonWords.qml" line="331"/>
+      <source>Min</source>
+      <extracomment>Short for Minimum</extracomment>
+      <translation>Min</translation>
+    </message>
+    <message id="settings_ess_deprecated">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="321"/>
+      <source>Deprecated settings</source>
+      <translation>Kullanımdan kaldırılmış ayarlar</translation>
+    </message>
+    <message id="settings_ess_max_charge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="328"/>
+      <source>Battery charge limit (% of CCL)</source>
+      <translation>Akü şarj limiti (CCL'nin %'si)</translation>
+    </message>
+    <message id="settings_ess_max_discharge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="339"/>
+      <source>Battery discharge limit (% of DCL)</source>
+      <translation>Akü deşarj limiti (DCL'nin %'si)</translation>
+    </message>
+    <message id="vebus_device_bms_message">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
+      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
+      <oldsource>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</oldsource>
+      <translation>Bir VE.Bus BMS, aküyü korumak gerektiğinde sistemi otomatik olarak kapatır. Bu nedenle, sistemi GX cihazından kontrol etmek mümkün değildir.</translation>
+    </message>
+    <message id="switchable_output_numeric_input">
+      <location filename="../../src/enums.cpp" line="418"/>
+      <source>Numeric input</source>
+      <translation>Sayısal giriş</translation>
     </message>
     <message id="autotoggleswitch_disable_auto_mode_info">
       <location filename="../../components/controls/AutoToggleButton.qml" line="34"/>
       <source>Disable Auto mode first</source>
-      <translation type="unfinished"/>
+      <translation>Önce Otomatik modu devre dışı bırakın</translation>
+    </message>
+    <message id="pagesettingsintegrations_venus_os_enable_large_features">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
+      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
+      <translation>Node-RED veya Signal-K kullanmak için Venus OS Large yazılımını etkinleştirin</translation>
+    </message>
+    <message id="settings_relays_sensors_tanks">
+      <location filename="../../pages/SettingsPage.qml" line="75"/>
+      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
+      <oldsource>Relays, Sensors, Tanks, PV Inverters, Modbus, MQTT…</oldsource>
+      <translation>Röleler, Sensörler, PV İnvertörler, Modbus, Node-RED</translation>
+    </message>
+    <message id="vebus_device_page_microgrid_parameters">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
+      <source>Microgrid parameters</source>
+      <translation>Mikro şebeke parametreleri</translation>
+    </message>
+    <message id="microgrid_mode_hybrid_droop">
+      <location filename="../../src/enums.cpp" line="539"/>
+      <source>Hybrid droop</source>
+      <translation>Hibrit droop</translation>
+    </message>
+    <message id="microgrid_mode_grid_following">
+      <location filename="../../src/enums.cpp" line="542"/>
+      <source>Grid-following</source>
+      <translation>Şebeke takibi</translation>
+    </message>
+    <message id="microgrid_mode_grid_forming">
+      <location filename="../../src/enums.cpp" line="545"/>
+      <source>Grid-forming</source>
+      <translation>Şebeke oluşturma</translation>
+    </message>
+    <message id="switchable_output_trip_low_voltage">
+      <location filename="../../src/enums.cpp" line="481"/>
+      <source>Trip low voltage</source>
+      <oldsource>Disabled</oldsource>
+      <translation>Düşük voltajda tetikleme</translation>
     </message>
     <message id="microgrid">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="15"/>
       <source>Microgrid</source>
-      <translation type="unfinished"/>
+      <translation>Mikro şebeke</translation>
     </message>
     <message id="page_microgrid_active_mode">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="19"/>
       <source>Active mode</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_microgrid_from_p1_to_p2">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="34"/>
-      <source>%1 %2 to %3 %4</source>
-      <extracomment>Describes a range from one quantity to another, e.g. "30 W to 60 W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
-      <translation type="unfinished"/>
+      <translation>Aktif mod</translation>
     </message>
     <message id="page_microgrid_hybrid_droop_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="92"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
       <source>Hybrid droop parameters</source>
-      <translation type="unfinished"/>
+      <translation>Hibrit droop parametreleri</translation>
     </message>
     <message id="page_microgrid_reference_active_power_p0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="105"/>
       <source>Reference active power (P&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Referans aktif güç (P&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_frequency_f0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="108"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="112"/>
       <source>Reference frequency (f&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Referans frekans (f&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_frequency_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="117"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="119"/>
       <source>Frequency droop slope (droop&lt;sub&gt;fP&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Frekans droop eğimi (droop&lt;sub&gt;fP&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_reactive_power">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="126"/>
       <source>Reference reactive power (Q&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Referans reaktif güç (Q&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_voltage">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="135"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="133"/>
       <source>Reference Voltage (U&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Referans Voltaj (U&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_voltage_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="144"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="140"/>
       <source>Voltage droop slope (droop&lt;sub&gt;UQ&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Voltaj droop eğimi (droop&lt;sub&gt;UQ&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_minimum_and_maximum_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="146"/>
       <source>Minimum and maximum parameters</source>
-      <translation type="unfinished"/>
+      <translation>Minimum ve maksimum parametreler</translation>
     </message>
     <message id="page_microgrid_allowed_active_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="156"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
       <source>Allowed active power range</source>
-      <translation type="unfinished"/>
+      <translation>İzin verilen aktif güç aralığı</translation>
     </message>
     <message id="page_microgrid_allowed_reactive_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="164"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="159"/>
       <source>Allowed reactive power range</source>
-      <translation type="unfinished"/>
+      <translation>İzin verilen reaktif güç aralığı</translation>
     </message>
     <message id="page_microgrid_p_q_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="176"/>
       <source>P-Q direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>P-Q doğrudan sürüş ayarları</translation>
     </message>
     <message id="page_microgrid_active_power_setpoint_p">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="186"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
       <source>Active power setpoint (P)</source>
-      <translation type="unfinished"/>
+      <translation>Aktif güç ayar noktası (P)</translation>
     </message>
     <message id="page_microgrid_reactive_power_setpoint_q">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="194"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="188"/>
       <source>Reactive power setpoint (Q)</source>
-      <translation type="unfinished"/>
+      <translation>Reaktif güç ayar noktası (Q)</translation>
     </message>
     <message id="page_microgrid_allowed_frequency_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="202"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="195"/>
       <source>Allowed frequency range</source>
-      <translation type="unfinished"/>
+      <translation>İzin verilen frekans aralığı</translation>
     </message>
     <message id="page_microgrid_allowed_voltage_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="210"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="203"/>
       <source>Allowed voltage range</source>
-      <translation type="unfinished"/>
+      <translation>İzin verilen voltaj aralığı</translation>
     </message>
     <message id="page_microgrid_v_f_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="227"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="220"/>
       <source>V-f direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>V-f doğrudan sürüş ayarları</translation>
     </message>
     <message id="page_microgrid_voltage_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="225"/>
       <source>Voltage setpoint (U)</source>
-      <translation type="unfinished"/>
+      <translation>Voltaj ayar noktası (U)</translation>
     </message>
     <message id="page_microgrid_frequency_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="240"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
       <source>Frequency setpoint (f)</source>
-      <translation type="unfinished"/>
+      <translation>Frekans ayar noktası (f)</translation>
     </message>
-    <message id="temperature_slider_current">
-      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
-      <source>Current</source>
-      <extracomment>The current temperature measurement</extracomment>
-      <translation type="unfinished">Akım</translation>
+    <message id="pagesettingsintegrations_canopenmotordrive">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
+      <source>CANopen motor drives</source>
+      <translation>CANopen motor sürücüleri</translation>
+    </message>
+    <message id="pagesettingsintegrations_ui_plugins">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
+      <source>UI Plugins</source>
+      <translation>UI Eklentileri</translation>
+    </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
+      <source>Motor Direction Inverted</source>
+      <translation>Motor Yönü Ters Çevrildi</translation>
     </message>
     <message id="page_settings_canopenmotordrive_scan_for_motor_drives">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="31"/>
       <source>Scan for motor drives</source>
-      <translation type="unfinished"/>
+      <translation>Motor sürücüleri için tara</translation>
     </message>
     <message id="page_settings_canopenmotordrive_discovered_motor_drive_ids">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="39"/>
       <source>Discovered motor drive IDs</source>
-      <translation type="unfinished"/>
+      <translation>Bulunan motor sürücü ID'leri</translation>
     </message>
-    <message id="switchableoutput_gx_device_relays">
-      <location filename="../../src/switchableoutput.cpp" line="388"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">GX cihazı röleleri</translation>
+    <message id="temperature_pm25">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
+      <source>PM2.5</source>
+      <translation>PM2.5</translation>
     </message>
-    <message id="gx_device_relays">
-      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">GX cihazı röleleri</translation>
+    <message id="temperature_co2">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+      <source>CO₂</source>
+      <translation>CO₂</translation>
     </message>
-    <message id="color_preset">
-      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
-      <source>Preset</source>
-      <translation type="unfinished"/>
+    <message id="temperature_voc">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
+      <source>VOC index</source>
+      <translation>VOC endeksi</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_location">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
-      <source>Add Modbus port and unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_nox">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
+      <source>NOx index</source>
+      <translation>NOx endeksi</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_unitid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
-      <source>Unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_luminosity">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
+      <source>Luminosity</source>
+      <translation>Aydınlık</translation>
     </message>
-    <message id="page_settings_fronius_unitid_invalid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation type="unfinished">1 geçerli bir birim numarası değil. 1-247 arasında bir sayı kullanın.</translation>
-    </message>
-    <message id="page_settings_fronius_add_modbus_location_button">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
-      <source>Add</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_locations_note">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
-      <source>The default modbus port is 502 and the default unit ID is 126.
-Here you can add additional ports and unit IDs to scan for PV inverters.</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_location_number">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
-      <source>Port/Unit ID %1</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location_description">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
-      <source>Port: %1 (Unit %2)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
-      <source>Remove Modbus port and unit ID?</source>
-      <translation type="unfinished"/>
+    <message id="switchable_output_bypassed">
+      <location filename="../../src/enums.cpp" line="484"/>
+      <source>Bypassed</source>
+      <translation>Baypas Edildi</translation>
     </message>
     <message id="switchableoutput_list_delegate_auto_status">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="84"/>
       <source>Auto (%1)</source>
       <extracomment>%1 = 'On' or 'Off'</extracomment>
-      <translation type="unfinished"/>
+      <translation>Otomatik (%1)</translation>
     </message>
     <message id="switchableoutput_list_delegate_state_forced">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="100"/>
       <source>Forced</source>
-      <translation type="unfinished"/>
+      <translation>Zorlandı</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_settings">
+      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
+      <source>Modbus port and unit ID settings</source>
+      <translation>Modbus portu ve birim ID'si ayarları</translation>
+    </message>
+    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
+      <source>Integrates with the device list</source>
+      <translation>Cihaz listesiyle entegre olur</translation>
+    </message>
+    <message id="common_words_color">
+      <location filename="../../components/CommonWords.qml" line="136"/>
+      <source>Color</source>
+      <translation>Renk</translation>
+    </message>
+    <message id="common_words_value_must_be_greater_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="557"/>
+      <source>Value must be greater than start value</source>
+      <translation>Değer, başlangıç değerinden büyük olmalıdır</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="566"/>
+      <source>Value must be lower than stop value</source>
+      <translation>Değer, bitiş değerinden küçük olmalıdır</translation>
+    </message>
+    <message id="notifications_page_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="43"/>
+      <source>Active Notifications</source>
+      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
+      <translation>Aktif Bildirimler</translation>
+    </message>
+    <message id="notifications_page_inactive_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="47"/>
+      <source>Inactive Notifications</source>
+      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
+      <translation>Etkin Olmayan Bildirimler</translation>
+    </message>
+    <message id="notifications_no_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="106"/>
+      <source>No active notifications</source>
+      <translation>Aktif bildirim yok</translation>
+    </message>
+    <message id="switchable_output_rgb_color_wheel">
+      <location filename="../../src/enums.cpp" line="427"/>
+      <source>RGB color wheel</source>
+      <translation>RGB renk çemberi</translation>
+    </message>
+    <message id="switchable_output_cct_color_wheel">
+      <location filename="../../src/enums.cpp" line="431"/>
+      <source>CCT color wheel</source>
+      <extracomment>Correlated Color Temperature color wheel</extracomment>
+      <translation>CCT renk çemberi</translation>
+    </message>
+    <message id="switchable_output_rgbw_color_wheel">
+      <location filename="../../src/enums.cpp" line="435"/>
+      <source>RGB + W color wheel</source>
+      <extracomment>RGB + white color wheel</extracomment>
+      <translation>RGB + W renk çemberi</translation>
+    </message>
+    <message id="listlink_show_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="43"/>
+      <source>Show QR code</source>
+      <translation>QR kodunu göster</translation>
+    </message>
+    <message id="listlink_scan_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="52"/>
+      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
+      <extracomment>%1 = url text</extracomment>
+      <oldsource>Scan the QR code with your portable device.&lt;br /&gt;Or insert the link: %1</oldsource>
+      <translation>Taşınabilir cihazınızla taramak için QR kodunu açın.&lt;br /&gt;Veya şu bağlantıyı girin: %1</translation>
+    </message>
+    <message id="color_preset">
+      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
+      <source>Preset</source>
+      <translation>Ön Ayar</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
+      <source>Add Modbus port and unit ID</source>
+      <translation>Modbus portu ve birim ID'si ekle</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_unitid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
+      <source>Unit ID</source>
+      <translation>Birim ID</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location_button">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
+      <source>Add</source>
+      <translation>Ekle</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_locations_note">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
+      <source>The default modbus port is 502 and the default unit ID is 126.
+Here you can add additional ports and unit IDs to scan for PV inverters.</source>
+      <translation>Varsayılan modbus portu 502 ve varsayılan birim ID'si 126'dır.
+Burada PV invertörlerini taramak için ek portlar ve birim ID'leri ekleyebilirsiniz.</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_location_number">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
+      <source>Port/Unit ID %1</source>
+      <translation>Port/Birim ID %1</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location_description">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
+      <source>Port: %1 (Unit %2)</source>
+      <translation>Port: %1 (Birim %2)</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
+      <source>Remove Modbus port and unit ID?</source>
+      <translation>Modbus portu ve birim ID'sini kaldırmak istiyor musunuz?</translation>
+    </message>
+    <message id="devicelist_tankshape_edit_point">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="182"/>
+      <source>Edit point %1</source>
+      <extracomment>%1 = which point is being edited, a number like "1" or "2"</extracomment>
+      <translation></translation>
+    </message>
+    <message id="settings_canbus_vecan">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
+      <source>VE.Can (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_250">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <source>VE.Can &amp; CANopen E-drive (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_500">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
+      <source>CANopen E-drive (500 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="page_microgrid_from_p1_to_p2">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="39"/>
+      <source>%1%2 to %3%4</source>
+      <extracomment>Describes a range from one quantity to another, e.g. "30W to 60W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
+      <translation></translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAfricaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
+      <source>Morocco Standard Time</source>
+      <translation>Fas Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
+      <source>W. Central Africa Standard Time</source>
+      <translation>Orta Batı Afrika Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
+      <source>South Africa Standard Time</source>
+      <translation>Güney Afrika Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
+      <source>Namibia Standard Time</source>
+      <translation>Namibya Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
+      <source>Egypt Standard Time</source>
+      <translation>Mısır Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
+      <source>E. Africa Standard Time</source>
+      <translation>Doğu Afrika Zaman Dilimi</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAmericaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
+      <source>Argentina Standard Time</source>
+      <translation>Arjantin Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
+      <source>E. South America Standard Time</source>
+      <translation>Güneydoğu Amerika Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
+      <source>Greenland Standard Time</source>
+      <translation>Grönland Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
+      <source>Montevideo Standard Time</source>
+      <translation>Montevideo Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
+      <source>Newfoundland Standard Time</source>
+      <translation>Newfoundland Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
+      <source>SA Eastern Standard Time</source>
+      <translation>Güney Amerika Doğu Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
+      <source>Atlantic Standard Time</source>
+      <translation>Atlantik Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
+      <source>Central Brazilian Standard Time</source>
+      <translation>Orta Brezilya Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>Güney Amerika Pasifik Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
+      <source>Paraguay Standard Time</source>
+      <translation>Paraguay Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
+      <source>SA Western Standard Time</source>
+      <translation>Güney Amerika Batı Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
+      <source>Venezuela Standard Time</source>
+      <translation>Venezuela Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
+      <source>Eastern Standard Time</source>
+      <translation>Doğu Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
+      <source>SA Pacific Standard Time</source>
+      <translation>Güney Amerika Pasifik Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
+      <source>US Eastern Standard Time</source>
+      <translation>ABD Doğu Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
+      <source>Canada Central Standard Time</source>
+      <translation>Orta Kanada Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
+      <source>Central America Standard Time</source>
+      <translation>Orta Amerika Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
+      <source>Central Standard Time (Mexico)</source>
+      <translation>Orta Zaman Dilimi (Meksika)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
+      <source>Central Standard Time</source>
+      <translation>Orta Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
+      <source>Mountain Standard Time (Mexico)</source>
+      <translation>Dağ Zaman Dilimi (Meksika)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
+      <source>Mountain Standard Time</source>
+      <translation>Dağ Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
+      <source>US Mountain Standard Time</source>
+      <translation>ABD Dağ Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
+      <source>Pacific Standard Time (Mexico)</source>
+      <translation>Pasifik Zaman Dilimi (Meksika)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
+      <source>Pacific Standard Time</source>
+      <translation>Pasifik Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
+      <source>Alaskan Standard Time</source>
+      <translation>Alaska Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
+      <source>Hawaii-Aleutian</source>
+      <translation>Hawaii-Aleut Adaları</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
+      <source>Atlantic Daylight Time</source>
+      <translation>Atlantik Yaz Saati</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAntarcticaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+      <source>New Zealand Standard Time</source>
+      <translation>Yeni Zelanda Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>Orta Pasifik Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+      <source>West Pacific Standard Time</source>
+      <translation>Batı Pasifik Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+      <source>W. Australia Standard Time</source>
+      <translation>Batı Avustralya Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+      <source>SE Asia Standard Time</source>
+      <translation>Güneydoğu Asya Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+      <source>Central Asia Standard Time</source>
+      <translation>Orta Asya Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+      <source>West Asia Standard Time</source>
+      <translation>Batı Asya Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+      <source>E. Africa Standard Time</source>
+      <translation>Doğu Afrika Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>Güney Amerika Pasifik Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+      <source>SA Western Standard Time</source>
+      <translation>Güney Amerika Batı Zaman Dilimi</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzArcticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
+      <source>W. Europe Standard Time</source>
+      <translation>Batı Avrupa Zaman Dilimi</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAsiaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
+      <source>Kamchatka Standard Time</source>
+      <translation>Kamçatka Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
+      <source>Magadan Standard Time</source>
+      <translation>Magadan Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
+      <source>Vladivostok Standard Time</source>
+      <translation>Vladivostok Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
+      <source>Yakutsk Standard Time</source>
+      <translation>Yakutistan Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
+      <source>Tokyo Standard Time</source>
+      <translation>Tokyo Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
+      <source>Korea Standard Time</source>
+      <translation>Kore Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
+      <source>Singapore Standard Time</source>
+      <translation>Singapur Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
+      <source>Ulaanbaatar Standard Time</source>
+      <translation>Ulan Batur Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
+      <source>Taipei Standard Time</source>
+      <translation>Taipei Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
+      <source>North Asia East Standard Time</source>
+      <translation>Kuzay Asya Doğu Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
+      <source>China Standard Time</source>
+      <translation>Çin Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
+      <source>SE Asia Standard Time</source>
+      <translation>Güneydoğu Asya Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
+      <source>North Asia Standard Time</source>
+      <translation>Kuzey Asya Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
+      <source>Myanmar Standard Time</source>
+      <translation>Myanmar Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
+      <source>N. Central Asia Standard Time</source>
+      <translation>Kuzey Orta Asya Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
+      <source>Central Asia Standard Time</source>
+      <translation>Orta Asya Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
+      <source>Bangladesh Standard Time</source>
+      <translation>Bangladeş Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
+      <source>Nepal Standard Time</source>
+      <translation>Nepal Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
+      <source>Sri Lanka Standard Time</source>
+      <translation>Sri Lanka Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
+      <source>India Standard Time</source>
+      <translation>Hindistan Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
+      <source>West Asia Standard Time</source>
+      <translation>Batı Asya Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
+      <source>Pakistan Standard Time</source>
+      <translation>Pakistan Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
+      <source>Ekaterinburg Standard Time</source>
+      <translation>Yekaterinburg Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
+      <source>Georgian Standard Time</source>
+      <translation>Gürcistan Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
+      <source>Caucasus Standard Time</source>
+      <translation>Kafkasya Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
+      <source>Azerbaijan Standard Time</source>
+      <translation>Azerbaycan Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
+      <source>Arabian Standard Time</source>
+      <translation>Arap Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
+      <source>Afghanistan Standard Time</source>
+      <translation>Afganistan Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
+      <source>Iran Standard Time</source>
+      <translation>İran Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
+      <source>Arabic Standard Time</source>
+      <translation>Arap Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
+      <source>Arab Standard Time</source>
+      <translation>Arap Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
+      <source>Syria Standard Time</source>
+      <translation>Suriye Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
+      <source>Middle East Standard Time</source>
+      <translation>Orta Doğu Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
+      <source>Jordan Standard Time</source>
+      <translation>Ürdün Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
+      <source>Israel Standard Time</source>
+      <translation>İsrail Zaman Dilimi</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAtlanticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+      <source>Greenwich Standard Time</source>
+      <translation>Greenwich Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+      <source>Azores Standard Time</source>
+      <translation>Azorlar Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+      <source>Cape Verde Standard Time</source>
+      <translation>Yeşil Burun Adaları Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
+      <source>Mid-Atlantic Standard Time</source>
+      <translation>Orta Atlantik Zaman Dilimi</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAustraliaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+      <source>Tasmania Standard Time</source>
+      <translation>Tazmanya Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+      <source>E. Australia Standard Time</source>
+      <translation>Doğu Avustralya Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+      <source>AUS Eastern Standard Time</source>
+      <translation>Doğu Avustralya Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+      <source>Cen. Australia Standard Time</source>
+      <translation>Orta Avustralya Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+      <source>AUS Central Standard Time</source>
+      <translation>Orta Avustralya Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+      <source>W. Australia Standard Time</source>
+      <translation>Batı Avustralya Zaman Dilimi</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEtcData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
+      <source>GMT +12</source>
+      <translation>GMT +12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
+      <source>GMT -02</source>
+      <translation>GMT -02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
+      <source>GMT -11</source>
+      <translation>GMT -11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
+      <source>GMT -13</source>
+      <translation>GMT -13</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
+      <source>GMT -12</source>
+      <translation>GMT -12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
+      <source>GMT -10</source>
+      <translation>GMT -10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
+      <source>GMT -09</source>
+      <translation>GMT -09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
+      <source>GMT -08</source>
+      <translation>GMT -08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
+      <source>GMT -07</source>
+      <translation>GMT -07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
+      <source>GMT -06</source>
+      <translation>GMT -06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
+      <source>GMT -05</source>
+      <translation>GMT -05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
+      <source>GMT -04</source>
+      <translation>GMT -04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
+      <source>GMT -03</source>
+      <translation>GMT -03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
+      <source>GMT -01</source>
+      <translation>GMT -01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
+      <source>GMT</source>
+      <translation>GMT</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
+      <source>GMT +01</source>
+      <translation>GMT +01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
+      <source>GMT +02</source>
+      <translation>GMT +02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
+      <source>GMT +03</source>
+      <translation>GMT +03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
+      <source>GMT +04</source>
+      <translation>GMT +04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
+      <source>GMT +05</source>
+      <translation>GMT +05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
+      <source>GMT +06</source>
+      <translation>GMT +06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
+      <source>GMT +07</source>
+      <translation>GMT +07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
+      <source>GMT +08</source>
+      <translation>GMT +08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
+      <source>GMT +09</source>
+      <translation>GMT +09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
+      <source>GMT +10</source>
+      <translation>GMT +10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
+      <source>GMT +11</source>
+      <translation>GMT +11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
+      <source>UTC</source>
+      <translation>UTC</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEuropeData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
+      <source>GMT Standard Time</source>
+      <translation>GMT Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
+      <source>Central Europe Standard Time</source>
+      <translation>Orta Avrupa Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
+      <source>Central European Standard Time</source>
+      <translation>Orta Avrupa Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
+      <source>Romance Standard Time</source>
+      <translation>Romanya Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
+      <source>W. Europe Standard Time</source>
+      <translation>Batı Avrupa Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
+      <source>E. Europe Standard Time</source>
+      <translation>Doğu Avrupa Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
+      <source>FLE Standard Time</source>
+      <translation>FLE Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
+      <source>GTB Standard Time</source>
+      <translation>GTB  Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
+      <source>Belarus Standard Time</source>
+      <translation>Beyaz Rusya Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
+      <source>Russian Standard Time</source>
+      <translation>Rusya Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
+      <source>Turkey Standard Time</source>
+      <translation>Türkiye Zaman Dilimi</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzIndianData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
+      <source>Mauritius Standard Time</source>
+      <translation>Mauritius Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
+      <source>Christmas Island Standard Time</source>
+      <translation>Christmas Island Standard Time</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzPacificData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
+      <source>Tonga Standard Time</source>
+      <translation>Tonga Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
+      <source>Fiji Standard Time</source>
+      <translation>Fiji Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
+      <source>New Zealand Standard Time</source>
+      <translation>Yeni Zelanda Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>Orta Pasifik Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
+      <source>West Pacific Standard Time</source>
+      <translation>Batı Pasifik Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
+      <source>Samoa Standard Time</source>
+      <translation>Samoa Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
+      <source>Hawaiian Standard Time</source>
+      <translation>Hawaii Zaman Dilimi</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
+      <source>Easter Island Standard Time</source>
+      <translation>Easter Island Standard Time</translation>
     </message>
   </context>
   <context>
@@ -12174,838 +11857,6 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
     </message>
   </context>
   <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>Fas Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>Orta Batı Afrika Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>Güney Afrika Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>Namibya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>Mısır Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Doğu Afrika Zaman Dilimi</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>Arjantin Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>Güneydoğu Amerika Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>Grönland Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>Montevideo Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>Newfoundland Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>Güney Amerika Doğu Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Atlantic Standard Time</source>
-      <translation>Atlantik Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>Orta Brezilya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Güney Amerika Pasifik Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>Paraguay Standard Time</source>
-      <translation>Paraguay Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>SA Western Standard Time</source>
-      <translation>Güney Amerika Batı Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Venezuela Standard Time</source>
-      <translation>Venezuela Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>Eastern Standard Time</source>
-      <translation>Doğu Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>Güney Amerika Pasifik Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>US Eastern Standard Time</source>
-      <translation>ABD Doğu Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Canada Central Standard Time</source>
-      <translation>Orta Kanada Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central America Standard Time</source>
-      <translation>Orta Amerika Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>Orta Zaman Dilimi (Meksika)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Central Standard Time</source>
-      <translation>Orta Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>Dağ Zaman Dilimi (Meksika)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>Mountain Standard Time</source>
-      <translation>Dağ Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>US Mountain Standard Time</source>
-      <translation>ABD Dağ Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>Pasifik Zaman Dilimi (Meksika)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Pacific Standard Time</source>
-      <translation>Pasifik Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Alaskan Standard Time</source>
-      <translation>Alaska Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>Hawaii-Aleut Adaları</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Daylight Time</source>
-      <translation>Atlantik Yaz Saati</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Yeni Zelanda Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Orta Pasifik Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Batı Pasifik Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Batı Avustralya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Güneydoğu Asya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Orta Asya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>Batı Asya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Doğu Afrika Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Güney Amerika Pasifik Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>Güney Amerika Batı Zaman Dilimi</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Batı Avrupa Zaman Dilimi</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>Kamçatka Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>Magadan Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>Vladivostok Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>Yakutistan Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>Tokyo Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>Kore Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>Singapur Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>Ulan Batur Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>Taipei Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>Kuzay Asya Doğu Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>Çin Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Güneydoğu Asya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>Kuzey Asya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>Myanmar Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>Kuzey Orta Asya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Orta Asya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>Bangladeş Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>Nepal Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>Sri Lanka Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>Hindistan Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>Batı Asya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>Pakistan Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>Yekaterinburg Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>Gürcistan Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>Kafkasya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>Azerbaycan Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>Arap Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>Afganistan Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>İran Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>Arap Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>Arap Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>Suriye Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>Orta Doğu Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>Ürdün Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>İsrail Zaman Dilimi</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>Greenwich Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>Azorlar Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>Yeşil Burun Adaları Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>Orta Atlantik Zaman Dilimi</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>Tazmanya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>Doğu Avustralya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>Doğu Avustralya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>Orta Avustralya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>Orta Avustralya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Batı Avustralya Zaman Dilimi</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
-      <source>GMT +12</source>
-      <translation>GMT +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
-      <source>GMT -02</source>
-      <translation>GMT -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT -13</source>
-      <translation>GMT -13</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT -12</source>
-      <translation>GMT -12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -10</source>
-      <translation>GMT -10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -09</source>
-      <translation>GMT -09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>GMT -08</source>
-      <translation>GMT -08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
-      <source>GMT -07</source>
-      <translation>GMT -07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
-      <source>GMT -06</source>
-      <translation>GMT -06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
-      <source>GMT -05</source>
-      <translation>GMT -05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
-      <source>GMT -04</source>
-      <translation>GMT -04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
-      <source>GMT -03</source>
-      <translation>GMT -03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
-      <source>GMT -01</source>
-      <translation>GMT -01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
-      <source>GMT</source>
-      <translation>GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
-      <source>GMT +01</source>
-      <translation>GMT +01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
-      <source>GMT +02</source>
-      <translation>GMT +02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
-      <source>GMT +03</source>
-      <translation>GMT +03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
-      <source>GMT +04</source>
-      <translation>GMT +04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
-      <source>GMT +05</source>
-      <translation>GMT +05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
-      <source>GMT +06</source>
-      <translation>GMT +06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
-      <source>GMT +07</source>
-      <translation>GMT +07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
-      <source>GMT +08</source>
-      <translation>GMT +08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
-      <source>GMT +09</source>
-      <translation>GMT +09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
-      <source>GMT +10</source>
-      <translation>GMT +10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
-      <source>GMT +11</source>
-      <translation>GMT +11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
-      <source>UTC</source>
-      <translation>UTC</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>GMT Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>Orta Avrupa Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>Orta Avrupa Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>Romanya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Batı Avrupa Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>Doğu Avrupa Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>FLE Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>GTB  Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>Beyaz Rusya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>Rusya Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>Türkiye Zaman Dilimi</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>Mauritius Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>Christmas Island Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>Tonga Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>Fiji Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Yeni Zelanda Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Orta Pasifik Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Batı Pasifik Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>Samoa Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>Hawaii Zaman Dilimi</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>Easter Island Standard Time</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation type="unfinished">Dahili hata</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation type="unfinished"/>
-    </message>
-  </context>
-  <context>
     <name>Wakespeed</name>
     <message>
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
@@ -13182,6 +12033,119 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
       <source>DC/DC misconfiguration</source>
       <translation>DC/DC yanlış yapılandırma</translation>
+    </message>
+  </context>
+  <context>
+    <name>VebusError</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+      <source>Device switched off</source>
+      <translation>Cihaz kapatıldı</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+      <source>Mixed old/new MK2</source>
+      <translation>Eski/yeni MK2 karışımı</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+      <source>Expected devices error</source>
+      <translation>Beklenen cihaz hatası</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+      <source>No other device detected</source>
+      <translation>Başka cihaz algılanmadı</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+      <source>Overvoltage on AC-out</source>
+      <translation>AC çıkışında aşırı gerilim</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+      <source>DDC program error</source>
+      <translation>DDC programı hatası</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+      <source>VE.Bus BMS without assistant</source>
+      <translation>Yardımcısı olmayan VE.Bus BMS</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+      <source>Ground relay test failed</source>
+      <translation>Topraklama rölesi testi başarısız</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+      <source>System time sync error</source>
+      <translation>Sistem saati senkronizasyon hatası</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+      <source>Grid relay test fault</source>
+      <translation>Şebeke rölesi testi arızası</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+      <source>Config mismatch with 2nd mcu</source>
+      <translation>2. mcu ile yapılandırma uyuşmazlığı</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+      <source>Device transmit error</source>
+      <translation>Cihaz iletim hatası</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+      <source>Awaiting configuration or dongle missing</source>
+      <translation>Yapılandırma bekleniyor veya dongle eksik</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+      <source>Phase master missing</source>
+      <translation>Faz ana cihazı eksik</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+      <source>Overvoltage has occurred</source>
+      <translation>Aşırı gerilim oluştu</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+      <source>Slave does not have AC input!</source>
+      <translation>Bağımlı cihazda AC girişi yok!</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+      <source>Device can't be slave</source>
+      <translation>Cihaz bağımlı olamaz</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+      <source>System protection initiated</source>
+      <translation>Sistem koruması başlatıldı</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+      <source>Firmware incompatibiltiy</source>
+      <translation>Donanım yazılımı uyumsuzluğu</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+      <source>Internal error</source>
+      <translation>İç hata</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+      <source>Failing relay test prevents connection</source>
+      <translation>Başarısız röle testi bağlantıyı engelliyor</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+      <source>VE.Bus error</source>
+      <translation>VE.Bus hatası</translation>
     </message>
   </context>
 </TS>

--- a/i18n/venus-gui-v2_uk.ts
+++ b/i18n/venus-gui-v2_uk.ts
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="uk">
   <context>
-    <name/>
+    <name></name>
     <message id="switchable_output_disabled">
       <location filename="../../src/enums.cpp" line="478"/>
       <source>Disabled</source>
@@ -22,6 +22,7 @@
     <message id="solarchargers_state_off">
       <location filename="../../src/enums.cpp" line="331"/>
       <source>Off</source>
+      <extracomment>Digital input state</extracomment>
       <translation>Вимкнено</translation>
     </message>
     <message id="common_words_auto">
@@ -52,18 +53,25 @@
     <message id="settings_startpage_none">
       <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
       <source>None</source>
+      <extracomment>Indicates no phase</extracomment>
       <translation>Жодного</translation>
     </message>
     <message id="common_words_position_ac">
       <location filename="../../components/CommonWords.qml" line="416"/>
       <source>Position</source>
-      <extracomment>AC input or output position</extracomment>
+      <extracomment>EVCS AC input/output position</extracomment>
       <translation>Позиція</translation>
     </message>
     <message id="settings_minmax_speed">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="193"/>
       <source>Speed</source>
+      <extracomment>A speed measurement value</extracomment>
       <translation>Швидкість</translation>
+    </message>
+    <message id="common_words_state">
+      <location filename="../../components/CommonWords.qml" line="502"/>
+      <source>State</source>
+      <translation>Стан</translation>
     </message>
     <message id="settings_firmware_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="67"/>
@@ -101,8 +109,8 @@
       <source>Solar yield</source>
       <translation>PV генерація</translation>
     </message>
-    <message id="ess_state_external_control">
-      <location filename="../../data/Ess.qml" line="41"/>
+    <message id="inverters_state_externalccontrol">
+      <location filename="../../data/System.qml" line="183"/>
       <source>External control</source>
       <translation>Зовнішнє керування</translation>
     </message>
@@ -140,6 +148,11 @@
       <location filename="../../components/CommonWords.qml" line="203"/>
       <source>ESS</source>
       <translation>ESS (система збереження енергії)</translation>
+    </message>
+    <message id="pagesettingsconnectivity_ethernet">
+      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
+      <source>Ethernet</source>
+      <translation>Локальна мережа Ethernet</translation>
     </message>
     <message id="pagesettingsconnectivity_wifi">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="28"/>
@@ -262,11 +275,6 @@
       <source>Name</source>
       <translation>Ім'я</translation>
     </message>
-    <message id="settings_deviceinfo_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="38"/>
-      <source>Name</source>
-      <translation type="unfinished">Ім'я</translation>
-    </message>
     <message id="settings_deviceinfo_product_id">
       <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
       <source>Product ID</source>
@@ -327,15 +335,20 @@
       <source>Daily run time</source>
       <translation>Щоденна тривалість роботи</translation>
     </message>
+    <message id="common_words_value_must_be_greater_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="560"/>
+      <source>Value must be greater than stop value</source>
+      <translation>Значення має бути більшим за кінцеве значення</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="563"/>
+      <source>Value must be lower than start value</source>
+      <translation>Значення має бути нижчим за початкове значення</translation>
+    </message>
     <message id="settings_minmax_acout_max_power">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="124"/>
       <source>AC output</source>
       <translation>Вихід AC</translation>
-    </message>
-    <message id="ac_output">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="15"/>
-      <source>AC output</source>
-      <translation type="unfinished">Вихід AC</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
       <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="25"/>
@@ -382,16 +395,6 @@
       <source>Unavailable monitor, set another</source>
       <translation>Монітор недоступний, встановіть інший</translation>
     </message>
-    <message id="page_generator_conditions_battery_monitor">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="42"/>
-      <source>Battery monitor</source>
-      <translation type="unfinished">Монітор батареї</translation>
-    </message>
-    <message id="page_generator_conditions_unavailable_monitor_set_another">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="44"/>
-      <source>Unavailable monitor, set another</source>
-      <translation type="unfinished">Монітор недоступний, встановіть інший</translation>
-    </message>
     <message id="page_generator_conditions_on_loss_of_communication">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="68"/>
       <source>On loss of communication</source>
@@ -416,11 +419,6 @@
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="105"/>
       <source>Battery SOC</source>
       <translation>SOC Батареї</translation>
-    </message>
-    <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="173"/>
-      <source>Periodic run</source>
-      <translation type="unfinished">Періодична робота</translation>
     </message>
     <message id="settings_inverter_high_temperature">
       <location filename="../../data/Generators.qml" line="83"/>
@@ -505,7 +503,7 @@
     <message id="settings_gps_speed_kmh">
       <location filename="../../pages/settings/PageGps.qml" line="83"/>
       <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometres per hour</extracomment>
+      <extracomment>GPS speed data, in kilometers per hour</extracomment>
       <translation>%1 км/год</translation>
     </message>
     <message id="settings_gps_speed_mph">
@@ -523,7 +521,7 @@
     <message id="settings_gps_speed_ms">
       <location filename="../../pages/settings/PageGps.qml" line="95"/>
       <source>%1 m/s</source>
-      <extracomment>GPS speed data, in metres per second</extracomment>
+      <extracomment>GPS speed data, in meters per second</extracomment>
       <translation>%1 м/с</translation>
     </message>
     <message id="settings_gps_course">
@@ -580,21 +578,6 @@
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="64"/>
       <source>%1 (Output %2)</source>
       <translation>%1 (Вихід %2)</translation>
-    </message>
-    <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">Активний монітор батареї</translation>
-    </message>
-    <message id="settings_batteries_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="101"/>
-      <source>Name</source>
-      <translation type="unfinished">Ім'я</translation>
-    </message>
-    <message id="settings_batteries_enter_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="103"/>
-      <source>Enter name</source>
-      <translation type="unfinished">Введіть ім'я</translation>
     </message>
     <message id="settings_briefview_center_active_battery_monitor">
       <location filename="../../components/listitems/ListBriefCenterDetails.qml" line="27"/>
@@ -656,45 +639,25 @@
       <source>CAN-bus profile</source>
       <translation>Профіль CAN-шини</translation>
     </message>
-    <message id="settings_disabled">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="31"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Вимкнено</translation>
-    </message>
-    <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; Lynx Ion BMS (250 кбіт/с)</translation>
-    </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
       <location filename="../../pages/settings/CanbusProfile.qml" line="42"/>
       <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
       <translation>VE.Can &amp; CAN-bus BMS (250 кбіт/с)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
       <source>Oceanvolt (250 kbit/s)</source>
       <translation>Oceanvolt (250 кбіт/с)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
       <source>RV-C (250 kbit/s)</source>
       <translation>RV-C (250 кбіт/с)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
       <source>Up, but no services (250 kbit/s)</source>
       <translation>Працює, але без служб (250 кбіт/с)</translation>
-    </message>
-    <message id="settings_canopen_motordrive_250">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
-      <source>CANopen Motor drive (250 kbit/s)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_canopen_motordrive_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
-      <source>CANopen Motor drive (500 kbit/s)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_devices">
       <location filename="../../components/CommonWords.qml" line="166"/>
@@ -731,11 +694,6 @@
       <source>Check Unique id numbers</source>
       <translation>Перевірте унікальні ідентифікаційні номери</translation>
     </message>
-    <message id="settings_canbus_unique_id_press_to_check">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Press to check</source>
-      <translation type="unfinished">Натисніть, щоб перевірити</translation>
-    </message>
     <message id="settings_canbus_unique_id_conflict">
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="125"/>
       <source>There is another device connected with this unique number, please select a new number.</source>
@@ -745,11 +703,6 @@
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="133"/>
       <source>OK: No other device is connected with this unique number.</source>
       <translation>OK: жоден інший пристрій не підключено до цього унікального номера.</translation>
-    </message>
-    <message id="pagesettingsintegrations_canopenmotordrive">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
-      <source>CANopen motor drives</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_network_status">
       <location filename="../../components/CommonWords.qml" line="349"/>
@@ -884,11 +837,6 @@
       <source>Unavailable sensor, set another</source>
       <translation>Недоступний датчик, встановіть інший</translation>
     </message>
-    <message id="settings_system_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="81"/>
-      <source>Unavailable sensor, set another</source>
-      <translation type="unfinished">Недоступний датчик, встановіть інший</translation>
-    </message>
     <message id="settings_dvcc_used_sensor">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="120"/>
       <source>Used sensor</source>
@@ -945,12 +893,6 @@
       <source>Auto selected</source>
       <translation>Автоматично вибрано</translation>
     </message>
-    <message id="settings_dvcc_auto_selected_none">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="208"/>
-      <source>None</source>
-      <extracomment>Indicates no option is selected</extracomment>
-      <translation type="unfinished">Жодного</translation>
-    </message>
     <message id="settings_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
       <source>Build date/time</source>
@@ -986,12 +928,6 @@
       <source>Installing %1</source>
       <extracomment>%1 = firmware version</extracomment>
       <translation>Встановлення %1</translation>
-    </message>
-    <message id="settings_firmware_offline_press_to_install">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">Натисніть, щоб оновити до %1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="90"/>
@@ -1062,12 +998,6 @@
       <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
       <translation>Встановлення %1 %2%</translation>
     </message>
-    <message id="settings_firmware_online_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="86"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">Встановлення %1...</translation>
-    </message>
     <message id="settings_firmware_update_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="109"/>
       <source>Update build date/time</source>
@@ -1097,11 +1027,6 @@
       <location filename="../../pages/settings/PageSettingsFronius.qml" line="56"/>
       <source>TCP port</source>
       <translation>порт TCP</translation>
-    </message>
-    <message id="page_settings_fronius_modbus_settings">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
-      <source>Modbus port and unit ID settings</source>
-      <translation type="unfinished"/>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
       <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
@@ -1153,16 +1078,6 @@
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="64"/>
       <source>AC-Out MP</source>
       <translation>AC-Out МультиФаза</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="52"/>
-      <source>AC-In1 L%1</source>
-      <translation type="unfinished">AC-In1 L%1</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="56"/>
-      <source>AC-In1 --</source>
-      <translation type="unfinished">AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="70"/>
@@ -1330,12 +1245,6 @@
       <source>Reset service timer</source>
       <translation>Скидання таймера обслуговування</translation>
     </message>
-    <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
-      <source>Volume</source>
-      <extracomment>Title for a list of units of volume (e.g. cubic metres, litres, gallons)</extracomment>
-      <translation type="unfinished">Об’єм</translation>
-    </message>
     <message id="settings_gps_format">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="69"/>
       <source>Format</source>
@@ -1438,42 +1347,6 @@ If that doesn't work, check sim-card in a phone to make sure that there is credi
       <source>Wrong PIN</source>
       <translation>Неправильний PIN-код</translation>
     </message>
-    <message id="page_settings_gsm_ok">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>OK</source>
-      <translation type="unfinished">ОК</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="128"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">Невідома помилка</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_state">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="153"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Невідоме</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_value">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="182"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Невідоме</translation>
-    </message>
-    <message id="page_settings_gsm_offline">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="173"/>
-      <source>Offline</source>
-      <translation type="unfinished">Офлайн</translation>
-    </message>
-    <message id="page_settings_gsm_connecting">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="176"/>
-      <source>Connecting</source>
-      <translation type="unfinished">Підключення...</translation>
-    </message>
-    <message id="page_settings_gsm_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="179"/>
-      <source>Connected</source>
-      <translation type="unfinished">Підключено</translation>
-    </message>
     <message id="page_settings_gsm_pin">
       <location filename="../../pages/settings/PageSettingsGsm.qml" line="191"/>
       <source>PIN</source>
@@ -1530,32 +1403,32 @@ If that doesn't work, check sim-card in a phone to make sure that there is credi
       <translation>Вимірювання мережі</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
       <source>External meter</source>
       <translation>Зовнішній лічильник</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="67"/>
       <source>Inverter/Charger</source>
       <translation>Інв./Зарядний</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
       <source>Multiphase regulation</source>
       <translation>Багатофазне регулювання</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="91"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
       <source>Total of all phases</source>
       <translation>Сумарно за всіма фазами</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="95"/>
       <source>Individual phase</source>
       <translation>Окрема фаза</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="99"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="101"/>
       <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
@@ -1564,68 +1437,13 @@ CAUTION: Use only if required by the utility provider.</source>
 УВАГА: Використовуйте тільки якщо цього вимагає постачальник електроенергії.</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="104"/>
       <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
       <translation>Сумарна потужність всіх фаз інтелектуально регулюється для досягнення заданого значення мережі (ефективність системи оптимізується).
 
 Використовуйте, якщо це не заборонено постачальником електроенергії.</translation>
-    </message>
-    <message id="settings_ess_min_soc">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation type="unfinished">Найнижчий рівень заряду (якщо немає збоїв у мережі)</translation>
-    </message>
-    <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="129"/>
-      <source>Active SOC limit</source>
-      <translation type="unfinished">Активне обмеження рівня заряду</translation>
-    </message>
-    <message id="settings_ess_battery_life_sustain">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
-      <source>Sustain</source>
-      <translation type="unfinished">Підтримувати</translation>
-    </message>
-    <message id="settings_ess_battery_life_recharge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="157"/>
-      <source>Recharge</source>
-      <translation type="unfinished">Повторне заряджання</translation>
-    </message>
-    <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <source>Scheduled charge levels</source>
-      <translation type="unfinished">Заплановані рівні заряду</translation>
-    </message>
-    <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="257"/>
-      <source>Active (%1)</source>
-      <translation type="unfinished">Активна (%1)</translation>
-    </message>
-    <message id="settings_ess_inactive">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="259"/>
-      <source>Inactive</source>
-      <translation type="unfinished">Неактивний</translation>
-    </message>
-    <message id="settings_ess_dynamic">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="293"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">Динамічна ESS</translation>
-    </message>
-    <message id="settings_ess_deprecated">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="319"/>
-      <source>Deprecated settings</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_charge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="326"/>
-      <source>Battery charge limit (% of CCL)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_discharge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="337"/>
-      <source>Battery discharge limit (% of DCL)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_rs_ess_min_soc">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="40"/>
@@ -1637,13 +1455,8 @@ Use unless prohibited by the utility provider.</source>
       <source>Active SOC limit</source>
       <translation>Активне обмеження рівня заряду</translation>
     </message>
-    <message id="scheduled_charge_inactive">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
-      <source>Inactive</source>
-      <translation type="unfinished">Неактивний</translation>
-    </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="245"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="247"/>
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
       <source>Peak shaving</source>
       <translation>Обмеження піків</translation>
@@ -1659,12 +1472,12 @@ Use unless prohibited by the utility provider.</source>
       <translation>Завжди</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="151"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
       <source>Discharge disabled</source>
       <translation>Розряджання вимкнене</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
       <source>Slow charge</source>
       <translation>Повільне заряджання</translation>
     </message>
@@ -1679,32 +1492,32 @@ Use unless prohibited by the utility provider.</source>
       <translation>Повторне заряджання</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="165"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="167"/>
       <source>Limit charge power</source>
       <translation>Обмежити потужність заряджання</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="183"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="185"/>
       <source>Maximum charge power</source>
       <translation>Максимальна потужність заряджання</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="196"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="198"/>
       <source>Limit inverter power</source>
       <translation>Обмежте потужність інвертора</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="214"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="216"/>
       <source>Maximum inverter power</source>
       <translation>Максимальна потужність інвертора</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="225"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="227"/>
       <source>Grid setpoint</source>
       <translation>Точка обміну з мережею</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="236"/>
       <source>Grid feed-in</source>
       <translation>Подача живлення в мережу</translation>
     </message>
@@ -1743,8 +1556,8 @@ Use unless prohibited by the utility provider.</source>
       <source>Door alarm</source>
       <translation>Тривога дверей</translation>
     </message>
-    <message id="digitalinputs_type_bilgepump">
-      <location filename="../../src/enums.cpp" line="201"/>
+    <message id="switchable_output_bilge_pump">
+      <location filename="../../src/enums.cpp" line="424"/>
       <source>Bilge pump</source>
       <translation>Трюмний насос</translation>
     </message>
@@ -1796,11 +1609,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Deferred by %1s</source>
       <extracomment>%1 = number of seconds</extracomment>
       <translation>Відкладено на %1 с</translation>
-    </message>
-    <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="75"/>
-      <source>Are you sure?</source>
-      <translation type="unfinished">Ти впевнений?</translation>
     </message>
     <message id="settings_vrm_portal_id">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="87"/>
@@ -1939,11 +1747,6 @@ Use unless prohibited by the utility provider.</source>
       <source>External storage</source>
       <translation>Зовнішній накопичувач</translation>
     </message>
-    <message id="settings_vrm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="308"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">Невідома помилка</translation>
-    </message>
     <message id="settings_vrm_no_error">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="311"/>
       <source>No Error</source>
@@ -2029,37 +1832,10 @@ Use unless prohibited by the utility provider.</source>
       <source>Function</source>
       <translation>Функція</translation>
     </message>
-    <message id="settings_relay_disabled">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="54"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="98"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Вимкнено</translation>
-    </message>
     <message id="settings_relay_alarm_relay">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="56"/>
       <source>Alarm relay</source>
       <translation>Реле тривоги</translation>
-    </message>
-    <message id="settings_relay_tank_pump">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="62"/>
-      <source>Tank pump</source>
-      <translation type="unfinished">Насос ємності</translation>
-    </message>
-    <message id="settings_relay_manual">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="64"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="100"/>
-      <source>Manual</source>
-      <translation type="unfinished">Вручну</translation>
-    </message>
-    <message id="settings_relay_polarity_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
-      <source>Polarity (Relay 1)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_relay_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
-      <source>Polarity</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_normally_open">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="83"/>
@@ -2075,11 +1851,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="93"/>
       <source>Function (Relay 2)</source>
       <translation>Функція (реле 2)</translation>
-    </message>
-    <message id="settings_relay_polarity_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
-      <source>Polarity (Relay 2)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_temp_control_rules">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="119"/>
@@ -2111,12 +1882,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
       <source>Press to boot</source>
       <translation>Натисніть для завантаження</translation>
-    </message>
-    <message id="settings_firmware_backup_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
-      <translation type="unfinished">Прошивка %1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
@@ -2152,6 +1917,7 @@ Use unless prohibited by the utility provider.</source>
     <message id="nav_boat">
       <location filename="../../pages/boat/BoatPage.qml" line="14"/>
       <source>Boat</source>
+      <extracomment>The 'Boat' page</extracomment>
       <translation>Човен</translation>
     </message>
     <message id="settings_system_name">
@@ -2219,11 +1985,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Solar charger current control</source>
       <translation>Регулювання струму сонячного зарядного</translation>
     </message>
-    <message id="settings_system_status_bms_params">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
-      <source>BMS control</source>
-      <translation type="unfinished">Керування BMS</translation>
-    </message>
     <message id="common_words_bms_control">
       <location filename="../../components/CommonWords.qml" line="101"/>
       <source>BMS control</source>
@@ -2238,11 +1999,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
       <source>Pump state</source>
       <translation>Стан насоса</translation>
-    </message>
-    <message id="settings_pump_auto">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="56"/>
-      <source>Auto</source>
-      <translation type="unfinished">Авто</translation>
     </message>
     <message id="settings_tank_sensor">
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
@@ -2271,11 +2027,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="35"/>
       <source>Unplugged</source>
       <translation>Від’єднано від мережі</translation>
-    </message>
-    <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="16"/>
-      <source>Name</source>
-      <translation type="unfinished">Ім'я</translation>
     </message>
     <message id="settings_tcpip_hidden">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="21"/>
@@ -2317,16 +2068,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="99"/>
       <source>IP configuration</source>
       <translation>Конфігурація IP</translation>
-    </message>
-    <message id="settings_tcpip_manual">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="105"/>
-      <source>Manual</source>
-      <translation type="unfinished">Вручну</translation>
-    </message>
-    <message id="settings_tcpip_off">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="107"/>
-      <source>Off</source>
-      <translation type="unfinished">Вимкнено</translation>
     </message>
     <message id="settings_tcpip_fixed">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="109"/>
@@ -2382,21 +2123,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="30"/>
       <source>Create access point</source>
       <translation>Створити точку доступу</translation>
-    </message>
-    <message id="settings_wifi_access_point_enter_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="68"/>
-      <source>Enter password</source>
-      <translation type="unfinished">Введіть пароль</translation>
-    </message>
-    <message id="page_settings_wifi_invalid_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
-      <source>Password length must be either 0 or between 10 and 63 characters long</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_wifi_password_updated">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
-      <source>Password updated</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_wifi_networks">
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="86"/>
@@ -2539,20 +2265,10 @@ Use unless prohibited by the utility provider.</source>
       <extracomment>Network status: Standalone</extracomment>
       <translation>Окремо</translation>
     </message>
-    <message id="charger_standalone">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="45"/>
-      <source>Standalone</source>
-      <translation type="unfinished">Окремо</translation>
-    </message>
     <message id="charger_charge">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="48"/>
       <source>Charge</source>
       <translation>Зарядка</translation>
-    </message>
-    <message id="charger_external_control">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="51"/>
-      <source>External control</source>
-      <translation type="unfinished">Зовнішнє керування</translation>
     </message>
     <message id="charger_charge_hub_1">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="54"/>
@@ -2584,16 +2300,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Master setting</source>
       <translation>Головні опції</translation>
     </message>
-    <message id="charger_slave">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="85"/>
-      <source>Slave</source>
-      <translation type="unfinished">Керований</translation>
-    </message>
-    <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation type="unfinished">Напруга заряджання</translation>
-    </message>
     <message id="systemsettings_networkstatus_slave">
       <location filename="../../data/SystemSettings.qml" line="148"/>
       <source>Slave</source>
@@ -2615,14 +2321,15 @@ Use unless prohibited by the utility provider.</source>
       <source>Group &amp; Charge master</source>
       <translation>Головний груп і екземплярів</translation>
     </message>
-    <message id="genset_charge_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="365"/>
+    <message id="charger_charge_voltage">
+      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
       <source>Charge voltage</source>
       <translation>Напруга заряджання</translation>
     </message>
     <message id="common_words_reset">
       <location filename="../../components/CommonWords.qml" line="448"/>
       <source>Reset</source>
+      <extracomment>Reset the BMS control</extracomment>
       <translation>Скинути</translation>
     </message>
     <message id="solarcharger_load">
@@ -2651,14 +2358,14 @@ Use unless prohibited by the utility provider.</source>
       <extracomment>Voltage alarm is at "Warning" level</extracomment>
       <translation>Попередження</translation>
     </message>
-    <message id="listitems_alarm_level_alarm">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="25"/>
+    <message id="digitalinputs_state_alarm">
+      <location filename="../../src/enums.cpp" line="270"/>
       <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
+      <extracomment>Relay function is 'alarm'</extracomment>
       <translation>Тривога</translation>
     </message>
-    <message id="devicelist_tankshape_volume">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="190"/>
+    <message id="components_volumeunit_volume">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
       <source>Volume</source>
       <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
       <translation>Об’єм</translation>
@@ -2808,26 +2515,10 @@ Use unless prohibited by the utility provider.</source>
       <source>Relay function</source>
       <translation>Функція реле</translation>
     </message>
-    <message id="batterysettingrelay_alarm">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation type="unfinished">Тривога</translation>
-    </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
       <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
       <source>Charger or generator start/stop</source>
       <translation>Пуск/зупинка зарядного або генератора</translation>
-    </message>
-    <message id="batterysettingrelay_manual_control">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
-      <source>Manual control</source>
-      <translation type="unfinished">Ручне управління</translation>
-    </message>
-    <message id="batterysettingrelay_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">Перегорів запобіжник</translation>
     </message>
     <message id="common_words_manual_control">
       <location filename="../../components/CommonWords.qml" line="302"/>
@@ -2853,12 +2544,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
       <source>Status LEDs</source>
       <translation>Світлодіоди стану</translation>
-    </message>
-    <message id="batterydiagnostics_none">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
-      <source>None</source>
-      <extracomment>Indicates no alarm is set</extracomment>
-      <translation type="unfinished">Жодного</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
@@ -2888,7 +2573,7 @@ Use unless prohibited by the utility provider.</source>
     <message id="common_words_switch">
       <location filename="../../components/CommonWords.qml" line="525"/>
       <source>Switch</source>
-      <extracomment>Change the mode value</extracomment>
+      <extracomment>Change the battery mode</extracomment>
       <translation>Перемикач</translation>
     </message>
     <message id="devicelist_battery_initializing">
@@ -2956,21 +2641,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Top section voltage</source>
       <translation>Напруга верхньої секції</translation>
     </message>
-    <message id="battery_bank_error_communication">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="96"/>
-      <source>Communication error</source>
-      <translation type="unfinished">Помилка зв'язку</translation>
-    </message>
-    <message id="battery_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="182"/>
-      <source>State of health</source>
-      <translation type="unfinished">Стан здоров'я</translation>
-    </message>
-    <message id="battery_bus_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="212"/>
-      <source>Bus voltage</source>
-      <translation type="unfinished">Напруга шини</translation>
-    </message>
     <message id="battery_bottom_section_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="228"/>
       <source>Bottom section voltage</source>
@@ -3016,16 +2686,6 @@ Use unless prohibited by the utility provider.</source>
       <source>IO</source>
       <translation>IO</translation>
     </message>
-    <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="391"/>
-      <source>System</source>
-      <translation type="unfinished">СТАТУС</translation>
-    </message>
-    <message id="battery_press_to_redetect">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="433"/>
-      <source>Press to redetect</source>
-      <translation type="unfinished">Натисніть , щоб знайти</translation>
-    </message>
     <message id="pagesettingsgeneral_system">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="107"/>
       <source>System</source>
@@ -3066,16 +2726,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Low SOC</source>
       <translation>Низький SOC</translation>
     </message>
-    <message id="batteryalarms_high_battery_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
-      <source>High battery voltage</source>
-      <translation type="unfinished">Висока напруга батареї</translation>
-    </message>
-    <message id="batteryalarms_low_soc">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low SOC</source>
-      <translation type="unfinished">Низький SOC</translation>
-    </message>
     <message id="batteryalarms_low_starter_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="73"/>
       <source>Low starter voltage</source>
@@ -3095,11 +2745,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
       <source>Mid-point voltage</source>
       <translation>Напруга в середній точці</translation>
-    </message>
-    <message id="batteryalarms_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">Перегорів запобіжник</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
@@ -3293,11 +2938,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Restore factory defaults</source>
       <translation>Відновлення заводських налаштувань</translation>
     </message>
-    <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation type="unfinished">Натисніть, щоб відновити</translation>
-    </message>
     <message id="vebus_backup_press_to_restore">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="362"/>
       <source>Press to restore</source>
@@ -3337,11 +2977,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="18"/>
       <source>Capacity</source>
       <translation>Обʼєм</translation>
-    </message>
-    <message id="batterysettingsbattery_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
-      <source>Capacity</source>
-      <translation type="unfinished">Обʼєм</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
@@ -3418,17 +3053,13 @@ Use unless prohibited by the utility provider.</source>
       <source>No power on busbar</source>
       <translation>Немає живлення на шині</translation>
     </message>
-    <message id="lynxdistributor_connection_lost">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
-      <source>Connection lost</source>
-      <translation type="unfinished">З’єднання втрачено</translation>
-    </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
       <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
       <source>%n fuse(s) blown</source>
       <extracomment>%n = number of fuses that have blown</extracomment>
       <translation type="unfinished">
         <numerusform>%n запобіжник згорів</numerusform>
+        <numerusform>%n запобіжників згоріло</numerusform>
         <numerusform>%n запобіжників згоріло</numerusform>
         <numerusform>%n запобіжників згоріло</numerusform>
       </translation>
@@ -3459,26 +3090,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Shutdowns due error</source>
       <translation>Вимкнення через помилку</translation>
     </message>
-    <message id="lynxiondiagnostics_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
-      <source>Last error</source>
-      <translation type="unfinished">Остання помилка</translation>
-    </message>
-    <message id="lynxiondiagnostics_2nd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
-      <source>2nd last error</source>
-      <translation type="unfinished">передостання помилка</translation>
-    </message>
-    <message id="lynxiondiagnostics_3rd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
-      <source>3rd last error</source>
-      <translation type="unfinished">третя помилка</translation>
-    </message>
-    <message id="lynxiondiagnostics_4th_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
-      <source>4th last error</source>
-      <translation type="unfinished">четверта помилка</translation>
-    </message>
     <message id="lynxionio_system_switch">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
       <source>System Switch</source>
@@ -3498,11 +3109,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../components/CommonWords.qml" line="54"/>
       <source>Batteries</source>
       <translation>Батареї</translation>
-    </message>
-    <message id="lynxionsystem_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
-      <source>Capacity</source>
-      <translation type="unfinished">Обʼєм</translation>
     </message>
     <message id="lynxionsystem_parallel">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="30"/>
@@ -3524,20 +3130,10 @@ Use unless prohibited by the utility provider.</source>
       <source>Min/max cell temperature</source>
       <translation>Мін./макс. температура комірки</translation>
     </message>
-    <message id="lynxionsystem_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="92"/>
-      <source>Balancing</source>
-      <translation type="unfinished">Балансування</translation>
-    </message>
     <message id="lynxionsystem_balancer_balancing">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
       <source>Balancing</source>
       <translation>Балансування</translation>
-    </message>
-    <message id="lynxionsystem_balancer_unknown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="117"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Невідоме</translation>
     </message>
     <message id="dc_output">
       <location filename="../../components/listitems/ListDcOutputQuantityGroup.qml" line="16"/>
@@ -3645,11 +3241,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Remaining</source>
       <translation>Залишилось</translation>
     </message>
-    <message id="devicelist_tanksensor_sensor_battery">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="51"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">Батарея датчика</translation>
-    </message>
     <message id="temperature_sensor_battery">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="112"/>
       <source>Sensor battery</source>
@@ -3678,7 +3269,7 @@ Use unless prohibited by the utility provider.</source>
     <message id="devicelist_tanksetup_custom">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="53"/>
       <source>Custom</source>
-      <translation type="unfinished">Власний</translation>
+      <translation>Власний</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="59"/>
@@ -3711,34 +3302,34 @@ Use unless prohibited by the utility provider.</source>
       <translation>Значення датчика</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="75"/>
       <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
       <translation>Власну форму не визначено. Ви можете визначити одну з десятьма точками. Зверніть увагу, що 0% і 100% маються на увазі.</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="91"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="89"/>
       <source>Point %1</source>
       <extracomment>%1 = the point number</extracomment>
       <translation>Точка %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="133"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="179"/>
       <source>Add point</source>
       <translation>Додати точку</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="156"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="205"/>
       <source>Sensor level</source>
       <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
       <translation>Рівень датчика</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="256"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="311"/>
       <source>Duplicate sensor level values are not allowed.</source>
       <translation>Повторення значень рівня датчика не допускається.</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="262"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="317"/>
       <source>Volume values must be increasing.</source>
       <translation>Об'ємні значення повинні збільшуватися.</translation>
     </message>
@@ -3778,11 +3369,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Switch position</source>
       <translation>Положення перемикача</translation>
     </message>
-    <message id="ac-in-setup_single_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="142"/>
-      <source>Single phase</source>
-      <translation type="unfinished">Однофазний</translation>
-    </message>
     <message id="ac-in-setup_two_phase">
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="144"/>
       <source>2-phase</source>
@@ -3792,11 +3378,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="146"/>
       <source>3-phase</source>
       <translation>3-фазний</translation>
-    </message>
-    <message id="ac-in-setup_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="161"/>
-      <source>Devices</source>
-      <translation type="unfinished">Пристрої</translation>
     </message>
     <message id="ac-in-genset_ac">
       <location filename="../../components/PageGensetModel.qml" line="194"/>
@@ -3890,12 +3471,6 @@ Use unless prohibited by the utility provider.</source>
       <extracomment>%1 = CT device number</extracomment>
       <translation>КТ %1</translation>
     </message>
-    <message id="smappeect_phase_none">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation type="unfinished">Жодного</translation>
-    </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
       <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
       <source>Flashing LED indicates this CT</source>
@@ -3909,11 +3484,13 @@ Use unless prohibited by the utility provider.</source>
     <message id="common_words_setting_disabled_when_dmc_connected">
       <location filename="../../components/CommonWords.qml" line="355"/>
       <source>This setting is disabled when a Digital Multi Control is connected.</source>
+      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>Цей параметр вимкнено, якщо підключено цифровий мульти контроль ( DMC ).</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
       <location filename="../../components/CommonWords.qml" line="358"/>
       <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>Цей параметр вимкнено, якщо підключено VE.Bus BMS.</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
@@ -3931,16 +3508,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="21"/>
       <source>Inverted</source>
       <translation>Перевернутий</translation>
-    </message>
-    <message id="digitalinput_enable_alarm">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="48"/>
-      <source>Enable alarm</source>
-      <translation type="unfinished">Увімкнути тривогу</translation>
-    </message>
-    <message id="digitalinput_inverted">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="54"/>
-      <source>Inverted</source>
-      <translation type="unfinished">Перевернутий</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
       <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="60"/>
@@ -3977,16 +3544,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Wind speed</source>
       <translation>Швидкість вітру</translation>
     </message>
-    <message id="page_meteo_battery_voltage">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="99"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">Батарея датчика</translation>
-    </message>
-    <message id="meteo_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="120"/>
-      <source>Low</source>
-      <translation type="unfinished">Низький</translation>
-    </message>
     <message id="page_meteo_settings_auto_detect">
       <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
       <source>Auto-detect</source>
@@ -4017,16 +3574,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Reset counter</source>
       <translation>Скинути лічильник</translation>
     </message>
-    <message id="temperature_short_circuited">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="32"/>
-      <source>Short circuited</source>
-      <translation type="unfinished">Коротке замикання</translation>
-    </message>
-    <message id="temperature_reverse_polarity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="35"/>
-      <source>Reverse polarity</source>
-      <translation type="unfinished">Зворотня полярність</translation>
-    </message>
     <message id="temperature_sensor_battery_low">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
       <source>Sensor battery low</source>
@@ -4041,36 +3588,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="62"/>
       <source>Pressure</source>
       <translation>Тиск</translation>
-    </message>
-    <message id="temperature_pm25">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
-      <source>PM2.5</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_co2">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>CO₂</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_voc">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
-      <source>VOC index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_nox">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
-      <source>NOx index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_luminosity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
-      <source>Luminosity</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="133"/>
-      <source>Low</source>
-      <translation type="unfinished">Низький</translation>
     </message>
     <message id="temperature_offset">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
@@ -4124,25 +3641,10 @@ NOTE: The update might temporarily stop the system.</source>
       <source>Updating the MK3, values will reappear after the update is complete</source>
       <translation>Значення з’являться знову після завершення оновлення MK3.</translation>
     </message>
-    <message id="vebus_device_charging_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="78"/>
-      <source>Charging the battery to 100%</source>
-      <translation type="unfinished">Заряджання батареї до 100%</translation>
-    </message>
     <message id="vebus_device_charging_the_battery_to_100">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="93"/>
       <source>Charging the battery to 100%</source>
       <translation>Заряджання батареї до 100%</translation>
-    </message>
-    <message id="vebus_device_page_microgrid_parameters">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
-      <source>Microgrid parameters</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="vebus_device_page_advanced">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
-      <source>Advanced</source>
-      <translation type="unfinished">Розширено</translation>
     </message>
     <message id="vebus_device_in_progress">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="80"/>
@@ -4198,15 +3700,15 @@ Do you want to continue?</source>
       <source>DC Current</source>
       <translation>DC струм</translation>
     </message>
+    <message id="vebus_device_page_advanced">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
+      <source>Advanced</source>
+      <translation>Розширено</translation>
+    </message>
     <message id="common_words_alarm_setup">
       <location filename="../../components/CommonWords.qml" line="65"/>
       <source>Alarm setup</source>
       <translation>Налаштування сигналу тривоги</translation>
-    </message>
-    <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
-      <translation type="unfinished">VE.Bus BMS автоматично вимикає систему, коли це потрібно для захисту батареї. А отже, керування системою за допомогою Color Control неможливе.</translation>
     </message>
     <message id="vebus_device_bms_not_found">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="240"/>
@@ -4247,7 +3749,7 @@ Do you want to continue?</source>
     <message id="vebus_device_starting">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="117"/>
       <source>Starting...</source>
-      <translation type="unfinished">Запускаю...</translation>
+      <translation>Запускаю...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="120"/>
@@ -4313,16 +3815,6 @@ Do you want to continue?</source>
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="260"/>
       <source>ESS Relay test</source>
       <translation>Тестування реле ESS</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_completed">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="266"/>
-      <source>Completed</source>
-      <translation type="unfinished">Завершено</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_pending">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="268"/>
-      <source>Pending</source>
-      <translation type="unfinished">Очікується...</translation>
     </message>
     <message id="cycle_history_completed">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
@@ -4509,6 +4001,7 @@ Do you want to continue?</source>
     <message id="rssystemalarms_overload">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
       <source>Overload</source>
+      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
       <translation>Перевантаження</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
@@ -4521,11 +4014,6 @@ Do you want to continue?</source>
       <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
       <source>Voltage Sensor</source>
       <translation>Датчик напруги</translation>
-    </message>
-    <message id="vebus_device_phase_rotation">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
-      <source>Phase rotation</source>
-      <translation type="unfinished">Чергування фаз</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
@@ -4557,12 +4045,6 @@ Do you want to continue?</source>
       <source>VE.Bus BMS version</source>
       <translation>Версія VE.Bus BMS</translation>
     </message>
-    <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="15"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="52"/>
-      <source>Minimum SOC</source>
-      <translation type="unfinished">Мін. SOC:</translation>
-    </message>
     <message id="ess_unless_grid_fails">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="32"/>
       <source>Unless grid fails</source>
@@ -4582,7 +4064,7 @@ Do you want to continue?</source>
     <message id="common_words_ac_input_role">
       <location filename="../../components/CommonWords.qml" line="24"/>
       <source>Role</source>
-      <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
       <translation>Роль</translation>
     </message>
     <message id="common_words_ac_load">
@@ -4621,18 +4103,6 @@ Do you want to continue?</source>
       <source>Active</source>
       <extracomment>Status is 'active'</extracomment>
       <translation>Активний</translation>
-    </message>
-    <message id="common_words_alarm">
-      <location filename="../../components/CommonWords.qml" line="51"/>
-      <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
-      <translation type="unfinished">Тривога</translation>
-    </message>
-    <message id="common_words_alarm_setting_overload">
-      <location filename="../../components/CommonWords.qml" line="58"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation type="unfinished">Перевантаження</translation>
     </message>
     <message id="common_words_alarm_status">
       <location filename="../../components/CommonWords.qml" line="68"/>
@@ -4679,8 +4149,8 @@ Do you want to continue?</source>
       <source>Charge current</source>
       <translation>Зар. струм</translation>
     </message>
-    <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="125"/>
+    <message id="battery_mode_charging">
+      <location filename="../../src/enums.cpp" line="30"/>
       <source>Charging</source>
       <extracomment>"Charging" state</extracomment>
       <translation>Зарядка</translation>
@@ -4694,7 +4164,7 @@ Do you want to continue?</source>
     <message id="digitalinputs_state_closed">
       <location filename="../../src/enums.cpp" line="262"/>
       <source>Closed</source>
-      <extracomment>Digital input state</extracomment>
+      <extracomment>Status is 'closed'</extracomment>
       <translation>Закрито</translation>
     </message>
     <message id="evchargers_status_connected">
@@ -4702,8 +4172,8 @@ Do you want to continue?</source>
       <source>Connected</source>
       <translation>Підключено</translation>
     </message>
-    <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="143"/>
+    <message id="temperature_slider_current">
+      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
       <source>Current</source>
       <extracomment>Electric current, as measured in Amps</extracomment>
       <translation>Струм</translation>
@@ -4730,9 +4200,10 @@ Do you want to continue?</source>
       <extracomment>Title for device information</extracomment>
       <translation>Пристрій</translation>
     </message>
-    <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="172"/>
+    <message id="battery_mode_discharging">
+      <location filename="../../src/enums.cpp" line="34"/>
       <source>Discharging</source>
+      <extracomment>Battery mode</extracomment>
       <translation>Розрядка</translation>
     </message>
     <message id="wifimodel_disconnected">
@@ -4818,13 +4289,14 @@ Do you want to continue?</source>
       <source>%1 Hour(s)</source>
       <translation>%1 Година(и)</translation>
     </message>
-    <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="251"/>
+    <message id="battery_mode_idle">
+      <location filename="../../src/enums.cpp" line="26"/>
       <source>Idle</source>
+      <extracomment>Battery mode</extracomment>
       <translation>Релаксую</translation>
     </message>
-    <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="258"/>
+    <message id="scheduled_charge_inactive">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
       <source>Inactive</source>
       <extracomment>Status is 'inactive'</extracomment>
       <translation>Неактивний</translation>
@@ -4926,8 +4398,8 @@ Do you want to continue?</source>
       <source>Offline</source>
       <translation>Офлайн</translation>
     </message>
-    <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="17"/>
+    <message id="digitalinputs_state_ok">
+      <location filename="../../src/enums.cpp" line="266"/>
       <source>OK</source>
       <extracomment>Voltage alarm is at "OK" level</extracomment>
       <translation>ОК</translation>
@@ -4935,6 +4407,7 @@ Do you want to continue?</source>
     <message id="switchable_output_on">
       <location filename="../../src/enums.cpp" line="471"/>
       <source>On</source>
+      <extracomment>Digital input state</extracomment>
       <translation>Увімкнено</translation>
     </message>
     <message id="common_words_online">
@@ -4945,7 +4418,7 @@ Do you want to continue?</source>
     <message id="digitalinputs_state_open">
       <location filename="../../src/enums.cpp" line="258"/>
       <source>Open</source>
-      <extracomment>Digital input open</extracomment>
+      <extracomment>Status is 'open'</extracomment>
       <translation>Відкрито</translation>
     </message>
     <message id="common_words_password">
@@ -5005,9 +4478,10 @@ Do you want to continue?</source>
       <source>Remove</source>
       <translation>Видалити</translation>
     </message>
-    <message id="switch_state_running">
-      <location filename="../../src/enums.cpp" line="363"/>
+    <message id="switchable_output_running">
+      <location filename="../../src/enums.cpp" line="468"/>
       <source>Running</source>
+      <extracomment>Status = "running"</extracomment>
       <translation>Працює</translation>
     </message>
     <message id="common_words_scanning">
@@ -5074,7 +4548,7 @@ Do you want to continue?</source>
     <message id="pvinverter_statusCode_startup">
       <location filename="../../src/enums.cpp" line="296"/>
       <source>Startup (%1)</source>
-      <extracomment>PV inverter status code. %1 = the startup status number</extracomment>
+      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
       <translation>Запуск (%1)</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
@@ -5129,8 +4603,10 @@ Do you want to continue?</source>
       <source>Unique Identity Number</source>
       <translation>Унікальний ідентифікаційний номер</translation>
     </message>
-    <message id="settings_radio_button_group_unknown">
-      <location filename="../../components/listitems/core/ListRadioButtonGroup.qml" line="44"/>
+    <message id="Unknown">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
       <source>Unknown</source>
       <translation>Невідоме</translation>
     </message>
@@ -5285,11 +4761,6 @@ Do you want to continue?</source>
       <source>Error while checking for firmware updates</source>
       <translation>Помилка під час перевірки оновлень прошивки</translation>
     </message>
-    <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation type="unfinished">Помилка під час перевірки оновлень прошивки</translation>
-    </message>
     <message id="settings_firmware_downloading_and_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="63"/>
       <source>Downloading and installing firmware %1...</source>
@@ -5316,6 +4787,66 @@ Do you want to continue?</source>
       <source>No firmware found</source>
       <translation>Прошивка не знайдена</translation>
     </message>
+    <message id="tank_type_fuel">
+      <location filename="../../src/enums.cpp" line="495"/>
+      <source>Fuel</source>
+      <translation>Паливо</translation>
+    </message>
+    <message id="tank_type_fresh_water">
+      <location filename="../../src/enums.cpp" line="498"/>
+      <source>Fresh water</source>
+      <translation>Прісна вода</translation>
+    </message>
+    <message id="tank_type_waste_water">
+      <location filename="../../src/enums.cpp" line="501"/>
+      <source>Waste water</source>
+      <translation>Стічні води</translation>
+    </message>
+    <message id="tank_type_live_well">
+      <location filename="../../src/enums.cpp" line="504"/>
+      <source>Live well</source>
+      <translation>Свердловина</translation>
+    </message>
+    <message id="tank_type_oil">
+      <location filename="../../src/enums.cpp" line="507"/>
+      <source>Oil</source>
+      <translation>Олива</translation>
+    </message>
+    <message id="tank_type_black_water">
+      <location filename="../../src/enums.cpp" line="510"/>
+      <source>Black water</source>
+      <translation>Стічні води з каналізації</translation>
+    </message>
+    <message id="tank_type_gasoline">
+      <location filename="../../src/enums.cpp" line="513"/>
+      <source>Gasoline</source>
+      <translation>Бензин</translation>
+    </message>
+    <message id="tank_type_diesel">
+      <location filename="../../src/enums.cpp" line="516"/>
+      <source>Diesel</source>
+      <translation>Дизельне паливо</translation>
+    </message>
+    <message id="tank_type_lpg">
+      <location filename="../../src/enums.cpp" line="519"/>
+      <source>LPG</source>
+      <translation>LPG</translation>
+    </message>
+    <message id="tank_type_lng">
+      <location filename="../../src/enums.cpp" line="522"/>
+      <source>LNG</source>
+      <translation>LNG</translation>
+    </message>
+    <message id="tank_type_hydraulic_oil">
+      <location filename="../../src/enums.cpp" line="525"/>
+      <source>Hydraulic oil</source>
+      <translation>Гідравлічна олива</translation>
+    </message>
+    <message id="tank_type_raw_water">
+      <location filename="../../src/enums.cpp" line="528"/>
+      <source>Raw water</source>
+      <translation>Неочищена вода</translation>
+    </message>
     <message id="listItem_no_access">
       <location filename="../../components/listitems/core/ListItem.qml" line="102"/>
       <source>Setting locked for access level</source>
@@ -5329,6 +4860,7 @@ Do you want to continue?</source>
     <message id="welcome_brief_title">
       <location filename="../../pages/welcome/WelcomeView.qml" line="81"/>
       <source>Brief</source>
+      <extracomment>The 'Brief' page</extracomment>
       <translation>Коротко</translation>
     </message>
     <message id="welcome_overview_title">
@@ -5345,23 +4877,6 @@ Do you want to continue?</source>
       <location filename="../../pages/NotificationsPage.qml" line="13"/>
       <source>Notifications</source>
       <translation>Сповіщення</translation>
-    </message>
-    <message id="notifications_page_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="43"/>
-      <source>Active Notifications</source>
-      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_page_inactive_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="47"/>
-      <source>Inactive Notifications</source>
-      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_no_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="106"/>
-      <source>No active notifications</source>
-      <translation type="unfinished"/>
     </message>
     <message id="utils_formatTimestamp_now">
       <location filename="../../components/Utils.js" line="258"/>
@@ -5466,11 +4981,6 @@ Do you want to continue?</source>
       <source>Self-consumption above limit</source>
       <translation>Власне споживання вище ліміту</translation>
     </message>
-    <message id="cgwacs_battery_schedule_pv">
-      <location filename="../../components/listitems/ListChargeSchedule.qml" line="171"/>
-      <source>PV</source>
-      <translation type="unfinished">PV</translation>
-    </message>
     <message id="settings_multirs_pv">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="185"/>
       <source>PV</source>
@@ -5481,8 +4991,8 @@ Do you want to continue?</source>
       <source>PV &amp; Battery</source>
       <translation>PV і Батарея</translation>
     </message>
-    <message id="settings_firmware_checking">
-      <location filename="../../components/listitems/ListFirmwareCheckButton.qml" line="16"/>
+    <message id="pagesettingssupportstate_firmware_checking">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
       <source>Checking...</source>
       <translation>Перевірка...</translation>
     </message>
@@ -5490,12 +5000,6 @@ Do you want to continue?</source>
       <location filename="../../components/listitems/ListAlarmState.qml" line="11"/>
       <source>Alarm state</source>
       <translation>Стан тривоги</translation>
-    </message>
-    <message id="devicelist_battery_alarm_state">
-      <location filename="../../components/listitems/ListAlarmState.qml" line="19"/>
-      <source>Alarm</source>
-      <extracomment>Alarm state is active</extracomment>
-      <translation type="unfinished">Тривога</translation>
     </message>
     <message id="clear_history_button_clear_history">
       <location filename="../../components/listitems/ListClearHistoryButton.qml" line="15"/>
@@ -5647,11 +5151,6 @@ Do you want to continue?</source>
       <source>Max Voltage</source>
       <translation>Макс. напруга</translation>
     </message>
-    <message id="charger_history_box_max_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="64"/>
-      <source>Max Voltage</source>
-      <translation type="unfinished">Макс. напруга</translation>
-    </message>
     <message id="charger_history_box_max_current">
       <location filename="../../components/SolarDetailBox.qml" line="70"/>
       <source>Max Current</source>
@@ -5662,24 +5161,6 @@ Do you want to continue?</source>
       <source>Charge time</source>
       <extracomment>Statistics for battery charging time</extracomment>
       <translation>Час зарядки</translation>
-    </message>
-    <message id="charger_history_box_bulk">
-      <location filename="../../components/SolarDetailBox.qml" line="136"/>
-      <source>Bulk</source>
-      <extracomment>Battery: time spent in 'Bulk' mode</extracomment>
-      <translation type="unfinished">Основний</translation>
-    </message>
-    <message id="charger_history_box_float">
-      <location filename="../../components/SolarDetailBox.qml" line="148"/>
-      <source>Float</source>
-      <extracomment>Battery: time spent in 'Float' mode</extracomment>
-      <translation type="unfinished">Плаваючий</translation>
-    </message>
-    <message id="charger_history_hr">
-      <location filename="../../components/SolarDetailBox.qml" line="174"/>
-      <source>hr</source>
-      <extracomment>Abbreviation of "hour"</extracomment>
-      <translation type="unfinished">год</translation>
     </message>
     <message id="solarchargers_state_bulk">
       <location filename="../../src/enums.cpp" line="337"/>
@@ -5751,11 +5232,6 @@ Do you want to continue?</source>
       <source>Connecting</source>
       <translation>Підключення...</translation>
     </message>
-    <message id="splash_view_connecting">
-      <location filename="../../components/SplashView.qml" line="288"/>
-      <source>Connecting</source>
-      <translation type="unfinished">Підключення...</translation>
-    </message>
     <message id="splash_view_connected">
       <location filename="../../components/SplashView.qml" line="290"/>
       <source>Connected, awaiting broker messages</source>
@@ -5811,6 +5287,11 @@ Do you want to continue?</source>
       <source>MQTT protocol level 5 error</source>
       <translation>Помилка 5-го рівня протоколу MQTT</translation>
     </message>
+    <message id="common_words_silence_alarm">
+      <location filename="../../components/CommonWords.qml" line="476"/>
+      <source>Silence alarm</source>
+      <translation>Беззвучна тривога</translation>
+    </message>
     <message id="vebus_device_page_total_power">
       <location filename="../../components/ThreePhaseQuantityTable.qml" line="47"/>
       <source>Total Power</source>
@@ -5861,20 +5342,10 @@ Do you want to continue?</source>
       <source>Retrieving IP address</source>
       <translation>Отримання IP-адреси</translation>
     </message>
-    <message id="utils_connman_connected">
-      <location filename="../../components/Utils.js" line="292"/>
-      <source>Connected</source>
-      <translation type="unfinished">Підключено</translation>
-    </message>
     <message id="utils_connman_disconnect">
       <location filename="../../components/Utils.js" line="295"/>
       <source>Disconnect</source>
       <translation>Відключити</translation>
-    </message>
-    <message id="utils_connman_disconnected">
-      <location filename="../../components/Utils.js" line="299"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Відключено</translation>
     </message>
     <message id="overview_widget_acloads_title">
       <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
@@ -5912,11 +5383,6 @@ Do you want to continue?</source>
       <source>Shore current limit</source>
       <translation>Обмеження портового струму</translation>
     </message>
-    <message id="acInputs_statusCode_stopping">
-      <location filename="../../data/AcInputs.qml" line="170"/>
-      <source>Stopping</source>
-      <translation type="unfinished">Зупинка</translation>
-    </message>
     <message id="page_generator_stopping">
       <location filename="../../data/Generators.qml" line="44"/>
       <source>Stopping</source>
@@ -5932,7 +5398,7 @@ Do you want to continue?</source>
       <location filename="../../data/common/TankDescription.qml" line="24"/>
       <location filename="../../src/device.cpp" line="133"/>
       <source>%1 tank (%2)</source>
-      <extracomment>Tank description. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
       <translation>Ємність %1 (%2)</translation>
     </message>
     <message id="dcMeter_ac_charger">
@@ -5981,11 +5447,6 @@ Do you want to continue?</source>
       <location filename="../../data/Ess.qml" line="20"/>
       <source>Keep batteries charged</source>
       <translation>Тримати батареї зарядженими</translation>
-    </message>
-    <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="50"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Відключено</translation>
     </message>
     <message id="evchargers_status_charged">
       <location filename="../../data/EvChargers.qml" line="58"/>
@@ -6046,16 +5507,6 @@ Do you want to continue?</source>
       <location filename="../../data/EvChargers.qml" line="97"/>
       <source>Start charging</source>
       <translation>Запустити заряджання</translation>
-    </message>
-    <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="113"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Невідоме</translation>
-    </message>
-    <message id="evchargers_mode_scheduled">
-      <location filename="../../data/EvChargers.qml" line="126"/>
-      <source>Scheduled</source>
-      <translation type="unfinished">Заплановано</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
       <location filename="../../data/System.qml" line="195"/>
@@ -6180,11 +5631,6 @@ Do you want to continue?</source>
       <source>Power supply mode</source>
       <translation>Режим живлення</translation>
     </message>
-    <message id="inverters_state_sustain">
-      <location filename="../../data/System.qml" line="158"/>
-      <source>Sustain</source>
-      <translation type="unfinished">Підтримувати</translation>
-    </message>
     <message id="inverters_state_wakeup">
       <location filename="../../data/System.qml" line="162"/>
       <source>Wake up</source>
@@ -6219,16 +5665,6 @@ Do you want to continue?</source>
       <location filename="../../data/System.qml" line="180"/>
       <source>Test</source>
       <translation>Тест</translation>
-    </message>
-    <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="183"/>
-      <source>External control</source>
-      <translation type="unfinished">Зовнішнє керування</translation>
-    </message>
-    <message id="inverters_state_dynamic_ess">
-      <location filename="../../data/System.qml" line="198"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">Динамічна ESS</translation>
     </message>
     <message id="settings_rs_ess_dess">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="97"/>
@@ -6307,16 +5743,13 @@ Do you want to continue?</source>
     <message id="ess_recommended">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="73"/>
       <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
       <translation>Для літієвих батарей не рекомендується заряджати їх нижче 10%. Для інших типів акумуляторів перевірте в технічному паспорті мінімальний рівень заряду, рекомендований виробником.</translation>
-    </message>
-    <message id="controlcard_generator_label_autostart">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="63"/>
-      <source>Autostart</source>
-      <translation type="unfinished">Автозапуск</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
       <location filename="../../pages/controlcards/GeneratorCard.qml" line="70"/>
       <source>Start and stop the generator based on the configured autostart conditions.</source>
+      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
       <translation>Запуск і зупинка генератора на основі налаштованих умов автозапуску.</translation>
     </message>
     <message id="generator_dialog_disabled">
@@ -6339,11 +5772,13 @@ Do you want to continue?</source>
       <location filename="../../pages/controlcards/InverterChargerCard.qml" line="26"/>
       <source>Inverter / Charger (%1)</source>
       <extracomment>%1 = the inverter/charger name</extracomment>
+      <oldsource>Inverter / Charger</oldsource>
       <translation>Інвертор/зарядний пристрій (%1)</translation>
     </message>
     <message id="settings_page_debug_quit_application">
       <location filename="../../pages/settings/debug/PageDebug.qml" line="36"/>
       <source>Quit application</source>
+      <oldsource>Quit Application</oldsource>
       <translation>Вийти з програми</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
@@ -6354,12 +5789,8 @@ Do you want to continue?</source>
     <message id="settings_page_relay_generator_run_time">
       <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
       <source>Current run time</source>
+      <oldsource>Run time</oldsource>
       <translation>Поточний час виконання</translation>
-    </message>
-    <message id="settings_page_genset_generator_run_time">
-      <location filename="../../components/PageGensetModel.qml" line="102"/>
-      <source>Current run time</source>
-      <translation type="unfinished">Поточний час виконання</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
       <location filename="../../components/PageGensetModel.qml" line="110"/>
@@ -6386,19 +5817,10 @@ Do you want to continue?</source>
       <source>Remote start mode</source>
       <translation>Режим дистанційного запуску</translation>
     </message>
-    <message id="ac-in-genset_speed">
-      <location filename="../../components/PageGensetModel.qml" line="245"/>
-      <source>Speed</source>
-      <translation type="unfinished">Швидкість</translation>
-    </message>
-    <message id="ac-in-genset_load">
-      <location filename="../../components/PageGensetModel.qml" line="252"/>
-      <source>Load</source>
-      <translation type="unfinished">Спожив.</translation>
-    </message>
     <message id="ac-in-genset_oil_pressure">
       <location filename="../../components/PageGensetModel.qml" line="260"/>
       <source>Oil pressure</source>
+      <oldsource>Oil Pressure</oldsource>
       <translation>Тиск мастила</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
@@ -6494,11 +5916,13 @@ Do you want to continue?</source>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
       <source>High starter battery voltage alarms</source>
+      <oldsource>High starter batttery voltage alarms</oldsource>
       <translation>Сигналізація про високу напругу стартерної батареї</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
       <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
       <translation>Зверніть увагу, що зміна параметра Час до розряду також змінює значення параметра Низький рівень заряду в меню реле.</translation>
     </message>
     <message id="lynxionsystem_cells_per_battery">
@@ -6575,6 +5999,7 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/devicelist/delegates/DeviceListDelegate_solarcharger.qml" line="34"/>
       <source>Error: #%1</source>
       <extracomment>%1 = error number</extracomment>
+      <oldsource>Error: %1</oldsource>
       <translation>Помилка: #%1</translation>
     </message>
     <message id="devicelistpage_genset">
@@ -6631,17 +6056,14 @@ Do you want to continue?</source>
     <message id="settings_page_relay_generator_auto_start_enabled">
       <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
       <source>Autostart functionality</source>
+      <oldsource>Auto start functionality</oldsource>
       <translation>Функція автозапуску</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="97"/>
       <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
       <translation>Переконайтеся, що генератор не підключений до входу змінного струму %1 під час використання цієї опції</translation>
-    </message>
-    <message id="page_generator_conditions_inverter_high_temperature">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="139"/>
-      <source>Inverter high temperature</source>
-      <translation type="unfinished">Висока температура інвертора</translation>
     </message>
     <message id="page_generator_conditions_tank_level">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="159"/>
@@ -6671,30 +6093,34 @@ Do you want to continue?</source>
     <message id="settings_generator_function_not_enabled">
       <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
       <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
+      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
       <translation>Функція запуску/зупинки генератора не ввімкнена, перейдіть до налаштувань реле та встановіть функцію на "Запуск/зупинка генератора"</translation>
     </message>
     <message id="settings_batteries_intro">
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="45"/>
       <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
       <translation>Використовуйте це меню, щоб визначити дані акумулятора, які відображаються при натисканні на піктограму "Акумулятор" на сторінці "Огляд". Той самий вибір також відображається на Порталі VRM.</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
       <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
       <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
       <translation>Безперервне сканування може перешкоджати роботі Wi-Fi.</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
       <source>CAN-bus BMS LV (500 kbit/s)</source>
+      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
       <translation>CAN-шина BMS LV (500 кбіт/с)</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
       <source>CAN-bus BMS HV (500 kbit/s)</source>
       <translation>CAN-шина BMS HV (500 кбіт/с)</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
       <source>Up, but no services (500 kbit/s)</source>
       <translation>Вгору, але без послуг (500 кбіт/с)</translation>
     </message>
@@ -6707,41 +6133,6 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="127"/>
       <source>Brief page</source>
       <translation>Коротка сторінка</translation>
-    </message>
-    <message id="settings_displayoff_1min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="46"/>
-      <source>1 min</source>
-      <translation type="unfinished">1 хв</translation>
-    </message>
-    <message id="settings_displayoff_10min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="48"/>
-      <source>10 min</source>
-      <translation type="unfinished">10 хв</translation>
-    </message>
-    <message id="settings_displayoff_30min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="50"/>
-      <source>30 min</source>
-      <translation type="unfinished">30 хв</translation>
-    </message>
-    <message id="settings_displayoff_never">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="52"/>
-      <source>Never</source>
-      <translation type="unfinished">Ніколи</translation>
-    </message>
-    <message id="settings_remote_console_appearance_auto">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="112"/>
-      <source>Auto</source>
-      <translation type="unfinished">Авто</translation>
-    </message>
-    <message id="settings_brief_view_start_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="119"/>
-      <source>Start page</source>
-      <translation type="unfinished">Початкова сторінка</translation>
-    </message>
-    <message id="settings_display_boat_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="135"/>
-      <source>Boat page</source>
-      <translation type="unfinished">Сторінка човна</translation>
     </message>
     <message id="settings_display_minmax">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="148"/>
@@ -6796,21 +6187,6 @@ Do you want to continue?</source>
       <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
       <translation>%1 встановлено на %2</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_unsupported_device">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="50"/>
-      <source>Unsupported GX device</source>
-      <translation type="unfinished">Непідтримуваний пристрій GX</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_clean">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="55"/>
-      <source>Clean</source>
-      <translation type="unfinished">Очистити</translation>
-    </message>
-    <message id="pagesettingsgeneral_firmware">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="112"/>
-      <source>Firmware</source>
-      <translation type="unfinished">Прошивка</translation>
-    </message>
     <message id="pagesettingsgeneral_access_and_security">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
       <source>Access &amp; Security</source>
@@ -6844,6 +6220,7 @@ Do you want to continue?</source>
     <message id="settings_language_please_wait">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="209"/>
       <source>Please wait while the language is changed.</source>
+      <oldsource>Please wait while the language is changed</oldsource>
       <translation>Будь ласка, зачекайте, поки мова зміниться.</translation>
     </message>
     <message id="settings_briefview_totals">
@@ -6860,11 +6237,6 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="71"/>
       <source>Tank is not connected.</source>
       <translation>Цистерна не підключена.</translation>
-    </message>
-    <message id="settings_briefview_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="83"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">Активний монітор батареї</translation>
     </message>
     <message id="settings_briefview_individual_batteries">
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="86"/>
@@ -6915,6 +6287,7 @@ Do you want to continue?</source>
     <message id="settings_dvcc_charge_current_limits">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="30"/>
       <source>Charge current limits</source>
+      <oldsource>Charge Current limits</oldsource>
       <translation>Обмеження струму заряду</translation>
     </message>
     <message id="settings_firmware_official_release">
@@ -6994,11 +6367,6 @@ Do you want to continue?</source>
       <source>No password and the network communication is not encrypted</source>
       <translation>Немає пароля і мережеве з'єднання не шифрується</translation>
     </message>
-    <message id="settings_logout_now">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
-      <source>Log out now</source>
-      <translation type="unfinished">Вийдіть з системи</translation>
-    </message>
     <message id="settings_security_profile_password_incorrect_length">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="28"/>
       <source>Password needs to be at least 8 characters long</source>
@@ -7049,25 +6417,10 @@ Do you want to continue?</source>
       <source>Page will automatically reload in 5 seconds</source>
       <translation>Сторінка автоматично перезавантажиться через 5 секунд</translation>
     </message>
-    <message id="settings_security_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="159"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">Пароль повинен мати довжину не менше 8 символів</translation>
-    </message>
     <message id="settings_root_password">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="269"/>
       <source>Root password</source>
       <translation>Рут-пароль</translation>
-    </message>
-    <message id="settings_root_enter_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="272"/>
-      <source>Enter password</source>
-      <translation type="unfinished">Введіть пароль</translation>
-    </message>
-    <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="277"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">Пароль повинен мати довжину не менше 8 символів</translation>
     </message>
     <message id="settings_root_password_changed_to">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="283"/>
@@ -7083,6 +6436,11 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="321"/>
       <source>Logout</source>
       <translation>Вихід</translation>
+    </message>
+    <message id="settings_logout_now">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
+      <source>Log out now</source>
+      <translation>Вийдіть з системи</translation>
     </message>
     <message id="settings_logout_dialog_title">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="335"/>
@@ -7142,11 +6500,13 @@ Do you want to continue?</source>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="141"/>
       <source>Alarm when generator is not in autostart mode</source>
+      <oldsource>Alarm when generator is not in auto start mode</oldsource>
       <translation>Тривога, коли генератор не в режимі автозапуску</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="147"/>
       <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
       <translation>Сигнал тривоги спрацьовує, якщо функцію автозапуску вимкнено більше ніж на 10 хвилин</translation>
     </message>
     <message id="settings_units_amps_exceptions">
@@ -7162,6 +6522,11 @@ Do you want to continue?</source>
     <message id="settings_ess_use_this_option_for_peak_shaving">
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
       <source>Use this option for peak shaving.</source>
+      <oldsource>Use this option for peak shaving.
+
+The peak shaving threshold is set using the AC input current limit setting.
+
+See documentation for further information.</oldsource>
       <translation>Використовуйте цю опцію для пікового гоління.</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
@@ -7205,17 +6570,17 @@ Do you want to continue?</source>
       <translation>Максимальний струм експорту системи (на фазу)</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="71"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="73"/>
       <source>Self-consumption from battery</source>
       <translation>Самоспоживання від акумулятора</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="76"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
       <source>All system loads</source>
       <translation>Всі навантаження системи</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="80"/>
       <source>Only critical loads</source>
       <translation>Тільки критичні навантаження</translation>
     </message>
@@ -7273,26 +6638,6 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="194"/>
       <source>Server Applications</source>
       <translation>Серверні програми</translation>
-    </message>
-    <message id="pagesettingsintegrations_venus_os_enable_large_features">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
-      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_large_victron_community">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="274"/>
-      <source>Victron Community</source>
-      <translation type="unfinished">Спільнота Victron</translation>
-    </message>
-    <message id="pagesettingsintegrations_ui_plugins">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
-      <source>UI Plugins</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
-      <source>Integrates with the device list</source>
-      <translation type="unfinished"/>
     </message>
     <message id="pagesettingssupportstate_modbus_tcp_server">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="453"/>
@@ -7395,25 +6740,10 @@ Do you want to continue?</source>
       <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
       <translation>Перемикання версії прошивки неможливе, якщо не вибрано "Профіль мережевої безпеки" у розділі "Налаштування/Загальні".</translation>
     </message>
-    <message id="pagesettingsconnectivity_ethernet">
-      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
-      <source>Ethernet</source>
-      <translation type="unfinished">Локальна мережа Ethernet</translation>
-    </message>
     <message id="pagesettingsconnectivity_mobile_network">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="53"/>
       <source>Mobile Network</source>
       <translation>Мобільна мережа</translation>
-    </message>
-    <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Boat</source>
-      <translation type="unfinished">Човен</translation>
-    </message>
-    <message id="settings_system_name_auto">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="32"/>
-      <source>Automatic</source>
-      <translation type="unfinished">Автоматична</translation>
     </message>
     <message id="pagesettingssystem_ac_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
@@ -7444,11 +6774,6 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="89"/>
       <source>Distributed Voltage and Current Control (DVCC)</source>
       <translation>Розподілене керування напругою та струмом (DVCC)</translation>
-    </message>
-    <message id="settings_system_grid">
-      <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="18"/>
-      <source>Grid</source>
-      <translation type="unfinished">Мережа</translation>
     </message>
     <message id="settings_system_ac_position">
       <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="58"/>
@@ -7488,16 +6813,19 @@ Do you want to continue?</source>
     <message id="settings_system_has_dc_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="97"/>
       <source>Display DC Loads</source>
+      <oldsource>Has DC system</oldsource>
       <translation>Відображення навантажень постійного струму</translation>
     </message>
     <message id="settings_system_battery_measurements">
       <location filename="../../pages/settings/PageSettingsBatteries.qml" line="65"/>
       <source>Battery measurements</source>
+      <oldsource>Battery Measurements</oldsource>
       <translation>Вимірювання батареї</translation>
     </message>
     <message id="settings_system_system_status">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
       <source>System status</source>
+      <oldsource>System Status</oldsource>
       <translation>Стан системи</translation>
     </message>
     <message id="settings_tcpip_wired">
@@ -7508,11 +6836,13 @@ Do you want to continue?</source>
     <message id="settings_vecan_device_instance">
       <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
       <source>VE.Can Device Instance</source>
+      <oldsource>Device Instance</oldsource>
       <translation>Екземпляр пристрою VE.Can</translation>
     </message>
     <message id="settings_vecan_device_number">
       <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="32"/>
       <source>VE.Can Instance# %1</source>
+      <oldsource>Device# %1</oldsource>
       <translation>VE.Can Instance# %1</translation>
     </message>
     <message id="settings_tz_antarctica">
@@ -7543,6 +6873,7 @@ Do you want to continue?</source>
     <message id="settings_vrm">
       <location filename="../../pages/SettingsPage.qml" line="59"/>
       <source>VRM</source>
+      <extracomment>Forced by %2 to dark</extracomment>
       <translation>VRM</translation>
     </message>
     <message id="settings_remote_monitoring_portal">
@@ -7550,20 +6881,10 @@ Do you want to continue?</source>
       <source>Remote monitoring portal</source>
       <translation>Портал віддаленого моніторингу</translation>
     </message>
-    <message id="settings_advanced">
-      <location filename="../../pages/SettingsPage.qml" line="68"/>
-      <source>Advanced</source>
-      <translation type="unfinished">Розширено</translation>
-    </message>
-    <message id="settings_integrations">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
+    <message id="pagesettingssupportstate_integrations">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
       <source>Integrations</source>
       <translation>Інтеграції</translation>
-    </message>
-    <message id="settings_relays_sensors_tanks">
-      <location filename="../../pages/SettingsPage.qml" line="75"/>
-      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
-      <translation type="unfinished">Реле, датчики, баки, фотоелектричні інвертори, Modbus, MQTT...</translation>
     </message>
     <message id="settings_acdcsystem_ess_dvcc_battery">
       <location filename="../../pages/SettingsPage.qml" line="84"/>
@@ -7583,11 +6904,13 @@ Do you want to continue?</source>
     <message id="settings_system_setup">
       <location filename="../../pages/SettingsPage.qml" line="82"/>
       <source>System Setup</source>
+      <oldsource>System setup</oldsource>
       <translation>Налаштування системи</translation>
     </message>
     <message id="settings_vrm_device_instances">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
       <source>VRM device instances</source>
+      <oldsource>VRM Device Instances</oldsource>
       <translation>Екземпляри пристроїв VRM</translation>
     </message>
     <message id="solarcharger_not_supported">
@@ -7605,28 +6928,10 @@ Do you want to continue?</source>
       <source>The firmware version in the MPPT Solar Charger must be v1.09 or later. Contact Victron Service for update instructions and files.</source>
       <translation>Версія мікропрограми сонячного зарядного пристрою MPPT повинна бути v1.09 або новішою. Зверніться до служби підтримки Victron за інструкціями та файлами для оновлення.</translation>
     </message>
-    <message id="solarcharger_pv">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="102"/>
-      <source>PV</source>
-      <extracomment>PV power for solar charger</extracomment>
-      <translation type="unfinished">PV</translation>
-    </message>
     <message id="solarcharger_total_power">
       <location filename="../../pages/solar/PageSolarCharger.qml" line="127"/>
       <source>Total PV power</source>
       <translation>Загальна фотоелектрична потужність</translation>
-    </message>
-    <message id="solarcharger_total_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="211"/>
-      <source>Total yield</source>
-      <extracomment>Solar charger total yield</extracomment>
-      <translation type="unfinished">Загальний вихід</translation>
-    </message>
-    <message id="solarcharger_system_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="220"/>
-      <source>System yield</source>
-      <extracomment>Solar charger system yield</extracomment>
-      <translation type="unfinished">Вихід системи</translation>
     </message>
     <message id="settings_multirs_total_yield">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="63"/>
@@ -7662,16 +6967,19 @@ Do you want to continue?</source>
     <message id="vebus_device_update_firmware">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="133"/>
       <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
       <translation>Ця функція потребує прошивки версії 400 або новішої. Зверніться до інсталятора, щоб оновити ваш Multi/Quattro.</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="139"/>
       <source>Charger not ready, equalization cannot be started</source>
+      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
       <translation>Зарядний пристрій не готовий, вирівнювання не може бути запущено</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="143"/>
       <source>Equalization cannot be triggered during bulk charge state</source>
+      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
       <translation>Вирівнювання не може спрацювати під час стану об'ємного заряду</translation>
     </message>
     <message id="vebus_device_restart_vebus_system_restart_confirmation_description">
@@ -7694,78 +7002,20 @@ Do you want to continue?</source>
       <source>Auto-started • %1</source>
       <translation>Автозапуск - %1</translation>
     </message>
-    <message id="common_words_battery">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_boat_page">
-      <location filename="../../components/CommonWords.qml" line="111"/>
-      <source>Boat</source>
-      <extracomment>The 'Boat' page</extracomment>
-      <translation type="unfinished">Човен</translation>
-    </message>
-    <message id="common_words_brief_page">
-      <location filename="../../components/CommonWords.qml" line="115"/>
-      <source>Brief</source>
-      <extracomment>The 'Brief' page</extracomment>
-      <translation type="unfinished">Коротко</translation>
-    </message>
-    <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation type="unfinished">Закрито</translation>
-    </message>
-    <message id="common_words_color">
-      <location filename="../../components/CommonWords.qml" line="136"/>
-      <source>Color</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_connected">
-      <location filename="../../components/CommonWords.qml" line="139"/>
-      <source>Connected</source>
-      <translation type="unfinished">Підключено</translation>
-    </message>
     <message id="common_words_daily_history">
       <location filename="../../components/CommonWords.qml" line="152"/>
       <source>Daily history</source>
       <translation>Щоденна історія</translation>
-    </message>
-    <message id="common_words_disabled">
-      <location filename="../../components/CommonWords.qml" line="169"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Вимкнено</translation>
-    </message>
-    <message id="common_words_disconnected">
-      <location filename="../../components/CommonWords.qml" line="175"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">Відключено</translation>
-    </message>
-    <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="191"/>
-      <source>Error</source>
-      <translation type="unfinished">Помилка</translation>
     </message>
     <message id="common_words_error_not_a_number">
       <location filename="../../components/CommonWords.qml" line="200"/>
       <source>'%1' is not a number.</source>
       <translation>'%1' не є числом.</translation>
     </message>
-    <message id="common_words_generator">
-      <location filename="../../components/CommonWords.qml" line="217"/>
-      <source>Generator</source>
-      <translation type="unfinished">Генератор</translation>
-    </message>
     <message id="common_words_input_current_limit">
       <location filename="../../components/CommonWords.qml" line="261"/>
       <source>Input current limit</source>
       <translation>Обмеження вхідного струму AC in 2</translation>
-    </message>
-    <message id="common_words_inverter_charger">
-      <location filename="../../components/CommonWords.qml" line="264"/>
-      <source>Inverter / Charger</source>
-      <translation type="unfinished">Інв. / Зарядний</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
       <location filename="../../components/CommonWords.qml" line="268"/>
@@ -7778,12 +7028,6 @@ Do you want to continue?</source>
       <source>Manual stop</source>
       <translation>Ручна зупинка</translation>
     </message>
-    <message id="common_words_max">
-      <location filename="../../components/CommonWords.qml" line="315"/>
-      <source>Max</source>
-      <extracomment>Short for Maximum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_maximum_current">
       <location filename="../../components/CommonWords.qml" line="318"/>
       <source>Maximum current</source>
@@ -7794,62 +7038,10 @@ Do you want to continue?</source>
       <source>Maximum power</source>
       <translation>Максимальна потужність</translation>
     </message>
-    <message id="common_words_min">
-      <location filename="../../components/CommonWords.qml" line="331"/>
-      <source>Min</source>
-      <extracomment>Short for Minimum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_minimum_current">
       <location filename="../../components/CommonWords.qml" line="334"/>
       <source>Minimum current</source>
       <translation>Мінімальний струм</translation>
-    </message>
-    <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="433"/>
-      <source>No</source>
-      <translation type="unfinished">Ні</translation>
-    </message>
-    <message id="common_words_none_option">
-      <location filename="../../components/CommonWords.qml" line="364"/>
-      <source>None</source>
-      <translation type="unfinished">Жодного</translation>
-    </message>
-    <message id="common_words_none_errors">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>None</source>
-      <extracomment>Indicates there are no errors</extracomment>
-      <translation type="unfinished">Жодного</translation>
-    </message>
-    <message id="common_words_not_available">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Not available</source>
-      <translation type="unfinished">Недоступний</translation>
-    </message>
-    <message id="common_words_off">
-      <location filename="../../components/CommonWords.qml" line="377"/>
-      <source>Off</source>
-      <translation type="unfinished">Вимкнено</translation>
-    </message>
-    <message id="common_words_ok">
-      <location filename="../../components/CommonWords.qml" line="383"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="41"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="45"/>
-      <source>OK</source>
-      <translation type="unfinished">ОК</translation>
-    </message>
-    <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="386"/>
-      <source>On</source>
-      <translation type="unfinished">Увімкнено</translation>
-    </message>
-    <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="393"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation type="unfinished">Відкрито</translation>
     </message>
     <message id="common_words_open_circuit">
       <location filename="../../components/CommonWords.qml" line="396"/>
@@ -7861,108 +7053,17 @@ Do you want to continue?</source>
       <source>Overall history</source>
       <translation>Загальна історія</translation>
     </message>
-    <message id="common_words_press">
-      <location filename="../../components/CommonWords.qml" line="419"/>
-      <source>Press</source>
-      <translation type="unfinished">Преса</translation>
-    </message>
-    <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation type="unfinished">Працює</translation>
-    </message>
-    <message id="common_words_settings">
-      <location filename="../../components/CommonWords.qml" line="467"/>
-      <source>Settings</source>
-      <translation type="unfinished">Налаштування</translation>
-    </message>
-    <message id="common_words_silence_alarm">
-      <location filename="../../components/CommonWords.qml" line="476"/>
-      <source>Silence alarm</source>
-      <translation type="unfinished">Беззвучна тривога</translation>
-    </message>
     <message id="common_words_soc">
       <location filename="../../components/CommonWords.qml" line="480"/>
       <source>SOC %1</source>
       <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
       <translation>SOC %1%</translation>
     </message>
-    <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation type="unfinished">Швидкість</translation>
-    </message>
-    <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="487"/>
-      <source>Standby</source>
-      <translation type="unfinished">Режим очікування</translation>
-    </message>
-    <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="502"/>
-      <source>State</source>
-      <translation type="unfinished">Стан</translation>
-    </message>
-    <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="512"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation type="unfinished">Запуск (%1)</translation>
-    </message>
-    <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>Stopped</source>
-      <translation type="unfinished">Зупинено</translation>
-    </message>
-    <message id="common_words_total_power">
-      <location filename="../../components/CommonWords.qml" line="540"/>
-      <source>Total power</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="547"/>
-      <source>Type</source>
-      <translation type="unfinished">Тип</translation>
-    </message>
-    <message id="common_words_unknown_status">
-      <location filename="../../components/CommonWords.qml" line="554"/>
-      <source>Unknown</source>
-      <extracomment>Status = "unknown"</extracomment>
-      <translation type="unfinished">Невідоме</translation>
-    </message>
-    <message id="common_words_value_must_be_greater_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="557"/>
-      <source>Value must be greater than start value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_value_must_be_greater_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="560"/>
-      <source>Value must be greater than stop value</source>
-      <translation type="unfinished">Значення має бути більшим за кінцеве значення</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="563"/>
-      <source>Value must be lower than start value</source>
-      <translation type="unfinished">Значення має бути нижчим за початкове значення</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="566"/>
-      <source>Value must be lower than stop value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="581"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="431"/>
-      <source>Yes</source>
-      <translation type="unfinished">Так</translation>
-    </message>
     <message id="common_words_yield_today">
       <location filename="../../components/CommonWords.qml" line="592"/>
       <source>Yield Today</source>
       <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+      <oldsource>Yield today</oldsource>
       <translation>Продуктивність сьогодні</translation>
     </message>
     <message id="common_words_format_error">
@@ -7989,10 +7090,11 @@ Do you want to continue?</source>
     <message id="settings_firmware_installed_rebooting">
       <location filename="../../components/FirmwareUpdate.qml" line="79"/>
       <source>Firmware installed, device rebooting</source>
+      <oldsource>Firmware installed, rebooting.</oldsource>
       <translation>Встановлено прошивку, пристрій перезавантажено</translation>
     </message>
-    <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/RadioButtonListPage.qml" line="121"/>
+    <message id="modaldialog_confirm">
+      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
       <source>Confirm</source>
       <extracomment>Confirm password, and verify it if possible</extracomment>
       <translation>Так, скасуйте підписку</translation>
@@ -8010,11 +7112,13 @@ Do you want to continue?</source>
     <message id="cgwacs_battery_schedule_duration">
       <location filename="../../components/listitems/ListChargeSchedule.qml" line="144"/>
       <source>Duration</source>
+      <oldsource>Duration (hh:mm)</oldsource>
       <translation>Тривалість</translation>
     </message>
     <message id="settings_relay_deactivation_value">
       <location filename="../../components/TemperatureRelaySettings.qml" line="86"/>
       <source>Deactivation value</source>
+      <oldsource>Deativation value</oldsource>
       <translation>Значення деактивації</translation>
     </message>
     <message id="splash_view_device_disconnected">
@@ -8062,29 +7166,6 @@ Do you want to continue?</source>
       <source>Temperature warning</source>
       <translation>Попередження про температуру</translation>
     </message>
-    <message id="battery_mode_idle">
-      <location filename="../../src/enums.cpp" line="26"/>
-      <source>Idle</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Релаксую</translation>
-    </message>
-    <message id="battery_mode_charging">
-      <location filename="../../src/enums.cpp" line="30"/>
-      <source>Charging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Зарядка</translation>
-    </message>
-    <message id="battery_mode_discharging">
-      <location filename="../../src/enums.cpp" line="34"/>
-      <source>Discharging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">Розрядка</translation>
-    </message>
-    <message id="dcMeter_bilge_pump">
-      <location filename="../../src/enums.cpp" line="115"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">Трюмний насос</translation>
-    </message>
     <message id="switch_state_channel_fault">
       <location filename="../../src/enums.cpp" line="372"/>
       <source>Channel Fault</source>
@@ -8115,26 +7196,6 @@ Do you want to continue?</source>
       <source>Slave of %1</source>
       <translation>Раб %1</translation>
     </message>
-    <message id="switchable_output_numeric_input">
-      <location filename="../../src/enums.cpp" line="418"/>
-      <source>Numeric input</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bilge_pump">
-      <location filename="../../src/enums.cpp" line="424"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">Трюмний насос</translation>
-    </message>
-    <message id="switchable_output_not_running">
-      <location filename="../../src/enums.cpp" line="448"/>
-      <source>Not running</source>
-      <translation type="unfinished">Не біжу.</translation>
-    </message>
-    <message id="switchable_output_off">
-      <location filename="../../src/enums.cpp" line="451"/>
-      <source>Off</source>
-      <translation type="unfinished">Вимкнено</translation>
-    </message>
     <message id="switchable_output_powered">
       <location filename="../../src/enums.cpp" line="455"/>
       <source>Powered</source>
@@ -8163,16 +7224,19 @@ Do you want to continue?</source>
     <message id="evchargers_status_welded_contacts_error">
       <location filename="../../data/EvChargers.qml" line="76"/>
       <source>Welded contacts test error (shorted)</source>
+      <oldsource>Welded contacts error</oldsource>
       <translation>Помилка тесту зварних контактів (закорочені)</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
       <location filename="../../data/EvChargers.qml" line="100"/>
       <source>Switching to 3 phase</source>
+      <oldsource>Switching to 3-phase</oldsource>
       <translation>Перехід на 3 фази</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
       <location filename="../../data/EvChargers.qml" line="103"/>
       <source>Switching to 1 phase</source>
+      <oldsource>Switching to single phase</oldsource>
       <translation>Перемикання на 1 фазу</translation>
     </message>
     <message id="evchargers_status_stop_charging">
@@ -8325,17 +7389,6 @@ If the generator is currently running due to a autostart condition, disabling au
       <source>Open link</source>
       <translation>Відкрийте посилання</translation>
     </message>
-    <message id="listlink_show_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="43"/>
-      <source>Show QR code</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="listlink_scan_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="52"/>
-      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
-      <extracomment>%1 = url text</extracomment>
-      <translation type="unfinished">Відскануйте QR-код своїм портативним пристроєм.&lt;br /&gt;Або вставте посилання: %1</translation>
-    </message>
     <message id="settings_services_mqtt_access">
       <location filename="../../components/listitems/ListMqttAccessSwitch.qml" line="11"/>
       <source>MQTT Access</source>
@@ -8407,12 +7460,6 @@ If the generator is currently running due to a autostart condition, disabling au
       <extracomment>The 'Brief' page, with the side panel opened</extracomment>
       <translation>Коротко (бічна панель відкрита)</translation>
     </message>
-    <message id="startpage_option_overview">
-      <location filename="../../data/StartPageConfiguration.qml" line="37"/>
-      <source>Overview</source>
-      <extracomment>The 'Overview' page</extracomment>
-      <translation type="unfinished">Огляд</translation>
-    </message>
     <message id="startpage_option_levels_tanks">
       <location filename="../../data/StartPageConfiguration.qml" line="43"/>
       <source>Levels (Tanks)</source>
@@ -8431,12 +7478,12 @@ If the generator is currently running due to a autostart condition, disabling au
       <translation>Список батарейок</translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
+      <location filename="../../pages/DialogLayer.qml" line="56"/>
       <source>GX device has been updated</source>
       <translation>Пристрій GX оновлено</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
+      <location filename="../../pages/DialogLayer.qml" line="58"/>
       <source>Page will automatically reload in ten seconds to load the latest version.</source>
       <translation>Сторінка автоматично перезавантажиться через десять секунд, щоб завантажити останню версію.</translation>
     </message>
@@ -8530,6 +7577,7 @@ Note that this menu only shows Carlo Gavazzi meters connected over RS485. For an
         <numerusform>Через %n хвилин(и)</numerusform>
         <numerusform>Через %n хвилин(и)</numerusform>
         <numerusform>Через %n хвилин(и)</numerusform>
+        <numerusform>Через %n хвилин(и)</numerusform>
       </translation>
     </message>
     <message id="settings_startpage_description">
@@ -8607,8 +7655,8 @@ Note that this menu only shows Carlo Gavazzi meters connected over RS485. For an
       <source>Unit</source>
       <translation>Пристрій</translation>
     </message>
-    <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="61"/>
+    <message id="page_settings_fronius_unitid_invalid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
       <source>%1 is not a valid unit number. Use a number between 1-247.</source>
       <translation>%1 не є допустимим номером одиниці виміру. Використовуйте номер в діапазоні 1-247.</translation>
     </message>
@@ -8724,11 +7772,6 @@ Note that this menu only shows Carlo Gavazzi meters connected over RS485. For an
       <source>Controller Temperature</source>
       <translation>Контролер температури</translation>
     </message>
-    <message id="devicelist_motordrive_motordirectioninverted">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
-      <source>Motor Direction Inverted</source>
-      <translation type="unfinished"/>
-    </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
       <source>Active cycle</source>
@@ -8824,7 +7867,7 @@ Note that this menu only shows Carlo Gavazzi meters connected over RS485. For an
     <message id="settings_rs_devices">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="99"/>
       <source>RS devices</source>
-      <translation>Пристрої ДЗЗ</translation>
+      <translation>Пристрої RS</translation>
     </message>
     <message id="rs_no_system_alarms">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
@@ -8919,11 +7962,6 @@ With streamlined navigation and a fresh look, everything you love is now even ea
     <message id="welcome_done">
       <location filename="../../pages/welcome/WelcomeView.qml" line="136"/>
       <source>Done</source>
-      <translation type="unfinished">Готово</translation>
-    </message>
-    <message id="mk2vsc_state_done">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="20"/>
-      <source>Done</source>
       <translation>Готово</translation>
     </message>
     <message id="welcome_next">
@@ -8981,6 +8019,7 @@ The GX device can only control one connected genset and takes the one with the l
     <message id="settings_tz_etc">
       <location filename="../../pages/settings/PageTzInfo.qml" line="280"/>
       <source>Other</source>
+      <oldsource>Etc</oldsource>
       <translation>Інше</translation>
     </message>
     <message id="ac-in-modeldefault_energy_reverse_x">
@@ -8998,6 +8037,11 @@ The GX device can only control one connected genset and takes the one with the l
       <location filename="../../src/enums.cpp" line="438"/>
       <source>Unsupported type: %1</source>
       <translation>Непідтримуваний тип: %1</translation>
+    </message>
+    <message id="common_words_press">
+      <location filename="../../components/CommonWords.qml" line="419"/>
+      <source>Press</source>
+      <translation>Преса</translation>
     </message>
     <message id="output_aux_battery_service_changed_dcdc">
       <location filename="../../components/listitems/ListOutputBatteryRadioButtonGroup.qml" line="27"/>
@@ -9138,13 +8182,6 @@ The GX device can only control one connected genset and takes the one with the l
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="38"/>
       <source>Resetting VE.Bus products</source>
       <translation>Скидання продуктів VE.Bus</translation>
-    </message>
-    <message id="Unknown">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Невідоме</translation>
     </message>
     <message id="mk2vsc_error_mk2_mk3_comm">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="47"/>
@@ -9450,11 +8487,6 @@ The GX device can only control one connected genset and takes the one with the l
       <source>Changing the GX Password</source>
       <translation>Зміна пароля GX</translation>
     </message>
-    <message id="modaldialog_confirm">
-      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
-      <source>Confirm</source>
-      <translation type="unfinished">Так, скасуйте підписку</translation>
-    </message>
     <message id="settings_security_profile_change_password_description">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="83"/>
       <source>Please enter a new GX password:</source>
@@ -9547,21 +8579,6 @@ The GX device can only control one connected genset and takes the one with the l
       <source>Modifications installed</source>
       <translation>Встановлені модифікації</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_modbus">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="28"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">Сервер Modbus TCP</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_signalk">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="32"/>
-      <source>Signal K</source>
-      <translation type="unfinished">Signal K</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_nodered">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="36"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">Node-RED</translation>
-    </message>
     <message id="pagesettingsgeneral_modificationchecks_running_integrations">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="43"/>
       <source>%1 running integrations</source>
@@ -9637,16 +8654,6 @@ The GX device can only control one connected genset and takes the one with the l
       <source>Installed and enabled, disables at next boot</source>
       <translation>Встановлено та увімкнено, вимкнеться при наступному завантаженні</translation>
     </message>
-    <message id="pagesettingssupportstate_firmware_checking">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
-      <source>Checking...</source>
-      <translation type="unfinished">Перевірка...</translation>
-    </message>
-    <message id="pagesettingssupportstate_firmware_unknown">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="166"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Невідоме</translation>
-    </message>
     <message id="pagesettingssupportstate_support_status">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="228"/>
       <source>Support status</source>
@@ -9668,11 +8675,6 @@ The GX device can only control one connected genset and takes the one with the l
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="288"/>
       <source>Press 'OK' to disable custom startup scripts and reboot</source>
       <translation>Натисніть 'OK', щоб вимкнути власні скрипти запуску та перезавантажити</translation>
-    </message>
-    <message id="pagesettingssupportstate_re_enable_custom_startup_scripts">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="309"/>
-      <source>Re-enable custom startup scripts</source>
-      <translation type="unfinished">Увімкнути власні скрипти запуску знову</translation>
     </message>
     <message id="pagesettingssupportstate_reenable_and_reboot_now">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="322"/>
@@ -9699,11 +8701,6 @@ The GX device can only control one connected genset and takes the one with the l
       <source>Disable also custom startup scripts?</source>
       <translation>Вимкнути також власні скрипти запуску?</translation>
     </message>
-    <message id="pagesettingssupportstate_integrations">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
-      <source>Integrations</source>
-      <translation type="unfinished">Інтеграції</translation>
-    </message>
     <message id="pagesettingssupportstate_orange_items_description">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="494"/>
       <source>Items colored orange are supported and provided by Victron Energy, but using them incorrectly can affect system stability. In case of troubleshooting, disable those first.</source>
@@ -9715,7 +8712,7 @@ The GX device can only control one connected genset and takes the one with the l
       <translation>Підключіть сумісний Bluetooth USB-адаптер, щоб увімкнути з’єднання Bluetooth.</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="140"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="142"/>
       <source>BatteryLife state</source>
       <translation>Стан BatteryLife</translation>
     </message>
@@ -9723,23 +8720,6 @@ The GX device can only control one connected genset and takes the one with the l
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="33"/>
       <source>Device Integrations</source>
       <translation>Інтеграції пристроїв</translation>
-    </message>
-    <message id="pagesettingsintegrations_modbus_tcp_server">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="201"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">Сервер Modbus TCP</translation>
-    </message>
-    <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="226"/>
-      <location filename="../../pages/settings/PageSettingsSignalK.qml" line="18"/>
-      <source>Signal K</source>
-      <translation type="unfinished">Signal K</translation>
-    </message>
-    <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="241"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">Node-RED</translation>
     </message>
     <message id="settings_venusos_large_documentation">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="267"/>
@@ -9749,6 +8729,7 @@ The GX device can only control one connected genset and takes the one with the l
     <message id="settings_modbus_enable_modbus_tcp">
       <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
       <source>Enable Modbus TCP Server</source>
+      <oldsource>Enable Modbus/TCP</oldsource>
       <translation>Увімкнути Modbus TCP Server</translation>
     </message>
     <message id="pagesettingsconnectivity_bluetooth_for_victronconnect_app">
@@ -9842,11 +8823,13 @@ The GX device can only control one connected genset and takes the one with the l
     <message id="settings_gps_format_kmh">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="93"/>
       <source>Kilometres per hour</source>
+      <oldsource>Kilometers per hour</oldsource>
       <translation>Кілометри на годину</translation>
     </message>
     <message id="settings_gps_format_ms">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="95"/>
       <source>Metres per second</source>
+      <oldsource>Meters per second</oldsource>
       <translation>Метри на секунду</translation>
     </message>
     <message id="components_volumeunit_cubic_metres">
@@ -9874,8 +8857,8 @@ The GX device can only control one connected genset and takes the one with the l
       <source>The Relay can now be found in the devices list</source>
       <translation>Реле тепер можна знайти в списку пристроїв</translation>
     </message>
-    <message id="common_words_gx_device_relays">
-      <location filename="../../components/CommonWords.qml" line="223"/>
+    <message id="gx_device_relays">
+      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
       <source>GX device relays</source>
       <translation>Реле пристрою GX</translation>
     </message>
@@ -9929,12 +8912,6 @@ The GX device can only control one connected genset and takes the one with the l
       <extracomment>Forced by app to %1</extracomment>
       <translation>авто</translation>
     </message>
-    <message id="settings_remote_console_forced_by_vrm">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="94"/>
-      <source>VRM</source>
-      <extracomment>Forced by %2 to dark</extracomment>
-      <translation type="unfinished">VRM</translation>
-    </message>
     <message id="settings_remote_console_forced_by_app">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="97"/>
       <source>app</source>
@@ -9984,6 +8961,7 @@ The GX device can only control one connected genset and takes the one with the l
     <message id="settings_large_access_signal_k">
       <location filename="../../pages/settings/PageSettingsSignalK.qml" line="24"/>
       <source>Access Signal K</source>
+      <oldsource>Access Signal K (local network)</oldsource>
       <translation>Доступ до Signal K</translation>
     </message>
     <message id="pagesettingsintegrations_shelly_devices">
@@ -9994,6 +8972,7 @@ The GX device can only control one connected genset and takes the one with the l
     <message id="settings_large_access_node_red">
       <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
       <source>Access Node-RED</source>
+      <oldsource>Access Node-RED (local network)</oldsource>
       <translation>Доступ до Node-RED</translation>
     </message>
     <message id="settings_wifi_access_point_password">
@@ -10061,57 +9040,6 @@ The GX device can only control one connected genset and takes the one with the l
       <source>Wind charger</source>
       <translation>Вітрогенератор</translation>
     </message>
-    <message id="digitalinputs_type_disabled">
-      <location filename="../../src/enums.cpp" line="192"/>
-      <source>Disabled</source>
-      <translation type="unfinished">Вимкнено</translation>
-    </message>
-    <message id="digitalinputs_state_off">
-      <location filename="../../src/enums.cpp" line="242"/>
-      <source>Off</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Вимкнено</translation>
-    </message>
-    <message id="digitalinputs_state_on">
-      <location filename="../../src/enums.cpp" line="246"/>
-      <source>On</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Увімкнено</translation>
-    </message>
-    <message id="digitalinputs_state_ok">
-      <location filename="../../src/enums.cpp" line="266"/>
-      <source>OK</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">ОК</translation>
-    </message>
-    <message id="digitalinputs_state_alarm">
-      <location filename="../../src/enums.cpp" line="270"/>
-      <source>Alarm</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Тривога</translation>
-    </message>
-    <message id="digitalinputs_state_running">
-      <location filename="../../src/enums.cpp" line="274"/>
-      <source>Running</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">Працює</translation>
-    </message>
-    <message id="pvinverter_statusCode_running">
-      <location filename="../../src/enums.cpp" line="300"/>
-      <source>Running</source>
-      <extracomment>PV inverter status code</extracomment>
-      <translation type="unfinished">Працює</translation>
-    </message>
-    <message id="solarchargers_state_external control">
-      <location filename="../../src/enums.cpp" line="352"/>
-      <source>External control</source>
-      <translation type="unfinished">Зовнішнє керування</translation>
-    </message>
-    <message id="switch_state_over_temperature">
-      <location filename="../../src/enums.cpp" line="366"/>
-      <source>Over temperature</source>
-      <translation type="unfinished">Перевищена температура</translation>
-    </message>
     <message id="switchable_output_temperature_setpoint">
       <location filename="../../src/enums.cpp" line="398"/>
       <source>Temperature setpoint</source>
@@ -10121,11 +9049,6 @@ The GX device can only control one connected genset and takes the one with the l
       <location filename="../../src/enums.cpp" line="401"/>
       <source>Stepped switch</source>
       <translation>Ступінчастий перемикач</translation>
-    </message>
-    <message id="switchable_output_slave">
-      <location filename="../../src/enums.cpp" line="408"/>
-      <source>Slave</source>
-      <translation type="unfinished">Керований</translation>
     </message>
     <message id="switchable_output_dropdown">
       <location filename="../../src/enums.cpp" line="412"/>
@@ -10137,122 +9060,10 @@ The GX device can only control one connected genset and takes the one with the l
       <source>Basic slider</source>
       <translation>Базовий повзунок</translation>
     </message>
-    <message id="switchable_output_rgb_color_wheel">
-      <location filename="../../src/enums.cpp" line="427"/>
-      <source>RGB color wheel</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_cct_color_wheel">
-      <location filename="../../src/enums.cpp" line="431"/>
-      <source>CCT color wheel</source>
-      <extracomment>Correlated Color Temperature color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_rgbw_color_wheel">
-      <location filename="../../src/enums.cpp" line="435"/>
-      <source>RGB + W color wheel</source>
-      <extracomment>RGB + white color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bypassed">
-      <location filename="../../src/enums.cpp" line="484"/>
-      <source>Bypassed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="tank_type_fuel">
-      <location filename="../../src/enums.cpp" line="495"/>
-      <source>Fuel</source>
-      <translation type="unfinished">Паливо</translation>
-    </message>
-    <message id="tank_type_fresh_water">
-      <location filename="../../src/enums.cpp" line="498"/>
-      <source>Fresh water</source>
-      <translation type="unfinished">Прісна вода</translation>
-    </message>
-    <message id="tank_type_waste_water">
-      <location filename="../../src/enums.cpp" line="501"/>
-      <source>Waste water</source>
-      <translation type="unfinished">Стічні води</translation>
-    </message>
-    <message id="tank_type_live_well">
-      <location filename="../../src/enums.cpp" line="504"/>
-      <source>Live well</source>
-      <translation type="unfinished">Свердловина</translation>
-    </message>
-    <message id="tank_type_oil">
-      <location filename="../../src/enums.cpp" line="507"/>
-      <source>Oil</source>
-      <translation type="unfinished">Олива</translation>
-    </message>
-    <message id="tank_type_black_water">
-      <location filename="../../src/enums.cpp" line="510"/>
-      <source>Black water</source>
-      <translation type="unfinished">Стічні води з каналізації</translation>
-    </message>
-    <message id="tank_type_gasoline">
-      <location filename="../../src/enums.cpp" line="513"/>
-      <source>Gasoline</source>
-      <translation type="unfinished">Бензин</translation>
-    </message>
-    <message id="tank_type_diesel">
-      <location filename="../../src/enums.cpp" line="516"/>
-      <source>Diesel</source>
-      <translation type="unfinished">Дизельне паливо</translation>
-    </message>
-    <message id="tank_type_lpg">
-      <location filename="../../src/enums.cpp" line="519"/>
-      <source>LPG</source>
-      <translation type="unfinished">LPG</translation>
-    </message>
-    <message id="tank_type_lng">
-      <location filename="../../src/enums.cpp" line="522"/>
-      <source>LNG</source>
-      <translation type="unfinished">LNG</translation>
-    </message>
-    <message id="tank_type_hydraulic_oil">
-      <location filename="../../src/enums.cpp" line="525"/>
-      <source>Hydraulic oil</source>
-      <translation type="unfinished">Гідравлічна олива</translation>
-    </message>
-    <message id="tank_type_raw_water">
-      <location filename="../../src/enums.cpp" line="528"/>
-      <source>Raw water</source>
-      <translation type="unfinished">Неочищена вода</translation>
-    </message>
-    <message id="microgrid_mode_hybrid_droop">
-      <location filename="../../src/enums.cpp" line="539"/>
-      <source>Hybrid droop</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_following">
-      <location filename="../../src/enums.cpp" line="542"/>
-      <source>Grid-following</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_forming">
-      <location filename="../../src/enums.cpp" line="545"/>
-      <source>Grid-forming</source>
-      <translation type="unfinished"/>
-    </message>
     <message id="switchable_output_three_state_switch">
       <location filename="../../src/enums.cpp" line="421"/>
       <source>Three-state switch</source>
       <translation>Трипозиційний перемикач</translation>
-    </message>
-    <message id="switchable_output_fault">
-      <location filename="../../src/enums.cpp" line="464"/>
-      <source>Fault</source>
-      <translation type="unfinished">Несправність</translation>
-    </message>
-    <message id="switchable_output_running">
-      <location filename="../../src/enums.cpp" line="468"/>
-      <source>Running</source>
-      <translation type="unfinished">Працює</translation>
-    </message>
-    <message id="switchable_output_trip_low_voltage">
-      <location filename="../../src/enums.cpp" line="481"/>
-      <source>Trip low voltage</source>
-      <translation type="unfinished">Вимкнено</translation>
     </message>
     <message id="settings_modbus_tcp_unit_id_note">
       <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="41"/>
@@ -10274,281 +9085,1152 @@ The GX device can only control one connected genset and takes the one with the l
       <source>Press to refresh</source>
       <translation>Натисніть для оновлення</translation>
     </message>
-    <message id="temperature_type_unknown">
-      <location filename="../../data/EnvironmentInputs.qml" line="65"/>
-      <source>Unknown</source>
-      <translation type="unfinished">Невідоме</translation>
-    </message>
-    <message id="brief_solar_yield">
-      <location filename="../../pages/BriefSidePanel.qml" line="24"/>
-      <source>Solar yield</source>
-      <translation type="unfinished">PV генерація</translation>
-    </message>
-    <message id="brief_dc_input">
-      <location filename="../../pages/BriefSidePanel.qml" line="214"/>
-      <source>DC input</source>
-      <translation type="unfinished">Вхід постійного струму</translation>
-    </message>
-    <message id="brief_ac_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="257"/>
-      <source>AC Loads</source>
-      <translation type="unfinished">AC Спож.</translation>
-    </message>
-    <message id="brief_dc_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="284"/>
-      <source>DC Loads</source>
-      <translation type="unfinished">DC спож.</translation>
-    </message>
-    <message id="nav_overview">
-      <location filename="../../pages/OverviewPage.qml" line="450"/>
-      <source>Overview</source>
-      <translation type="unfinished">Огляд</translation>
-    </message>
-    <message id="settings_state">
-      <location filename="../../pages/settings/PageCanbusStatus.qml" line="116"/>
-      <source>State</source>
-      <translation type="unfinished">Стан</translation>
-    </message>
-    <message id="inverter_pv">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="56"/>
-      <source>PV</source>
-      <translation type="unfinished">PV</translation>
-    </message>
-    <message id="inverter_total_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="76"/>
-      <source>Total yield</source>
-      <translation type="unfinished">Загальний вихід</translation>
-    </message>
-    <message id="inverter_system_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="84"/>
-      <source>System yield</source>
-      <translation type="unfinished">Вихід системи</translation>
-    </message>
-    <message id="charger_total_pv_power">
-      <location filename="../../pages/solar/SolarDevicePage.qml" line="61"/>
-      <source>Total PV Power</source>
-      <translation type="unfinished">Загальна PV потужність</translation>
-    </message>
-    <message id="vebus_device_alarm_only">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
-      <source>Alarm only</source>
-      <translation type="unfinished">Тільки тривоги</translation>
-    </message>
-    <message id="vebus_device_alarms_and_warnings">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
-      <source>Alarms &amp; warnings</source>
-      <translation type="unfinished">Тривоги та попередження</translation>
-    </message>
-    <message id="vebus_device_alarm_group_warning">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
-      <source>Warning</source>
-      <translation type="unfinished">Попередження</translation>
-    </message>
-    <message id="load_delegate_status">
-      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
-      <source>Status: %1</source>
-      <translation type="unfinished"/>
+    <message id="common_words_total_power">
+      <location filename="../../components/CommonWords.qml" line="540"/>
+      <source>Total power</source>
+      <translation>Загальна потужність</translation>
     </message>
     <message id="venus_os_gui">
       <location filename="../../Main.qml" line="17"/>
       <source>Venus OS GUI</source>
       <extracomment>Application title</extracomment>
-      <translation type="unfinished"/>
       <extra-Context>only shown on desktop systems</extra-Context>
+      <translation>Venus OS GUI</translation>
+    </message>
+    <message id="load_delegate_status">
+      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
+      <source>Status: %1</source>
+      <translation>Статус: %1</translation>
+    </message>
+    <message id="settings_relay_polarity_relay1">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
+      <source>Polarity (Relay 1)</source>
+      <translation>Полярність (Реле 1)</translation>
+    </message>
+    <message id="settings_relay_polarity">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
+      <source>Polarity</source>
+      <translation>Полярність</translation>
+    </message>
+    <message id="settings_relay_polarity_relay2">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
+      <source>Polarity (Relay 2)</source>
+      <translation>Полярність (Реле 2)</translation>
+    </message>
+    <message id="page_settings_wifi_invalid_password">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
+      <source>Password length must be either 0 or between 10 and 63 characters long</source>
+      <translation>Довжина пароля має бути 0 або від 10 до 63 символів</translation>
+    </message>
+    <message id="page_settings_wifi_password_updated">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
+      <source>Password updated</source>
+      <translation>Пароль оновлено</translation>
+    </message>
+    <message id="common_words_max">
+      <location filename="../../components/CommonWords.qml" line="315"/>
+      <source>Max</source>
+      <extracomment>Short for Maximum</extracomment>
+      <translation>Макс.</translation>
+    </message>
+    <message id="common_words_min">
+      <location filename="../../components/CommonWords.qml" line="331"/>
+      <source>Min</source>
+      <extracomment>Short for Minimum</extracomment>
+      <translation>Мін.</translation>
+    </message>
+    <message id="settings_ess_deprecated">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="321"/>
+      <source>Deprecated settings</source>
+      <translation>Застарілі налаштування</translation>
+    </message>
+    <message id="settings_ess_max_charge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="328"/>
+      <source>Battery charge limit (% of CCL)</source>
+      <translation>Ліміт заряду батареї (% від CCL)</translation>
+    </message>
+    <message id="settings_ess_max_discharge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="339"/>
+      <source>Battery discharge limit (% of DCL)</source>
+      <translation>Ліміт розряду батареї (% від DCL)</translation>
+    </message>
+    <message id="vebus_device_bms_message">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
+      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
+      <oldsource>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</oldsource>
+      <translation>VE.Bus BMS автоматично вимикає систему, коли це необхідно для захисту акумулятора. Тому керування системою з пристрою GX неможливе.</translation>
+    </message>
+    <message id="switchable_output_numeric_input">
+      <location filename="../../src/enums.cpp" line="418"/>
+      <source>Numeric input</source>
+      <translation>Числовий ввід</translation>
     </message>
     <message id="autotoggleswitch_disable_auto_mode_info">
       <location filename="../../components/controls/AutoToggleButton.qml" line="34"/>
       <source>Disable Auto mode first</source>
-      <translation type="unfinished"/>
+      <translation>Спочатку вимкніть автоматичний режим</translation>
+    </message>
+    <message id="pagesettingsintegrations_venus_os_enable_large_features">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
+      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
+      <translation>Увімкнути велику прошивку Venus OS для використання Node-RED або Signal-K</translation>
+    </message>
+    <message id="settings_relays_sensors_tanks">
+      <location filename="../../pages/SettingsPage.qml" line="75"/>
+      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
+      <oldsource>Relays, Sensors, Tanks, PV Inverters, Modbus, MQTT…</oldsource>
+      <translation>Реле, датчики, PV інвертори, Modbus, Node-RED</translation>
+    </message>
+    <message id="vebus_device_page_microgrid_parameters">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
+      <source>Microgrid parameters</source>
+      <translation>Параметри мікромережі</translation>
+    </message>
+    <message id="microgrid_mode_hybrid_droop">
+      <location filename="../../src/enums.cpp" line="539"/>
+      <source>Hybrid droop</source>
+      <translation>Гібридне регулювання</translation>
+    </message>
+    <message id="microgrid_mode_grid_following">
+      <location filename="../../src/enums.cpp" line="542"/>
+      <source>Grid-following</source>
+      <translation>Слідування за мережею</translation>
+    </message>
+    <message id="microgrid_mode_grid_forming">
+      <location filename="../../src/enums.cpp" line="545"/>
+      <source>Grid-forming</source>
+      <translation>Формування мережі</translation>
+    </message>
+    <message id="switchable_output_trip_low_voltage">
+      <location filename="../../src/enums.cpp" line="481"/>
+      <source>Trip low voltage</source>
+      <oldsource>Disabled</oldsource>
+      <translation>Відключення при низькій напрузі</translation>
     </message>
     <message id="microgrid">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="15"/>
       <source>Microgrid</source>
-      <translation type="unfinished"/>
+      <translation>Мікромережа</translation>
     </message>
     <message id="page_microgrid_active_mode">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="19"/>
       <source>Active mode</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_microgrid_from_p1_to_p2">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="34"/>
-      <source>%1 %2 to %3 %4</source>
-      <extracomment>Describes a range from one quantity to another, e.g. "30 W to 60 W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
-      <translation type="unfinished"/>
+      <translation>Активний режим</translation>
     </message>
     <message id="page_microgrid_hybrid_droop_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="92"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
       <source>Hybrid droop parameters</source>
-      <translation type="unfinished"/>
+      <translation>Параметри гібридного регулювання</translation>
     </message>
     <message id="page_microgrid_reference_active_power_p0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="105"/>
       <source>Reference active power (P&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Опорна активна потужність (P&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_frequency_f0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="108"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="112"/>
       <source>Reference frequency (f&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Опорна частота (f&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_frequency_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="117"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="119"/>
       <source>Frequency droop slope (droop&lt;sub&gt;fP&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Крутизна частотної характеристики (droop&lt;sub&gt;fP&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_reactive_power">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="126"/>
       <source>Reference reactive power (Q&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Опорна реактивна потужність (Q&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_voltage">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="135"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="133"/>
       <source>Reference Voltage (U&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Опорна напруга (U&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_voltage_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="144"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="140"/>
       <source>Voltage droop slope (droop&lt;sub&gt;UQ&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>Крутизна вольт-амперної характеристики (droop&lt;sub&gt;UQ&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_minimum_and_maximum_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="146"/>
       <source>Minimum and maximum parameters</source>
-      <translation type="unfinished"/>
+      <translation>Мінімальні та максимальні параметри</translation>
     </message>
     <message id="page_microgrid_allowed_active_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="156"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
       <source>Allowed active power range</source>
-      <translation type="unfinished"/>
+      <translation>Дозволений діапазон активної потужності</translation>
     </message>
     <message id="page_microgrid_allowed_reactive_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="164"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="159"/>
       <source>Allowed reactive power range</source>
-      <translation type="unfinished"/>
+      <translation>Дозволений діапазон реактивної потужності</translation>
     </message>
     <message id="page_microgrid_p_q_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="176"/>
       <source>P-Q direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>Налаштування прямого керування P-Q</translation>
     </message>
     <message id="page_microgrid_active_power_setpoint_p">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="186"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
       <source>Active power setpoint (P)</source>
-      <translation type="unfinished"/>
+      <translation>Задане значення активної потужності (P)</translation>
     </message>
     <message id="page_microgrid_reactive_power_setpoint_q">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="194"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="188"/>
       <source>Reactive power setpoint (Q)</source>
-      <translation type="unfinished"/>
+      <translation>Задане значення реактивної потужності (Q)</translation>
     </message>
     <message id="page_microgrid_allowed_frequency_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="202"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="195"/>
       <source>Allowed frequency range</source>
-      <translation type="unfinished"/>
+      <translation>Дозволений діапазон частот</translation>
     </message>
     <message id="page_microgrid_allowed_voltage_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="210"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="203"/>
       <source>Allowed voltage range</source>
-      <translation type="unfinished"/>
+      <translation>Дозволений діапазон напруг</translation>
     </message>
     <message id="page_microgrid_v_f_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="227"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="220"/>
       <source>V-f direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>Налаштування прямого керування V-f</translation>
     </message>
     <message id="page_microgrid_voltage_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="225"/>
       <source>Voltage setpoint (U)</source>
-      <translation type="unfinished"/>
+      <translation>Задане значення напруги (U)</translation>
     </message>
     <message id="page_microgrid_frequency_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="240"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
       <source>Frequency setpoint (f)</source>
-      <translation type="unfinished"/>
+      <translation>Задане значення частоти (f)</translation>
     </message>
-    <message id="temperature_slider_current">
-      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
-      <source>Current</source>
-      <extracomment>The current temperature measurement</extracomment>
-      <translation type="unfinished">Струм</translation>
+    <message id="pagesettingsintegrations_canopenmotordrive">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
+      <source>CANopen motor drives</source>
+      <translation>Приводи двигунів CANopen</translation>
+    </message>
+    <message id="pagesettingsintegrations_ui_plugins">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
+      <source>UI Plugins</source>
+      <translation>Плагіни інтерфейсу користувача</translation>
+    </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
+      <source>Motor Direction Inverted</source>
+      <translation>Інвертований напрямок двигуна</translation>
     </message>
     <message id="page_settings_canopenmotordrive_scan_for_motor_drives">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="31"/>
       <source>Scan for motor drives</source>
-      <translation type="unfinished"/>
+      <translation>Пошук приводів двигунів</translation>
     </message>
     <message id="page_settings_canopenmotordrive_discovered_motor_drive_ids">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="39"/>
       <source>Discovered motor drive IDs</source>
-      <translation type="unfinished"/>
+      <translation>Виявлені ідентифікатори приводів двигунів</translation>
     </message>
-    <message id="switchableoutput_gx_device_relays">
-      <location filename="../../src/switchableoutput.cpp" line="388"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">Реле пристрою GX</translation>
+    <message id="temperature_pm25">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
+      <source>PM2.5</source>
+      <translation>PM2.5</translation>
     </message>
-    <message id="gx_device_relays">
-      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">Реле пристрою GX</translation>
+    <message id="temperature_co2">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+      <source>CO₂</source>
+      <translation>CO₂</translation>
     </message>
-    <message id="color_preset">
-      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
-      <source>Preset</source>
-      <translation type="unfinished"/>
+    <message id="temperature_voc">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
+      <source>VOC index</source>
+      <translation>Індекс ЛОС</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_location">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
-      <source>Add Modbus port and unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_nox">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
+      <source>NOx index</source>
+      <translation>Індекс NOx</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_unitid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
-      <source>Unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_luminosity">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
+      <source>Luminosity</source>
+      <translation>Яскравість</translation>
     </message>
-    <message id="page_settings_fronius_unitid_invalid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation type="unfinished">%1 не є допустимим номером одиниці виміру. Використовуйте номер в діапазоні 1-247.</translation>
-    </message>
-    <message id="page_settings_fronius_add_modbus_location_button">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
-      <source>Add</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_locations_note">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
-      <source>The default modbus port is 502 and the default unit ID is 126.
-Here you can add additional ports and unit IDs to scan for PV inverters.</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_location_number">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
-      <source>Port/Unit ID %1</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location_description">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
-      <source>Port: %1 (Unit %2)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
-      <source>Remove Modbus port and unit ID?</source>
-      <translation type="unfinished"/>
+    <message id="switchable_output_bypassed">
+      <location filename="../../src/enums.cpp" line="484"/>
+      <source>Bypassed</source>
+      <translation>Обійдено</translation>
     </message>
     <message id="switchableoutput_list_delegate_auto_status">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="84"/>
       <source>Auto (%1)</source>
       <extracomment>%1 = 'On' or 'Off'</extracomment>
-      <translation type="unfinished"/>
+      <translation>Авто (%1)</translation>
     </message>
     <message id="switchableoutput_list_delegate_state_forced">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="100"/>
       <source>Forced</source>
-      <translation type="unfinished"/>
+      <translation>Примусово</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_settings">
+      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
+      <source>Modbus port and unit ID settings</source>
+      <translation>Налаштування порту Modbus та ідентифікатора пристрою</translation>
+    </message>
+    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
+      <source>Integrates with the device list</source>
+      <translation>Інтегрується зі списком пристроїв</translation>
+    </message>
+    <message id="common_words_color">
+      <location filename="../../components/CommonWords.qml" line="136"/>
+      <source>Color</source>
+      <translation>Колір</translation>
+    </message>
+    <message id="common_words_value_must_be_greater_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="557"/>
+      <source>Value must be greater than start value</source>
+      <translation>Значення має бути більшим за початкове</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="566"/>
+      <source>Value must be lower than stop value</source>
+      <translation>Значення має бути меншим за кінцеве</translation>
+    </message>
+    <message id="notifications_page_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="43"/>
+      <source>Active Notifications</source>
+      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
+      <translation>Активні сповіщення</translation>
+    </message>
+    <message id="notifications_page_inactive_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="47"/>
+      <source>Inactive Notifications</source>
+      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
+      <translation>Неактивні сповіщення</translation>
+    </message>
+    <message id="notifications_no_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="106"/>
+      <source>No active notifications</source>
+      <translation>Немає активних сповіщень</translation>
+    </message>
+    <message id="switchable_output_rgb_color_wheel">
+      <location filename="../../src/enums.cpp" line="427"/>
+      <source>RGB color wheel</source>
+      <translation>Колірне коло RGB</translation>
+    </message>
+    <message id="switchable_output_cct_color_wheel">
+      <location filename="../../src/enums.cpp" line="431"/>
+      <source>CCT color wheel</source>
+      <extracomment>Correlated Color Temperature color wheel</extracomment>
+      <translation>Колірне коло CCT</translation>
+    </message>
+    <message id="switchable_output_rgbw_color_wheel">
+      <location filename="../../src/enums.cpp" line="435"/>
+      <source>RGB + W color wheel</source>
+      <extracomment>RGB + white color wheel</extracomment>
+      <translation>Колірне коло RGB + W</translation>
+    </message>
+    <message id="listlink_show_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="43"/>
+      <source>Show QR code</source>
+      <translation>Показати QR-код</translation>
+    </message>
+    <message id="listlink_scan_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="52"/>
+      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
+      <extracomment>%1 = url text</extracomment>
+      <oldsource>Scan the QR code with your portable device.&lt;br /&gt;Or insert the link: %1</oldsource>
+      <translation>Відкрийте QR-код, щоб відсканувати його за допомогою портативного пристрою.&lt;br /&gt;Або вставте посилання: %1</translation>
+    </message>
+    <message id="color_preset">
+      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
+      <source>Preset</source>
+      <translation>Предустановка</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
+      <source>Add Modbus port and unit ID</source>
+      <translation>Додати порт Modbus та ідентифікатор пристрою</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_unitid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
+      <source>Unit ID</source>
+      <translation>Ідентифікатор пристрою</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location_button">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
+      <source>Add</source>
+      <translation>Додати</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_locations_note">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
+      <source>The default modbus port is 502 and the default unit ID is 126.
+Here you can add additional ports and unit IDs to scan for PV inverters.</source>
+      <translation>Порт Modbus за замовчуванням - 502, а ідентифікатор пристрою за замовчуванням - 126.
+Тут ви можете додати додаткові порти та ідентифікатори пристроїв для сканування PV інверторів.</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_location_number">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
+      <source>Port/Unit ID %1</source>
+      <translation>Порт/Ідентифікатор пристрою %1</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location_description">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
+      <source>Port: %1 (Unit %2)</source>
+      <translation>Порт: %1 (Пристрій %2)</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
+      <source>Remove Modbus port and unit ID?</source>
+      <translation>Видалити порт Modbus та ідентифікатор пристрою?</translation>
+    </message>
+    <message id="devicelist_tankshape_edit_point">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="182"/>
+      <source>Edit point %1</source>
+      <extracomment>%1 = which point is being edited, a number like "1" or "2"</extracomment>
+      <translation></translation>
+    </message>
+    <message id="settings_canbus_vecan">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
+      <source>VE.Can (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_250">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <source>VE.Can &amp; CANopen E-drive (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_500">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
+      <source>CANopen E-drive (500 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="page_microgrid_from_p1_to_p2">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="39"/>
+      <source>%1%2 to %3%4</source>
+      <extracomment>Describes a range from one quantity to another, e.g. "30W to 60W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
+      <translation></translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAfricaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
+      <source>Morocco Standard Time</source>
+      <translation>Стандартний час Марокко</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
+      <source>W. Central Africa Standard Time</source>
+      <translation>Західно- і центральноафриканський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
+      <source>South Africa Standard Time</source>
+      <translation>Південноафриканський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
+      <source>Namibia Standard Time</source>
+      <translation>Стандартний час Намібії</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
+      <source>Egypt Standard Time</source>
+      <translation>Стандартний час Єгипту</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
+      <source>E. Africa Standard Time</source>
+      <translation>Східноафриканський стандартний час</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAmericaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
+      <source>Argentina Standard Time</source>
+      <translation>Аргентинський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
+      <source>E. South America Standard Time</source>
+      <translation>Східно- і Південноамериканський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
+      <source>Greenland Standard Time</source>
+      <translation>Стандартний час Гренландії</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
+      <source>Montevideo Standard Time</source>
+      <translation>Стандартний час Монтевідео</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
+      <source>Newfoundland Standard Time</source>
+      <translation>Ньюфаундлендський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
+      <source>SA Eastern Standard Time</source>
+      <translation>Південноамериканський східний стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
+      <source>Atlantic Standard Time</source>
+      <translation>Атлантичний стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
+      <source>Central Brazilian Standard Time</source>
+      <translation>Центральний бразильський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>Тихоокеанський південноамериканський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
+      <source>Paraguay Standard Time</source>
+      <translation>Парагвайський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
+      <source>SA Western Standard Time</source>
+      <translation>Південноамериканський західний стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
+      <source>Venezuela Standard Time</source>
+      <translation>Стандартний час Венесуели</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
+      <source>Eastern Standard Time</source>
+      <translation>Східний стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
+      <source>SA Pacific Standard Time</source>
+      <translation>Південноамериканський тихоокеанський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
+      <source>US Eastern Standard Time</source>
+      <translation>Східний стандартний час США</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
+      <source>Canada Central Standard Time</source>
+      <translation>Канадський центральний стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
+      <source>Central America Standard Time</source>
+      <translation>Центральноамериканський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
+      <source>Central Standard Time (Mexico)</source>
+      <translation>Центральний стандартний час (Мексика)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
+      <source>Central Standard Time</source>
+      <translation>Центральний стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
+      <source>Mountain Standard Time (Mexico)</source>
+      <translation>Гірський стандартний час (Мексика)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
+      <source>Mountain Standard Time</source>
+      <translation>Гірський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
+      <source>US Mountain Standard Time</source>
+      <translation>Гірський стандартний час США</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
+      <source>Pacific Standard Time (Mexico)</source>
+      <translation>Тихоокеанський стандартний час (Мексика)</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
+      <source>Pacific Standard Time</source>
+      <translation>Тихоокеанський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
+      <source>Alaskan Standard Time</source>
+      <translation>Аляскинський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
+      <source>Hawaii-Aleutian</source>
+      <translation>Гавайсько-алеутський</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
+      <source>Atlantic Daylight Time</source>
+      <translation>Атлантичний літній час</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAntarcticaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+      <source>New Zealand Standard Time</source>
+      <translation>Новозеландський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>Центральний тихоокеанський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+      <source>West Pacific Standard Time</source>
+      <translation>Західний тихоокеанський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+      <source>W. Australia Standard Time</source>
+      <translation>Західноавстралійський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+      <source>SE Asia Standard Time</source>
+      <translation>Стандартний час Південно-Східної Азії</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+      <source>Central Asia Standard Time</source>
+      <translation>Стандартний час Центральної Азії</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+      <source>West Asia Standard Time</source>
+      <translation>Стандартний час Західної Азії</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+      <source>E. Africa Standard Time</source>
+      <translation>Східноафриканський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>Тихоокеанський південноамериканський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+      <source>SA Western Standard Time</source>
+      <translation>Південноамериканський західний стандартний час</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzArcticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
+      <source>W. Europe Standard Time</source>
+      <translation>Західноєвропейський стандартний час</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAsiaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
+      <source>Kamchatka Standard Time</source>
+      <translation>Камчатський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
+      <source>Magadan Standard Time</source>
+      <translation>Магаданський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
+      <source>Vladivostok Standard Time</source>
+      <translation>Владивостоцький стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
+      <source>Yakutsk Standard Time</source>
+      <translation>Якутський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
+      <source>Tokyo Standard Time</source>
+      <translation>Токійський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
+      <source>Korea Standard Time</source>
+      <translation>Корейський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
+      <source>Singapore Standard Time</source>
+      <translation>Сингапурський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
+      <source>Ulaanbaatar Standard Time</source>
+      <translation>Стандартний час в Улан-Баторі</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
+      <source>Taipei Standard Time</source>
+      <translation>Стандартний час в Тайбеї</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
+      <source>North Asia East Standard Time</source>
+      <translation>Східний стандартний час Північної Азії</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
+      <source>China Standard Time</source>
+      <translation>Китайський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
+      <source>SE Asia Standard Time</source>
+      <translation>Стандартний час Південно-Східної Азії</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
+      <source>North Asia Standard Time</source>
+      <translation>Стандартний час Північної Азії</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
+      <source>Myanmar Standard Time</source>
+      <translation>Стандартний час М’янми</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
+      <source>N. Central Asia Standard Time</source>
+      <translation>Стандартний час Північно-Центральної Азії</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
+      <source>Central Asia Standard Time</source>
+      <translation>Стандартний час Центральної Азії</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
+      <source>Bangladesh Standard Time</source>
+      <translation>Стандартний час Бангладеш</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
+      <source>Nepal Standard Time</source>
+      <translation>Непальський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
+      <source>Sri Lanka Standard Time</source>
+      <translation>Стандартний час Шрі-Ланки</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
+      <source>India Standard Time</source>
+      <translation>Індійський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
+      <source>West Asia Standard Time</source>
+      <translation>Стандартний час Західної Азії</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
+      <source>Pakistan Standard Time</source>
+      <translation>Пакистанський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
+      <source>Ekaterinburg Standard Time</source>
+      <translation>Єкатеринбурзький стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
+      <source>Georgian Standard Time</source>
+      <translation>Грузинський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
+      <source>Caucasus Standard Time</source>
+      <translation>Кавказький стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
+      <source>Azerbaijan Standard Time</source>
+      <translation>Азербайджанський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
+      <source>Arabian Standard Time</source>
+      <translation>Арабський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
+      <source>Afghanistan Standard Time</source>
+      <translation>Стандартний час в Афганістані</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
+      <source>Iran Standard Time</source>
+      <translation>Іранський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
+      <source>Arabic Standard Time</source>
+      <translation>Аравійський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
+      <source>Arab Standard Time</source>
+      <translation>Аравійський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
+      <source>Syria Standard Time</source>
+      <translation>Сирійський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
+      <source>Middle East Standard Time</source>
+      <translation>Близькосхідний стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
+      <source>Jordan Standard Time</source>
+      <translation>Стандартний час Йорданії</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
+      <source>Israel Standard Time</source>
+      <translation>Ізраїльський стандартний час</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAtlanticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+      <source>Greenwich Standard Time</source>
+      <translation>Гринвіцький стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+      <source>Azores Standard Time</source>
+      <translation>Стандартний час на Азорських островах</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+      <source>Cape Verde Standard Time</source>
+      <translation>Стандартний час Кабо-Верде</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
+      <source>Mid-Atlantic Standard Time</source>
+      <translation>Середньоатлантичний стандартний час</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAustraliaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+      <source>Tasmania Standard Time</source>
+      <translation>Стандартний час Тасманії</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+      <source>E. Australia Standard Time</source>
+      <translation>Східноавстралійський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+      <source>AUS Eastern Standard Time</source>
+      <translation>Австралійський східний стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+      <source>Cen. Australia Standard Time</source>
+      <translation>Центр. Австралійський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+      <source>AUS Central Standard Time</source>
+      <translation>Австралійський центральний стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+      <source>W. Australia Standard Time</source>
+      <translation>Західноавстралійський стандартний час</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEtcData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
+      <source>GMT +12</source>
+      <translation>GMT +12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
+      <source>GMT -02</source>
+      <translation>GMT -02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
+      <source>GMT -11</source>
+      <translation>GMT -11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
+      <source>GMT -13</source>
+      <translation>GMT -13</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
+      <source>GMT -12</source>
+      <translation>GMT -12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
+      <source>GMT -10</source>
+      <translation>GMT -10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
+      <source>GMT -09</source>
+      <translation>GMT -09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
+      <source>GMT -08</source>
+      <translation>GMT -08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
+      <source>GMT -07</source>
+      <translation>GMT -07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
+      <source>GMT -06</source>
+      <translation>GMT -06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
+      <source>GMT -05</source>
+      <translation>GMT -05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
+      <source>GMT -04</source>
+      <translation>GMT -04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
+      <source>GMT -03</source>
+      <translation>GMT -03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
+      <source>GMT -01</source>
+      <translation>GMT -01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
+      <source>GMT</source>
+      <translation>GMT</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
+      <source>GMT +01</source>
+      <translation>GMT +01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
+      <source>GMT +02</source>
+      <translation>GMT +02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
+      <source>GMT +03</source>
+      <translation>GMT +03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
+      <source>GMT +04</source>
+      <translation>GMT +04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
+      <source>GMT +05</source>
+      <translation>GMT +05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
+      <source>GMT +06</source>
+      <translation>GMT +06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
+      <source>GMT +07</source>
+      <translation>GMT +07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
+      <source>GMT +08</source>
+      <translation>GMT +08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
+      <source>GMT +09</source>
+      <translation>GMT +09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
+      <source>GMT +10</source>
+      <translation>GMT +10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
+      <source>GMT +11</source>
+      <translation>GMT +11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
+      <source>UTC</source>
+      <translation>UTC</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEuropeData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
+      <source>GMT Standard Time</source>
+      <translation>Стандартний час GMT</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
+      <source>Central Europe Standard Time</source>
+      <translation>Стандартний час Центральної Європи</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
+      <source>Central European Standard Time</source>
+      <translation>Центральноєвропейський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
+      <source>Romance Standard Time</source>
+      <translation>Романський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
+      <source>W. Europe Standard Time</source>
+      <translation>Західноєвропейський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
+      <source>E. Europe Standard Time</source>
+      <translation>Східноєвропейський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
+      <source>FLE Standard Time</source>
+      <translation>Стандартний час FLE</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
+      <source>GTB Standard Time</source>
+      <translation>Стандартний час GTB</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
+      <source>Belarus Standard Time</source>
+      <translation>Білоруський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
+      <source>Russian Standard Time</source>
+      <translation>Російський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
+      <source>Turkey Standard Time</source>
+      <translation>Стандартний час Туреччини</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzIndianData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
+      <source>Mauritius Standard Time</source>
+      <translation>Маврикійський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
+      <source>Christmas Island Standard Time</source>
+      <translation>Стандартний час острова Різдва</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzPacificData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
+      <source>Tonga Standard Time</source>
+      <translation>Стандартний час Тонга</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
+      <source>Fiji Standard Time</source>
+      <translation>Стандартний час Фіджі</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
+      <source>New Zealand Standard Time</source>
+      <translation>Новозеландський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>Центральний тихоокеанський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
+      <source>West Pacific Standard Time</source>
+      <translation>Західний тихоокеанський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
+      <source>Samoa Standard Time</source>
+      <translation>Стандартний час Самоа</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
+      <source>Hawaiian Standard Time</source>
+      <translation>Гавайський стандартний час</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
+      <source>Easter Island Standard Time</source>
+      <translation>Стандартний час острова Пасхи</translation>
     </message>
   </context>
   <context>
@@ -12177,838 +11859,6 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
     </message>
   </context>
   <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>Стандартний час Марокко</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>Західно- і центральноафриканський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>Південноафриканський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>Стандартний час Намібії</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>Стандартний час Єгипту</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Східноафриканський стандартний час</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>Аргентинський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>Східно- і Південноамериканський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>Стандартний час Гренландії</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>Стандартний час Монтевідео</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>Ньюфаундлендський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>Південноамериканський східний стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Atlantic Standard Time</source>
-      <translation>Атлантичний стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>Центральний бразильський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Тихоокеанський південноамериканський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>Paraguay Standard Time</source>
-      <translation>Парагвайський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>SA Western Standard Time</source>
-      <translation>Південноамериканський західний стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Venezuela Standard Time</source>
-      <translation>Стандартний час Венесуели</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>Eastern Standard Time</source>
-      <translation>Східний стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>Південноамериканський тихоокеанський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>US Eastern Standard Time</source>
-      <translation>Східний стандартний час США</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Canada Central Standard Time</source>
-      <translation>Канадський центральний стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central America Standard Time</source>
-      <translation>Центральноамериканський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>Центральний стандартний час (Мексика)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Central Standard Time</source>
-      <translation>Центральний стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>Гірський стандартний час (Мексика)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>Mountain Standard Time</source>
-      <translation>Гірський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>US Mountain Standard Time</source>
-      <translation>Гірський стандартний час США</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>Тихоокеанський стандартний час (Мексика)</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Pacific Standard Time</source>
-      <translation>Тихоокеанський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Alaskan Standard Time</source>
-      <translation>Аляскинський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>Гавайсько-алеутський</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Daylight Time</source>
-      <translation>Атлантичний літній час</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Новозеландський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Центральний тихоокеанський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Західний тихоокеанський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Західноавстралійський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Стандартний час Південно-Східної Азії</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Стандартний час Центральної Азії</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>Стандартний час Західної Азії</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>Східноафриканський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>Тихоокеанський південноамериканський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>Південноамериканський західний стандартний час</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Західноєвропейський стандартний час</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>Камчатський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>Магаданський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>Владивостоцький стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>Якутський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>Токійський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>Корейський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>Сингапурський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>Стандартний час в Улан-Баторі</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>Стандартний час в Тайбеї</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>Східний стандартний час Північної Азії</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>Китайський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>Стандартний час Південно-Східної Азії</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>Стандартний час Північної Азії</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>Стандартний час М’янми</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>Стандартний час Північно-Центральної Азії</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>Стандартний час Центральної Азії</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>Стандартний час Бангладеш</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>Непальський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>Стандартний час Шрі-Ланки</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>Індійський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>Стандартний час Західної Азії</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>Пакистанський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>Єкатеринбурзький стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>Грузинський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>Кавказький стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>Азербайджанський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>Арабський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>Стандартний час в Афганістані</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>Іранський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>Аравійський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>Аравійський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>Сирійський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>Близькосхідний стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>Стандартний час Йорданії</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>Ізраїльський стандартний час</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>Гринвіцький стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>Стандартний час на Азорських островах</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>Стандартний час Кабо-Верде</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>Середньоатлантичний стандартний час</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>Стандартний час Тасманії</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>Східноавстралійський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>Австралійський східний стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>Центр. Австралійський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>Австралійський центральний стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>Західноавстралійський стандартний час</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
-      <source>GMT +12</source>
-      <translation>GMT +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
-      <source>GMT -02</source>
-      <translation>GMT -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT -13</source>
-      <translation>GMT -13</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT -12</source>
-      <translation>GMT -12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -10</source>
-      <translation>GMT -10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -09</source>
-      <translation>GMT -09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>GMT -08</source>
-      <translation>GMT -08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
-      <source>GMT -07</source>
-      <translation>GMT -07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
-      <source>GMT -06</source>
-      <translation>GMT -06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
-      <source>GMT -05</source>
-      <translation>GMT -05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
-      <source>GMT -04</source>
-      <translation>GMT -04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
-      <source>GMT -03</source>
-      <translation>GMT -03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
-      <source>GMT -01</source>
-      <translation>GMT -01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
-      <source>GMT</source>
-      <translation>GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
-      <source>GMT +01</source>
-      <translation>GMT +01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
-      <source>GMT +02</source>
-      <translation>GMT +02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
-      <source>GMT +03</source>
-      <translation>GMT +03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
-      <source>GMT +04</source>
-      <translation>GMT +04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
-      <source>GMT +05</source>
-      <translation>GMT +05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
-      <source>GMT +06</source>
-      <translation>GMT +06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
-      <source>GMT +07</source>
-      <translation>GMT +07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
-      <source>GMT +08</source>
-      <translation>GMT +08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
-      <source>GMT +09</source>
-      <translation>GMT +09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
-      <source>GMT +10</source>
-      <translation>GMT +10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
-      <source>GMT +11</source>
-      <translation>GMT +11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
-      <source>UTC</source>
-      <translation>UTC</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>Стандартний час GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>Стандартний час Центральної Європи</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>Центральноєвропейський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>Романський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>Західноєвропейський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>Східноєвропейський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>Стандартний час FLE</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>Стандартний час GTB</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>Білоруський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>Російський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>Стандартний час Туреччини</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>Маврикійський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>Стандартний час острова Різдва</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>Стандартний час Тонга</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>Стандартний час Фіджі</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>Новозеландський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>Центральний тихоокеанський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>Західний тихоокеанський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>Стандартний час Самоа</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>Гавайський стандартний час</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>Стандартний час острова Пасхи</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation type="unfinished">Внутрішня помилка</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation type="unfinished"/>
-    </message>
-  </context>
-  <context>
     <name>Wakespeed</name>
     <message>
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
@@ -13185,6 +12035,119 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
       <source>DC/DC misconfiguration</source>
       <translation>Неправильна конфігурація пост. ст./пост. ст.</translation>
+    </message>
+  </context>
+  <context>
+    <name>VebusError</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+      <source>Device switched off</source>
+      <translation>Пристрій вимкнено</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+      <source>Mixed old/new MK2</source>
+      <translation>Змішаний старий/новий MK2</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+      <source>Expected devices error</source>
+      <translation>Помилка очікуваних пристроїв</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+      <source>No other device detected</source>
+      <translation>Інший пристрій не виявлено</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+      <source>Overvoltage on AC-out</source>
+      <translation>Перенапруга на AC-out</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+      <source>DDC program error</source>
+      <translation>Помилка програми DDC</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+      <source>VE.Bus BMS without assistant</source>
+      <translation>VE.Bus BMS без асистента</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+      <source>Ground relay test failed</source>
+      <translation>Помилка тесту реле заземлення</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+      <source>System time sync error</source>
+      <translation>Помилка синхронізації системного часу</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+      <source>Grid relay test fault</source>
+      <translation>Помилка тесту реле мережі</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+      <source>Config mismatch with 2nd mcu</source>
+      <translation>Неузгодженість конфігурації з 2-м mcu</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+      <source>Device transmit error</source>
+      <translation>Помилка передачі пристрою</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+      <source>Awaiting configuration or dongle missing</source>
+      <translation>Очікування конфігурації або відсутній ключ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+      <source>Phase master missing</source>
+      <translation>Відсутній фазовий головний пристрій</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+      <source>Overvoltage has occurred</source>
+      <translation>Сталася перенапруга</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+      <source>Slave does not have AC input!</source>
+      <translation>Slave не має AC входу!</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+      <source>Device can't be slave</source>
+      <translation>Пристрій не може бути slave</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+      <source>System protection initiated</source>
+      <translation>Ініційовано захист системи</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+      <source>Firmware incompatibiltiy</source>
+      <translation>Несумісність прошивки</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+      <source>Internal error</source>
+      <translation>Внутрішня помилка</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+      <source>Failing relay test prevents connection</source>
+      <translation>Неуспішний тест реле перешкоджає з'єднанню</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+      <source>VE.Bus error</source>
+      <translation>Помилка VE.Bus</translation>
     </message>
   </context>
 </TS>

--- a/i18n/venus-gui-v2_zh_CN.ts
+++ b/i18n/venus-gui-v2_zh_CN.ts
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="zh_CN">
   <context>
-    <name/>
+    <name></name>
     <message id="switchable_output_disabled">
       <location filename="../../src/enums.cpp" line="478"/>
       <source>Disabled</source>
@@ -22,6 +22,7 @@
     <message id="solarchargers_state_off">
       <location filename="../../src/enums.cpp" line="331"/>
       <source>Off</source>
+      <extracomment>Digital input state</extracomment>
       <translation>关</translation>
     </message>
     <message id="common_words_auto">
@@ -52,18 +53,25 @@
     <message id="settings_startpage_none">
       <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="53"/>
       <source>None</source>
+      <extracomment>Indicates no phase</extracomment>
       <translation>无</translation>
     </message>
     <message id="common_words_position_ac">
       <location filename="../../components/CommonWords.qml" line="416"/>
       <source>Position</source>
-      <extracomment>AC input or output position</extracomment>
+      <extracomment>EVCS AC input/output position</extracomment>
       <translation>位置</translation>
     </message>
     <message id="settings_minmax_speed">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="193"/>
       <source>Speed</source>
+      <extracomment>A speed measurement value</extracomment>
       <translation>速度</translation>
+    </message>
+    <message id="common_words_state">
+      <location filename="../../components/CommonWords.qml" line="502"/>
+      <source>State</source>
+      <translation>状态</translation>
     </message>
     <message id="settings_firmware_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="67"/>
@@ -101,8 +109,8 @@
       <source>Solar yield</source>
       <translation>太阳能发电量</translation>
     </message>
-    <message id="ess_state_external_control">
-      <location filename="../../data/Ess.qml" line="41"/>
+    <message id="inverters_state_externalccontrol">
+      <location filename="../../data/System.qml" line="183"/>
       <source>External control</source>
       <translation>外部控制</translation>
     </message>
@@ -140,6 +148,11 @@
       <location filename="../../components/CommonWords.qml" line="203"/>
       <source>ESS</source>
       <translation>ESS储能系统</translation>
+    </message>
+    <message id="pagesettingsconnectivity_ethernet">
+      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
+      <source>Ethernet</source>
+      <translation>以太网</translation>
     </message>
     <message id="pagesettingsconnectivity_wifi">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="28"/>
@@ -262,11 +275,6 @@
       <source>Name</source>
       <translation>名字</translation>
     </message>
-    <message id="settings_deviceinfo_name">
-      <location filename="../../pages/settings/PageDeviceInfo.qml" line="38"/>
-      <source>Name</source>
-      <translation type="unfinished">名字</translation>
-    </message>
     <message id="settings_deviceinfo_product_id">
       <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
       <source>Product ID</source>
@@ -327,15 +335,20 @@
       <source>Daily run time</source>
       <translation>每日运行时间</translation>
     </message>
+    <message id="common_words_value_must_be_greater_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="560"/>
+      <source>Value must be greater than stop value</source>
+      <translation>数值必须大于停止值</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="563"/>
+      <source>Value must be lower than start value</source>
+      <translation>数值必须低于启动值</translation>
+    </message>
     <message id="settings_minmax_acout_max_power">
       <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="124"/>
       <source>AC output</source>
       <translation>交流输出</translation>
-    </message>
-    <message id="ac_output">
-      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="15"/>
-      <source>AC output</source>
-      <translation type="unfinished">交流输出</translation>
     </message>
     <message id="page_generator_ac_load_use_ac_load">
       <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="25"/>
@@ -382,16 +395,6 @@
       <source>Unavailable monitor, set another</source>
       <translation>监测仪不可用，设置另一监测仪</translation>
     </message>
-    <message id="page_generator_conditions_battery_monitor">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="42"/>
-      <source>Battery monitor</source>
-      <translation type="unfinished">电池监测器</translation>
-    </message>
-    <message id="page_generator_conditions_unavailable_monitor_set_another">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="44"/>
-      <source>Unavailable monitor, set another</source>
-      <translation type="unfinished">监测仪不可用，设置另一监测仪</translation>
-    </message>
     <message id="page_generator_conditions_on_loss_of_communication">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="68"/>
       <source>On loss of communication</source>
@@ -416,11 +419,6 @@
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="105"/>
       <source>Battery SOC</source>
       <translation>电池SOC</translation>
-    </message>
-    <message id="page_generator_conditions_periodic_run">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="173"/>
-      <source>Periodic run</source>
-      <translation type="unfinished">定期运行</translation>
     </message>
     <message id="settings_inverter_high_temperature">
       <location filename="../../data/Generators.qml" line="83"/>
@@ -505,7 +503,7 @@
     <message id="settings_gps_speed_kmh">
       <location filename="../../pages/settings/PageGps.qml" line="83"/>
       <source>%1 km/h</source>
-      <extracomment>GPS speed data, in kilometres per hour</extracomment>
+      <extracomment>GPS speed data, in kilometers per hour</extracomment>
       <translation>%1 公里/小时</translation>
     </message>
     <message id="settings_gps_speed_mph">
@@ -523,7 +521,7 @@
     <message id="settings_gps_speed_ms">
       <location filename="../../pages/settings/PageGps.qml" line="95"/>
       <source>%1 m/s</source>
-      <extracomment>GPS speed data, in metres per second</extracomment>
+      <extracomment>GPS speed data, in meters per second</extracomment>
       <translation>%1 米/秒</translation>
     </message>
     <message id="settings_gps_course">
@@ -580,21 +578,6 @@
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="64"/>
       <source>%1 (Output %2)</source>
       <translation>%1（输出%2）</translation>
-    </message>
-    <message id="settings_batteries_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="88"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">主动式电池监测器</translation>
-    </message>
-    <message id="settings_batteries_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="101"/>
-      <source>Name</source>
-      <translation type="unfinished">名字</translation>
-    </message>
-    <message id="settings_batteries_enter_name">
-      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="103"/>
-      <source>Enter name</source>
-      <translation type="unfinished">输入名称</translation>
     </message>
     <message id="settings_briefview_center_active_battery_monitor">
       <location filename="../../components/listitems/ListBriefCenterDetails.qml" line="27"/>
@@ -656,45 +639,25 @@
       <source>CAN-bus profile</source>
       <translation>CAN总线配置文件</translation>
     </message>
-    <message id="settings_disabled">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="31"/>
-      <source>Disabled</source>
-      <translation type="unfinished">已禁用</translation>
-    </message>
-    <message id="settings_canbus_vecan_lynx_ion_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
-      <source>VE.Can &amp; Lynx Ion BMS (250 kbit/s)</source>
-      <translation>VE.Can &amp; Lynx Ion BMS(250 kbit/s)</translation>
-    </message>
     <message id="settings_canbus_vecan_and_can_bus_bms">
       <location filename="../../pages/settings/CanbusProfile.qml" line="42"/>
       <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
       <translation>VE.Can &amp; CAN-bus BMS(250 kbit/s)</translation>
     </message>
     <message id="settings_oceanvolt">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
       <source>Oceanvolt (250 kbit/s)</source>
       <translation>Oceanvolt (250 kbit/s)</translation>
     </message>
     <message id="settings_rvc">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
       <source>RV-C (250 kbit/s)</source>
       <translation>RV-C (250 kbit/s)</translation>
     </message>
     <message id="settings_up_bu_no_services">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
       <source>Up, but no services (250 kbit/s)</source>
       <translation>正常运行，但无服务（250 kbit/s）</translation>
-    </message>
-    <message id="settings_canopen_motordrive_250">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
-      <source>CANopen Motor drive (250 kbit/s)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_canopen_motordrive_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
-      <source>CANopen Motor drive (500 kbit/s)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_devices">
       <location filename="../../components/CommonWords.qml" line="166"/>
@@ -731,11 +694,6 @@
       <source>Check Unique id numbers</source>
       <translation>检查唯一ID编号</translation>
     </message>
-    <message id="settings_canbus_unique_id_press_to_check">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="112"/>
-      <source>Press to check</source>
-      <translation type="unfinished">按下查看</translation>
-    </message>
     <message id="settings_canbus_unique_id_conflict">
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="125"/>
       <source>There is another device connected with this unique number, please select a new number.</source>
@@ -745,11 +703,6 @@
       <location filename="../../pages/settings/PageSettingsCanbus.qml" line="133"/>
       <source>OK: No other device is connected with this unique number.</source>
       <translation>可以：没有其他设备与此唯一编号连接。</translation>
-    </message>
-    <message id="pagesettingsintegrations_canopenmotordrive">
-      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
-      <source>CANopen motor drives</source>
-      <translation type="unfinished"/>
     </message>
     <message id="common_words_network_status">
       <location filename="../../components/CommonWords.qml" line="349"/>
@@ -884,11 +837,6 @@
       <source>Unavailable sensor, set another</source>
       <translation>传感器不可用，请另设置一个</translation>
     </message>
-    <message id="settings_system_unavailable_sensor">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="81"/>
-      <source>Unavailable sensor, set another</source>
-      <translation type="unfinished">传感器不可用，请另设置一个</translation>
-    </message>
     <message id="settings_dvcc_used_sensor">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="120"/>
       <source>Used sensor</source>
@@ -945,12 +893,6 @@
       <source>Auto selected</source>
       <translation>自动选择</translation>
     </message>
-    <message id="settings_dvcc_auto_selected_none">
-      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="208"/>
-      <source>None</source>
-      <extracomment>Indicates no option is selected</extracomment>
-      <translation type="unfinished">无</translation>
-    </message>
     <message id="settings_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
       <source>Build date/time</source>
@@ -986,12 +928,6 @@
       <source>Installing %1</source>
       <extracomment>%1 = firmware version</extracomment>
       <translation>正在安装 %1</translation>
-    </message>
-    <message id="settings_firmware_offline_press_to_install">
-      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="36"/>
-      <source>Press to update to %1</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">按下更新到%1</translation>
     </message>
     <message id="settings_firmware_online_press_to_update_to">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="90"/>
@@ -1062,12 +998,6 @@
       <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
       <translation>正在安装 %1 %2%</translation>
     </message>
-    <message id="settings_firmware_online_installing">
-      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="86"/>
-      <source>Installing %1...</source>
-      <extracomment>%1 = firmware version</extracomment>
-      <translation type="unfinished">正在安装 %1...</translation>
-    </message>
     <message id="settings_firmware_update_build_date_time">
       <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="109"/>
       <source>Update build date/time</source>
@@ -1097,11 +1027,6 @@
       <location filename="../../pages/settings/PageSettingsFronius.qml" line="56"/>
       <source>TCP port</source>
       <translation>TCP端口</translation>
-    </message>
-    <message id="page_settings_fronius_modbus_settings">
-      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
-      <source>Modbus port and unit ID settings</source>
-      <translation type="unfinished"/>
     </message>
     <message id="page_settings_fronius_inverter_multiphase">
       <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
@@ -1153,16 +1078,6 @@
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="64"/>
       <source>AC-Out MP</source>
       <translation>交流输出 MP</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_l">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="52"/>
-      <source>AC-In1 L%1</source>
-      <translation type="unfinished">AC-In1 L%1</translation>
-    </message>
-    <message id="page_setting_fronius_inverters_ac_in1_phase_unknown">
-      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="56"/>
-      <source>AC-In1 --</source>
-      <translation type="unfinished">AC-In1 --</translation>
     </message>
     <message id="page_setting_fronius_inverters_ac_out_l">
       <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="70"/>
@@ -1330,12 +1245,6 @@
       <source>Reset service timer</source>
       <translation>重置服务计时器</translation>
     </message>
-    <message id="components_volumeunit_volume">
-      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
-      <source>Volume</source>
-      <extracomment>Title for a list of units of volume (e.g. cubic metres, litres, gallons)</extracomment>
-      <translation type="unfinished">容积</translation>
-    </message>
     <message id="settings_gps_format">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="69"/>
       <source>Format</source>
@@ -1438,42 +1347,6 @@ If that doesn't work, check sim-card in a phone to make sure that there is credi
       <source>Wrong PIN</source>
       <translation>密码错误</translation>
     </message>
-    <message id="page_settings_gsm_ok">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="125"/>
-      <source>OK</source>
-      <translation type="unfinished">正常</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="128"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">未知错误</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_state">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="153"/>
-      <source>Unknown</source>
-      <translation type="unfinished">未知</translation>
-    </message>
-    <message id="page_settings_gsm_unknown_value">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="182"/>
-      <source>Unknown</source>
-      <translation type="unfinished">未知</translation>
-    </message>
-    <message id="page_settings_gsm_offline">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="173"/>
-      <source>Offline</source>
-      <translation type="unfinished">离线</translation>
-    </message>
-    <message id="page_settings_gsm_connecting">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="176"/>
-      <source>Connecting</source>
-      <translation type="unfinished">正在连接</translation>
-    </message>
-    <message id="page_settings_gsm_connected">
-      <location filename="../../pages/settings/PageSettingsGsm.qml" line="179"/>
-      <source>Connected</source>
-      <translation type="unfinished">已连接</translation>
-    </message>
     <message id="page_settings_gsm_pin">
       <location filename="../../pages/settings/PageSettingsGsm.qml" line="191"/>
       <source>PIN</source>
@@ -1530,32 +1403,32 @@ If that doesn't work, check sim-card in a phone to make sure that there is credi
       <translation>电网供电量统计</translation>
     </message>
     <message id="settings_ess_external_meter">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
       <source>External meter</source>
       <translation>外部计量表</translation>
     </message>
     <message id="settings_ess_inverter_charger">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="67"/>
       <source>Inverter/Charger</source>
       <translation>逆变器/充电器</translation>
     </message>
     <message id="settings_ess_multiphase_regulation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="84"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
       <source>Multiphase regulation</source>
       <translation>多相调节</translation>
     </message>
     <message id="settings_ess_phase_compensation">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="91"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
       <source>Total of all phases</source>
       <translation>所有相位总计</translation>
     </message>
     <message id="settings_ess_individual_phase">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="95"/>
       <source>Individual phase</source>
       <translation>每个相位</translation>
     </message>
     <message id="settings_ess_multiphase_split_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="99"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="101"/>
       <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
 
 CAUTION: Use only if required by the utility provider.</source>
@@ -1564,68 +1437,13 @@ CAUTION: Use only if required by the utility provider.</source>
 注意：仅在电力公司要求时使用。</translation>
     </message>
     <message id="settings_ess_multiphase_total_notif">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="102"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="104"/>
       <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
 
 Use unless prohibited by the utility provider.</source>
       <translation>智能调节所有相位的总和，以达到电网设定点（优化系统效率）。
 
 除非电力公司禁止，否则请使用。</translation>
-    </message>
-    <message id="settings_ess_min_soc">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="111"/>
-      <source>Minimum SOC (unless grid fails)</source>
-      <translation type="unfinished">最低放电量（除非电网故障）</translation>
-    </message>
-    <message id="settings_ess_active_soc_limit">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="129"/>
-      <source>Active SOC limit</source>
-      <translation type="unfinished">实际充电状态限制</translation>
-    </message>
-    <message id="settings_ess_battery_life_sustain">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
-      <source>Sustain</source>
-      <translation type="unfinished">维持</translation>
-    </message>
-    <message id="settings_ess_battery_life_recharge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="157"/>
-      <source>Recharge</source>
-      <translation type="unfinished">重新充电</translation>
-    </message>
-    <message id="settings_ess_scheduled_charge_levels">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="254"/>
-      <source>Scheduled charge levels</source>
-      <translation type="unfinished">预定的充电水平</translation>
-    </message>
-    <message id="settings_ess_active">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="257"/>
-      <source>Active (%1)</source>
-      <translation type="unfinished">活动 (%1)</translation>
-    </message>
-    <message id="settings_ess_inactive">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="259"/>
-      <source>Inactive</source>
-      <translation type="unfinished">不激活</translation>
-    </message>
-    <message id="settings_ess_dynamic">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="293"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">动态ESS</translation>
-    </message>
-    <message id="settings_ess_deprecated">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="319"/>
-      <source>Deprecated settings</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_charge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="326"/>
-      <source>Battery charge limit (% of CCL)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_ess_max_discharge_percentage">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="337"/>
-      <source>Battery discharge limit (% of DCL)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_rs_ess_min_soc">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="40"/>
@@ -1637,13 +1455,8 @@ Use unless prohibited by the utility provider.</source>
       <source>Active SOC limit</source>
       <translation>实际充电状态限制</translation>
     </message>
-    <message id="scheduled_charge_inactive">
-      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
-      <source>Inactive</source>
-      <translation type="unfinished">不激活</translation>
-    </message>
     <message id="settings_ess_peak_shaving">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="245"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="247"/>
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
       <source>Peak shaving</source>
       <translation>削峰</translation>
@@ -1659,12 +1472,12 @@ Use unless prohibited by the utility provider.</source>
       <translation>总是</translation>
     </message>
     <message id="settings_ess_battery_life_discharge_disabled">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="151"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
       <source>Discharge disabled</source>
       <translation>放电已禁用</translation>
     </message>
     <message id="settings_ess_battery_life_slow_charge">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="153"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="155"/>
       <source>Slow charge</source>
       <translation>慢冲</translation>
     </message>
@@ -1679,32 +1492,32 @@ Use unless prohibited by the utility provider.</source>
       <translation>重新充电</translation>
     </message>
     <message id="settings_ess_limit_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="165"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="167"/>
       <source>Limit charge power</source>
       <translation>限制充电功率</translation>
     </message>
     <message id="settings_ess_max_charge_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="183"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="185"/>
       <source>Maximum charge power</source>
       <translation>最大充电功率</translation>
     </message>
     <message id="settings_ess_limit_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="196"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="198"/>
       <source>Limit inverter power</source>
       <translation>限制逆变器功率</translation>
     </message>
     <message id="settings_ess_max_inverter_power">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="214"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="216"/>
       <source>Maximum inverter power</source>
       <translation>最大逆变器功率</translation>
     </message>
     <message id="settings_ess_grid_setpoint">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="225"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="227"/>
       <source>Grid setpoint</source>
       <translation>电网设定点</translation>
     </message>
     <message id="settings_ess_grid_feed_in">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="234"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="236"/>
       <source>Grid feed-in</source>
       <translation>上网</translation>
     </message>
@@ -1743,8 +1556,8 @@ Use unless prohibited by the utility provider.</source>
       <source>Door alarm</source>
       <translation>门铃</translation>
     </message>
-    <message id="digitalinputs_type_bilgepump">
-      <location filename="../../src/enums.cpp" line="201"/>
+    <message id="switchable_output_bilge_pump">
+      <location filename="../../src/enums.cpp" line="424"/>
       <source>Bilge pump</source>
       <translation>舱底泵</translation>
     </message>
@@ -1796,11 +1609,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Deferred by %1s</source>
       <extracomment>%1 = number of seconds</extracomment>
       <translation>推迟 %1s</translation>
-    </message>
-    <message id="settings_vrm_portal_mode_confirm_title">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="75"/>
-      <source>Are you sure?</source>
-      <translation type="unfinished">你确定吗？</translation>
     </message>
     <message id="settings_vrm_portal_id">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="87"/>
@@ -1939,11 +1747,6 @@ Use unless prohibited by the utility provider.</source>
       <source>External storage</source>
       <translation>外部存储</translation>
     </message>
-    <message id="settings_vrm_unknown_error">
-      <location filename="../../pages/settings/PageSettingsLogger.qml" line="308"/>
-      <source>Unknown error</source>
-      <translation type="unfinished">未知错误</translation>
-    </message>
     <message id="settings_vrm_no_error">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="311"/>
       <source>No Error</source>
@@ -2029,37 +1832,10 @@ Use unless prohibited by the utility provider.</source>
       <source>Function</source>
       <translation>功能</translation>
     </message>
-    <message id="settings_relay_disabled">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="54"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="98"/>
-      <source>Disabled</source>
-      <translation type="unfinished">已禁用</translation>
-    </message>
     <message id="settings_relay_alarm_relay">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="56"/>
       <source>Alarm relay</source>
       <translation>报警继电器</translation>
-    </message>
-    <message id="settings_relay_tank_pump">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="62"/>
-      <source>Tank pump</source>
-      <translation type="unfinished">水箱泵</translation>
-    </message>
-    <message id="settings_relay_manual">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="64"/>
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="100"/>
-      <source>Manual</source>
-      <translation type="unfinished">手动</translation>
-    </message>
-    <message id="settings_relay_polarity_relay1">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
-      <source>Polarity (Relay 1)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_relay_polarity">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
-      <source>Polarity</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_normally_open">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="83"/>
@@ -2075,11 +1851,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="93"/>
       <source>Function (Relay 2)</source>
       <translation>功能（继电器2）</translation>
-    </message>
-    <message id="settings_relay_polarity_relay2">
-      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
-      <source>Polarity (Relay 2)</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_relay_temp_control_rules">
       <location filename="../../pages/settings/PageSettingsRelay.qml" line="119"/>
@@ -2111,12 +1882,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
       <source>Press to boot</source>
       <translation>按下重启</translation>
-    </message>
-    <message id="settings_firmware_backup_version">
-      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="59"/>
-      <source>Firmware %1 (%2)</source>
-      <extracomment>%1 = backup version, %2 = backup version build number</extracomment>
-      <translation type="unfinished">固件%1 (%2)</translation>
     </message>
     <message id="settings_firmware_rebooting_to">
       <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
@@ -2152,6 +1917,7 @@ Use unless prohibited by the utility provider.</source>
     <message id="nav_boat">
       <location filename="../../pages/boat/BoatPage.qml" line="14"/>
       <source>Boat</source>
+      <extracomment>The 'Boat' page</extracomment>
       <translation>船</translation>
     </message>
     <message id="settings_system_name">
@@ -2219,11 +1985,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Solar charger current control</source>
       <translation>太阳能充电器电流控制</translation>
     </message>
-    <message id="settings_system_status_bms_params">
-      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="44"/>
-      <source>BMS control</source>
-      <translation type="unfinished">BMS控制</translation>
-    </message>
     <message id="common_words_bms_control">
       <location filename="../../components/CommonWords.qml" line="101"/>
       <source>BMS control</source>
@@ -2238,11 +1999,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
       <source>Pump state</source>
       <translation>泵状态</translation>
-    </message>
-    <message id="settings_pump_auto">
-      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="56"/>
-      <source>Auto</source>
-      <translation type="unfinished">自动</translation>
     </message>
     <message id="settings_tank_sensor">
       <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
@@ -2271,11 +2027,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="35"/>
       <source>Unplugged</source>
       <translation>未插电</translation>
-    </message>
-    <message id="settings_tcpip_name">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="16"/>
-      <source>Name</source>
-      <translation type="unfinished">名字</translation>
     </message>
     <message id="settings_tcpip_hidden">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="21"/>
@@ -2317,16 +2068,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="99"/>
       <source>IP configuration</source>
       <translation>IP配置</translation>
-    </message>
-    <message id="settings_tcpip_manual">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="105"/>
-      <source>Manual</source>
-      <translation type="unfinished">手动</translation>
-    </message>
-    <message id="settings_tcpip_off">
-      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="107"/>
-      <source>Off</source>
-      <translation type="unfinished">关</translation>
     </message>
     <message id="settings_tcpip_fixed">
       <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="109"/>
@@ -2382,21 +2123,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="30"/>
       <source>Create access point</source>
       <translation>创建接入点</translation>
-    </message>
-    <message id="settings_wifi_access_point_enter_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="68"/>
-      <source>Enter password</source>
-      <translation type="unfinished">输入密码</translation>
-    </message>
-    <message id="page_settings_wifi_invalid_password">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
-      <source>Password length must be either 0 or between 10 and 63 characters long</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_wifi_password_updated">
-      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
-      <source>Password updated</source>
-      <translation type="unfinished"/>
     </message>
     <message id="settings_wifi_networks">
       <location filename="../../pages/settings/PageSettingsWifi.qml" line="86"/>
@@ -2539,20 +2265,10 @@ Use unless prohibited by the utility provider.</source>
       <extracomment>Network status: Standalone</extracomment>
       <translation>单机</translation>
     </message>
-    <message id="charger_standalone">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="45"/>
-      <source>Standalone</source>
-      <translation type="unfinished">单机</translation>
-    </message>
     <message id="charger_charge">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="48"/>
       <source>Charge</source>
       <translation>充电</translation>
-    </message>
-    <message id="charger_external_control">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="51"/>
-      <source>External control</source>
-      <translation type="unfinished">外部控制</translation>
     </message>
     <message id="charger_charge_hub_1">
       <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="54"/>
@@ -2584,16 +2300,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Master setting</source>
       <translation>主机设置</translation>
     </message>
-    <message id="charger_slave">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="85"/>
-      <source>Slave</source>
-      <translation type="unfinished">从机</translation>
-    </message>
-    <message id="charger_charge_voltage">
-      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
-      <source>Charge voltage</source>
-      <translation type="unfinished">充电电压</translation>
-    </message>
     <message id="systemsettings_networkstatus_slave">
       <location filename="../../data/SystemSettings.qml" line="148"/>
       <source>Slave</source>
@@ -2615,14 +2321,15 @@ Use unless prohibited by the utility provider.</source>
       <source>Group &amp; Charge master</source>
       <translation>组&amp;充电主机</translation>
     </message>
-    <message id="genset_charge_voltage">
-      <location filename="../../components/PageGensetModel.qml" line="365"/>
+    <message id="charger_charge_voltage">
+      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
       <source>Charge voltage</source>
       <translation>充电电压</translation>
     </message>
     <message id="common_words_reset">
       <location filename="../../components/CommonWords.qml" line="448"/>
       <source>Reset</source>
+      <extracomment>Reset the BMS control</extracomment>
       <translation>重置</translation>
     </message>
     <message id="solarcharger_load">
@@ -2651,14 +2358,14 @@ Use unless prohibited by the utility provider.</source>
       <extracomment>Voltage alarm is at "Warning" level</extracomment>
       <translation>警告</translation>
     </message>
-    <message id="listitems_alarm_level_alarm">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="25"/>
+    <message id="digitalinputs_state_alarm">
+      <location filename="../../src/enums.cpp" line="270"/>
       <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
+      <extracomment>Relay function is 'alarm'</extracomment>
       <translation>报警</translation>
     </message>
-    <message id="devicelist_tankshape_volume">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="190"/>
+    <message id="components_volumeunit_volume">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="35"/>
       <source>Volume</source>
       <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
       <translation>容积</translation>
@@ -2808,26 +2515,10 @@ Use unless prohibited by the utility provider.</source>
       <source>Relay function</source>
       <translation>继电器功能</translation>
     </message>
-    <message id="batterysettingrelay_alarm">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="31"/>
-      <source>Alarm</source>
-      <extracomment>Relay function is 'alarm'</extracomment>
-      <translation type="unfinished">报警</translation>
-    </message>
     <message id="batterysettingrelay_charger_or_generator_start_stop">
       <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
       <source>Charger or generator start/stop</source>
       <translation>充电器或发动机启/停</translation>
-    </message>
-    <message id="batterysettingrelay_manual_control">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="35"/>
-      <source>Manual control</source>
-      <translation type="unfinished">手动控制</translation>
-    </message>
-    <message id="batterysettingrelay_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="122"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">保险熔断</translation>
     </message>
     <message id="common_words_manual_control">
       <location filename="../../components/CommonWords.qml" line="302"/>
@@ -2853,12 +2544,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="18"/>
       <source>Status LEDs</source>
       <translation>状态指示灯</translation>
-    </message>
-    <message id="batterydiagnostics_none">
-      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="42"/>
-      <source>None</source>
-      <extracomment>Indicates no alarm is set</extracomment>
-      <translation type="unfinished">无</translation>
     </message>
     <message id="batterydiagnostics_main_switch">
       <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="48"/>
@@ -2888,7 +2573,7 @@ Use unless prohibited by the utility provider.</source>
     <message id="common_words_switch">
       <location filename="../../components/CommonWords.qml" line="525"/>
       <source>Switch</source>
-      <extracomment>Change the mode value</extracomment>
+      <extracomment>Change the battery mode</extracomment>
       <translation>开关</translation>
     </message>
     <message id="devicelist_battery_initializing">
@@ -2956,21 +2641,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Top section voltage</source>
       <translation>顶边电压</translation>
     </message>
-    <message id="battery_bank_error_communication">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="96"/>
-      <source>Communication error</source>
-      <translation type="unfinished">通信错误</translation>
-    </message>
-    <message id="battery_state_of_health">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="182"/>
-      <source>State of health</source>
-      <translation type="unfinished">健康状态</translation>
-    </message>
-    <message id="battery_bus_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="212"/>
-      <source>Bus voltage</source>
-      <translation type="unfinished">总线电压</translation>
-    </message>
     <message id="battery_bottom_section_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="228"/>
       <source>Bottom section voltage</source>
@@ -3016,16 +2686,6 @@ Use unless prohibited by the utility provider.</source>
       <source>IO</source>
       <translation>IO</translation>
     </message>
-    <message id="battery_settings_system">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="391"/>
-      <source>System</source>
-      <translation type="unfinished">系统</translation>
-    </message>
-    <message id="battery_press_to_redetect">
-      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="433"/>
-      <source>Press to redetect</source>
-      <translation type="unfinished">按下重新检测</translation>
-    </message>
     <message id="pagesettingsgeneral_system">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="107"/>
       <source>System</source>
@@ -3066,16 +2726,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Low SOC</source>
       <translation>SOC低</translation>
     </message>
-    <message id="batteryalarms_high_battery_voltage">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="24"/>
-      <source>High battery voltage</source>
-      <translation type="unfinished">电池电压高</translation>
-    </message>
-    <message id="batteryalarms_low_soc">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="59"/>
-      <source>Low SOC</source>
-      <translation type="unfinished">SOC低</translation>
-    </message>
     <message id="batteryalarms_low_starter_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="73"/>
       <source>Low starter voltage</source>
@@ -3095,11 +2745,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
       <source>Mid-point voltage</source>
       <translation>中间点电压</translation>
-    </message>
-    <message id="batteryalarms_fuse_blown">
-      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="113"/>
-      <source>Fuse blown</source>
-      <translation type="unfinished">保险熔断</translation>
     </message>
     <message id="batteryalarms_high_internal_temperature">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
@@ -3293,11 +2938,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Restore factory defaults</source>
       <translation>恢复出厂默认设置</translation>
     </message>
-    <message id="batterysettings_press_to_restore">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="68"/>
-      <source>Press to restore</source>
-      <translation type="unfinished">按下恢复</translation>
-    </message>
     <message id="vebus_backup_press_to_restore">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="362"/>
       <source>Press to restore</source>
@@ -3337,11 +2977,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="18"/>
       <source>Capacity</source>
       <translation>容量</translation>
-    </message>
-    <message id="batterysettingsbattery_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="39"/>
-      <source>Capacity</source>
-      <translation type="unfinished">容量</translation>
     </message>
     <message id="batterysettingsbattery_charged_voltage">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
@@ -3418,11 +3053,6 @@ Use unless prohibited by the utility provider.</source>
       <source>No power on busbar</source>
       <translation>母排无供电</translation>
     </message>
-    <message id="lynxdistributor_connection_lost">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="49"/>
-      <source>Connection lost</source>
-      <translation type="unfinished">连接丢失</translation>
-    </message>
     <message id="lynxdistributor_count_fuses_blown" numerus="yes">
       <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
       <source>%n fuse(s) blown</source>
@@ -3457,26 +3087,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Shutdowns due error</source>
       <translation>出错关机</translation>
     </message>
-    <message id="lynxiondiagnostics_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="29"/>
-      <source>Last error</source>
-      <translation type="unfinished">上次出错</translation>
-    </message>
-    <message id="lynxiondiagnostics_2nd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="31"/>
-      <source>2nd last error</source>
-      <translation type="unfinished">第二次出错</translation>
-    </message>
-    <message id="lynxiondiagnostics_3rd_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="33"/>
-      <source>3rd last error</source>
-      <translation type="unfinished">第三次出错</translation>
-    </message>
-    <message id="lynxiondiagnostics_4th_last_error">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="35"/>
-      <source>4th last error</source>
-      <translation type="unfinished">第四次出错</translation>
-    </message>
     <message id="lynxionio_system_switch">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
       <source>System Switch</source>
@@ -3496,11 +3106,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../components/CommonWords.qml" line="54"/>
       <source>Batteries</source>
       <translation>电池</translation>
-    </message>
-    <message id="lynxionsystem_capacity">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="18"/>
-      <source>Capacity</source>
-      <translation type="unfinished">容量</translation>
     </message>
     <message id="lynxionsystem_parallel">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="30"/>
@@ -3522,20 +3127,10 @@ Use unless prohibited by the utility provider.</source>
       <source>Min/max cell temperature</source>
       <translation>最低/最高电芯温度</translation>
     </message>
-    <message id="lynxionsystem_balancing">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="92"/>
-      <source>Balancing</source>
-      <translation type="unfinished">均衡中</translation>
-    </message>
     <message id="lynxionsystem_balancer_balancing">
       <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="110"/>
       <source>Balancing</source>
       <translation>均衡中</translation>
-    </message>
-    <message id="lynxionsystem_balancer_unknown">
-      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="117"/>
-      <source>Unknown</source>
-      <translation type="unfinished">未知</translation>
     </message>
     <message id="dc_output">
       <location filename="../../components/listitems/ListDcOutputQuantityGroup.qml" line="16"/>
@@ -3643,11 +3238,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Remaining</source>
       <translation>剩余</translation>
     </message>
-    <message id="devicelist_tanksensor_sensor_battery">
-      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="51"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">感应器电池</translation>
-    </message>
     <message id="temperature_sensor_battery">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="112"/>
       <source>Sensor battery</source>
@@ -3676,7 +3266,7 @@ Use unless prohibited by the utility provider.</source>
     <message id="devicelist_tanksetup_custom">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="53"/>
       <source>Custom</source>
-      <translation type="unfinished">自定义</translation>
+      <translation>自定义</translation>
     </message>
     <message id="devicelist_tanksetup_sensor_value_when_empty">
       <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="59"/>
@@ -3709,34 +3299,34 @@ Use unless prohibited by the utility provider.</source>
       <translation>感应器数值</translation>
     </message>
     <message id="devicelist_tankshape_empty">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="77"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="75"/>
       <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
       <translation>未定义自定义形状。您最多可以定义 10 个点。请注意，0% 和 100% 是隐含的。</translation>
     </message>
     <message id="devicelist_tankshape_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="91"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="89"/>
       <source>Point %1</source>
       <extracomment>%1 = the point number</extracomment>
       <translation>点 %1</translation>
     </message>
     <message id="devicelist_tankshape_add_point">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="133"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="179"/>
       <source>Add point</source>
       <translation>添加点</translation>
     </message>
     <message id="devicelist_tankshape_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="156"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="205"/>
       <source>Sensor level</source>
       <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
       <translation>传感器液位</translation>
     </message>
     <message id="devicelist_tankshape_duplicate_sensor_level">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="256"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="311"/>
       <source>Duplicate sensor level values are not allowed.</source>
       <translation>不允许重复传感器数值。</translation>
     </message>
     <message id="devicelist_tankshape_volume_not_increasing">
-      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="262"/>
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="317"/>
       <source>Volume values must be increasing.</source>
       <translation>体积值必须不断增加。</translation>
     </message>
@@ -3776,11 +3366,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Switch position</source>
       <translation>开关位置</translation>
     </message>
-    <message id="ac-in-setup_single_phase">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="142"/>
-      <source>Single phase</source>
-      <translation type="unfinished">单相</translation>
-    </message>
     <message id="ac-in-setup_two_phase">
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="144"/>
       <source>2-phase</source>
@@ -3790,11 +3375,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="146"/>
       <source>3-phase</source>
       <translation>三相</translation>
-    </message>
-    <message id="ac-in-setup_devices">
-      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="161"/>
-      <source>Devices</source>
-      <translation type="unfinished">设备</translation>
     </message>
     <message id="ac-in-genset_ac">
       <location filename="../../components/PageGensetModel.qml" line="194"/>
@@ -3888,12 +3468,6 @@ Use unless prohibited by the utility provider.</source>
       <extracomment>%1 = CT device number</extracomment>
       <translation>CT %1</translation>
     </message>
-    <message id="smappeect_phase_none">
-      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="53"/>
-      <source>None</source>
-      <extracomment>Indicates no phase</extracomment>
-      <translation type="unfinished">无</translation>
-    </message>
     <message id="smappeect_flashing_led_indicates_this_ct">
       <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
       <source>Flashing LED indicates this CT</source>
@@ -3907,11 +3481,13 @@ Use unless prohibited by the utility provider.</source>
     <message id="common_words_setting_disabled_when_dmc_connected">
       <location filename="../../components/CommonWords.qml" line="355"/>
       <source>This setting is disabled when a Digital Multi Control is connected.</source>
+      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>连接数字多功能控制器时，此设置将被禁用。</translation>
     </message>
     <message id="common_words_setting_disabled_when_bms_connected">
       <location filename="../../components/CommonWords.qml" line="358"/>
       <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
       <translation>连接 VE.Bus BMS 时，此设置将被禁用。</translation>
     </message>
     <message id="settings_multirs_ac_in_phase">
@@ -3929,16 +3505,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="21"/>
       <source>Inverted</source>
       <translation>倒置</translation>
-    </message>
-    <message id="digitalinput_enable_alarm">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="48"/>
-      <source>Enable alarm</source>
-      <translation type="unfinished">启用报警</translation>
-    </message>
-    <message id="digitalinput_inverted">
-      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="54"/>
-      <source>Inverted</source>
-      <translation type="unfinished">倒置</translation>
     </message>
     <message id="digitalinput_invert_alarm_logic">
       <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="60"/>
@@ -3975,16 +3541,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Wind speed</source>
       <translation>风速</translation>
     </message>
-    <message id="page_meteo_battery_voltage">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="99"/>
-      <source>Sensor battery</source>
-      <translation type="unfinished">感应器电池</translation>
-    </message>
-    <message id="meteo_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="120"/>
-      <source>Low</source>
-      <translation type="unfinished">低</translation>
-    </message>
     <message id="page_meteo_settings_auto_detect">
       <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
       <source>Auto-detect</source>
@@ -4015,16 +3571,6 @@ Use unless prohibited by the utility provider.</source>
       <source>Reset counter</source>
       <translation>复位计数器</translation>
     </message>
-    <message id="temperature_short_circuited">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="32"/>
-      <source>Short circuited</source>
-      <translation type="unfinished">短路</translation>
-    </message>
-    <message id="temperature_reverse_polarity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="35"/>
-      <source>Reverse polarity</source>
-      <translation type="unfinished">极性接反</translation>
-    </message>
     <message id="temperature_sensor_battery_low">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="38"/>
       <source>Sensor battery low</source>
@@ -4039,36 +3585,6 @@ Use unless prohibited by the utility provider.</source>
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="62"/>
       <source>Pressure</source>
       <translation>压力</translation>
-    </message>
-    <message id="temperature_pm25">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
-      <source>PM2.5</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_co2">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
-      <source>CO₂</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_voc">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
-      <source>VOC index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_nox">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
-      <source>NOx index</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_luminosity">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
-      <source>Luminosity</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="temperature_sensor_battery_status_low">
-      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="133"/>
-      <source>Low</source>
-      <translation type="unfinished">低</translation>
     </message>
     <message id="temperature_offset">
       <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
@@ -4122,25 +3638,10 @@ NOTE: The update might temporarily stop the system.</source>
       <source>Updating the MK3, values will reappear after the update is complete</source>
       <translation>更新MK3，更新完成后数值会重新出现</translation>
     </message>
-    <message id="vebus_device_charging_to_100">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="78"/>
-      <source>Charging the battery to 100%</source>
-      <translation type="unfinished">电池充满到100%</translation>
-    </message>
     <message id="vebus_device_charging_the_battery_to_100">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="93"/>
       <source>Charging the battery to 100%</source>
       <translation>电池充满到100%</translation>
-    </message>
-    <message id="vebus_device_page_microgrid_parameters">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
-      <source>Microgrid parameters</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="vebus_device_page_advanced">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
-      <source>Advanced</source>
-      <translation type="unfinished">高级</translation>
     </message>
     <message id="vebus_device_in_progress">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="80"/>
@@ -4196,15 +3697,15 @@ Do you want to continue?</source>
       <source>DC Current</source>
       <translation>直流电流</translation>
     </message>
+    <message id="vebus_device_page_advanced">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
+      <source>Advanced</source>
+      <translation>高级</translation>
+    </message>
     <message id="common_words_alarm_setup">
       <location filename="../../components/CommonWords.qml" line="65"/>
       <source>Alarm setup</source>
       <translation>报警设置</translation>
-    </message>
-    <message id="vebus_device_bms_message">
-      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
-      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
-      <translation type="unfinished">需要保护电池时，VE BUS BMS自动关闭系统。因此不能用Color Control来控制系统。</translation>
     </message>
     <message id="vebus_device_bms_not_found">
       <location filename="../../pages/vebusdevice/PageVeBus.qml" line="240"/>
@@ -4245,7 +3746,7 @@ Do you want to continue?</source>
     <message id="vebus_device_starting">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="117"/>
       <source>Starting...</source>
-      <translation type="unfinished">正在启动...</translation>
+      <translation>正在启动...</translation>
     </message>
     <message id="vebus_device_press_to_interrupt">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="120"/>
@@ -4311,16 +3812,6 @@ Do you want to continue?</source>
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="260"/>
       <source>ESS Relay test</source>
       <translation>ESS继电器测试</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_completed">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="266"/>
-      <source>Completed</source>
-      <translation type="unfinished">已完成</translation>
-    </message>
-    <message id="vebus_device_ess_relay_test_pending">
-      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="268"/>
-      <source>Pending</source>
-      <translation type="unfinished">等待中</translation>
     </message>
     <message id="cycle_history_completed">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
@@ -4507,6 +3998,7 @@ Do you want to continue?</source>
     <message id="rssystemalarms_overload">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
       <source>Overload</source>
+      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
       <translation>过载</translation>
     </message>
     <message id="common_words_alarm_setting_dc_ripple">
@@ -4519,11 +4011,6 @@ Do you want to continue?</source>
       <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
       <source>Voltage Sensor</source>
       <translation>电压传感器</translation>
-    </message>
-    <message id="vebus_device_phase_rotation">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="19"/>
-      <source>Phase rotation</source>
-      <translation type="unfinished">相位旋转</translation>
     </message>
     <message id="rssystemalarms_phase_rotation">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
@@ -4555,12 +4042,6 @@ Do you want to continue?</source>
       <source>VE.Bus BMS version</source>
       <translation>VE.Bus BMS版本</translation>
     </message>
-    <message id="ess_card_minimum_soc">
-      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="15"/>
-      <location filename="../../pages/controlcards/ESSCard.qml" line="52"/>
-      <source>Minimum SOC</source>
-      <translation type="unfinished">最小SOC</translation>
-    </message>
     <message id="ess_unless_grid_fails">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="32"/>
       <source>Unless grid fails</source>
@@ -4580,7 +4061,7 @@ Do you want to continue?</source>
     <message id="common_words_ac_input_role">
       <location filename="../../components/CommonWords.qml" line="24"/>
       <source>Role</source>
-      <extracomment>The role for an AC input (grid, genset, acload, etc.)</extracomment>
+      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
       <translation>作用</translation>
     </message>
     <message id="common_words_ac_load">
@@ -4619,18 +4100,6 @@ Do you want to continue?</source>
       <source>Active</source>
       <extracomment>Status is 'active'</extracomment>
       <translation>激活</translation>
-    </message>
-    <message id="common_words_alarm">
-      <location filename="../../components/CommonWords.qml" line="51"/>
-      <source>Alarm</source>
-      <extracomment>Voltage alarm is at "Alarm" level</extracomment>
-      <translation type="unfinished">报警</translation>
-    </message>
-    <message id="common_words_alarm_setting_overload">
-      <location filename="../../components/CommonWords.qml" line="58"/>
-      <source>Overload</source>
-      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
-      <translation type="unfinished">过载</translation>
     </message>
     <message id="common_words_alarm_status">
       <location filename="../../components/CommonWords.qml" line="68"/>
@@ -4677,8 +4146,8 @@ Do you want to continue?</source>
       <source>Charge current</source>
       <translation>充电电流</translation>
     </message>
-    <message id="common_words_charging">
-      <location filename="../../components/CommonWords.qml" line="125"/>
+    <message id="battery_mode_charging">
+      <location filename="../../src/enums.cpp" line="30"/>
       <source>Charging</source>
       <extracomment>"Charging" state</extracomment>
       <translation>充电</translation>
@@ -4692,7 +4161,7 @@ Do you want to continue?</source>
     <message id="digitalinputs_state_closed">
       <location filename="../../src/enums.cpp" line="262"/>
       <source>Closed</source>
-      <extracomment>Digital input state</extracomment>
+      <extracomment>Status is 'closed'</extracomment>
       <translation>已关闭</translation>
     </message>
     <message id="evchargers_status_connected">
@@ -4700,8 +4169,8 @@ Do you want to continue?</source>
       <source>Connected</source>
       <translation>已连接</translation>
     </message>
-    <message id="common_words_current_amps">
-      <location filename="../../components/CommonWords.qml" line="143"/>
+    <message id="temperature_slider_current">
+      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
       <source>Current</source>
       <extracomment>Electric current, as measured in Amps</extracomment>
       <translation>电流</translation>
@@ -4728,9 +4197,10 @@ Do you want to continue?</source>
       <extracomment>Title for device information</extracomment>
       <translation>设备</translation>
     </message>
-    <message id="common_words_discharging">
-      <location filename="../../components/CommonWords.qml" line="172"/>
+    <message id="battery_mode_discharging">
+      <location filename="../../src/enums.cpp" line="34"/>
       <source>Discharging</source>
+      <extracomment>Battery mode</extracomment>
       <translation>放电</translation>
     </message>
     <message id="wifimodel_disconnected">
@@ -4816,13 +4286,14 @@ Do you want to continue?</source>
       <source>%1 Hour(s)</source>
       <translation>%1 小时</translation>
     </message>
-    <message id="common_words_idle">
-      <location filename="../../components/CommonWords.qml" line="251"/>
+    <message id="battery_mode_idle">
+      <location filename="../../src/enums.cpp" line="26"/>
       <source>Idle</source>
+      <extracomment>Battery mode</extracomment>
       <translation>空闲</translation>
     </message>
-    <message id="common_words_inactive_status">
-      <location filename="../../components/CommonWords.qml" line="258"/>
+    <message id="scheduled_charge_inactive">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
       <source>Inactive</source>
       <extracomment>Status is 'inactive'</extracomment>
       <translation>不激活</translation>
@@ -4924,8 +4395,8 @@ Do you want to continue?</source>
       <source>Offline</source>
       <translation>离线</translation>
     </message>
-    <message id="listitems_alarm_level_ok">
-      <location filename="../../components/listitems/core/ListAlarm.qml" line="17"/>
+    <message id="digitalinputs_state_ok">
+      <location filename="../../src/enums.cpp" line="266"/>
       <source>OK</source>
       <extracomment>Voltage alarm is at "OK" level</extracomment>
       <translation>正常</translation>
@@ -4933,6 +4404,7 @@ Do you want to continue?</source>
     <message id="switchable_output_on">
       <location filename="../../src/enums.cpp" line="471"/>
       <source>On</source>
+      <extracomment>Digital input state</extracomment>
       <translation>开</translation>
     </message>
     <message id="common_words_online">
@@ -4943,7 +4415,7 @@ Do you want to continue?</source>
     <message id="digitalinputs_state_open">
       <location filename="../../src/enums.cpp" line="258"/>
       <source>Open</source>
-      <extracomment>Digital input open</extracomment>
+      <extracomment>Status is 'open'</extracomment>
       <translation>打开</translation>
     </message>
     <message id="common_words_password">
@@ -5003,9 +4475,10 @@ Do you want to continue?</source>
       <source>Remove</source>
       <translation>删除</translation>
     </message>
-    <message id="switch_state_running">
-      <location filename="../../src/enums.cpp" line="363"/>
+    <message id="switchable_output_running">
+      <location filename="../../src/enums.cpp" line="468"/>
       <source>Running</source>
+      <extracomment>Status = "running"</extracomment>
       <translation>运行</translation>
     </message>
     <message id="common_words_scanning">
@@ -5072,7 +4545,7 @@ Do you want to continue?</source>
     <message id="pvinverter_statusCode_startup">
       <location filename="../../src/enums.cpp" line="296"/>
       <source>Startup (%1)</source>
-      <extracomment>PV inverter status code. %1 = the startup status number</extracomment>
+      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
       <translation>启动（%1）</translation>
     </message>
     <message id="common_words_stop_value_during_quiet_hours">
@@ -5127,8 +4600,10 @@ Do you want to continue?</source>
       <source>Unique Identity Number</source>
       <translation>唯一身份号码</translation>
     </message>
-    <message id="settings_radio_button_group_unknown">
-      <location filename="../../components/listitems/core/ListRadioButtonGroup.qml" line="44"/>
+    <message id="Unknown">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
       <source>Unknown</source>
       <translation>未知</translation>
     </message>
@@ -5283,11 +4758,6 @@ Do you want to continue?</source>
       <source>Error while checking for firmware updates</source>
       <translation>检查固件更新时出错</translation>
     </message>
-    <message id="settings_firmware_error_during_checking_for_updates">
-      <location filename="../../components/FirmwareUpdate.qml" line="55"/>
-      <source>Error while checking for firmware updates</source>
-      <translation type="unfinished">检查固件更新时出错</translation>
-    </message>
     <message id="settings_firmware_downloading_and_installing">
       <location filename="../../components/FirmwareUpdate.qml" line="63"/>
       <source>Downloading and installing firmware %1...</source>
@@ -5314,6 +4784,66 @@ Do you want to continue?</source>
       <source>No firmware found</source>
       <translation>未找到固件</translation>
     </message>
+    <message id="tank_type_fuel">
+      <location filename="../../src/enums.cpp" line="495"/>
+      <source>Fuel</source>
+      <translation>燃料</translation>
+    </message>
+    <message id="tank_type_fresh_water">
+      <location filename="../../src/enums.cpp" line="498"/>
+      <source>Fresh water</source>
+      <translation>清水</translation>
+    </message>
+    <message id="tank_type_waste_water">
+      <location filename="../../src/enums.cpp" line="501"/>
+      <source>Waste water</source>
+      <translation>废水</translation>
+    </message>
+    <message id="tank_type_live_well">
+      <location filename="../../src/enums.cpp" line="504"/>
+      <source>Live well</source>
+      <translation>活鱼池</translation>
+    </message>
+    <message id="tank_type_oil">
+      <location filename="../../src/enums.cpp" line="507"/>
+      <source>Oil</source>
+      <translation>石油</translation>
+    </message>
+    <message id="tank_type_black_water">
+      <location filename="../../src/enums.cpp" line="510"/>
+      <source>Black water</source>
+      <translation>黑水</translation>
+    </message>
+    <message id="tank_type_gasoline">
+      <location filename="../../src/enums.cpp" line="513"/>
+      <source>Gasoline</source>
+      <translation>汽油</translation>
+    </message>
+    <message id="tank_type_diesel">
+      <location filename="../../src/enums.cpp" line="516"/>
+      <source>Diesel</source>
+      <translation>柴油</translation>
+    </message>
+    <message id="tank_type_lpg">
+      <location filename="../../src/enums.cpp" line="519"/>
+      <source>LPG</source>
+      <translation>LPG</translation>
+    </message>
+    <message id="tank_type_lng">
+      <location filename="../../src/enums.cpp" line="522"/>
+      <source>LNG</source>
+      <translation>LNG</translation>
+    </message>
+    <message id="tank_type_hydraulic_oil">
+      <location filename="../../src/enums.cpp" line="525"/>
+      <source>Hydraulic oil</source>
+      <translation>液压油</translation>
+    </message>
+    <message id="tank_type_raw_water">
+      <location filename="../../src/enums.cpp" line="528"/>
+      <source>Raw water</source>
+      <translation>生水</translation>
+    </message>
     <message id="listItem_no_access">
       <location filename="../../components/listitems/core/ListItem.qml" line="102"/>
       <source>Setting locked for access level</source>
@@ -5327,6 +4857,7 @@ Do you want to continue?</source>
     <message id="welcome_brief_title">
       <location filename="../../pages/welcome/WelcomeView.qml" line="81"/>
       <source>Brief</source>
+      <extracomment>The 'Brief' page</extracomment>
       <translation>概要</translation>
     </message>
     <message id="welcome_overview_title">
@@ -5343,23 +4874,6 @@ Do you want to continue?</source>
       <location filename="../../pages/NotificationsPage.qml" line="13"/>
       <source>Notifications</source>
       <translation>通知</translation>
-    </message>
-    <message id="notifications_page_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="43"/>
-      <source>Active Notifications</source>
-      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_page_inactive_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="47"/>
-      <source>Inactive Notifications</source>
-      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="notifications_no_active_notifications">
-      <location filename="../../pages/NotificationsPage.qml" line="106"/>
-      <source>No active notifications</source>
-      <translation type="unfinished"/>
     </message>
     <message id="utils_formatTimestamp_now">
       <location filename="../../components/Utils.js" line="258"/>
@@ -5464,11 +4978,6 @@ Do you want to continue?</source>
       <source>Self-consumption above limit</source>
       <translation>自耗超限</translation>
     </message>
-    <message id="cgwacs_battery_schedule_pv">
-      <location filename="../../components/listitems/ListChargeSchedule.qml" line="171"/>
-      <source>PV</source>
-      <translation type="unfinished">光伏</translation>
-    </message>
     <message id="settings_multirs_pv">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="185"/>
       <source>PV</source>
@@ -5479,8 +4988,8 @@ Do you want to continue?</source>
       <source>PV &amp; Battery</source>
       <translation>光伏&amp;电池</translation>
     </message>
-    <message id="settings_firmware_checking">
-      <location filename="../../components/listitems/ListFirmwareCheckButton.qml" line="16"/>
+    <message id="pagesettingssupportstate_firmware_checking">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
       <source>Checking...</source>
       <translation>检查...</translation>
     </message>
@@ -5488,12 +4997,6 @@ Do you want to continue?</source>
       <location filename="../../components/listitems/ListAlarmState.qml" line="11"/>
       <source>Alarm state</source>
       <translation>报警状态</translation>
-    </message>
-    <message id="devicelist_battery_alarm_state">
-      <location filename="../../components/listitems/ListAlarmState.qml" line="19"/>
-      <source>Alarm</source>
-      <extracomment>Alarm state is active</extracomment>
-      <translation type="unfinished">报警</translation>
     </message>
     <message id="clear_history_button_clear_history">
       <location filename="../../components/listitems/ListClearHistoryButton.qml" line="15"/>
@@ -5645,11 +5148,6 @@ Do you want to continue?</source>
       <source>Max Voltage</source>
       <translation>最大电压</translation>
     </message>
-    <message id="charger_history_box_max_voltage">
-      <location filename="../../components/SolarDetailBox.qml" line="64"/>
-      <source>Max Voltage</source>
-      <translation type="unfinished">最大电压</translation>
-    </message>
     <message id="charger_history_box_max_current">
       <location filename="../../components/SolarDetailBox.qml" line="70"/>
       <source>Max Current</source>
@@ -5660,24 +5158,6 @@ Do you want to continue?</source>
       <source>Charge time</source>
       <extracomment>Statistics for battery charging time</extracomment>
       <translation>充电时间</translation>
-    </message>
-    <message id="charger_history_box_bulk">
-      <location filename="../../components/SolarDetailBox.qml" line="136"/>
-      <source>Bulk</source>
-      <extracomment>Battery: time spent in 'Bulk' mode</extracomment>
-      <translation type="unfinished">快充</translation>
-    </message>
-    <message id="charger_history_box_float">
-      <location filename="../../components/SolarDetailBox.qml" line="148"/>
-      <source>Float</source>
-      <extracomment>Battery: time spent in 'Float' mode</extracomment>
-      <translation type="unfinished">浮充</translation>
-    </message>
-    <message id="charger_history_hr">
-      <location filename="../../components/SolarDetailBox.qml" line="174"/>
-      <source>hr</source>
-      <extracomment>Abbreviation of "hour"</extracomment>
-      <translation type="unfinished">小时</translation>
     </message>
     <message id="solarchargers_state_bulk">
       <location filename="../../src/enums.cpp" line="337"/>
@@ -5749,11 +5229,6 @@ Do you want to continue?</source>
       <source>Connecting</source>
       <translation>正在连接</translation>
     </message>
-    <message id="splash_view_connecting">
-      <location filename="../../components/SplashView.qml" line="288"/>
-      <source>Connecting</source>
-      <translation type="unfinished">正在连接</translation>
-    </message>
     <message id="splash_view_connected">
       <location filename="../../components/SplashView.qml" line="290"/>
       <source>Connected, awaiting broker messages</source>
@@ -5809,6 +5284,11 @@ Do you want to continue?</source>
       <source>MQTT protocol level 5 error</source>
       <translation>MQTT 协议 5 级错误</translation>
     </message>
+    <message id="common_words_silence_alarm">
+      <location filename="../../components/CommonWords.qml" line="476"/>
+      <source>Silence alarm</source>
+      <translation>静音警报</translation>
+    </message>
     <message id="vebus_device_page_total_power">
       <location filename="../../components/ThreePhaseQuantityTable.qml" line="47"/>
       <source>Total Power</source>
@@ -5859,20 +5339,10 @@ Do you want to continue?</source>
       <source>Retrieving IP address</source>
       <translation>检索IP地址</translation>
     </message>
-    <message id="utils_connman_connected">
-      <location filename="../../components/Utils.js" line="292"/>
-      <source>Connected</source>
-      <translation type="unfinished">已连接</translation>
-    </message>
     <message id="utils_connman_disconnect">
       <location filename="../../components/Utils.js" line="295"/>
       <source>Disconnect</source>
       <translation>断开</translation>
-    </message>
-    <message id="utils_connman_disconnected">
-      <location filename="../../components/Utils.js" line="299"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">已断开连接</translation>
     </message>
     <message id="overview_widget_acloads_title">
       <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
@@ -5910,11 +5380,6 @@ Do you want to continue?</source>
       <source>Shore current limit</source>
       <translation>岸电电流限制</translation>
     </message>
-    <message id="acInputs_statusCode_stopping">
-      <location filename="../../data/AcInputs.qml" line="170"/>
-      <source>Stopping</source>
-      <translation type="unfinished">停止</translation>
-    </message>
     <message id="page_generator_stopping">
       <location filename="../../data/Generators.qml" line="44"/>
       <source>Stopping</source>
@@ -5930,7 +5395,7 @@ Do you want to continue?</source>
       <location filename="../../data/common/TankDescription.qml" line="24"/>
       <location filename="../../src/device.cpp" line="133"/>
       <source>%1 tank (%2)</source>
-      <extracomment>Tank description. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
       <translation>%1 箱 (%2)</translation>
     </message>
     <message id="dcMeter_ac_charger">
@@ -5979,11 +5444,6 @@ Do you want to continue?</source>
       <location filename="../../data/Ess.qml" line="20"/>
       <source>Keep batteries charged</source>
       <translation>让电池保持在充电状态</translation>
-    </message>
-    <message id="evchargers_status_disconnected">
-      <location filename="../../data/EvChargers.qml" line="50"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">已断开连接</translation>
     </message>
     <message id="evchargers_status_charged">
       <location filename="../../data/EvChargers.qml" line="58"/>
@@ -6044,16 +5504,6 @@ Do you want to continue?</source>
       <location filename="../../data/EvChargers.qml" line="97"/>
       <source>Start charging</source>
       <translation>开始充电</translation>
-    </message>
-    <message id="evchargers_status_unknown">
-      <location filename="../../data/EvChargers.qml" line="113"/>
-      <source>Unknown</source>
-      <translation type="unfinished">未知</translation>
-    </message>
-    <message id="evchargers_mode_scheduled">
-      <location filename="../../data/EvChargers.qml" line="126"/>
-      <source>Scheduled</source>
-      <translation type="unfinished">已定时</translation>
     </message>
     <message id="inverters_state_scheduledcharge">
       <location filename="../../data/System.qml" line="195"/>
@@ -6178,11 +5628,6 @@ Do you want to continue?</source>
       <source>Power supply mode</source>
       <translation>电源模式</translation>
     </message>
-    <message id="inverters_state_sustain">
-      <location filename="../../data/System.qml" line="158"/>
-      <source>Sustain</source>
-      <translation type="unfinished">维持</translation>
-    </message>
     <message id="inverters_state_wakeup">
       <location filename="../../data/System.qml" line="162"/>
       <source>Wake up</source>
@@ -6217,16 +5662,6 @@ Do you want to continue?</source>
       <location filename="../../data/System.qml" line="180"/>
       <source>Test</source>
       <translation>测试</translation>
-    </message>
-    <message id="inverters_state_externalccontrol">
-      <location filename="../../data/System.qml" line="183"/>
-      <source>External control</source>
-      <translation type="unfinished">外部控制</translation>
-    </message>
-    <message id="inverters_state_dynamic_ess">
-      <location filename="../../data/System.qml" line="198"/>
-      <source>Dynamic ESS</source>
-      <translation type="unfinished">动态ESS</translation>
     </message>
     <message id="settings_rs_ess_dess">
       <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="97"/>
@@ -6305,16 +5740,13 @@ Do you want to continue?</source>
     <message id="ess_recommended">
       <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="73"/>
       <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
       <translation>对于锂电池，不建议充电低于 10%。对于其他类型的电池，请查看数据表，了解制造商建议的最低电量。</translation>
-    </message>
-    <message id="controlcard_generator_label_autostart">
-      <location filename="../../pages/controlcards/GeneratorCard.qml" line="63"/>
-      <source>Autostart</source>
-      <translation type="unfinished">自动启动</translation>
     </message>
     <message id="controlcard_generator_autostart_conditions">
       <location filename="../../pages/controlcards/GeneratorCard.qml" line="70"/>
       <source>Start and stop the generator based on the configured autostart conditions.</source>
+      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
       <translation>根据配置的自动启动条件启动和停止发电机。</translation>
     </message>
     <message id="generator_dialog_disabled">
@@ -6337,11 +5769,13 @@ Do you want to continue?</source>
       <location filename="../../pages/controlcards/InverterChargerCard.qml" line="26"/>
       <source>Inverter / Charger (%1)</source>
       <extracomment>%1 = the inverter/charger name</extracomment>
+      <oldsource>Inverter / Charger</oldsource>
       <translation>逆变器/充电器 (%1)</translation>
     </message>
     <message id="settings_page_debug_quit_application">
       <location filename="../../pages/settings/debug/PageDebug.qml" line="36"/>
       <source>Quit application</source>
+      <oldsource>Quit Application</oldsource>
       <translation>退出应用程序</translation>
     </message>
     <message id="genset_controller_requires_helper_relay">
@@ -6352,12 +5786,8 @@ Do you want to continue?</source>
     <message id="settings_page_relay_generator_run_time">
       <location filename="../../pages/settings/PageGenerator.qml" line="71"/>
       <source>Current run time</source>
+      <oldsource>Run time</oldsource>
       <translation>当前运行时间</translation>
-    </message>
-    <message id="settings_page_genset_generator_run_time">
-      <location filename="../../components/PageGensetModel.qml" line="102"/>
-      <source>Current run time</source>
-      <translation type="unfinished">当前运行时间</translation>
     </message>
     <message id="ac-in-genset_auto_control_status">
       <location filename="../../components/PageGensetModel.qml" line="110"/>
@@ -6384,19 +5814,10 @@ Do you want to continue?</source>
       <source>Remote start mode</source>
       <translation>远程启动模式</translation>
     </message>
-    <message id="ac-in-genset_speed">
-      <location filename="../../components/PageGensetModel.qml" line="245"/>
-      <source>Speed</source>
-      <translation type="unfinished">速度</translation>
-    </message>
-    <message id="ac-in-genset_load">
-      <location filename="../../components/PageGensetModel.qml" line="252"/>
-      <source>Load</source>
-      <translation type="unfinished">负载</translation>
-    </message>
     <message id="ac-in-genset_oil_pressure">
       <location filename="../../components/PageGensetModel.qml" line="260"/>
       <source>Oil pressure</source>
+      <oldsource>Oil Pressure</oldsource>
       <translation>油压</translation>
     </message>
     <message id="ac-in-genset_oil_temperature">
@@ -6492,11 +5913,13 @@ Do you want to continue?</source>
     <message id="batteryhistory_high_starter_bat_voltage_alarms">
       <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
       <source>High starter battery voltage alarms</source>
+      <oldsource>High starter batttery voltage alarms</oldsource>
       <translation>启动电池电压过高报警</translation>
     </message>
     <message id="batterysettingsbattery_time_to_go_discharge_note">
       <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
       <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
       <translation>请注意，更改放电下限时间设置也会更改继电器菜单中的低充电状态设置。</translation>
     </message>
     <message id="lynxionsystem_cells_per_battery">
@@ -6573,6 +5996,7 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/devicelist/delegates/DeviceListDelegate_solarcharger.qml" line="34"/>
       <source>Error: #%1</source>
       <extracomment>%1 = error number</extracomment>
+      <oldsource>Error: %1</oldsource>
       <translation>错误：#%1</translation>
     </message>
     <message id="devicelistpage_genset">
@@ -6629,17 +6053,14 @@ Do you want to continue?</source>
     <message id="settings_page_relay_generator_auto_start_enabled">
       <location filename="../../pages/settings/PageGenerator.qml" line="53"/>
       <source>Autostart functionality</source>
+      <oldsource>Auto start functionality</oldsource>
       <translation>自动启动功能</translation>
     </message>
     <message id="page_generator_conditions_make_sure_generator_is_not_connected">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="97"/>
       <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
       <translation>使用此选项时，确保发电机未连接至交流输入 %1</translation>
-    </message>
-    <message id="page_generator_conditions_inverter_high_temperature">
-      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="139"/>
-      <source>Inverter high temperature</source>
-      <translation type="unfinished">逆变器高温</translation>
     </message>
     <message id="page_generator_conditions_tank_level">
       <location filename="../../pages/settings/PageGeneratorConditions.qml" line="159"/>
@@ -6669,30 +6090,34 @@ Do you want to continue?</source>
     <message id="settings_generator_function_not_enabled">
       <location filename="../../pages/settings/PageRelayGenerator.qml" line="25"/>
       <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
+      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
       <translation>发电机启动/停止功能未启用，进入继电器设置，将功能设置为 "发电机组启动/停止"。</translation>
     </message>
     <message id="settings_batteries_intro">
       <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="45"/>
       <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
       <translation>单击概览页面上的电池图标时，可使用此菜单定义显示的电池数据。在 VRM 门户上也可以看到相同的选择。</translation>
     </message>
     <message id="settings_continuous_scan_may_interfere">
       <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
       <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
       <translation>连续扫描可能会干扰 Wi-Fi 操作。</translation>
     </message>
     <message id="settings_canbus_bms">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
       <source>CAN-bus BMS LV (500 kbit/s)</source>
+      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
       <translation>CAN 总线 BMS LV（500 kbit/s）</translation>
     </message>
     <message id="settings_canbus_high_voltage">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
       <source>CAN-bus BMS HV (500 kbit/s)</source>
       <translation>CAN 总线 BMS HV（500 kbit/秒）</translation>
     </message>
     <message id="settings_up_but_no_services_500">
-      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
+      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
       <source>Up, but no services (500 kbit/s)</source>
       <translation>正常运行，但无服务（500 kbit/s）</translation>
     </message>
@@ -6705,41 +6130,6 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="127"/>
       <source>Brief page</source>
       <translation>简短页面</translation>
-    </message>
-    <message id="settings_displayoff_1min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="46"/>
-      <source>1 min</source>
-      <translation type="unfinished">1分钟</translation>
-    </message>
-    <message id="settings_displayoff_10min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="48"/>
-      <source>10 min</source>
-      <translation type="unfinished">10分钟</translation>
-    </message>
-    <message id="settings_displayoff_30min">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="50"/>
-      <source>30 min</source>
-      <translation type="unfinished">30分钟</translation>
-    </message>
-    <message id="settings_displayoff_never">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="52"/>
-      <source>Never</source>
-      <translation type="unfinished">从不</translation>
-    </message>
-    <message id="settings_remote_console_appearance_auto">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="112"/>
-      <source>Auto</source>
-      <translation type="unfinished">自动</translation>
-    </message>
-    <message id="settings_brief_view_start_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="119"/>
-      <source>Start page</source>
-      <translation type="unfinished">启动页</translation>
-    </message>
-    <message id="settings_display_boat_page">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="135"/>
-      <source>Boat page</source>
-      <translation type="unfinished">船只页面</translation>
     </message>
     <message id="settings_display_minmax">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="148"/>
@@ -6794,21 +6184,6 @@ Do you want to continue?</source>
       <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
       <translation>%1 设置为 %2</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_unsupported_device">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="50"/>
-      <source>Unsupported GX device</source>
-      <translation type="unfinished">不支持的GX 设备</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_clean">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="55"/>
-      <source>Clean</source>
-      <translation type="unfinished">清洁</translation>
-    </message>
-    <message id="pagesettingsgeneral_firmware">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="112"/>
-      <source>Firmware</source>
-      <translation type="unfinished">固件</translation>
-    </message>
     <message id="pagesettingsgeneral_access_and_security">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="124"/>
       <source>Access &amp; Security</source>
@@ -6842,6 +6217,7 @@ Do you want to continue?</source>
     <message id="settings_language_please_wait">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="209"/>
       <source>Please wait while the language is changed.</source>
+      <oldsource>Please wait while the language is changed</oldsource>
       <translation>请稍候，语言正在更改。</translation>
     </message>
     <message id="settings_briefview_totals">
@@ -6858,11 +6234,6 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="71"/>
       <source>Tank is not connected.</source>
       <translation>水箱未连接。</translation>
-    </message>
-    <message id="settings_briefview_active_battery_monitor">
-      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="83"/>
-      <source>Active battery monitor</source>
-      <translation type="unfinished">主动式电池监测器</translation>
     </message>
     <message id="settings_briefview_individual_batteries">
       <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="86"/>
@@ -6913,6 +6284,7 @@ Do you want to continue?</source>
     <message id="settings_dvcc_charge_current_limits">
       <location filename="../../pages/settings/PageSettingsDvcc.qml" line="30"/>
       <source>Charge current limits</source>
+      <oldsource>Charge Current limits</oldsource>
       <translation>充电电流限制</translation>
     </message>
     <message id="settings_firmware_official_release">
@@ -6992,11 +6364,6 @@ Do you want to continue?</source>
       <source>No password and the network communication is not encrypted</source>
       <translation>无密码，网络通信未加密</translation>
     </message>
-    <message id="settings_logout_now">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
-      <source>Log out now</source>
-      <translation type="unfinished">立即退出</translation>
-    </message>
     <message id="settings_security_profile_password_incorrect_length">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="28"/>
       <source>Password needs to be at least 8 characters long</source>
@@ -7047,25 +6414,10 @@ Do you want to continue?</source>
       <source>Page will automatically reload in 5 seconds</source>
       <translation>页面将在 5 秒后自动重新加载</translation>
     </message>
-    <message id="settings_security_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="159"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">密码长度至少为 8 个字符</translation>
-    </message>
     <message id="settings_root_password">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="269"/>
       <source>Root password</source>
       <translation>根密码</translation>
-    </message>
-    <message id="settings_root_enter_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="272"/>
-      <source>Enter password</source>
-      <translation type="unfinished">输入密码</translation>
-    </message>
-    <message id="settings_root_too_short_password">
-      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="277"/>
-      <source>Password needs to be at least 8 characters long</source>
-      <translation type="unfinished">密码长度至少为 8 个字符</translation>
     </message>
     <message id="settings_root_password_changed_to">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="283"/>
@@ -7081,6 +6433,11 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="321"/>
       <source>Logout</source>
       <translation>登出</translation>
+    </message>
+    <message id="settings_logout_now">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
+      <source>Log out now</source>
+      <translation>立即退出</translation>
     </message>
     <message id="settings_logout_dialog_title">
       <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="335"/>
@@ -7140,11 +6497,13 @@ Do you want to continue?</source>
     <message id="page_settings_generator_alarm_when_not_in_auto_start">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="141"/>
       <source>Alarm when generator is not in autostart mode</source>
+      <oldsource>Alarm when generator is not in auto start mode</oldsource>
       <translation>发电机未进入自动启动模式时报警</translation>
     </message>
     <message id="page_settings_generator_alarm_info">
       <location filename="../../pages/settings/PageSettingsGenerator.qml" line="147"/>
       <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
       <translation>如果自动启动功能被禁用超过 10 分钟，则会触发警报</translation>
     </message>
     <message id="settings_units_amps_exceptions">
@@ -7160,6 +6519,11 @@ Do you want to continue?</source>
     <message id="settings_ess_use_this_option_for_peak_shaving">
       <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
       <source>Use this option for peak shaving.</source>
+      <oldsource>Use this option for peak shaving.
+
+The peak shaving threshold is set using the AC input current limit setting.
+
+See documentation for further information.</oldsource>
       <translation>在剃须高峰期使用该选项。</translation>
     </message>
     <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
@@ -7203,17 +6567,17 @@ Do you want to continue?</source>
       <translation>最大系统输出电流（每相）</translation>
     </message>
     <message id="settings_ess_self_consumption_battery">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="71"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="73"/>
       <source>Self-consumption from battery</source>
       <translation>从电池自消耗</translation>
     </message>
     <message id="settings_ess_all_system_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="76"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
       <source>All system loads</source>
       <translation>所有系统负载</translation>
     </message>
     <message id="settings_ess_only_critical_loads">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="78"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="80"/>
       <source>Only critical loads</source>
       <translation>只限关键负载</translation>
     </message>
@@ -7271,26 +6635,6 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="194"/>
       <source>Server Applications</source>
       <translation>服务器应用</translation>
-    </message>
-    <message id="pagesettingsintegrations_venus_os_enable_large_features">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
-      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="settings_large_victron_community">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="274"/>
-      <source>Victron Community</source>
-      <translation type="unfinished">Victron社区</translation>
-    </message>
-    <message id="pagesettingsintegrations_ui_plugins">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
-      <source>UI Plugins</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
-      <source>Integrates with the device list</source>
-      <translation type="unfinished"/>
     </message>
     <message id="pagesettingssupportstate_modbus_tcp_server">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="453"/>
@@ -7393,25 +6737,10 @@ Do you want to continue?</source>
       <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
       <translation>如果没有选择 "设置/常规 "中的 "网络安全配置文件"，则无法切换固件版本。</translation>
     </message>
-    <message id="pagesettingsconnectivity_ethernet">
-      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="18"/>
-      <source>Ethernet</source>
-      <translation type="unfinished">以太网</translation>
-    </message>
     <message id="pagesettingsconnectivity_mobile_network">
       <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="53"/>
       <source>Mobile Network</source>
       <translation>移动网络</translation>
-    </message>
-    <message id="settings_system_name_boat">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="21"/>
-      <source>Boat</source>
-      <translation type="unfinished">船</translation>
-    </message>
-    <message id="settings_system_name_auto">
-      <location filename="../../pages/settings/PageSettingsSystem.qml" line="32"/>
-      <source>Automatic</source>
-      <translation type="unfinished">自动</translation>
     </message>
     <message id="pagesettingssystem_ac_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="60"/>
@@ -7442,11 +6771,6 @@ Do you want to continue?</source>
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="89"/>
       <source>Distributed Voltage and Current Control (DVCC)</source>
       <translation>分布式电压和电流控制 (DVCC)</translation>
-    </message>
-    <message id="settings_system_grid">
-      <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="18"/>
-      <source>Grid</source>
-      <translation type="unfinished">电网</translation>
     </message>
     <message id="settings_system_ac_position">
       <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="58"/>
@@ -7486,16 +6810,19 @@ Do you want to continue?</source>
     <message id="settings_system_has_dc_system">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="97"/>
       <source>Display DC Loads</source>
+      <oldsource>Has DC system</oldsource>
       <translation>显示直流负载</translation>
     </message>
     <message id="settings_system_battery_measurements">
       <location filename="../../pages/settings/PageSettingsBatteries.qml" line="65"/>
       <source>Battery measurements</source>
+      <oldsource>Battery Measurements</oldsource>
       <translation>电池测量</translation>
     </message>
     <message id="settings_system_system_status">
       <location filename="../../pages/settings/PageSettingsSystem.qml" line="102"/>
       <source>System status</source>
+      <oldsource>System Status</oldsource>
       <translation>系统状态</translation>
     </message>
     <message id="settings_tcpip_wired">
@@ -7506,11 +6833,13 @@ Do you want to continue?</source>
     <message id="settings_vecan_device_instance">
       <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="34"/>
       <source>VE.Can Device Instance</source>
+      <oldsource>Device Instance</oldsource>
       <translation>VE.CAN设备示例</translation>
     </message>
     <message id="settings_vecan_device_number">
       <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="32"/>
       <source>VE.Can Instance# %1</source>
+      <oldsource>Device# %1</oldsource>
       <translation>VE.Can示例# %1</translation>
     </message>
     <message id="settings_tz_antarctica">
@@ -7541,6 +6870,7 @@ Do you want to continue?</source>
     <message id="settings_vrm">
       <location filename="../../pages/SettingsPage.qml" line="59"/>
       <source>VRM</source>
+      <extracomment>Forced by %2 to dark</extracomment>
       <translation>VRM</translation>
     </message>
     <message id="settings_remote_monitoring_portal">
@@ -7548,20 +6878,10 @@ Do you want to continue?</source>
       <source>Remote monitoring portal</source>
       <translation>远程监控门户</translation>
     </message>
-    <message id="settings_advanced">
-      <location filename="../../pages/SettingsPage.qml" line="68"/>
-      <source>Advanced</source>
-      <translation type="unfinished">高级</translation>
-    </message>
-    <message id="settings_integrations">
-      <location filename="../../pages/SettingsPage.qml" line="73"/>
+    <message id="pagesettingssupportstate_integrations">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
       <source>Integrations</source>
       <translation>集成</translation>
-    </message>
-    <message id="settings_relays_sensors_tanks">
-      <location filename="../../pages/SettingsPage.qml" line="75"/>
-      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
-      <translation type="unfinished">继电器、传感器、液位、光伏逆变器、Modbus、MQTT...</translation>
     </message>
     <message id="settings_acdcsystem_ess_dvcc_battery">
       <location filename="../../pages/SettingsPage.qml" line="84"/>
@@ -7581,11 +6901,13 @@ Do you want to continue?</source>
     <message id="settings_system_setup">
       <location filename="../../pages/SettingsPage.qml" line="82"/>
       <source>System Setup</source>
+      <oldsource>System setup</oldsource>
       <translation>系统设置</translation>
     </message>
     <message id="settings_vrm_device_instances">
       <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
       <source>VRM device instances</source>
+      <oldsource>VRM Device Instances</oldsource>
       <translation>VRM 设备实例</translation>
     </message>
     <message id="solarcharger_not_supported">
@@ -7603,28 +6925,10 @@ Do you want to continue?</source>
       <source>The firmware version in the MPPT Solar Charger must be v1.09 or later. Contact Victron Service for update instructions and files.</source>
       <translation>MPPT 太阳能充电器的固件版本必须为 v1.09 或更高版本。请联系 Victron 服务以获取更新说明和文件。</translation>
     </message>
-    <message id="solarcharger_pv">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="102"/>
-      <source>PV</source>
-      <extracomment>PV power for solar charger</extracomment>
-      <translation type="unfinished">光伏</translation>
-    </message>
     <message id="solarcharger_total_power">
       <location filename="../../pages/solar/PageSolarCharger.qml" line="127"/>
       <source>Total PV power</source>
       <translation>总的光伏功率</translation>
-    </message>
-    <message id="solarcharger_total_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="211"/>
-      <source>Total yield</source>
-      <extracomment>Solar charger total yield</extracomment>
-      <translation type="unfinished">总计发电</translation>
-    </message>
-    <message id="solarcharger_system_yield">
-      <location filename="../../pages/solar/PageSolarCharger.qml" line="220"/>
-      <source>System yield</source>
-      <extracomment>Solar charger system yield</extracomment>
-      <translation type="unfinished">系统发电</translation>
     </message>
     <message id="settings_multirs_total_yield">
       <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="63"/>
@@ -7660,16 +6964,19 @@ Do you want to continue?</source>
     <message id="vebus_device_update_firmware">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="133"/>
       <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
       <translation>该功能需要 400 或更高版本的固件。请联系安装人员更新 Multi/Quattro。</translation>
     </message>
     <message id="vebus_device_charger_not_ready">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="139"/>
       <source>Charger not ready, equalization cannot be started</source>
+      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
       <translation>充电器未准备就绪，均衡无法启动</translation>
     </message>
     <message id="vebus_device_no_equalisation_during_bulk">
       <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="143"/>
       <source>Equalization cannot be triggered during bulk charge state</source>
+      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
       <translation>在快充状态下无法触发均衡功能</translation>
     </message>
     <message id="vebus_device_restart_vebus_system_restart_confirmation_description">
@@ -7692,78 +6999,20 @@ Do you want to continue?</source>
       <source>Auto-started • %1</source>
       <translation>自动启动 - %1</translation>
     </message>
-    <message id="common_words_battery">
-      <location filename="../../components/CommonWords.qml" line="89"/>
-      <source>Battery</source>
-      <translation type="unfinished">电池</translation>
-    </message>
-    <message id="common_words_boat_page">
-      <location filename="../../components/CommonWords.qml" line="111"/>
-      <source>Boat</source>
-      <extracomment>The 'Boat' page</extracomment>
-      <translation type="unfinished">船</translation>
-    </message>
-    <message id="common_words_brief_page">
-      <location filename="../../components/CommonWords.qml" line="115"/>
-      <source>Brief</source>
-      <extracomment>The 'Brief' page</extracomment>
-      <translation type="unfinished">概要</translation>
-    </message>
-    <message id="common_words_closed_status">
-      <location filename="../../components/CommonWords.qml" line="133"/>
-      <source>Closed</source>
-      <extracomment>Status is 'closed'</extracomment>
-      <translation type="unfinished">已关闭</translation>
-    </message>
-    <message id="common_words_color">
-      <location filename="../../components/CommonWords.qml" line="136"/>
-      <source>Color</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_connected">
-      <location filename="../../components/CommonWords.qml" line="139"/>
-      <source>Connected</source>
-      <translation type="unfinished">已连接</translation>
-    </message>
     <message id="common_words_daily_history">
       <location filename="../../components/CommonWords.qml" line="152"/>
       <source>Daily history</source>
       <translation>每日历史记录</translation>
-    </message>
-    <message id="common_words_disabled">
-      <location filename="../../components/CommonWords.qml" line="169"/>
-      <source>Disabled</source>
-      <translation type="unfinished">已禁用</translation>
-    </message>
-    <message id="common_words_disconnected">
-      <location filename="../../components/CommonWords.qml" line="175"/>
-      <source>Disconnected</source>
-      <translation type="unfinished">已断开连接</translation>
-    </message>
-    <message id="common_words_error">
-      <location filename="../../components/CommonWords.qml" line="191"/>
-      <source>Error</source>
-      <translation type="unfinished">错误</translation>
     </message>
     <message id="common_words_error_not_a_number">
       <location filename="../../components/CommonWords.qml" line="200"/>
       <source>'%1' is not a number.</source>
       <translation>%1 "不是数字。</translation>
     </message>
-    <message id="common_words_generator">
-      <location filename="../../components/CommonWords.qml" line="217"/>
-      <source>Generator</source>
-      <translation type="unfinished">发电机</translation>
-    </message>
     <message id="common_words_input_current_limit">
       <location filename="../../components/CommonWords.qml" line="261"/>
       <source>Input current limit</source>
       <translation>输入限制电流</translation>
-    </message>
-    <message id="common_words_inverter_charger">
-      <location filename="../../components/CommonWords.qml" line="264"/>
-      <source>Inverter / Charger</source>
-      <translation type="unfinished">逆变器/充电器</translation>
     </message>
     <message id="common_words_inverter_mode_eco">
       <location filename="../../components/CommonWords.qml" line="268"/>
@@ -7776,12 +7025,6 @@ Do you want to continue?</source>
       <source>Manual stop</source>
       <translation>手动停止</translation>
     </message>
-    <message id="common_words_max">
-      <location filename="../../components/CommonWords.qml" line="315"/>
-      <source>Max</source>
-      <extracomment>Short for Maximum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_maximum_current">
       <location filename="../../components/CommonWords.qml" line="318"/>
       <source>Maximum current</source>
@@ -7792,62 +7035,10 @@ Do you want to continue?</source>
       <source>Maximum power</source>
       <translation>最大功率</translation>
     </message>
-    <message id="common_words_min">
-      <location filename="../../components/CommonWords.qml" line="331"/>
-      <source>Min</source>
-      <extracomment>Short for Minimum</extracomment>
-      <translation type="unfinished"/>
-    </message>
     <message id="common_words_minimum_current">
       <location filename="../../components/CommonWords.qml" line="334"/>
       <source>Minimum current</source>
       <translation>最小电流</translation>
-    </message>
-    <message id="common_words_no">
-      <location filename="../../components/CommonWords.qml" line="352"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="433"/>
-      <source>No</source>
-      <translation type="unfinished">不</translation>
-    </message>
-    <message id="common_words_none_option">
-      <location filename="../../components/CommonWords.qml" line="364"/>
-      <source>None</source>
-      <translation type="unfinished">无</translation>
-    </message>
-    <message id="common_words_none_errors">
-      <location filename="../../components/CommonWords.qml" line="368"/>
-      <source>None</source>
-      <extracomment>Indicates there are no errors</extracomment>
-      <translation type="unfinished">无</translation>
-    </message>
-    <message id="common_words_not_available">
-      <location filename="../../components/CommonWords.qml" line="371"/>
-      <source>Not available</source>
-      <translation type="unfinished">不可用</translation>
-    </message>
-    <message id="common_words_off">
-      <location filename="../../components/CommonWords.qml" line="377"/>
-      <source>Off</source>
-      <translation type="unfinished">关</translation>
-    </message>
-    <message id="common_words_ok">
-      <location filename="../../components/CommonWords.qml" line="383"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="41"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="45"/>
-      <source>OK</source>
-      <translation type="unfinished">正常</translation>
-    </message>
-    <message id="common_words_on">
-      <location filename="../../components/CommonWords.qml" line="386"/>
-      <source>On</source>
-      <translation type="unfinished">开</translation>
-    </message>
-    <message id="common_words_open_status">
-      <location filename="../../components/CommonWords.qml" line="393"/>
-      <source>Open</source>
-      <extracomment>Status is 'open'</extracomment>
-      <translation type="unfinished">打开</translation>
     </message>
     <message id="common_words_open_circuit">
       <location filename="../../components/CommonWords.qml" line="396"/>
@@ -7859,108 +7050,17 @@ Do you want to continue?</source>
       <source>Overall history</source>
       <translation>总体历史记录</translation>
     </message>
-    <message id="common_words_press">
-      <location filename="../../components/CommonWords.qml" line="419"/>
-      <source>Press</source>
-      <translation type="unfinished">报道</translation>
-    </message>
-    <message id="common_words_running_status">
-      <location filename="../../components/CommonWords.qml" line="458"/>
-      <source>Running</source>
-      <extracomment>Status = "running"</extracomment>
-      <translation type="unfinished">运行</translation>
-    </message>
-    <message id="common_words_settings">
-      <location filename="../../components/CommonWords.qml" line="467"/>
-      <source>Settings</source>
-      <translation type="unfinished">设置</translation>
-    </message>
-    <message id="common_words_silence_alarm">
-      <location filename="../../components/CommonWords.qml" line="476"/>
-      <source>Silence alarm</source>
-      <translation type="unfinished">静音警报</translation>
-    </message>
     <message id="common_words_soc">
       <location filename="../../components/CommonWords.qml" line="480"/>
       <source>SOC %1</source>
       <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
       <translation>SOC %1%</translation>
     </message>
-    <message id="common_words_speed">
-      <location filename="../../components/CommonWords.qml" line="484"/>
-      <source>Speed</source>
-      <extracomment>A speed measurement value</extracomment>
-      <translation type="unfinished">速度</translation>
-    </message>
-    <message id="common_words_standby">
-      <location filename="../../components/CommonWords.qml" line="487"/>
-      <source>Standby</source>
-      <translation type="unfinished">待机</translation>
-    </message>
-    <message id="common_words_state">
-      <location filename="../../components/CommonWords.qml" line="502"/>
-      <source>State</source>
-      <translation type="unfinished">状态</translation>
-    </message>
-    <message id="common_words_startup_status">
-      <location filename="../../components/CommonWords.qml" line="512"/>
-      <source>Startup (%1)</source>
-      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
-      <translation type="unfinished">启动（%1）</translation>
-    </message>
-    <message id="common_words_stopped">
-      <location filename="../../components/CommonWords.qml" line="521"/>
-      <source>Stopped</source>
-      <translation type="unfinished">已停止</translation>
-    </message>
-    <message id="common_words_total_power">
-      <location filename="../../components/CommonWords.qml" line="540"/>
-      <source>Total power</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_type">
-      <location filename="../../components/CommonWords.qml" line="547"/>
-      <source>Type</source>
-      <translation type="unfinished">类型</translation>
-    </message>
-    <message id="common_words_unknown_status">
-      <location filename="../../components/CommonWords.qml" line="554"/>
-      <source>Unknown</source>
-      <extracomment>Status = "unknown"</extracomment>
-      <translation type="unfinished">未知</translation>
-    </message>
-    <message id="common_words_value_must_be_greater_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="557"/>
-      <source>Value must be greater than start value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_value_must_be_greater_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="560"/>
-      <source>Value must be greater than stop value</source>
-      <translation type="unfinished">数值必须大于停止值</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_start_value">
-      <location filename="../../components/CommonWords.qml" line="563"/>
-      <source>Value must be lower than start value</source>
-      <translation type="unfinished">数值必须低于启动值</translation>
-    </message>
-    <message id="common_words_value_must_be_lower_than_stop_value">
-      <location filename="../../components/CommonWords.qml" line="566"/>
-      <source>Value must be lower than stop value</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="common_words_yes">
-      <location filename="../../components/CommonWords.qml" line="581"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="159"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="431"/>
-      <source>Yes</source>
-      <translation type="unfinished">是</translation>
-    </message>
     <message id="common_words_yield_today">
       <location filename="../../components/CommonWords.qml" line="592"/>
       <source>Yield Today</source>
       <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+      <oldsource>Yield today</oldsource>
       <translation>今日发电量</translation>
     </message>
     <message id="common_words_format_error">
@@ -7987,10 +7087,11 @@ Do you want to continue?</source>
     <message id="settings_firmware_installed_rebooting">
       <location filename="../../components/FirmwareUpdate.qml" line="79"/>
       <source>Firmware installed, device rebooting</source>
+      <oldsource>Firmware installed, rebooting.</oldsource>
       <translation>固件已安装，设备正在重启</translation>
     </message>
-    <message id="settings_radio_button_group_confirm">
-      <location filename="../../components/RadioButtonListPage.qml" line="121"/>
+    <message id="modaldialog_confirm">
+      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
       <source>Confirm</source>
       <extracomment>Confirm password, and verify it if possible</extracomment>
       <translation>是的，退订</translation>
@@ -8008,11 +7109,13 @@ Do you want to continue?</source>
     <message id="cgwacs_battery_schedule_duration">
       <location filename="../../components/listitems/ListChargeSchedule.qml" line="144"/>
       <source>Duration</source>
+      <oldsource>Duration (hh:mm)</oldsource>
       <translation>期限</translation>
     </message>
     <message id="settings_relay_deactivation_value">
       <location filename="../../components/TemperatureRelaySettings.qml" line="86"/>
       <source>Deactivation value</source>
+      <oldsource>Deativation value</oldsource>
       <translation>禁用值</translation>
     </message>
     <message id="splash_view_device_disconnected">
@@ -8060,29 +7163,6 @@ Do you want to continue?</source>
       <source>Temperature warning</source>
       <translation>温度警告</translation>
     </message>
-    <message id="battery_mode_idle">
-      <location filename="../../src/enums.cpp" line="26"/>
-      <source>Idle</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">空闲</translation>
-    </message>
-    <message id="battery_mode_charging">
-      <location filename="../../src/enums.cpp" line="30"/>
-      <source>Charging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">充电</translation>
-    </message>
-    <message id="battery_mode_discharging">
-      <location filename="../../src/enums.cpp" line="34"/>
-      <source>Discharging</source>
-      <extracomment>Battery mode</extracomment>
-      <translation type="unfinished">放电</translation>
-    </message>
-    <message id="dcMeter_bilge_pump">
-      <location filename="../../src/enums.cpp" line="115"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">舱底泵</translation>
-    </message>
     <message id="switch_state_channel_fault">
       <location filename="../../src/enums.cpp" line="372"/>
       <source>Channel Fault</source>
@@ -8113,26 +7193,6 @@ Do you want to continue?</source>
       <source>Slave of %1</source>
       <translation>%1 的从属设备</translation>
     </message>
-    <message id="switchable_output_numeric_input">
-      <location filename="../../src/enums.cpp" line="418"/>
-      <source>Numeric input</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bilge_pump">
-      <location filename="../../src/enums.cpp" line="424"/>
-      <source>Bilge pump</source>
-      <translation type="unfinished">舱底泵</translation>
-    </message>
-    <message id="switchable_output_not_running">
-      <location filename="../../src/enums.cpp" line="448"/>
-      <source>Not running</source>
-      <translation type="unfinished">不运行</translation>
-    </message>
-    <message id="switchable_output_off">
-      <location filename="../../src/enums.cpp" line="451"/>
-      <source>Off</source>
-      <translation type="unfinished">关</translation>
-    </message>
     <message id="switchable_output_powered">
       <location filename="../../src/enums.cpp" line="455"/>
       <source>Powered</source>
@@ -8161,16 +7221,19 @@ Do you want to continue?</source>
     <message id="evchargers_status_welded_contacts_error">
       <location filename="../../data/EvChargers.qml" line="76"/>
       <source>Welded contacts test error (shorted)</source>
+      <oldsource>Welded contacts error</oldsource>
       <translation>焊接触点测试错误（短路）</translation>
     </message>
     <message id="evchargers_status_switching_to_three_phase">
       <location filename="../../data/EvChargers.qml" line="100"/>
       <source>Switching to 3 phase</source>
+      <oldsource>Switching to 3-phase</oldsource>
       <translation>切换到三相</translation>
     </message>
     <message id="evchargers_status_switching_to_single_phase">
       <location filename="../../data/EvChargers.qml" line="103"/>
       <source>Switching to 1 phase</source>
+      <oldsource>Switching to single phase</oldsource>
       <translation>切换到单相</translation>
     </message>
     <message id="evchargers_status_stop_charging">
@@ -8323,17 +7386,6 @@ If the generator is currently running due to a autostart condition, disabling au
       <source>Open link</source>
       <translation>打开链接</translation>
     </message>
-    <message id="listlink_show_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="43"/>
-      <source>Show QR code</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="listlink_scan_qr_code">
-      <location filename="../../components/listitems/ListLink.qml" line="52"/>
-      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
-      <extracomment>%1 = url text</extracomment>
-      <translation type="unfinished">&lt;br /&gt;或插入链接：%1</translation>
-    </message>
     <message id="settings_services_mqtt_access">
       <location filename="../../components/listitems/ListMqttAccessSwitch.qml" line="11"/>
       <source>MQTT Access</source>
@@ -8405,12 +7457,6 @@ If the generator is currently running due to a autostart condition, disabling au
       <extracomment>The 'Brief' page, with the side panel opened</extracomment>
       <translation>概要（侧面板打开）</translation>
     </message>
-    <message id="startpage_option_overview">
-      <location filename="../../data/StartPageConfiguration.qml" line="37"/>
-      <source>Overview</source>
-      <extracomment>The 'Overview' page</extracomment>
-      <translation type="unfinished">总览</translation>
-    </message>
     <message id="startpage_option_levels_tanks">
       <location filename="../../data/StartPageConfiguration.qml" line="43"/>
       <source>Levels (Tanks)</source>
@@ -8429,12 +7475,12 @@ If the generator is currently running due to a autostart condition, disabling au
       <translation>电池清单</translation>
     </message>
     <message id="firmware_installed_build_gx_device_updated">
-      <location filename="../../pages/DialogLayer.qml" line="55"/>
+      <location filename="../../pages/DialogLayer.qml" line="56"/>
       <source>GX device has been updated</source>
       <translation>GX 设备已更新</translation>
     </message>
     <message id="firmware_installed_build_page_will_reload">
-      <location filename="../../pages/DialogLayer.qml" line="57"/>
+      <location filename="../../pages/DialogLayer.qml" line="58"/>
       <source>Page will automatically reload in ten seconds to load the latest version.</source>
       <translation>页面将在十秒后自动重新加载，以加载最新版本。</translation>
     </message>
@@ -8603,8 +7649,8 @@ Note that this menu only shows Carlo Gavazzi meters connected over RS485. For an
       <source>Unit</source>
       <translation>装置</translation>
     </message>
-    <message id="modbus_add_unit_invalid">
-      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="61"/>
+    <message id="page_settings_fronius_unitid_invalid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
       <source>%1 is not a valid unit number. Use a number between 1-247.</source>
       <translation>%1 不是有效的单位编号。请使用 1-247 之间的数字。</translation>
     </message>
@@ -8719,11 +7765,6 @@ Note that this menu only shows Carlo Gavazzi meters connected over RS485. For an
       <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="66"/>
       <source>Controller Temperature</source>
       <translation>控制器温度</translation>
-    </message>
-    <message id="devicelist_motordrive_motordirectioninverted">
-      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
-      <source>Motor Direction Inverted</source>
-      <translation type="unfinished"/>
     </message>
     <message id="cycle_history_active">
       <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
@@ -8915,11 +7956,6 @@ With streamlined navigation and a fresh look, everything you love is now even ea
     <message id="welcome_done">
       <location filename="../../pages/welcome/WelcomeView.qml" line="136"/>
       <source>Done</source>
-      <translation type="unfinished">完成</translation>
-    </message>
-    <message id="mk2vsc_state_done">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="20"/>
-      <source>Done</source>
       <translation>完成</translation>
     </message>
     <message id="welcome_next">
@@ -8977,6 +8013,7 @@ GX 设备只能控制一个已连接的发电机组，并选择 VRM 实例编号
     <message id="settings_tz_etc">
       <location filename="../../pages/settings/PageTzInfo.qml" line="280"/>
       <source>Other</source>
+      <oldsource>Etc</oldsource>
       <translation>其他</translation>
     </message>
     <message id="ac-in-modeldefault_energy_reverse_x">
@@ -8994,6 +8031,11 @@ GX 设备只能控制一个已连接的发电机组，并选择 VRM 实例编号
       <location filename="../../src/enums.cpp" line="438"/>
       <source>Unsupported type: %1</source>
       <translation>不支持的类型：%1</translation>
+    </message>
+    <message id="common_words_press">
+      <location filename="../../components/CommonWords.qml" line="419"/>
+      <source>Press</source>
+      <translation>报道</translation>
     </message>
     <message id="output_aux_battery_service_changed_dcdc">
       <location filename="../../components/listitems/ListOutputBatteryRadioButtonGroup.qml" line="27"/>
@@ -9134,13 +8176,6 @@ GX 设备只能控制一个已连接的发电机组，并选择 VRM 实例编号
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="38"/>
       <source>Resetting VE.Bus products</source>
       <translation>重置 VE.Bus 产品</translation>
-    </message>
-    <message id="Unknown">
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
-      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
-      <source>Unknown</source>
-      <translation type="unfinished">未知</translation>
     </message>
     <message id="mk2vsc_error_mk2_mk3_comm">
       <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="47"/>
@@ -9446,11 +8481,6 @@ GX 设备只能控制一个已连接的发电机组，并选择 VRM 实例编号
       <source>Changing the GX Password</source>
       <translation>更改 GX 密码</translation>
     </message>
-    <message id="modaldialog_confirm">
-      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
-      <source>Confirm</source>
-      <translation type="unfinished">是的，退订</translation>
-    </message>
     <message id="settings_security_profile_change_password_description">
       <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="83"/>
       <source>Please enter a new GX password:</source>
@@ -9543,21 +8573,6 @@ GX 设备只能控制一个已连接的发电机组，并选择 VRM 实例编号
       <source>Modifications installed</source>
       <translation>已安装的修改</translation>
     </message>
-    <message id="pagesettingsgeneral_modificationchecks_modbus">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="28"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">Modbus TCP 服务器</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_signalk">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="32"/>
-      <source>Signal K</source>
-      <translation type="unfinished">Signal K</translation>
-    </message>
-    <message id="pagesettingsgeneral_modificationchecks_nodered">
-      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="36"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">Node-RED</translation>
-    </message>
     <message id="pagesettingsgeneral_modificationchecks_running_integrations">
       <location filename="../../pages/settings/PageSettingsGeneral.qml" line="43"/>
       <source>%1 running integrations</source>
@@ -9633,16 +8648,6 @@ GX 设备只能控制一个已连接的发电机组，并选择 VRM 实例编号
       <source>Installed and enabled, disables at next boot</source>
       <translation>已安装并启用，下次启动时禁用</translation>
     </message>
-    <message id="pagesettingssupportstate_firmware_checking">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="153"/>
-      <source>Checking...</source>
-      <translation type="unfinished">检查...</translation>
-    </message>
-    <message id="pagesettingssupportstate_firmware_unknown">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="166"/>
-      <source>Unknown</source>
-      <translation type="unfinished">未知</translation>
-    </message>
     <message id="pagesettingssupportstate_support_status">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="228"/>
       <source>Support status</source>
@@ -9664,11 +8669,6 @@ GX 设备只能控制一个已连接的发电机组，并选择 VRM 实例编号
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="288"/>
       <source>Press 'OK' to disable custom startup scripts and reboot</source>
       <translation>按下“确定”禁用自定义启动脚本并重启</translation>
-    </message>
-    <message id="pagesettingssupportstate_re_enable_custom_startup_scripts">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="309"/>
-      <source>Re-enable custom startup scripts</source>
-      <translation type="unfinished">重新启用自定义启动脚本</translation>
     </message>
     <message id="pagesettingssupportstate_reenable_and_reboot_now">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="322"/>
@@ -9695,11 +8695,6 @@ GX 设备只能控制一个已连接的发电机组，并选择 VRM 实例编号
       <source>Disable also custom startup scripts?</source>
       <translation>同时禁用自定义启动脚本？</translation>
     </message>
-    <message id="pagesettingssupportstate_integrations">
-      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="448"/>
-      <source>Integrations</source>
-      <translation type="unfinished">集成</translation>
-    </message>
     <message id="pagesettingssupportstate_orange_items_description">
       <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="494"/>
       <source>Items colored orange are supported and provided by Victron Energy, but using them incorrectly can affect system stability. In case of troubleshooting, disable those first.</source>
@@ -9711,7 +8706,7 @@ GX 设备只能控制一个已连接的发电机组，并选择 VRM 实例编号
       <translation>连接兼容的蓝牙 USB 加密狗以启用蓝牙连接。</translation>
     </message>
     <message id="settings_ess_batteryLife_state">
-      <location filename="../../pages/settings/PageSettingsHub4.qml" line="140"/>
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="142"/>
       <source>BatteryLife state</source>
       <translation>BatteryLife 状态</translation>
     </message>
@@ -9719,23 +8714,6 @@ GX 设备只能控制一个已连接的发电机组，并选择 VRM 实例编号
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="33"/>
       <source>Device Integrations</source>
       <translation>设备集成</translation>
-    </message>
-    <message id="pagesettingsintegrations_modbus_tcp_server">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="201"/>
-      <source>Modbus TCP Server</source>
-      <translation type="unfinished">Modbus TCP 服务器</translation>
-    </message>
-    <message id="settings_large_signal_k">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="226"/>
-      <location filename="../../pages/settings/PageSettingsSignalK.qml" line="18"/>
-      <source>Signal K</source>
-      <translation type="unfinished">Signal K</translation>
-    </message>
-    <message id="settings_large_node_red">
-      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="241"/>
-      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="17"/>
-      <source>Node-RED</source>
-      <translation type="unfinished">Node-RED</translation>
     </message>
     <message id="settings_venusos_large_documentation">
       <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="267"/>
@@ -9745,6 +8723,7 @@ GX 设备只能控制一个已连接的发电机组，并选择 VRM 实例编号
     <message id="settings_modbus_enable_modbus_tcp">
       <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
       <source>Enable Modbus TCP Server</source>
+      <oldsource>Enable Modbus/TCP</oldsource>
       <translation>启用 Modbus TCP 服务器</translation>
     </message>
     <message id="pagesettingsconnectivity_bluetooth_for_victronconnect_app">
@@ -9838,11 +8817,13 @@ GX 设备只能控制一个已连接的发电机组，并选择 VRM 实例编号
     <message id="settings_gps_format_kmh">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="93"/>
       <source>Kilometres per hour</source>
+      <oldsource>Kilometers per hour</oldsource>
       <translation>公里/小时</translation>
     </message>
     <message id="settings_gps_format_ms">
       <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="95"/>
       <source>Metres per second</source>
+      <oldsource>Meters per second</oldsource>
       <translation>米/秒</translation>
     </message>
     <message id="components_volumeunit_cubic_metres">
@@ -9870,8 +8851,8 @@ GX 设备只能控制一个已连接的发电机组，并选择 VRM 实例编号
       <source>The Relay can now be found in the devices list</source>
       <translation>现在可以在设备列表中找到继电器</translation>
     </message>
-    <message id="common_words_gx_device_relays">
-      <location filename="../../components/CommonWords.qml" line="223"/>
+    <message id="gx_device_relays">
+      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
       <source>GX device relays</source>
       <translation>GX 设备继电器</translation>
     </message>
@@ -9925,12 +8906,6 @@ GX 设备只能控制一个已连接的发电机组，并选择 VRM 实例编号
       <extracomment>Forced by app to %1</extracomment>
       <translation>自动</translation>
     </message>
-    <message id="settings_remote_console_forced_by_vrm">
-      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="94"/>
-      <source>VRM</source>
-      <extracomment>Forced by %2 to dark</extracomment>
-      <translation type="unfinished">VRM</translation>
-    </message>
     <message id="settings_remote_console_forced_by_app">
       <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="97"/>
       <source>app</source>
@@ -9980,6 +8955,7 @@ GX 设备只能控制一个已连接的发电机组，并选择 VRM 实例编号
     <message id="settings_large_access_signal_k">
       <location filename="../../pages/settings/PageSettingsSignalK.qml" line="24"/>
       <source>Access Signal K</source>
+      <oldsource>Access Signal K (local network)</oldsource>
       <translation>访问 Signal K</translation>
     </message>
     <message id="pagesettingsintegrations_shelly_devices">
@@ -9990,6 +8966,7 @@ GX 设备只能控制一个已连接的发电机组，并选择 VRM 实例编号
     <message id="settings_large_access_node_red">
       <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
       <source>Access Node-RED</source>
+      <oldsource>Access Node-RED (local network)</oldsource>
       <translation>访问 Node-RED</translation>
     </message>
     <message id="settings_wifi_access_point_password">
@@ -10057,57 +9034,6 @@ GX 设备只能控制一个已连接的发电机组，并选择 VRM 实例编号
       <source>Wind charger</source>
       <translation>风力充电器</translation>
     </message>
-    <message id="digitalinputs_type_disabled">
-      <location filename="../../src/enums.cpp" line="192"/>
-      <source>Disabled</source>
-      <translation type="unfinished">已禁用</translation>
-    </message>
-    <message id="digitalinputs_state_off">
-      <location filename="../../src/enums.cpp" line="242"/>
-      <source>Off</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">关</translation>
-    </message>
-    <message id="digitalinputs_state_on">
-      <location filename="../../src/enums.cpp" line="246"/>
-      <source>On</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">开</translation>
-    </message>
-    <message id="digitalinputs_state_ok">
-      <location filename="../../src/enums.cpp" line="266"/>
-      <source>OK</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">正常</translation>
-    </message>
-    <message id="digitalinputs_state_alarm">
-      <location filename="../../src/enums.cpp" line="270"/>
-      <source>Alarm</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">报警</translation>
-    </message>
-    <message id="digitalinputs_state_running">
-      <location filename="../../src/enums.cpp" line="274"/>
-      <source>Running</source>
-      <extracomment>Digital input state</extracomment>
-      <translation type="unfinished">运行</translation>
-    </message>
-    <message id="pvinverter_statusCode_running">
-      <location filename="../../src/enums.cpp" line="300"/>
-      <source>Running</source>
-      <extracomment>PV inverter status code</extracomment>
-      <translation type="unfinished">运行</translation>
-    </message>
-    <message id="solarchargers_state_external control">
-      <location filename="../../src/enums.cpp" line="352"/>
-      <source>External control</source>
-      <translation type="unfinished">外部控制</translation>
-    </message>
-    <message id="switch_state_over_temperature">
-      <location filename="../../src/enums.cpp" line="366"/>
-      <source>Over temperature</source>
-      <translation type="unfinished">温度过高</translation>
-    </message>
     <message id="switchable_output_temperature_setpoint">
       <location filename="../../src/enums.cpp" line="398"/>
       <source>Temperature setpoint</source>
@@ -10117,11 +9043,6 @@ GX 设备只能控制一个已连接的发电机组，并选择 VRM 实例编号
       <location filename="../../src/enums.cpp" line="401"/>
       <source>Stepped switch</source>
       <translation>步进开关</translation>
-    </message>
-    <message id="switchable_output_slave">
-      <location filename="../../src/enums.cpp" line="408"/>
-      <source>Slave</source>
-      <translation type="unfinished">从机</translation>
     </message>
     <message id="switchable_output_dropdown">
       <location filename="../../src/enums.cpp" line="412"/>
@@ -10133,122 +9054,10 @@ GX 设备只能控制一个已连接的发电机组，并选择 VRM 实例编号
       <source>Basic slider</source>
       <translation>基础滑块</translation>
     </message>
-    <message id="switchable_output_rgb_color_wheel">
-      <location filename="../../src/enums.cpp" line="427"/>
-      <source>RGB color wheel</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_cct_color_wheel">
-      <location filename="../../src/enums.cpp" line="431"/>
-      <source>CCT color wheel</source>
-      <extracomment>Correlated Color Temperature color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_rgbw_color_wheel">
-      <location filename="../../src/enums.cpp" line="435"/>
-      <source>RGB + W color wheel</source>
-      <extracomment>RGB + white color wheel</extracomment>
-      <translation type="unfinished"/>
-    </message>
-    <message id="switchable_output_bypassed">
-      <location filename="../../src/enums.cpp" line="484"/>
-      <source>Bypassed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="tank_type_fuel">
-      <location filename="../../src/enums.cpp" line="495"/>
-      <source>Fuel</source>
-      <translation type="unfinished">燃料</translation>
-    </message>
-    <message id="tank_type_fresh_water">
-      <location filename="../../src/enums.cpp" line="498"/>
-      <source>Fresh water</source>
-      <translation type="unfinished">清水</translation>
-    </message>
-    <message id="tank_type_waste_water">
-      <location filename="../../src/enums.cpp" line="501"/>
-      <source>Waste water</source>
-      <translation type="unfinished">废水</translation>
-    </message>
-    <message id="tank_type_live_well">
-      <location filename="../../src/enums.cpp" line="504"/>
-      <source>Live well</source>
-      <translation type="unfinished">活鱼池</translation>
-    </message>
-    <message id="tank_type_oil">
-      <location filename="../../src/enums.cpp" line="507"/>
-      <source>Oil</source>
-      <translation type="unfinished">石油</translation>
-    </message>
-    <message id="tank_type_black_water">
-      <location filename="../../src/enums.cpp" line="510"/>
-      <source>Black water</source>
-      <translation type="unfinished">黑水</translation>
-    </message>
-    <message id="tank_type_gasoline">
-      <location filename="../../src/enums.cpp" line="513"/>
-      <source>Gasoline</source>
-      <translation type="unfinished">汽油</translation>
-    </message>
-    <message id="tank_type_diesel">
-      <location filename="../../src/enums.cpp" line="516"/>
-      <source>Diesel</source>
-      <translation type="unfinished">柴油</translation>
-    </message>
-    <message id="tank_type_lpg">
-      <location filename="../../src/enums.cpp" line="519"/>
-      <source>LPG</source>
-      <translation type="unfinished">LPG</translation>
-    </message>
-    <message id="tank_type_lng">
-      <location filename="../../src/enums.cpp" line="522"/>
-      <source>LNG</source>
-      <translation type="unfinished">LNG</translation>
-    </message>
-    <message id="tank_type_hydraulic_oil">
-      <location filename="../../src/enums.cpp" line="525"/>
-      <source>Hydraulic oil</source>
-      <translation type="unfinished">液压油</translation>
-    </message>
-    <message id="tank_type_raw_water">
-      <location filename="../../src/enums.cpp" line="528"/>
-      <source>Raw water</source>
-      <translation type="unfinished">生水</translation>
-    </message>
-    <message id="microgrid_mode_hybrid_droop">
-      <location filename="../../src/enums.cpp" line="539"/>
-      <source>Hybrid droop</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_following">
-      <location filename="../../src/enums.cpp" line="542"/>
-      <source>Grid-following</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="microgrid_mode_grid_forming">
-      <location filename="../../src/enums.cpp" line="545"/>
-      <source>Grid-forming</source>
-      <translation type="unfinished"/>
-    </message>
     <message id="switchable_output_three_state_switch">
       <location filename="../../src/enums.cpp" line="421"/>
       <source>Three-state switch</source>
       <translation>三态开关</translation>
-    </message>
-    <message id="switchable_output_fault">
-      <location filename="../../src/enums.cpp" line="464"/>
-      <source>Fault</source>
-      <translation type="unfinished">错误</translation>
-    </message>
-    <message id="switchable_output_running">
-      <location filename="../../src/enums.cpp" line="468"/>
-      <source>Running</source>
-      <translation type="unfinished">运行</translation>
-    </message>
-    <message id="switchable_output_trip_low_voltage">
-      <location filename="../../src/enums.cpp" line="481"/>
-      <source>Trip low voltage</source>
-      <translation type="unfinished">已禁用</translation>
     </message>
     <message id="settings_modbus_tcp_unit_id_note">
       <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="41"/>
@@ -10270,281 +9079,1152 @@ GX 设备只能控制一个已连接的发电机组，并选择 VRM 实例编号
       <source>Press to refresh</source>
       <translation>按下以刷新</translation>
     </message>
-    <message id="temperature_type_unknown">
-      <location filename="../../data/EnvironmentInputs.qml" line="65"/>
-      <source>Unknown</source>
-      <translation type="unfinished">未知</translation>
-    </message>
-    <message id="brief_solar_yield">
-      <location filename="../../pages/BriefSidePanel.qml" line="24"/>
-      <source>Solar yield</source>
-      <translation type="unfinished">太阳能发电量</translation>
-    </message>
-    <message id="brief_dc_input">
-      <location filename="../../pages/BriefSidePanel.qml" line="214"/>
-      <source>DC input</source>
-      <translation type="unfinished">直流输入</translation>
-    </message>
-    <message id="brief_ac_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="257"/>
-      <source>AC Loads</source>
-      <translation type="unfinished">交流负载</translation>
-    </message>
-    <message id="brief_dc_loads">
-      <location filename="../../pages/BriefSidePanel.qml" line="284"/>
-      <source>DC Loads</source>
-      <translation type="unfinished">直流负载</translation>
-    </message>
-    <message id="nav_overview">
-      <location filename="../../pages/OverviewPage.qml" line="450"/>
-      <source>Overview</source>
-      <translation type="unfinished">总览</translation>
-    </message>
-    <message id="settings_state">
-      <location filename="../../pages/settings/PageCanbusStatus.qml" line="116"/>
-      <source>State</source>
-      <translation type="unfinished">状态</translation>
-    </message>
-    <message id="inverter_pv">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="56"/>
-      <source>PV</source>
-      <translation type="unfinished">光伏</translation>
-    </message>
-    <message id="inverter_total_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="76"/>
-      <source>Total yield</source>
-      <translation type="unfinished">总计发电</translation>
-    </message>
-    <message id="inverter_system_yield">
-      <location filename="../../pages/settings/devicelist/inverter/PageInverter.qml" line="84"/>
-      <source>System yield</source>
-      <translation type="unfinished">系统发电</translation>
-    </message>
-    <message id="charger_total_pv_power">
-      <location filename="../../pages/solar/SolarDevicePage.qml" line="61"/>
-      <source>Total PV Power</source>
-      <translation type="unfinished">总的光伏功率</translation>
-    </message>
-    <message id="vebus_device_alarm_only">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="18"/>
-      <source>Alarm only</source>
-      <translation type="unfinished">只报警</translation>
-    </message>
-    <message id="vebus_device_alarms_and_warnings">
-      <location filename="../../pages/vebusdevice/PageVeBusAlarmSettings.qml" line="20"/>
-      <source>Alarms &amp; warnings</source>
-      <translation type="unfinished">报警&amp;警告</translation>
-    </message>
-    <message id="vebus_device_alarm_group_warning">
-      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmGroup.qml" line="44"/>
-      <source>Warning</source>
-      <translation type="unfinished">警告</translation>
-    </message>
-    <message id="load_delegate_status">
-      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
-      <source>Status: %1</source>
-      <translation type="unfinished"/>
+    <message id="common_words_total_power">
+      <location filename="../../components/CommonWords.qml" line="540"/>
+      <source>Total power</source>
+      <translation>总功率</translation>
     </message>
     <message id="venus_os_gui">
       <location filename="../../Main.qml" line="17"/>
       <source>Venus OS GUI</source>
       <extracomment>Application title</extracomment>
-      <translation type="unfinished"/>
       <extra-Context>only shown on desktop systems</extra-Context>
+      <translation>Venus OS 图形界面</translation>
+    </message>
+    <message id="load_delegate_status">
+      <location filename="../../pages/loads/LoadListDelegate.qml" line="72"/>
+      <source>Status: %1</source>
+      <translation>状态：%1</translation>
+    </message>
+    <message id="settings_relay_polarity_relay1">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
+      <source>Polarity (Relay 1)</source>
+      <translation>极性 (继电器 1)</translation>
+    </message>
+    <message id="settings_relay_polarity">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="78"/>
+      <source>Polarity</source>
+      <translation>极性</translation>
+    </message>
+    <message id="settings_relay_polarity_relay2">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
+      <source>Polarity (Relay 2)</source>
+      <translation>极性 (继电器 2)</translation>
+    </message>
+    <message id="page_settings_wifi_invalid_password">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="76"/>
+      <source>Password length must be either 0 or between 10 and 63 characters long</source>
+      <translation>密码长度必须为 0 或介于 10 到 63 个字符之间</translation>
+    </message>
+    <message id="page_settings_wifi_password_updated">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="80"/>
+      <source>Password updated</source>
+      <translation>密码已更新</translation>
+    </message>
+    <message id="common_words_max">
+      <location filename="../../components/CommonWords.qml" line="315"/>
+      <source>Max</source>
+      <extracomment>Short for Maximum</extracomment>
+      <translation>最大值</translation>
+    </message>
+    <message id="common_words_min">
+      <location filename="../../components/CommonWords.qml" line="331"/>
+      <source>Min</source>
+      <extracomment>Short for Minimum</extracomment>
+      <translation>最小值</translation>
+    </message>
+    <message id="settings_ess_deprecated">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="321"/>
+      <source>Deprecated settings</source>
+      <translation>已弃用的设置</translation>
+    </message>
+    <message id="settings_ess_max_charge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="328"/>
+      <source>Battery charge limit (% of CCL)</source>
+      <translation>电池充电限制（占 CCL 的百分比）</translation>
+    </message>
+    <message id="settings_ess_max_discharge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="339"/>
+      <source>Battery discharge limit (% of DCL)</source>
+      <translation>电池放电限制（占 DCL 的百分比）</translation>
+    </message>
+    <message id="vebus_device_bms_message">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
+      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
+      <oldsource>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</oldsource>
+      <translation>VE.Bus BMS 会在需要时自动关闭系统以保护电池。因此，无法通过 GX 设备控制系统。</translation>
+    </message>
+    <message id="switchable_output_numeric_input">
+      <location filename="../../src/enums.cpp" line="418"/>
+      <source>Numeric input</source>
+      <translation>数值输入</translation>
     </message>
     <message id="autotoggleswitch_disable_auto_mode_info">
       <location filename="../../components/controls/AutoToggleButton.qml" line="34"/>
       <source>Disable Auto mode first</source>
-      <translation type="unfinished"/>
+      <translation>请先禁用自动模式</translation>
+    </message>
+    <message id="pagesettingsintegrations_venus_os_enable_large_features">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="219"/>
+      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
+      <translation>启用 Venus OS Large 固件以使用 Node-RED 或 Signal-K</translation>
+    </message>
+    <message id="settings_relays_sensors_tanks">
+      <location filename="../../pages/SettingsPage.qml" line="75"/>
+      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
+      <oldsource>Relays, Sensors, Tanks, PV Inverters, Modbus, MQTT…</oldsource>
+      <translation>继电器、传感器、光伏逆变器、Modbus、Node-RED</translation>
+    </message>
+    <message id="vebus_device_page_microgrid_parameters">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
+      <source>Microgrid parameters</source>
+      <translation>微电网参数</translation>
+    </message>
+    <message id="microgrid_mode_hybrid_droop">
+      <location filename="../../src/enums.cpp" line="539"/>
+      <source>Hybrid droop</source>
+      <translation>混合型下垂控制</translation>
+    </message>
+    <message id="microgrid_mode_grid_following">
+      <location filename="../../src/enums.cpp" line="542"/>
+      <source>Grid-following</source>
+      <translation>并网跟随</translation>
+    </message>
+    <message id="microgrid_mode_grid_forming">
+      <location filename="../../src/enums.cpp" line="545"/>
+      <source>Grid-forming</source>
+      <translation>并网形成</translation>
+    </message>
+    <message id="switchable_output_trip_low_voltage">
+      <location filename="../../src/enums.cpp" line="481"/>
+      <source>Trip low voltage</source>
+      <oldsource>Disabled</oldsource>
+      <translation>低电压跳闸</translation>
     </message>
     <message id="microgrid">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="15"/>
       <source>Microgrid</source>
-      <translation type="unfinished"/>
+      <translation>微电网</translation>
     </message>
     <message id="page_microgrid_active_mode">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="19"/>
       <source>Active mode</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_microgrid_from_p1_to_p2">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="34"/>
-      <source>%1 %2 to %3 %4</source>
-      <extracomment>Describes a range from one quantity to another, e.g. "30 W to 60 W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
-      <translation type="unfinished"/>
+      <translation>激活模式</translation>
     </message>
     <message id="page_microgrid_hybrid_droop_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="92"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
       <source>Hybrid droop parameters</source>
-      <translation type="unfinished"/>
+      <translation>混合型下垂控制参数</translation>
     </message>
     <message id="page_microgrid_reference_active_power_p0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="99"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="105"/>
       <source>Reference active power (P&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>参考有功功率 (P&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_frequency_f0">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="108"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="112"/>
       <source>Reference frequency (f&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>参考频率 (f&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_frequency_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="117"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="119"/>
       <source>Frequency droop slope (droop&lt;sub&gt;fP&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>频率下垂斜率 (droop&lt;sub&gt;fP&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_reactive_power">
       <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="126"/>
       <source>Reference reactive power (Q&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>参考无功功率 (Q&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_reference_voltage">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="135"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="133"/>
       <source>Reference Voltage (U&lt;sub&gt;0&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>参考电压 (U&lt;sub&gt;0&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_voltage_droop_slope">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="144"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="140"/>
       <source>Voltage droop slope (droop&lt;sub&gt;UQ&lt;/sub&gt;)</source>
-      <translation type="unfinished"/>
+      <translation>电压下垂斜率 (droop&lt;sub&gt;UQ&lt;/sub&gt;)</translation>
     </message>
     <message id="page_microgrid_minimum_and_maximum_parameters">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="146"/>
       <source>Minimum and maximum parameters</source>
-      <translation type="unfinished"/>
+      <translation>最小值和最大值参数</translation>
     </message>
     <message id="page_microgrid_allowed_active_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="156"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="151"/>
       <source>Allowed active power range</source>
-      <translation type="unfinished"/>
+      <translation>允许的有功功率范围</translation>
     </message>
     <message id="page_microgrid_allowed_reactive_power_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="164"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="159"/>
       <source>Allowed reactive power range</source>
-      <translation type="unfinished"/>
+      <translation>允许的无功功率范围</translation>
     </message>
     <message id="page_microgrid_p_q_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="176"/>
       <source>P-Q direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>P-Q 直接驱动设置</translation>
     </message>
     <message id="page_microgrid_active_power_setpoint_p">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="186"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="181"/>
       <source>Active power setpoint (P)</source>
-      <translation type="unfinished"/>
+      <translation>有功功率设定点 (P)</translation>
     </message>
     <message id="page_microgrid_reactive_power_setpoint_q">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="194"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="188"/>
       <source>Reactive power setpoint (Q)</source>
-      <translation type="unfinished"/>
+      <translation>无功功率设定点 (Q)</translation>
     </message>
     <message id="page_microgrid_allowed_frequency_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="202"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="195"/>
       <source>Allowed frequency range</source>
-      <translation type="unfinished"/>
+      <translation>允许的频率范围</translation>
     </message>
     <message id="page_microgrid_allowed_voltage_range">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="210"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="203"/>
       <source>Allowed voltage range</source>
-      <translation type="unfinished"/>
+      <translation>允许的电压范围</translation>
     </message>
     <message id="page_microgrid_v_f_direct_drive_settings">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="227"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="220"/>
       <source>V-f direct drive settings</source>
-      <translation type="unfinished"/>
+      <translation>V-f 直接驱动设置</translation>
     </message>
     <message id="page_microgrid_voltage_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="225"/>
       <source>Voltage setpoint (U)</source>
-      <translation type="unfinished"/>
+      <translation>电压设定点 (U)</translation>
     </message>
     <message id="page_microgrid_frequency_setpoint">
-      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="240"/>
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="232"/>
       <source>Frequency setpoint (f)</source>
-      <translation type="unfinished"/>
+      <translation>频率设定点 (f)</translation>
     </message>
-    <message id="temperature_slider_current">
-      <location filename="../../components/controls/TemperatureSlider.qml" line="160"/>
-      <source>Current</source>
-      <extracomment>The current temperature measurement</extracomment>
-      <translation type="unfinished">电流</translation>
+    <message id="pagesettingsintegrations_canopenmotordrive">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="173"/>
+      <source>CANopen motor drives</source>
+      <translation>CANopen 马达驱动器</translation>
+    </message>
+    <message id="pagesettingsintegrations_ui_plugins">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="283"/>
+      <source>UI Plugins</source>
+      <translation>UI 插件</translation>
+    </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="73"/>
+      <source>Motor Direction Inverted</source>
+      <translation>电机方向反转</translation>
     </message>
     <message id="page_settings_canopenmotordrive_scan_for_motor_drives">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="31"/>
       <source>Scan for motor drives</source>
-      <translation type="unfinished"/>
+      <translation>扫描马达驱动器</translation>
     </message>
     <message id="page_settings_canopenmotordrive_discovered_motor_drive_ids">
       <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="39"/>
       <source>Discovered motor drive IDs</source>
-      <translation type="unfinished"/>
+      <translation>已发现的马达驱动器 ID</translation>
     </message>
-    <message id="switchableoutput_gx_device_relays">
-      <location filename="../../src/switchableoutput.cpp" line="388"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">GX 设备继电器</translation>
+    <message id="temperature_pm25">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
+      <source>PM2.5</source>
+      <translation>PM2.5</translation>
     </message>
-    <message id="gx_device_relays">
-      <location filename="../../src/switchableoutputgroupmodel.cpp" line="103"/>
-      <source>GX device relays</source>
-      <translation type="unfinished">GX 设备继电器</translation>
+    <message id="temperature_co2">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+      <source>CO₂</source>
+      <translation>CO₂</translation>
     </message>
-    <message id="color_preset">
-      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
-      <source>Preset</source>
-      <translation type="unfinished"/>
+    <message id="temperature_voc">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
+      <source>VOC index</source>
+      <translation>VOC 指数</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_location">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
-      <source>Add Modbus port and unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_nox">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
+      <source>NOx index</source>
+      <translation>NOx 指数</translation>
     </message>
-    <message id="page_settings_fronius_add_modbus_unitid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
-      <source>Unit ID</source>
-      <translation type="unfinished"/>
+    <message id="temperature_luminosity">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
+      <source>Luminosity</source>
+      <translation>亮度</translation>
     </message>
-    <message id="page_settings_fronius_unitid_invalid">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
-      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
-      <translation type="unfinished">%1 不是有效的单位编号。请使用 1-247 之间的数字。</translation>
-    </message>
-    <message id="page_settings_fronius_add_modbus_location_button">
-      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
-      <source>Add</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_locations_note">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
-      <source>The default modbus port is 502 and the default unit ID is 126.
-Here you can add additional ports and unit IDs to scan for PV inverters.</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_location_number">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
-      <source>Port/Unit ID %1</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location_description">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
-      <source>Port: %1 (Unit %2)</source>
-      <translation type="unfinished"/>
-    </message>
-    <message id="page_settings_fronius_modbus_remove_location">
-      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
-      <source>Remove Modbus port and unit ID?</source>
-      <translation type="unfinished"/>
+    <message id="switchable_output_bypassed">
+      <location filename="../../src/enums.cpp" line="484"/>
+      <source>Bypassed</source>
+      <translation>已旁路</translation>
     </message>
     <message id="switchableoutput_list_delegate_auto_status">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="84"/>
       <source>Auto (%1)</source>
       <extracomment>%1 = 'On' or 'Off'</extracomment>
-      <translation type="unfinished"/>
+      <translation>自动 (%1)</translation>
     </message>
     <message id="switchableoutput_list_delegate_state_forced">
       <location filename="../../pages/settings/devicelist/switchable-outputs/SwitchableOutputListDelegate.qml" line="100"/>
       <source>Forced</source>
-      <translation type="unfinished"/>
+      <translation>强制</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_settings">
+      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
+      <source>Modbus port and unit ID settings</source>
+      <translation>Modbus端口和设备ID设置</translation>
+    </message>
+    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="322"/>
+      <source>Integrates with the device list</source>
+      <translation>与设备列表集成</translation>
+    </message>
+    <message id="common_words_color">
+      <location filename="../../components/CommonWords.qml" line="136"/>
+      <source>Color</source>
+      <translation>颜色</translation>
+    </message>
+    <message id="common_words_value_must_be_greater_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="557"/>
+      <source>Value must be greater than start value</source>
+      <translation>值必须大于起始值</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="566"/>
+      <source>Value must be lower than stop value</source>
+      <translation>值必须小于停止值</translation>
+    </message>
+    <message id="notifications_page_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="43"/>
+      <source>Active Notifications</source>
+      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
+      <translation>激活的通知</translation>
+    </message>
+    <message id="notifications_page_inactive_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="47"/>
+      <source>Inactive Notifications</source>
+      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
+      <translation>未激活的通知</translation>
+    </message>
+    <message id="notifications_no_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="106"/>
+      <source>No active notifications</source>
+      <translation>无激活的通知</translation>
+    </message>
+    <message id="switchable_output_rgb_color_wheel">
+      <location filename="../../src/enums.cpp" line="427"/>
+      <source>RGB color wheel</source>
+      <translation>RGB 色轮</translation>
+    </message>
+    <message id="switchable_output_cct_color_wheel">
+      <location filename="../../src/enums.cpp" line="431"/>
+      <source>CCT color wheel</source>
+      <extracomment>Correlated Color Temperature color wheel</extracomment>
+      <translation>CCT 色轮</translation>
+    </message>
+    <message id="switchable_output_rgbw_color_wheel">
+      <location filename="../../src/enums.cpp" line="435"/>
+      <source>RGB + W color wheel</source>
+      <extracomment>RGB + white color wheel</extracomment>
+      <translation>RGB + W 色轮</translation>
+    </message>
+    <message id="listlink_show_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="43"/>
+      <source>Show QR code</source>
+      <translation>显示二维码</translation>
+    </message>
+    <message id="listlink_scan_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="52"/>
+      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
+      <extracomment>%1 = url text</extracomment>
+      <oldsource>Scan the QR code with your portable device.&lt;br /&gt;Or insert the link: %1</oldsource>
+      <translation>打开二维码，用您的便携设备扫描。&lt;br /&gt;或插入链接: %1</translation>
+    </message>
+    <message id="color_preset">
+      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
+      <source>Preset</source>
+      <translation>预设</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
+      <source>Add Modbus port and unit ID</source>
+      <translation>添加Modbus端口和设备ID</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_unitid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
+      <source>Unit ID</source>
+      <translation>设备ID</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location_button">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
+      <source>Add</source>
+      <translation>添加</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_locations_note">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="40"/>
+      <source>The default modbus port is 502 and the default unit ID is 126.
+Here you can add additional ports and unit IDs to scan for PV inverters.</source>
+      <translation>默认的Modbus端口是502，默认的设备ID是126。
+您可以在这里添加额外的端口和设备ID来扫描光伏逆变器。</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_location_number">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="50"/>
+      <source>Port/Unit ID %1</source>
+      <translation>端口/设备ID %1</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location_description">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="72"/>
+      <source>Port: %1 (Unit %2)</source>
+      <translation>端口: %1 (设备 %2)</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="94"/>
+      <source>Remove Modbus port and unit ID?</source>
+      <translation>移除Modbus端口和设备ID？</translation>
+    </message>
+    <message id="devicelist_tankshape_edit_point">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="182"/>
+      <source>Edit point %1</source>
+      <extracomment>%1 = which point is being edited, a number like "1" or "2"</extracomment>
+      <translation></translation>
+    </message>
+    <message id="settings_canbus_vecan">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
+      <source>VE.Can (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_250">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <source>VE.Can &amp; CANopen E-drive (250 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_canopen_motordrive_500">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
+      <source>CANopen E-drive (500 kbit/s)</source>
+      <translation></translation>
+    </message>
+    <message id="page_microgrid_from_p1_to_p2">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="39"/>
+      <source>%1%2 to %3%4</source>
+      <extracomment>Describes a range from one quantity to another, e.g. "30W to 60W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
+      <translation></translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAfricaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
+      <source>Morocco Standard Time</source>
+      <translation>摩洛哥标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
+      <source>W. Central Africa Standard Time</source>
+      <translation>中非西部标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
+      <source>South Africa Standard Time</source>
+      <translation>南非标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
+      <source>Namibia Standard Time</source>
+      <translation>纳米比亚标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
+      <source>Egypt Standard Time</source>
+      <translation>埃及标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
+      <source>E. Africa Standard Time</source>
+      <translation>非洲东部标准时间</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAmericaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
+      <source>Argentina Standard Time</source>
+      <translation>阿根廷标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
+      <source>E. South America Standard Time</source>
+      <translation>南美东部标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
+      <source>Greenland Standard Time</source>
+      <translation>格陵兰标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
+      <source>Montevideo Standard Time</source>
+      <translation>蒙得维的亚标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
+      <source>Newfoundland Standard Time</source>
+      <translation>纽芬兰标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
+      <source>SA Eastern Standard Time</source>
+      <translation>南美东部标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
+      <source>Atlantic Standard Time</source>
+      <translation>大西洋标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
+      <source>Central Brazilian Standard Time</source>
+      <translation>巴西中部标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>太平洋南美洲标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
+      <source>Paraguay Standard Time</source>
+      <translation>巴拉圭标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
+      <source>SA Western Standard Time</source>
+      <translation>南美西部标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
+      <source>Venezuela Standard Time</source>
+      <translation>委内瑞拉标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
+      <source>Eastern Standard Time</source>
+      <translation>东部标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
+      <source>SA Pacific Standard Time</source>
+      <translation>南美太平洋标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
+      <source>US Eastern Standard Time</source>
+      <translation>美国东部标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
+      <source>Canada Central Standard Time</source>
+      <translation>加拿大中部标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
+      <source>Central America Standard Time</source>
+      <translation>中美洲标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
+      <source>Central Standard Time (Mexico)</source>
+      <translation>中部标准时间（墨西哥）</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
+      <source>Central Standard Time</source>
+      <translation>中部标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
+      <source>Mountain Standard Time (Mexico)</source>
+      <translation>山区标准时间（墨西哥）</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
+      <source>Mountain Standard Time</source>
+      <translation>山区标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
+      <source>US Mountain Standard Time</source>
+      <translation>美国山区标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
+      <source>Pacific Standard Time (Mexico)</source>
+      <translation>太平洋标准时间（墨西哥）</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
+      <source>Pacific Standard Time</source>
+      <translation>太平洋标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
+      <source>Alaskan Standard Time</source>
+      <translation>阿拉斯加标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
+      <source>Hawaii-Aleutian</source>
+      <translation>夏威夷-阿留申</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
+      <source>Atlantic Daylight Time</source>
+      <translation>大西洋夏令时间</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAntarcticaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+      <source>New Zealand Standard Time</source>
+      <translation>新西兰标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>太平洋中部标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+      <source>West Pacific Standard Time</source>
+      <translation>太平洋西部标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+      <source>W. Australia Standard Time</source>
+      <translation>澳大利亚西部标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+      <source>SE Asia Standard Time</source>
+      <translation>东南亚标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+      <source>Central Asia Standard Time</source>
+      <translation>中亚标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+      <source>West Asia Standard Time</source>
+      <translation>西亚标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+      <source>E. Africa Standard Time</source>
+      <translation>非洲东部标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>太平洋南美洲标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+      <source>SA Western Standard Time</source>
+      <translation>南美西部标准时间</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzArcticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
+      <source>W. Europe Standard Time</source>
+      <translation>西欧标准时间</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAsiaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
+      <source>Kamchatka Standard Time</source>
+      <translation>堪察加标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
+      <source>Magadan Standard Time</source>
+      <translation>马加丹标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
+      <source>Vladivostok Standard Time</source>
+      <translation>符拉迪沃斯托克标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
+      <source>Yakutsk Standard Time</source>
+      <translation>雅库茨克标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
+      <source>Tokyo Standard Time</source>
+      <translation>东京标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
+      <source>Korea Standard Time</source>
+      <translation>韩国标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
+      <source>Singapore Standard Time</source>
+      <translation>新加坡标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
+      <source>Ulaanbaatar Standard Time</source>
+      <translation>乌兰巴托标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
+      <source>Taipei Standard Time</source>
+      <translation>台北标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
+      <source>North Asia East Standard Time</source>
+      <translation>北亚东部标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
+      <source>China Standard Time</source>
+      <translation>中国标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
+      <source>SE Asia Standard Time</source>
+      <translation>东南亚标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
+      <source>North Asia Standard Time</source>
+      <translation>北亚标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
+      <source>Myanmar Standard Time</source>
+      <translation>缅甸标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
+      <source>N. Central Asia Standard Time</source>
+      <translation>中亚北部标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
+      <source>Central Asia Standard Time</source>
+      <translation>中亚标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
+      <source>Bangladesh Standard Time</source>
+      <translation>孟加拉国标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
+      <source>Nepal Standard Time</source>
+      <translation>尼泊尔标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
+      <source>Sri Lanka Standard Time</source>
+      <translation>斯里兰卡标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
+      <source>India Standard Time</source>
+      <translation>印度标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
+      <source>West Asia Standard Time</source>
+      <translation>西亚标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
+      <source>Pakistan Standard Time</source>
+      <translation>巴基斯坦标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
+      <source>Ekaterinburg Standard Time</source>
+      <translation>叶卡特琳堡标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
+      <source>Georgian Standard Time</source>
+      <translation>格鲁吉亚标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
+      <source>Caucasus Standard Time</source>
+      <translation>高加索标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
+      <source>Azerbaijan Standard Time</source>
+      <translation>阿塞拜疆标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
+      <source>Arabian Standard Time</source>
+      <translation>阿拉伯标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
+      <source>Afghanistan Standard Time</source>
+      <translation>阿富汗标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
+      <source>Iran Standard Time</source>
+      <translation>伊朗标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
+      <source>Arabic Standard Time</source>
+      <translation>阿拉伯标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
+      <source>Arab Standard Time</source>
+      <translation>阿拉伯标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
+      <source>Syria Standard Time</source>
+      <translation>叙利亚标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
+      <source>Middle East Standard Time</source>
+      <translation>中东标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
+      <source>Jordan Standard Time</source>
+      <translation>约旦标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
+      <source>Israel Standard Time</source>
+      <translation>以色列标准时间</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAtlanticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+      <source>Greenwich Standard Time</source>
+      <translation>格林尼治标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+      <source>Azores Standard Time</source>
+      <translation>亚速尔群岛标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+      <source>Cape Verde Standard Time</source>
+      <translation>佛得角标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
+      <source>Mid-Atlantic Standard Time</source>
+      <translation>大西洋中部标准时间</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAustraliaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+      <source>Tasmania Standard Time</source>
+      <translation>塔斯马尼亚标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+      <source>E. Australia Standard Time</source>
+      <translation>澳大利亚东部标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+      <source>AUS Eastern Standard Time</source>
+      <translation>澳大利亚东部标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+      <source>Cen. Australia Standard Time</source>
+      <translation>澳大利亚中部标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+      <source>AUS Central Standard Time</source>
+      <translation>澳大利亚中部标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+      <source>W. Australia Standard Time</source>
+      <translation>澳大利亚西部标准时间</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEtcData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
+      <source>GMT +12</source>
+      <translation>GMT +12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
+      <source>GMT -02</source>
+      <translation>GMT -02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
+      <source>GMT -11</source>
+      <translation>GMT -11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
+      <source>GMT -13</source>
+      <translation>格林尼治标准时间-13</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
+      <source>GMT -12</source>
+      <translation>格林尼治标准时间 -12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
+      <source>GMT -10</source>
+      <translation>格林尼治标准时间 -10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
+      <source>GMT -09</source>
+      <translation>格林尼治标准时间 -09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
+      <source>GMT -08</source>
+      <translation>格林尼治标准时间 -08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
+      <source>GMT -07</source>
+      <translation>格林尼治标准时间 -07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
+      <source>GMT -06</source>
+      <translation>格林尼治标准时间 -06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
+      <source>GMT -05</source>
+      <translation>格林尼治标准时间 -05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
+      <source>GMT -04</source>
+      <translation>格林尼治标准时间 -04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
+      <source>GMT -03</source>
+      <translation>格林尼治标准时间 -03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
+      <source>GMT -01</source>
+      <translation>格林威治标准时间 -01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
+      <source>GMT</source>
+      <translation>GMT</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
+      <source>GMT +01</source>
+      <translation>格林尼治标准时间 +01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
+      <source>GMT +02</source>
+      <translation>格林尼治标准时间 +02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
+      <source>GMT +03</source>
+      <translation>格林尼治标准时间 +03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
+      <source>GMT +04</source>
+      <translation>格林尼治标准时间 +04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
+      <source>GMT +05</source>
+      <translation>格林尼治标准时间 +05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
+      <source>GMT +06</source>
+      <translation>格林尼治标准时间 +06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
+      <source>GMT +07</source>
+      <translation>格林尼治标准时间 +07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
+      <source>GMT +08</source>
+      <translation>格林尼治标准时间 +08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
+      <source>GMT +09</source>
+      <translation>格林尼治标准时间 +09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
+      <source>GMT +10</source>
+      <translation>格林尼治标准时间 +10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
+      <source>GMT +11</source>
+      <translation>格林尼治标准时间 +11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
+      <source>UTC</source>
+      <translation>UTC</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEuropeData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
+      <source>GMT Standard Time</source>
+      <translation>GMT标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
+      <source>Central Europe Standard Time</source>
+      <translation>中欧标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
+      <source>Central European Standard Time</source>
+      <translation>欧洲中部标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
+      <source>Romance Standard Time</source>
+      <translation>罗曼斯标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
+      <source>W. Europe Standard Time</source>
+      <translation>西欧标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
+      <source>E. Europe Standard Time</source>
+      <translation>东欧标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
+      <source>FLE Standard Time</source>
+      <translation>FLE标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
+      <source>GTB Standard Time</source>
+      <translation>GTB标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
+      <source>Belarus Standard Time</source>
+      <translation>白俄罗斯标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
+      <source>Russian Standard Time</source>
+      <translation>俄罗斯标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
+      <source>Turkey Standard Time</source>
+      <translation>土耳其标准时间</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzIndianData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
+      <source>Mauritius Standard Time</source>
+      <translation>毛里求斯标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
+      <source>Christmas Island Standard Time</source>
+      <translation>圣诞岛标准时</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzPacificData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
+      <source>Tonga Standard Time</source>
+      <translation>汤加标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
+      <source>Fiji Standard Time</source>
+      <translation>斐济标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
+      <source>New Zealand Standard Time</source>
+      <translation>新西兰标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>太平洋中部标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
+      <source>West Pacific Standard Time</source>
+      <translation>太平洋西部标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
+      <source>Samoa Standard Time</source>
+      <translation>萨摩亚标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
+      <source>Hawaiian Standard Time</source>
+      <translation>夏威夷标准时间</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
+      <source>Easter Island Standard Time</source>
+      <translation>东部岛屿标准时</translation>
     </message>
   </context>
   <context>
@@ -12173,838 +11853,6 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
     </message>
   </context>
   <context>
-    <name>TzAfricaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
-      <source>Morocco Standard Time</source>
-      <translation>摩洛哥标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
-      <source>W. Central Africa Standard Time</source>
-      <translation>中非西部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
-      <source>South Africa Standard Time</source>
-      <translation>南非标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
-      <source>Namibia Standard Time</source>
-      <translation>纳米比亚标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
-      <source>Egypt Standard Time</source>
-      <translation>埃及标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
-      <source>E. Africa Standard Time</source>
-      <translation>非洲东部标准时间</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAmericaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
-      <source>Argentina Standard Time</source>
-      <translation>阿根廷标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
-      <source>E. South America Standard Time</source>
-      <translation>南美东部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
-      <source>Greenland Standard Time</source>
-      <translation>格陵兰标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
-      <source>Montevideo Standard Time</source>
-      <translation>蒙得维的亚标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
-      <source>Newfoundland Standard Time</source>
-      <translation>纽芬兰标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
-      <source>SA Eastern Standard Time</source>
-      <translation>南美东部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
-      <source>Atlantic Standard Time</source>
-      <translation>大西洋标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
-      <source>Central Brazilian Standard Time</source>
-      <translation>巴西中部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>太平洋南美洲标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
-      <source>Paraguay Standard Time</source>
-      <translation>巴拉圭标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
-      <source>SA Western Standard Time</source>
-      <translation>南美西部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
-      <source>Venezuela Standard Time</source>
-      <translation>委内瑞拉标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
-      <source>Eastern Standard Time</source>
-      <translation>东部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
-      <source>SA Pacific Standard Time</source>
-      <translation>南美太平洋标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
-      <source>US Eastern Standard Time</source>
-      <translation>美国东部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
-      <source>Canada Central Standard Time</source>
-      <translation>加拿大中部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
-      <source>Central America Standard Time</source>
-      <translation>中美洲标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
-      <source>Central Standard Time (Mexico)</source>
-      <translation>中部标准时间（墨西哥）</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
-      <source>Central Standard Time</source>
-      <translation>中部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
-      <source>Mountain Standard Time (Mexico)</source>
-      <translation>山区标准时间（墨西哥）</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
-      <source>Mountain Standard Time</source>
-      <translation>山区标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
-      <source>US Mountain Standard Time</source>
-      <translation>美国山区标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
-      <source>Pacific Standard Time (Mexico)</source>
-      <translation>太平洋标准时间（墨西哥）</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
-      <source>Pacific Standard Time</source>
-      <translation>太平洋标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
-      <source>Alaskan Standard Time</source>
-      <translation>阿拉斯加标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
-      <source>Hawaii-Aleutian</source>
-      <translation>夏威夷-阿留申</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
-      <source>Atlantic Daylight Time</source>
-      <translation>大西洋夏令时间</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAntarcticaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
-      <source>New Zealand Standard Time</source>
-      <translation>新西兰标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>太平洋中部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
-      <source>West Pacific Standard Time</source>
-      <translation>太平洋西部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
-      <source>W. Australia Standard Time</source>
-      <translation>澳大利亚西部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
-      <source>SE Asia Standard Time</source>
-      <translation>东南亚标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
-      <source>Central Asia Standard Time</source>
-      <translation>中亚标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
-      <source>West Asia Standard Time</source>
-      <translation>西亚标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
-      <source>E. Africa Standard Time</source>
-      <translation>非洲东部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
-      <source>Pacific SA Standard Time</source>
-      <translation>太平洋南美洲标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
-      <source>SA Western Standard Time</source>
-      <translation>南美西部标准时间</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzArcticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
-      <source>W. Europe Standard Time</source>
-      <translation>西欧标准时间</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAsiaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
-      <source>Kamchatka Standard Time</source>
-      <translation>堪察加标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
-      <source>Magadan Standard Time</source>
-      <translation>马加丹标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
-      <source>Vladivostok Standard Time</source>
-      <translation>符拉迪沃斯托克标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
-      <source>Yakutsk Standard Time</source>
-      <translation>雅库茨克标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
-      <source>Tokyo Standard Time</source>
-      <translation>东京标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
-      <source>Korea Standard Time</source>
-      <translation>韩国标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
-      <source>Singapore Standard Time</source>
-      <translation>新加坡标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
-      <source>Ulaanbaatar Standard Time</source>
-      <translation>乌兰巴托标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
-      <source>Taipei Standard Time</source>
-      <translation>台北标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
-      <source>North Asia East Standard Time</source>
-      <translation>北亚东部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
-      <source>China Standard Time</source>
-      <translation>中国标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
-      <source>SE Asia Standard Time</source>
-      <translation>东南亚标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
-      <source>North Asia Standard Time</source>
-      <translation>北亚标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
-      <source>Myanmar Standard Time</source>
-      <translation>缅甸标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
-      <source>N. Central Asia Standard Time</source>
-      <translation>中亚北部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
-      <source>Central Asia Standard Time</source>
-      <translation>中亚标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
-      <source>Bangladesh Standard Time</source>
-      <translation>孟加拉国标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
-      <source>Nepal Standard Time</source>
-      <translation>尼泊尔标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
-      <source>Sri Lanka Standard Time</source>
-      <translation>斯里兰卡标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
-      <source>India Standard Time</source>
-      <translation>印度标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
-      <source>West Asia Standard Time</source>
-      <translation>西亚标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
-      <source>Pakistan Standard Time</source>
-      <translation>巴基斯坦标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
-      <source>Ekaterinburg Standard Time</source>
-      <translation>叶卡特琳堡标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
-      <source>Georgian Standard Time</source>
-      <translation>格鲁吉亚标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
-      <source>Caucasus Standard Time</source>
-      <translation>高加索标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
-      <source>Azerbaijan Standard Time</source>
-      <translation>阿塞拜疆标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
-      <source>Arabian Standard Time</source>
-      <translation>阿拉伯标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
-      <source>Afghanistan Standard Time</source>
-      <translation>阿富汗标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
-      <source>Iran Standard Time</source>
-      <translation>伊朗标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
-      <source>Arabic Standard Time</source>
-      <translation>阿拉伯标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
-      <source>Arab Standard Time</source>
-      <translation>阿拉伯标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
-      <source>Syria Standard Time</source>
-      <translation>叙利亚标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
-      <source>Middle East Standard Time</source>
-      <translation>中东标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
-      <source>Jordan Standard Time</source>
-      <translation>约旦标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
-      <source>Israel Standard Time</source>
-      <translation>以色列标准时间</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAtlanticData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
-      <source>Greenwich Standard Time</source>
-      <translation>格林尼治标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
-      <source>Azores Standard Time</source>
-      <translation>亚速尔群岛标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
-      <source>Cape Verde Standard Time</source>
-      <translation>佛得角标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
-      <source>Mid-Atlantic Standard Time</source>
-      <translation>大西洋中部标准时间</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzAustraliaData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
-      <source>Tasmania Standard Time</source>
-      <translation>塔斯马尼亚标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
-      <source>E. Australia Standard Time</source>
-      <translation>澳大利亚东部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
-      <source>AUS Eastern Standard Time</source>
-      <translation>澳大利亚东部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
-      <source>Cen. Australia Standard Time</source>
-      <translation>澳大利亚中部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
-      <source>AUS Central Standard Time</source>
-      <translation>澳大利亚中部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
-      <source>W. Australia Standard Time</source>
-      <translation>澳大利亚西部标准时间</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEtcData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
-      <source>GMT +12</source>
-      <translation>GMT +12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
-      <source>GMT -02</source>
-      <translation>GMT -02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
-      <source>GMT -11</source>
-      <translation>GMT -11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
-      <source>GMT -13</source>
-      <translation>格林尼治标准时间-13</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
-      <source>GMT -12</source>
-      <translation>格林尼治标准时间 -12</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
-      <source>GMT -10</source>
-      <translation>格林尼治标准时间 -10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
-      <source>GMT -09</source>
-      <translation>格林尼治标准时间 -09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
-      <source>GMT -08</source>
-      <translation>格林尼治标准时间 -08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
-      <source>GMT -07</source>
-      <translation>格林尼治标准时间 -07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
-      <source>GMT -06</source>
-      <translation>格林尼治标准时间 -06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
-      <source>GMT -05</source>
-      <translation>格林尼治标准时间 -05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
-      <source>GMT -04</source>
-      <translation>格林尼治标准时间 -04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
-      <source>GMT -03</source>
-      <translation>格林尼治标准时间 -03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
-      <source>GMT -01</source>
-      <translation>格林威治标准时间 -01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
-      <source>GMT</source>
-      <translation>GMT</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
-      <source>GMT +01</source>
-      <translation>格林尼治标准时间 +01</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
-      <source>GMT +02</source>
-      <translation>格林尼治标准时间 +02</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
-      <source>GMT +03</source>
-      <translation>格林尼治标准时间 +03</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
-      <source>GMT +04</source>
-      <translation>格林尼治标准时间 +04</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
-      <source>GMT +05</source>
-      <translation>格林尼治标准时间 +05</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
-      <source>GMT +06</source>
-      <translation>格林尼治标准时间 +06</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
-      <source>GMT +07</source>
-      <translation>格林尼治标准时间 +07</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
-      <source>GMT +08</source>
-      <translation>格林尼治标准时间 +08</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
-      <source>GMT +09</source>
-      <translation>格林尼治标准时间 +09</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
-      <source>GMT +10</source>
-      <translation>格林尼治标准时间 +10</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
-      <source>GMT +11</source>
-      <translation>格林尼治标准时间 +11</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
-      <source>UTC</source>
-      <translation>UTC</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzEuropeData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
-      <source>GMT Standard Time</source>
-      <translation>GMT标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
-      <source>Central Europe Standard Time</source>
-      <translation>中欧标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
-      <source>Central European Standard Time</source>
-      <translation>欧洲中部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
-      <source>Romance Standard Time</source>
-      <translation>罗曼斯标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
-      <source>W. Europe Standard Time</source>
-      <translation>西欧标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
-      <source>E. Europe Standard Time</source>
-      <translation>东欧标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
-      <source>FLE Standard Time</source>
-      <translation>FLE标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
-      <source>GTB Standard Time</source>
-      <translation>GTB标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
-      <source>Belarus Standard Time</source>
-      <translation>白俄罗斯标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
-      <source>Russian Standard Time</source>
-      <translation>俄罗斯标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
-      <source>Turkey Standard Time</source>
-      <translation>土耳其标准时间</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzIndianData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
-      <source>Mauritius Standard Time</source>
-      <translation>毛里求斯标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
-      <source>Christmas Island Standard Time</source>
-      <translation>圣诞岛标准时</translation>
-    </message>
-  </context>
-  <context>
-    <name>TzPacificData</name>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
-      <source>Tonga Standard Time</source>
-      <translation>汤加标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
-      <source>Fiji Standard Time</source>
-      <translation>斐济标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
-      <source>New Zealand Standard Time</source>
-      <translation>新西兰标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
-      <source>Central Pacific Standard Time</source>
-      <translation>太平洋中部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
-      <source>West Pacific Standard Time</source>
-      <translation>太平洋西部标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
-      <source>Samoa Standard Time</source>
-      <translation>萨摩亚标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
-      <source>Hawaiian Standard Time</source>
-      <translation>夏威夷标准时间</translation>
-    </message>
-    <message>
-      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
-      <source>Easter Island Standard Time</source>
-      <translation>东部岛屿标准时</translation>
-    </message>
-  </context>
-  <context>
-    <name>VebusError</name>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
-      <source>Device switched off</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
-      <source>Mixed old/new MK2</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
-      <source>Expected devices error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
-      <source>No other device detected</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
-      <source>Overvoltage on AC-out</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
-      <source>DDC program error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
-      <source>VE.Bus BMS without assistant</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
-      <source>Ground relay test failed</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
-      <source>System time sync error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
-      <source>Grid relay test fault</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
-      <source>Config mismatch with 2nd mcu</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
-      <source>Device transmit error</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
-      <source>Awaiting configuration or dongle missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
-      <source>Phase master missing</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
-      <source>Overvoltage has occurred</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
-      <source>Slave does not have AC input!</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
-      <source>Device can't be slave</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
-      <source>System protection initiated</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
-      <source>Firmware incompatibiltiy</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
-      <source>Internal error</source>
-      <translation type="unfinished">内部错误</translation>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
-      <source>Failing relay test prevents connection</source>
-      <translation type="unfinished"/>
-    </message>
-    <message>
-      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
-      <source>VE.Bus error</source>
-      <translation type="unfinished"/>
-    </message>
-  </context>
-  <context>
     <name>Wakespeed</name>
     <message>
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
@@ -13181,6 +12029,119 @@ Here you can add additional ports and unit IDs to scan for PV inverters.</source
       <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
       <source>DC/DC misconfiguration</source>
       <translation>DC/DC错误配置</translation>
+    </message>
+  </context>
+  <context>
+    <name>VebusError</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+      <source>Device switched off</source>
+      <translation>设备已关闭</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+      <source>Mixed old/new MK2</source>
+      <translation>新旧 MK2 混合使用</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+      <source>Expected devices error</source>
+      <translation>预期设备错误</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+      <source>No other device detected</source>
+      <translation>未检测到其他设备</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+      <source>Overvoltage on AC-out</source>
+      <translation>交流输出过压</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+      <source>DDC program error</source>
+      <translation>DDC 程序错误</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+      <source>VE.Bus BMS without assistant</source>
+      <translation>VE.Bus BMS 无助手</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+      <source>Ground relay test failed</source>
+      <translation>接地继电器测试失败</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+      <source>System time sync error</source>
+      <translation>系统时间同步错误</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+      <source>Grid relay test fault</source>
+      <translation>电网继电器测试故障</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+      <source>Config mismatch with 2nd mcu</source>
+      <translation>与第二个 MCU 的配置不匹配</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+      <source>Device transmit error</source>
+      <translation>设备传输错误</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+      <source>Awaiting configuration or dongle missing</source>
+      <translation>等待配置或缺少加密狗</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+      <source>Phase master missing</source>
+      <translation>缺少相位主设备</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+      <source>Overvoltage has occurred</source>
+      <translation>发生过压</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+      <source>Slave does not have AC input!</source>
+      <translation>从设备没有交流输入！</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+      <source>Device can't be slave</source>
+      <translation>设备不能是从设备</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+      <source>System protection initiated</source>
+      <translation>系统保护已启动</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+      <source>Firmware incompatibiltiy</source>
+      <translation>固件不兼容</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+      <source>Internal error</source>
+      <translation>内部错误</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+      <source>Failing relay test prevents connection</source>
+      <translation>继电器测试失败阻止连接</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+      <source>VE.Bus error</source>
+      <translation>VE.Bus 错误</translation>
     </message>
   </context>
 </TS>


### PR DESCRIPTION
Running the translations update after manually applying (https://github.com/victronenergy/gui-v2/pull/2636). 
This changes a lot of translations as it really didn't update much since the 15th of August.