### PR TITLE
UI Controls: provide more space for units with longer text

### DIFF
--- a/components/QuantityTableMetrics.qml
+++ b/components/QuantityTableMetrics.qml
@@ -19,9 +19,7 @@ FontMetrics {
 
 		// Give the unit symbol some extra space on the column.
 		// Due to QTBUG-124588, use tightBoundingRect() instead of advanceWidth().
-		const maxTextRect = unit === VenusOS.Units_Energy_KiloWattHour
-				? tightBoundingRect("99.99kWH")
-				: tightBoundingRect("99.99W")
+		const maxTextRect = tightBoundingRect("99.99" + Units.defaultUnitString(unit))
 		return maxTextRect.width + maxTextRect.x
 	}
 


### PR DESCRIPTION
When calculating the space required for quantity labels, take the length of the specific unit text into account.

Fixes #2647