### PR TITLE
Key navigation: support navigation in VE.Bus backup/restore list

### DIFF
--- a/data/mock/InverterChargersImpl.qml
+++ b/data/mock/InverterChargersImpl.qml
@@ -132,6 +132,8 @@ Item {
 	// When backup/restore features are triggered, mimic a successful action that is finished after
 	// a brief delay.
 	VeQuickItem {
+		id: _backupRestoreAction
+
 		uid: Global.venusPlatform.serviceUid + "/Vebus/Interface/ttyS2/Action"
 		onValueChanged: {
 			if (valid && value !== VenusOS.VeBusDevice_Backup_Restore_Action_None) {
@@ -144,21 +146,37 @@ Item {
 			interval: 2000
 			onTriggered: {
 				let successCode = _backupRestoreAction.value
+				const backupName = backupRestoreFileItem.value || ""
+				let backupList = availableBackupsItem.value || ""
+				backupList = backupList ? JSON.parse(backupList) : []
+
 				switch (_backupRestoreAction.value) {
 				case VenusOS.VeBusDevice_Backup_Restore_Action_Backup:
+					backupList.push(backupName + "-ttyS2")
 					successCode = 1
 					break
 				case VenusOS.VeBusDevice_Backup_Restore_Action_Restore:
+					backupList.splice(backupList.indexOf(backupName + "-ttyS2"), 1)
 					successCode = 2
 					break
 				case VenusOS.VeBusDevice_Backup_Restore_Action_Delete:
+					backupList.splice(backupList.indexOf(backupName + "-ttyS2"), 1)
 					successCode = 3
 					break
 				}
+				availableBackupsItem.setValue(JSON.stringify(backupList))
 				_backupRestoreAction.setValue(VenusOS.VeBusDevice_Backup_Restore_Action_None)
 				MockManager.setValue(Global.venusPlatform.serviceUid + "/Vebus/Interface/ttyS2/Notify", successCode)
 			}
 		}
+	}
+	VeQuickItem {
+		id: availableBackupsItem
+		uid: Global.venusPlatform.serviceUid + "/Vebus/Interface/ttyS2/AvailableBackups"
+	}
+	VeQuickItem {
+		id: backupRestoreFileItem
+		uid: Global.venusPlatform.serviceUid + "/Vebus/Interface/ttyS2/File"
 	}
 
 	// Animate AC-out values; AC-in values are already animated by SystemAcImpl.qml, and DC values

--- a/data/mock/conf/services/quattro-3phase-grid-genset.json
+++ b/data/mock/conf/services/quattro-3phase-grid-genset.json
@@ -464,6 +464,9 @@
         "/VebusMainState": 9,
         "/VebusSetChargeState": 0
     },
+    "com.victronenergy.platform": {
+        "/Vebus/Interface/ttyS2/Action": 0
+    },
     "com.victronenergy.settings": {
         "/Settings/Alarm/Vebus/HighDcCurrent": 2,
         "/Settings/Alarm/Vebus/HighDcRipple": 2,

--- a/pages/vebusdevice/PageVeBusBackupRestore.qml
+++ b/pages/vebusdevice/PageVeBusBackupRestore.qml
@@ -294,7 +294,7 @@ Page {
 				text: qsTrId("backup_name")
 				preferredVisible: _backupRestoreAction.value != VenusOS.VeBusDevice_Backup_Restore_Action_Backup
 						&& !_backupButton.backupFileName
-				enabled: _backupRestoreAction.value == VenusOS.VeBusDevice_Backup_Restore_Action_None
+				interactive: _backupRestoreAction.value == VenusOS.VeBusDevice_Backup_Restore_Action_None
 				//% "Enter backup name"
 				placeholderText: qsTrId("vebus_backup_backup_name")
 				validateInput: function() {
@@ -326,7 +326,7 @@ Page {
 					//% "Backing up..."
 					: qsTrId("vebus_backup_backing_up") + (_backupRestoreInfo.valid? " " + get_mk2vsc_state(_backupRestoreInfo.value): "")
 				)
-				enabled: _backupRestoreAction.value == VenusOS.VeBusDevice_Backup_Restore_Action_None
+				interactive: _backupRestoreAction.value == VenusOS.VeBusDevice_Backup_Restore_Action_None
 				preferredVisible: !_backupNameInput.visible
 				onClicked: {
 					_backupRestoreFile.setValue(backupFileName)
@@ -345,7 +345,7 @@ Page {
 				popDestination: root
 				preferredVisible: _backupRestoreAction.value != VenusOS.VeBusDevice_Backup_Restore_Action_Restore
 						&& !_restoreButton.fileToRestore
-				enabled: _backupRestoreAction.value == VenusOS.VeBusDevice_Backup_Restore_Action_None
+				interactive: _backupRestoreAction.value == VenusOS.VeBusDevice_Backup_Restore_Action_None
 				onOptionClicked: function(index) {
 					_restoreButton.fileNameToRestore = _availableBackupsModel.get(index).display
 					_restoreButton.fileToRestore = _availableBackupsModel.get(index).value
@@ -363,7 +363,7 @@ Page {
 					//% "Restoring..."
 					: qsTrId("vebus_backup_restoring") + (_backupRestoreInfo.valid? " " + get_mk2vsc_state(_backupRestoreInfo.value): "")
 				)
-				enabled: _backupRestoreAction.value == VenusOS.VeBusDevice_Backup_Restore_Action_None
+				interactive: _backupRestoreAction.value == VenusOS.VeBusDevice_Backup_Restore_Action_None
 				preferredVisible: !_restoreOptionsList.preferredVisible
 				onClicked: {
 					_backupRestoreFile.setValue(fileToRestore)
@@ -382,7 +382,7 @@ Page {
 				popDestination: root
 				preferredVisible: _backupRestoreAction.value != VenusOS.VeBusDevice_Backup_Restore_Action_Delete
 						&& !_deleteButton.fileToDelete
-				enabled: _backupRestoreAction.value == VenusOS.VeBusDevice_Backup_Restore_Action_None
+				interactive: _backupRestoreAction.value == VenusOS.VeBusDevice_Backup_Restore_Action_None
 				onOptionClicked: function(index) {
 					_deleteButton.fileNameToDelete = _mergedBackupsModel.get(index).display
 					_deleteButton.fileToDelete = _mergedBackupsModel.get(index).value
@@ -400,7 +400,7 @@ Page {
 					//% "Deleting..."
 					: qsTrId("vebus_backup_deleting") + (_backupRestoreInfo.valid? " " + get_mk2vsc_state(_backupRestoreInfo.value): "")
 				)
-				enabled: _backupRestoreAction.value == VenusOS.VeBusDevice_Backup_Restore_Action_None
+				interactive: _backupRestoreAction.value == VenusOS.VeBusDevice_Backup_Restore_Action_None
 				preferredVisible: !_deleteOptionsList.preferredVisible
 				onClicked: {
 					_backupRestoreFile.setValue(fileToDelete)
@@ -413,7 +413,7 @@ Page {
 				text: CommonWords.cancel
 				//% "Press to cancel"
 				secondaryText: qsTrId("vebus_backup_press_to_cancel")
-				enabled: _backupRestoreAction.value == VenusOS.VeBusDevice_Backup_Restore_Action_None
+				interactive: _backupRestoreAction.value == VenusOS.VeBusDevice_Backup_Restore_Action_None
 				preferredVisible: _backupRestoreAction.value == VenusOS.VeBusDevice_Backup_Restore_Action_None && (!_deleteOptionsList.preferredVisible  ||
 								  !_restoreOptionsList.preferredVisible || !_backupNameInput.preferredVisible)
 				onClicked: {


### PR DESCRIPTION
Set 'interactive' instead of 'enabled' so that list items are focusable by key navigation, even when they are not clickable.

Also fix the mock backup/restore implementation so that the feature can be used in mock mode.

---

Note, with the mock maximal conf, the feature is found here:

<img width="912" height="620" alt="image" src="https://github.com/user-attachments/assets/d1227ccf-6907-433a-bdaa-5ba937904110" />
