### PR TITLE
DVCC: ensure 'Charge current limits' page can be loaded

### DIFF
--- a/cmake/ModuleVenus_Sources.cmake
+++ b/cmake/ModuleVenus_Sources.cmake
@@ -124,6 +124,7 @@ set (VictronVenusOS_QML_MODULE_SOURCES
     components/Utils.js
     components/ValueRange.qml
     components/VeBusAcIODisplay.qml
+    components/VeQItemFilteredServiceModel.qml
     components/ViewGradient.qml
     components/WasmVirtualKeyboardHandler.qml
     components/WifiModel.qml

--- a/components/VeQItemFilteredServiceModel.qml
+++ b/components/VeQItemFilteredServiceModel.qml
@@ -1,0 +1,52 @@
+/*
+** Copyright (C) 2024 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+/*
+	Loads a QAbstractItemModel containing all services of the requested type.
+
+	On D-Bus/Mock backends, service uids include unique device strings. For example, if the
+	serviceType='tank', the uids from this model might be:
+		"dbus/com.victronenergy.tank.adc_builtin1_1"
+		"dbus/com.victronenergy.tank.adc_builtin1_4"
+
+	On MQTT backends, service uids only include the service type and device instance, so the uids
+	from the model would be like this instead:
+		"mqtt/tank/22"
+		"mqtt/tank/23"
+*/
+VeQItemSortTableModel {
+	id: root
+
+	required property list<string> serviceTypes
+
+	// On D-Bus, the model contains the top-level values (e.g. "com.victronenergy.vebus.ttyO1").
+	// Apply a regex filter to find "com.victronenergy.<serviceType>." matches.
+	dynamicSortFilter: BackendConnection.type !== BackendConnection.MqttSource
+	filterRole: VeQItemTableModel.UniqueIdRole
+	filterRegExp: BackendConnection.type === BackendConnection.MqttSource ? ""
+			: "^%1/com\\.victronenergy\\.(?:%2)\\."
+					.arg(BackendConnection.uidPrefix())
+					.arg(root.serviceTypes.join("|"))
+	model: BackendConnection.type === BackendConnection.MqttSource ? mqttModel : dbusModel
+
+	// On MQTT, the model does not contain the top-level services (e.g. "mqtt/vebus").
+	// VeQItemTableModel provides the children of the specified uids, e.g. "mqtt/vebus/123" if the
+	// device instance is 123.
+	readonly property VeQItemTableModel mqttModel: VeQItemTableModel {
+		uids: BackendConnection.type === BackendConnection.MqttSource
+			  ? root.serviceTypes.map(function(serviceType) { return "mqtt/" + serviceType })
+			  : []
+		flags: VeQItemTableModel.AddChildren | VeQItemTableModel.AddNonLeaves | VeQItemTableModel.DontAddItem
+	}
+
+	readonly property VeQItemTableModel dbusModel: VeQItemTableModel {
+		uids: [ BackendConnection.uidPrefix() ]
+		flags: VeQItemTableModel.AddChildren | VeQItemTableModel.AddNonLeaves | VeQItemTableModel.DontAddItem
+	}
+}
+


### PR DESCRIPTION
PageChargeCurrentLimits.qml refers to VeQItemFilteredServiceModel, which does not exist.

Restore this file, which was removed (as VeQItemServiceModel) during the model rework in 050ad220226dadd5527f3e70c3123b92754872c2.

---

Testable in mock mode:

<img width="912" height="620" alt="image" src="https://github.com/user-attachments/assets/d674ca8d-ba38-4148-a632-9a459b41e768" />
