### PR TITLE
Switches: adapt to changes in /ShowUIControl value format

### DIFF
--- a/pages/settings/devicelist/switchable-outputs/PageSwitchableOutput.qml
+++ b/pages/settings/devicelist/switchable-outputs/PageSwitchableOutput.qml
@@ -110,13 +110,22 @@ Page {
 				defaultSecondaryText: VenusOS.switchableOutput_typeToText(root.switchableOutput.type, root.switchableOutput.outputId)
 			}
 
-			ListSwitch {
+			ListRadioButtonGroup {
 				//: Whether UI controls should be shown for this output
 				//% "Show controls"
 				text: qsTrId("page_switchable_show_controls")
 				dataItem.uid: root.switchableOutput.uid + "/Settings/ShowUIControl"
 				writeAccessLevel: VenusOS.User_AccessType_User
 				preferredVisible: dataItem.valid
+				optionModel: [
+					{ display: CommonWords.off, value: VenusOS.SwitchableOutput_ShowUiControl_Off },
+					//% "Always"
+					{ display: qsTrId("page_switchable_output_show_always"), value: VenusOS.SwitchableOutput_ShowUiControl_Always },
+					//% "Only local"
+					{ display: qsTrId("page_switchable_output_show_local"), value: VenusOS.SwitchableOutput_ShowUiControl_Local },
+					//% "Only on VRM"
+					{ display: qsTrId("page_switchable_output_show_vrm"), value: VenusOS.SwitchableOutput_ShowUiControl_Remote }
+				]
 			}
 
 			ListQuantity {

--- a/src/enums.h
+++ b/src/enums.h
@@ -535,6 +535,14 @@ public:
 	};
 	Q_ENUM(SwitchableOutput_Status)
 
+	enum SwitchableOutput_ShowUiControl {
+		SwitchableOutput_ShowUiControl_Off = 0x0,
+		SwitchableOutput_ShowUiControl_Always = 0x1,
+		SwitchableOutput_ShowUiControl_Local = 0x2,
+		SwitchableOutput_ShowUiControl_Remote = 0x4,
+	};
+	Q_ENUM(SwitchableOutput_ShowUiControl)
+
 	enum Notification_Type {
 		Notification_Warning,
 		Notification_Alarm,

--- a/src/switchableoutput.h
+++ b/src/switchableoutput.h
@@ -140,6 +140,7 @@ private:
 	void updateHasValidType();
 	void updateAllowedInGroupModel();
 	void updateFormattedName();
+	bool shouldShowUiControl() const;
 
 	QPointer<VeQItem> m_outputItem;
 

--- a/tests/switchableoutput/tst_switchableoutput.qml
+++ b/tests/switchableoutput/tst_switchableoutput.qml
@@ -333,6 +333,104 @@ TestCase {
 		MockManager.removeValue(data.uid)
 	}
 
+	function test_showUiControl_data() {
+		return [
+			{
+				tag: "ShowUIControl not set",
+				uid: "mock/com.victronenergy.test.a/SwitchableOutput/1",
+				outputProperties: {
+					"State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0
+				},
+				allowedInGroupModel: true,
+			},
+			{
+				tag: "ShowUIControl=Off",
+				uid: "mock/com.victronenergy.test.a/SwitchableOutput/1",
+				outputProperties: {
+					"Settings/ShowUIControl": 0, // Off=0
+					"State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0
+				},
+				allowedInGroupModel: false,
+			},
+			{
+				tag: "ShowUIControl=Always",
+				uid: "mock/com.victronenergy.test.a/SwitchableOutput/1",
+				outputProperties: {
+					"Settings/ShowUIControl": 1, // Always=1
+					"State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0
+				},
+				allowedInGroupModel: true,
+			},
+			{
+				tag: "ShowUIControl=Local",
+				uid: "mock/com.victronenergy.test.a/SwitchableOutput/1",
+				outputProperties: {
+					"Settings/ShowUIControl": 2, // Local=0x2
+					"State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0
+				},
+				vrm: false,
+				allowedInGroupModel: true,
+			},
+			{
+				tag: "ShowUIControl=Remote",
+				uid: "mock/com.victronenergy.test.a/SwitchableOutput/1",
+				outputProperties: {
+					"Settings/ShowUIControl": 4, // Remote=0x4
+					"State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0
+				},
+				vrm: true,
+				allowedInGroupModel: true,
+			},
+			{
+				tag: "ShowUIControl=Local+Remote, local connection",
+				uid: "mock/com.victronenergy.test.a/SwitchableOutput/1",
+				outputProperties: {
+					"Settings/ShowUIControl": 6, // Local+Remote = 0x2 | 0x4
+					"State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0
+				},
+				vrm: false,
+				allowedInGroupModel: true,
+			},
+			{
+				tag: "ShowUIControl=Local+Remote, remote connection",
+				uid: "mock/com.victronenergy.test.a/SwitchableOutput/1",
+				outputProperties: {
+					"Settings/ShowUIControl": 6, // Local+Remote = 0x2 | 0x4
+					"State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0
+				},
+				vrm: true,
+				allowedInGroupModel: true,
+			},
+			{
+				// If value is invalid, then show the control (just like if ShowUIControl is not set)
+				tag: "ShowUIControl=0x5 (invalid)",
+				uid: "mock/com.victronenergy.test.a/SwitchableOutput/1",
+				outputProperties: {
+					"Settings/ShowUIControl": 5,
+					"State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0
+				},
+				allowedInGroupModel: true,
+			},
+		]
+	}
+
+	function test_showUiControl(data) {
+		compare(output.allowedInGroupModel, false)
+		if (data.vrm !== undefined) {
+			BackendConnection.vrm = data.vrm
+		}
+
+		setOutputProperties(data.uid, data.outputProperties)
+		output.uid = data.uid
+		compare(output.uid, data.uid)
+		compare(output.allowedInGroupModel, data.allowedInGroupModel)
+
+		// Clean up
+		output.uid = ""
+		MockManager.removeValue(data.uid)
+		BackendConnection.vrm = false
+	}
+
 	function test_formattedName_data() {
 		return [
 			{


### PR DESCRIPTION
The /SwitchableOutput/x/Settings/ShowUIControl value has changed from a binary 0 or 1 value to:

0 = Off
1 = Always
0x2 = Only local
0x4 = Only on VRM

Change the UI setting from a toggle switch to a radio button list, and update SwitchableOutput::allowedInGroupModel() to check for the new values that are possible for /ShowUIControl.

Fixes #2583