### PR TITLE
VE.Bus: mention system redetect option if mode/limit control is disabled

### DIFF
--- a/components/CommonWords.qml
+++ b/components/CommonWords.qml
@@ -216,6 +216,10 @@ QtObject {
 	//% "Generator"
 	readonly property string generator: qsTrId("common_words_generator")
 
+	//: %1 = name of the device
+	//% "If it was recently disconnected, go to Settings → Devices → %1 → Advanced, and select 'Redetect VE.Bus system'."
+	readonly property string go_to_redetect_system: qsTrId("common_words_go_to_redetect_system")
+
 	//% "Grid"
 	readonly property string grid: qsTrId("common_words_grid")
 
@@ -350,12 +354,6 @@ QtObject {
 
 	//% "No"
 	readonly property string no: qsTrId("common_words_no")
-
-	//% "This setting is disabled when a Digital Multi Control is connected."
-	readonly property string noAdjustableByDmc: qsTrId("common_words_setting_disabled_when_dmc_connected")
-
-	//% "This setting is disabled when a VE.Bus BMS is connected."
-	readonly property string noAdjustableByBms: qsTrId("common_words_setting_disabled_when_bms_connected")
 
 	//% "No error"
 	readonly property string no_error: qsTrId("common_words_no_error")
@@ -650,5 +648,27 @@ QtObject {
 			  //% "4th last error"
 			: errorIndex === 3 ? qsTrId("common_words_4th_last_error")
 			: ""
+	}
+
+	function notAdjustableDueToBms(serviceType, deviceName) {
+		//% "This setting is disabled when a VE.Bus BMS is connected."
+		const s = qsTrId("common_words_setting_disabled_when_bms_connected")
+		return serviceType === "vebus"
+			  //: %1 = the translated text of common_words_setting_disabled_when_bms_connected
+			  //: %2 = the translated text of common_words_go_to_redetect_system
+			  //% "%1 %2"
+			? qsTrId("common_words_bms_disabled_go_to_redetect").arg(s).arg(go_to_redetect_system.arg(deviceName))
+			: s
+	}
+
+	function notAdjustableDueToDmc(serviceType, deviceName) {
+		//% "This setting is disabled when a Digital Multi Control is connected."
+		const s = qsTrId("common_words_setting_disabled_when_dmc_connected")
+		return serviceType === "vebus"
+			  //: %1 = the translated text of common_words_setting_disabled_when_dmc_connected
+			  //: %2 = the translated text of common_words_go_to_redetect_system
+			  //% "%1 %2"
+			? qsTrId("common_words_dmc_disabled_go_to_redetect").arg(s).arg(go_to_redetect_system.arg(deviceName))
+			: s
 	}
 }

--- a/components/listitems/ListCurrentLimitButton.qml
+++ b/components/listitems/ListCurrentLimitButton.qml
@@ -13,15 +13,14 @@ ListButton {
 	required property int inputNumber // note this is 1-based, i.e. first AC input has inputNumber=1, not 0
 	required property int inputType
 
-	readonly property string serviceType: BackendConnection.serviceTypeFromUid(serviceUid)
 	readonly property bool limitAdjustable: currentLimitIsAdjustable.value !== 0
 
 	function _currentLimitNotAdjustableText() {
-		if (serviceType !== "acsystem") {
+		if (device.serviceType !== "acsystem") {
 			if (dmc.valid) {
-				return CommonWords.noAdjustableByDmc
+				return CommonWords.notAdjustableDueToDmc(device.serviceType, device.name)
 			} else if (bmsMode.valid) {
-				return CommonWords.noAdjustableByBms
+				return CommonWords.notAdjustableDueToBms(device.serviceType, device.name)
 			}
 		}
 		//% "This current limit is fixed in the system configuration. It cannot be adjusted."
@@ -35,11 +34,15 @@ ListButton {
 
 	onClicked: {
 		if (!limitAdjustable) {
-			Global.showToastNotification(VenusOS.Notification_Info, root._currentLimitNotAdjustableText(),
-										 Theme.animation_veBusDeviceModeNotAdjustable_toastNotication_duration)
+			Global.showToastNotification(VenusOS.Notification_Info, root._currentLimitNotAdjustableText())
 			return
 		}
 		Global.dialogLayer.open(currentLimitDialogComponent, { value: currentLimitItem.value })
+	}
+
+	Device {
+		id: device
+		serviceUid: root.serviceUid
 	}
 
 	VeQuickItem {

--- a/components/listitems/ListInverterChargerModeButton.qml
+++ b/components/listitems/ListInverterChargerModeButton.qml
@@ -10,12 +10,10 @@ ListButton {
 	id: root
 
 	required property string serviceUid
-
-	readonly property string serviceType: BackendConnection.serviceTypeFromUid(serviceUid)
 	readonly property bool modeAdjustable: modeIsAdjustable.value !== 0
 
 	text: CommonWords.mode
-	secondaryText: serviceType !== "inverter" || isInverterChargerItem.value === 1
+	secondaryText: device.serviceType !== "inverter" || isInverterChargerItem.value === 1
 			? Global.inverterChargers.inverterChargerModeToText(modeItem.value)
 			: Global.inverterChargers.inverterModeToText(modeItem.value)
 
@@ -25,20 +23,22 @@ ListButton {
 	onClicked: {
 		if (!modeAdjustable) {
 			if (dmc.valid) {
-				Global.showToastNotification(VenusOS.Notification_Info, CommonWords.noAdjustableByDmc,
-											 Theme.animation_veBusDeviceModeNotAdjustable_toastNotication_duration)
+				Global.showToastNotification(VenusOS.Notification_Info, CommonWords.notAdjustableDueToDmc(device.serviceType, device.name))
 			} else if (bmsMode.valid) {
-				Global.showToastNotification(VenusOS.Notification_Info, CommonWords.noAdjustableByBms,
-											 Theme.animation_veBusDeviceModeNotAdjustable_toastNotication_duration)
+				Global.showToastNotification(VenusOS.Notification_Info, CommonWords.notAdjustableDueToBms(device.serviceType, device.name))
 			} else {
 				//% "The mode is fixed in the system configuration. It cannot be adjusted."
-				Global.showToastNotification(VenusOS.Notification_Info, qsTrId("inverter_mode_not_adjustable"),
-											 Theme.animation_veBusDeviceModeNotAdjustable_toastNotication_duration)
+				Global.showToastNotification(VenusOS.Notification_Info, qsTrId("inverter_mode_not_adjustable"))
 			}
 			return
 		}
 
 		Global.dialogLayer.open(modeDialogComponent, { mode: modeItem.value })
+	}
+
+	Device {
+		id: device
+		serviceUid: root.serviceUid
 	}
 
 	VeQuickItem {

--- a/themes/animation/Animation.json
+++ b/themes/animation/Animation.json
@@ -43,6 +43,5 @@
     "animation_settings_radioButtonPage_autoClose_duration": 600,
     "animation_loadGraph_model_length": 12,
     "animation_solarHistoryErrorView_expand_duration": 100,
-    "animation_acceptButtonBackground_expand_duration": 1200,
-    "animation_veBusDeviceModeNotAdjustable_toastNotication_duration": 5000
+    "animation_acceptButtonBackground_expand_duration": 1200
 }


### PR DESCRIPTION
If the user attempts to change the VE.Bus current limit or mode, and this action is disabled because a BMS or DMC is connected, provide information about the "Redetect VE.Bus system" option in the error notification text.

This aligns with the behaviour in gui-v1.

Fixes #2673

----
Testing in mock mode:

In data/mock/conf/services/quattro-3phase-grid-genset.json, set "/Devices/Dmc/Version" or "/Devices/Bms/Version" to 1, and then try to set the current limit in the control cards.