### PR TITLE
Gui Plugins: use zlib for resource compression for WASM support

### DIFF
--- a/tools/gui-v2-plugin-compiler.py
+++ b/tools/gui-v2-plugin-compiler.py
@@ -76,6 +76,7 @@ def run_rcc(name):
     rccFile = "" + name + ".rcc"
     cmd = [rccPath]
     cmd.extend(['-binary'])
+    cmd.extend(['-compress-algo', 'zlib'])
     cmd.extend(['-o', rccFile])
     cmd.extend([qrcFile])
     try:


### PR DESCRIPTION
QtWebAssembly doesn't support zstd compression in the version of Qt we use.  Use zlib instead, which is bundled with Qt, allowing qUncompress() etc to work by default.

Contributes to issue #2623