### PR TITLE
Switchable outputs: Add some optional settings

### DIFF
--- a/pages/settings/devicelist/switchable-outputs/PageSwitchableOutput.qml
+++ b/pages/settings/devicelist/switchable-outputs/PageSwitchableOutput.qml
@@ -53,6 +53,58 @@ Page {
 			}
 
 			ListRadioButtonGroup {
+				//% "Switch mode"
+				text: qsTrId("page_switchable_output_switch_mode")
+				dataItem.uid: root.outputUid + "/Settings/SwitchMode"
+				preferredVisible: dataItem.valid
+				optionModel: [
+					//% "Disabled"
+					{ display: qsTrId("page_switchable_output_switch_mode_disabled"), value: 0 },
+					//% "Permanent on"
+					{ display: qsTrId("page_switchable_output_switch_mode_linear"), value: 1 },
+					//% "Switching"
+					{ display: qsTrId("page_switchable_output_switch_mode_optical"), value: 2 }
+				]
+			}
+
+			ListRadioButtonGroup {
+				//% "Dim mode"
+				text: qsTrId("page_switchable_output_dim_mode")
+				dataItem.uid: root.outputUid + "/Settings/DimMode"
+				preferredVisible: dataItem.valid
+				optionModel: [
+					//% "Dimming disabled"
+					{ display: qsTrId("page_switchable_output_dim_mode_disabled"), value: 0 },
+					//% "Linear"
+					{ display: qsTrId("page_switchable_output_dim_mode_linear"), value: 1 },
+					//% "Optical curve"
+					{ display: qsTrId("page_switchable_output_dim_mode_optical"), value: 2 }
+				]
+			}
+
+			ListRadioButtonGroup {
+				//% "Fuse detection mode"
+				text: qsTrId("page_switchable_output_fuse_detection_mode")
+				dataItem.uid: root.outputUid + "/Settings/FuseDetection"
+				preferredVisible: dataItem.valid
+				optionModel: [
+					{ display: CommonWords.disabled, value: 0 },
+					{ display: CommonWords.enabled, value: 1 },
+					//% "Only when the output is off"
+					{ display: qsTrId("page_switchable_output_fuse_detection_mode_only_when_off"), value: 2 }
+				]
+			}
+
+			ListSpinBox {
+				//% "Fuse rating"
+				text:  qsTrId("page_switchable_output_fuse_rating")
+				dataItem.uid: root.outputUid + "/Settings/FuseRating"
+				decimals: 0 // backend does not allow for decimal precision
+				suffix: Units.defaultUnitString(VenusOS.Units_Amp)
+				preferredVisible: dataItem.valid
+			}
+
+			ListRadioButtonGroup {
 				//% "Type"
 				text: qsTrId("page_switchable_output_type")
 				dataItem.uid: root.outputUid + "/Settings/Type"
@@ -70,20 +122,104 @@ Page {
 				preferredVisible: dataItem.valid
 			}
 
-			ListSpinBox {
-				//% "Fuse rating"
-				text:  qsTrId("page_switchable_output_fuse_rating")
-				dataItem.uid: root.outputUid + "/Settings/FuseRating"
-				decimals: 0 // backend does not allow for decimal precision
-				suffix: Units.defaultUnitString(VenusOS.Units_Amp)
-				preferredVisible: dataItem.valid
-			}
-
 			ListQuantity {
 				text: CommonWords.current_amps
 				dataItem.uid: root.outputUid + "/Current"
 				preferredVisible: dataItem.valid
 				unit: VenusOS.Units_Amp
+			}
+
+			ListRadioButtonGroup {
+				//% "Startup switch state"
+				text: qsTrId("page_switchable_output_startup_state")
+				dataItem.uid: root.outputUid + "/Settings/StartupState"
+				preferredVisible: dataItem.valid
+				optionModel: [
+					{ display: CommonWords.off, value: 0 },
+					{ display: CommonWords.on, value: 1 },
+					//% "Restore from memory"
+					{ display: qsTrId("page_switchable_output_startup_state_restore_from_memory"), value: -1 }
+				]
+			}
+
+			ListNavigation {
+				//% "Startup dim level"
+				text: qsTrId("page_switchable_output_startup_dim_level")
+				secondaryText: startupDimLevel.valid ? startupDimLevel.value === -1 ? qsTrId("page_switchable_output_startup_state_restore_from_memory") : startupDimLevel.value + "%" : ""
+				preferredVisible: startupDimLevel.valid
+				onClicked: Global.pageManager.pushPage(dimStartupStateComponent, { title: text })
+
+				VeQuickItem {
+					id: startupDimLevel
+					uid: root.outputUid + "/Settings/StartupDimming"
+				}
+
+				Component {
+					id: dimStartupStateComponent
+					Page {
+						GradientListView {
+							id: settingsListView
+
+							model: VisibleItemModel {
+								ListSwitch {
+									id: restoreDimLevelSwitch
+									//% "Restore dim level from memory"
+									text: qsTrId("page_switchable_output_restore_dim_level")
+									checked: startupDimLevel.valid && startupDimLevel.value === -1
+									onClicked: {
+										startupDimLevel.setValue(startupDimLevel.value === -1 ? 0 : -1)
+									}
+								}
+
+								ListSpinBox {
+
+									//% "Startup dim level"
+									text: qsTrId("settings_dvcc_startup_dim_level")
+									preferredVisible: restoreDimLevelSwitch.visible && !restoreDimLevelSwitch.checked
+									from: 0
+									to: 100
+									suffix: "%"
+									dataItem.uid: startupDimLevel.uid
+								}
+							}
+						}
+					}
+				}
+			}
+
+			ListRadioButtonGroup {
+				//% "Polarity"
+				text: qsTrId("page_switchable_output_polarity")
+				dataItem.uid: root.outputUid + "/Settings/Polarity"
+				preferredVisible: dataItem.valid
+				optionModel: [
+					//% "Active high / Normally open"
+					{ display: qsTrId("page_switchable_output_polarity_active_high"), value: 0 },
+					//% "Active low / Normally closed"
+					{ display: qsTrId("page_switchable_output_polarity_active_low"), value: 1 }
+				]
+			}
+
+			ListSpinBox {
+				//% "Output limit min"
+				text: qsTrId("settings_dvcc_output_limit_min")
+				preferredVisible: dataItem.valid
+				from: 0
+				to: 100
+				decimals: 2
+				suffix: "%"
+				dataItem.uid: root.outputUid + "/Settings/OutputLimitMin"
+			}
+
+			ListSpinBox {
+				//% "Output limit max"
+				text: qsTrId("settings_dvcc_output_limit_max")
+				preferredVisible: dataItem.valid
+				from: 0
+				to: 100
+				decimals: 2
+				suffix: "%"
+				dataItem.uid: root.outputUid + "/Settings/OutputLimitMax"
 			}
 		}
 	}


### PR DESCRIPTION
This adds a bunch of optional settings, mainly used for the Aurelia digital switching device. 

Some screenshots:
<img width="793" height="477" alt="Screenshot from 2025-11-11 14-18-14" src="https://github.com/user-attachments/assets/d3f48780-6985-462a-bdd3-10f2b151dde0" />
<img width="793" height="477" alt="Screenshot from 2025-11-11 14-18-09" src="https://github.com/user-attachments/assets/834884ea-6bd3-4474-917a-b47dd6357f1c" />
<img width="793" height="477" alt="image" src="https://github.com/user-attachments/assets/33a1a1ca-31b8-43f5-8a1e-20ac0024b077" />


Contributes to: https://github.com/victronenergy/gui-v2/issues/2591