### PR TITLE
Wi-Fi: do not confirm/validate access point password prematurely

### DIFF
--- a/cmake/ModuleVenus_Sources.cmake
+++ b/cmake/ModuleVenus_Sources.cmake
@@ -200,6 +200,7 @@ set (VictronVenusOS_QML_MODULE_SOURCES
     components/listitems/ListMountStateButton.qml
     components/listitems/ListAcInPositionRadioButtonGroup.qml
     components/listitems/ListOutputBatteryRadioButtonGroup.qml
+    components/listitems/ListPasswordField.qml
     components/listitems/ListPvInverterPositionRadioButtonGroup.qml
     components/listitems/ListRebootButton.qml
     components/listitems/ListRelayState.qml

--- a/components/RadioButtonListPage.qml
+++ b/components/RadioButtonListPage.qml
@@ -112,32 +112,13 @@ Page {
 						preferredVisible: bottomContentLoader.caption.length > 0
 					}
 
-					ListTextField {
+					ListPasswordField {
 						id: passwordField
 
-						readonly property ListItemButton confirmButton: ListItemButton {
-							//: Confirm password, and verify it if possible
-							//% "Confirm"
-							text: qsTrId("settings_radio_button_group_confirm")
-							onClicked: {
-								passwordField.validateOnConfirm = true
-								if (passwordField.textField.activeFocus) {
-									// Trigger the validation that occurs when focus is lost.
-									passwordField.textField.focus = false
-								} else {
-									passwordField.runValidation(VenusOS.InputValidation_ValidateAndSave)
-								}
-							}
-						}
-						property bool validateOnConfirm
 						property bool showField
 
-						//% "Enter password"
-						placeholderText: qsTrId("settings_radio_button_enter_password")
-						text: ""
 						flickable: optionsListView
 						primaryLabel.color: Theme.color_font_secondary
-						textField.echoMode: TextInput.Password
 						interactive: radioButton.interactive
 						background.color: "transparent"
 						showAccessLevel: root.showAccessLevel
@@ -145,16 +126,6 @@ Page {
 						preferredVisible: showField && model.index === optionsListView.selectedIndex && !!root.validatePassword
 						KeyNavigationHighlight.fill: radioButton
 						validateInput: function() {
-							// Validate the password on Enter/Return, or when "Confirm" is
-							// clicked. Ignore validation requests when the field does not
-							// have focus: e.g. when the selected radio button changes, or
-							// when this page is popped, or when an external dialog opens
-							// and causes focus to be lost. We want to only validate the
-							// password when the user explicitly indicates it should be done.
-							if (!textField.activeFocus && !passwordField.validateOnConfirm) {
-								return Utils.validationResult(VenusOS.InputValidation_Result_Unknown)
-							}
-							passwordField.validateOnConfirm = false
 							return root.validatePassword(model.index, textField.text)
 						}
 						saveInput: function() {
@@ -162,10 +133,6 @@ Page {
 								radioButton.select()
 							}
 						}
-						content.children: [
-							defaultContent,
-							confirmButton
-						]
 					}
 				}
 			}

--- a/components/listitems/ListPasswordField.qml
+++ b/components/listitems/ListPasswordField.qml
@@ -1,0 +1,35 @@
+/*
+** Copyright (C) 2025 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+/*
+	Provides a text field and a "Confirm" button.
+
+	The text is only validated when the button is clicked, and not when it loses focus.
+*/
+ListTextField {
+	id: root
+
+	readonly property ListItemButton confirmButton: ListItemButton {
+		//: Confirm password, and verify it if possible
+		//% "Confirm"
+		text: qsTrId("settings_radio_button_group_confirm")
+		visible: root.interactive
+		focusPolicy: Qt.NoFocus
+		onClicked: root.runValidation(VenusOS.InputValidation_ValidateAndSave)
+	}
+
+	//% "Enter password"
+	placeholderText: qsTrId("settings_radio_button_enter_password")
+	echoMode: TextInput.Password
+	validateOnFocusLost: false
+
+	content.children: [
+		defaultContent,
+		confirmButton
+	]
+}

--- a/components/listitems/core/ListTextField.qml
+++ b/components/listitems/core/ListTextField.qml
@@ -13,6 +13,7 @@ ListItem {
 	property alias textField: textField
 	property alias secondaryText: textField.text
 	property alias placeholderText: textField.placeholderText
+	property int echoMode: TextInput.Normal
 	property string suffix
 	property var flickable: root.ListView ? root.ListView.view : null
 
@@ -21,6 +22,8 @@ ListItem {
 	//   Utils.validationResult() to describe the validation result.
 	// - saveInput: saves the text field input. The default implementation saves the value to the
 	//   dataItem, if it has a valid uid.
+	// - validateOnFocusLost: whether the text should be validated when it loses active focus
+	//   (default is true).
 	//
 	// When the text field loses focus or is accepted, validateInput is called; if it returns a result
 	// of InputValidation_Result_OK or InputValidation_Result_Warning, then saveInput() is called.
@@ -32,6 +35,7 @@ ListItem {
 			dataItem.setValue(textField.text)
 		}
 	}
+	property bool validateOnFocusLost: true
 
 	signal accepted()
 
@@ -130,6 +134,7 @@ ListItem {
 		horizontalAlignment: root.suffix ? Text.AlignRight : Text.AlignHCenter
 		borderColor: _showErrorHighlight ? Theme.color_red : Theme.color_ok
 		focusPolicy: Qt.ClickFocus
+		echoMode: root.echoMode
 
 		onTextEdited: {
 			// When the input is marked as invalid, run the validation again each time the input is
@@ -161,8 +166,10 @@ ListItem {
 			if (activeFocus) {
 				_initialText = text
 			} else if (_validateBeforeSaving && !_inputCancelled) {
-				// When focus is lost and the text was changed, validate and save the text.
-				_showErrorHighlight = root.runValidation(VenusOS.InputValidation_ValidateAndSave) === VenusOS.InputValidation_Result_Error
+				if (validateOnFocusLost) {
+					// When focus is lost and the text was changed, validate and save the text.
+					_showErrorHighlight = root.runValidation(VenusOS.InputValidation_ValidateAndSave) === VenusOS.InputValidation_Result_Error
+				}
 				_validateBeforeSaving = false
 			}
 		}

--- a/data/mock/conf/setup-common.json
+++ b/data/mock/conf/setup-common.json
@@ -29,6 +29,7 @@
         "/Settings/Services/Modbus": 0,
         "/Settings/Services/MqttLocal": 0,
         "/Settings/Services/MqttLocalInsecure": 0,
+        "/Settings/Services/AccessPointPassword": "bad password",
         "/Settings/System/AccessLevel": 3,
         "/Settings/System/SecurityProfile": 0,
         "/Settings/System/TimeZone": "Europe/Berlin",

--- a/pages/settings/PageSettingsAccessAndSecurity.qml
+++ b/pages/settings/PageSettingsAccessAndSecurity.qml
@@ -270,7 +270,7 @@ Page {
 				showAccessLevel: VenusOS.User_AccessType_SuperUser
 				//% "Enter password"
 				placeholderText: qsTrId("settings_root_enter_password")
-				textField.echoMode: TextInput.Password
+				echoMode: TextInput.Password
 				saveInput: function() {
 					if (secondaryText.length < 8) {
 						//% "Password needs to be at least 8 characters long"

--- a/pages/settings/PageSettingsWifi.qml
+++ b/pages/settings/PageSettingsWifi.qml
@@ -61,13 +61,12 @@ Page {
 				}
 			}
 
-			ListTextField {
+			ListPasswordField {
 				//% "Access Point password"
 				text: qsTrId("settings_wifi_access_point_password")
-				//% "Enter password"
-				placeholderText: qsTrId("settings_wifi_access_point_enter_password")
 				writeAccessLevel: VenusOS.User_AccessType_User
 				preferredVisible: accessPoint.valid
+				echoMode: TextInput.Normal // password is shown on entry, but server will return it as obfuscated asterisks
 				dataItem.uid: Global.systemSettings.serviceUid + "/Settings/Services/AccessPointPassword"
 				validateInput: function() {
 					const length = textField.text.length
@@ -75,7 +74,6 @@ Page {
 						//% "Password length must be either 0 or between 10 and 63 characters long"
 						return Utils.validationResult(VenusOS.InputValidation_Result_Error, qsTrId("page_settings_wifi_invalid_password"))
 					}
-
 					//% "Password updated"
 					return Utils.validationResult(VenusOS.Notification_Info, qsTrId("page_settings_wifi_password_updated"))
 				}


### PR DESCRIPTION
When setting the Wi-Fi access point password, show a "Confirm" button next to the text field, and only confirm or validate the password text when the button is pressed (and not when the field loses focus). This is the same as the behaviour required by radio button options that show a password with a "Confirm" button.

This fixes a bug where the password is accepted/validated when the Wi-Fi network list updates, as QTBUG-141478 causes the list view to steal focus from the text field (causing it to validate as focus has been lost) when items are removed from the list.

Also for mock mode, set a non-empty string for
/Settings/Services/AccessPointPassword so that the access point password field appears.

Fixes #2572