### PR TITLE
AC Load: Add PhaseSetting to acload model

### DIFF
--- a/data/mock/conf/services/em-acload.json
+++ b/data/mock/conf/services/em-acload.json
@@ -53,6 +53,7 @@
         "/N2kUniqueNumber": 435059,
         "/NrOfPhases": 3,
         "/PhaseSequence": 1,
+        "/PhaseSetting": 1,
         "/ProductId": 41393,
         "/ProductName": "Energy Meter VM-3P75CT",
         "/RefreshTime": 1000,

--- a/pages/settings/devicelist/ac-in/PageAcInModel.qml
+++ b/pages/settings/devicelist/ac-in/PageAcInModel.qml
@@ -169,6 +169,18 @@ VisibleItemModel {
 				: qsTrId("ac-in-modeldefault_phase_sequence_ordered")
 	}
 
+	ListRadioButtonGroup {
+		//% "Phase Setting"
+		text: qsTrId("ac-in-modeldefault_phase_setting")
+		dataItem.uid: root.bindPrefix + "/PhaseSetting"
+		preferredVisible: dataItem.valid
+		optionModel: [
+			{ display: CommonWords.ac_phase_x.arg(1), value: 1 },
+			{ display: CommonWords.ac_phase_x.arg(2), value: 2 },
+			{ display: CommonWords.ac_phase_x.arg(3), value: 3 },
+		]
+	}
+
 	ListNavigation {
 		text: CommonWords.setup
 		preferredVisible: allowedRoles.valid


### PR DESCRIPTION
Shelly devices with energy measuring capabilities will show on dbus as an acload. The phase these devices switch and meter can be setup as required. Provide a mechanism to set this metered phase in the device settings.

Fixes #2554