### PR TITLE
Revert "ESS: Auto setting for ESS meter selection"

### DIFF
--- a/pages/settings/PageSettingsHub4.qml
+++ b/pages/settings/PageSettingsHub4.qml
@@ -59,8 +59,6 @@ Page {
 			dataItem.uid: Global.systemSettings.serviceUid + "/Settings/CGwacs/RunWithoutGridMeter"
 			preferredVisible: essMode.value !== VenusOS.Ess_Hub4ModeState_Disabled
 			optionModel: [
-				//% "Auto"
-				{ display: qsTrId("settings_ess_auto_meter"), value: 2 },
 				//% "External meter"
 				{ display: qsTrId("settings_ess_external_meter"), value: 0 },
 				//% "Inverter/Charger"


### PR DESCRIPTION
We decided it is better to make this behaviour standard, so that it always falls back to internal measurement if the meter is lost.

This reverts commit 5f06124b275188dcf5e7c8a3df7bf972f034efa7.