### PR TITLE
Overview: hide AC Loads widget if HasAcLoads is false

### DIFF
--- a/cmake/ModuleMock_Sources.cmake
+++ b/cmake/ModuleMock_Sources.cmake
@@ -22,6 +22,7 @@ set(VictronMock_QML_MODULE_SOURCES
 
 SET(VictronMock_QML_MODULE_RESOURCES
     data/mock/conf/barebones.json
+    data/mock/conf/dc-only.json
     data/mock/conf/maximal.json
     data/mock/conf/multi-rs.json
     data/mock/conf/split-phase.json

--- a/data/System.qml
+++ b/data/System.qml
@@ -14,6 +14,7 @@ QtObject {
 
 	readonly property bool hasGridMeter: _gridDeviceType.valid
 	readonly property bool hasAcOutSystem: _hasAcOutSystem.valid && _hasAcOutSystem.value === 1
+	readonly property bool hasAcLoads: !_hasAcLoads.valid || _hasAcLoads.value === 1 // show AC loads by default if the path isn't valid
 	readonly property bool hasVebusEss: _systemType.value === "ESS" || _systemType.value === "Hub-4"
 	readonly property bool hasEss: hasVebusEss || _systemType.value === "AC System"
 	readonly property bool showInputLoads: load.acIn.hasPower
@@ -102,6 +103,10 @@ QtObject {
 
 	readonly property VeQuickItem _gridDeviceType: VeQuickItem {
 		uid: root.serviceUid + "/Ac/Grid/DeviceType"
+	}
+
+	readonly property VeQuickItem _hasAcLoads: VeQuickItem {
+		uid: root.serviceUid + "/Ac/HasAcLoads"
 	}
 
 	readonly property VeQuickItem _hasAcOutSystem: VeQuickItem {

--- a/data/mock/MockShortcuts.qml
+++ b/data/mock/MockShortcuts.qml
@@ -174,6 +174,10 @@ QtObject {
 				MockManager.setValue("com.victronenergy.modem/Connected", oldValue === 1 ? 0 : 1)
 			}
 			break
+		case Qt.Key_H:
+			const hasAcLoads = MockManager.value(Global.system.serviceUid + "/Ac/HasAcLoads")
+			MockManager.setValue(Global.system.serviceUid + "/Ac/HasAcLoads", hasAcLoads === 1 ? 0 : 1)
+			break
 		case Qt.Key_L:
 			Language.setCurrentLanguage((Language.current === Language.English ? Language.French : Language.English))
 			pageConfigTitle.text = "Language: " + Language.toString(Language.current)

--- a/data/mock/SystemAcImpl.qml
+++ b/data/mock/SystemAcImpl.qml
@@ -10,17 +10,18 @@ Item {
 	id: root
 
 	function setSystemValue(path, value) {
-		MockManager.setValue("com.victronenergy.system" + path, value)
+		MockManager.setValue(Global.system.serviceUid + path, value)
 	}
+
 	function systemValue(path) {
-		return MockManager.value("com.victronenergy.system" + path)
+		return MockManager.value(Global.system.serviceUid + path)
 	}
 
 	function setGaugesValue(path, value) {
 		MockManager.setValue(Global.systemSettings.serviceUid + "/Settings/Gui/Gauges" + path, value)
 	}
 	function gaugesValue(path) {
-		return MockManager.value("com.victronenergy.settings/Settings/Gui/Gauges" + path)
+		return MockManager.value(Global.systemSettings.serviceUid + "/Settings/Gui/Gauges" + path)
 	}
 
 	VeQuickItem {
@@ -100,8 +101,11 @@ Item {
 				let phaseAcOutCurrent = NaN
 				for (let objectIndex = 0; objectIndex < count; ++objectIndex) {
 					const acService = objectAt(objectIndex)
+					if (!acService) {
+						continue
+					}
 					const acServicePhaseCount = Math.max(acService.acIn.phaseCount, acService.acOut.phaseCount)
-					if (!acService || phaseIndex >= acServicePhaseCount) {
+					if (phaseIndex >= acServicePhaseCount) {
 						continue
 					}
 					phaseAcInPower = Units.sumRealNumbers(phaseAcInPower, acService.acIn["powerL" + (phaseIndex + 1)].value)
@@ -304,6 +308,16 @@ Item {
 				VeQuickItem { uid: acObject.uid + "/Ac/L2/Voltage" }
 				VeQuickItem { uid: acObject.uid + "/Ac/L3/Voltage" }
 			}
+		}
+	}
+
+	FilteredServiceModel {
+		id: hasAcLoadsModel
+		serviceTypes: ["inverter", "charger", "evcharger", "acload", "heatpump", "vebus", "acsystem"]
+		onCountChanged: Qt.callLater(updateHasAcLoads)
+		Component.onCompleted: Qt.callLater(updateHasAcLoads)
+		function updateHasAcLoads() {
+			root.setSystemValue("/Ac/HasAcLoads", count === 0 ? 0 : 1)
 		}
 	}
 }

--- a/data/mock/conf/dc-only.json
+++ b/data/mock/conf/dc-only.json
@@ -1,0 +1,15 @@
+{
+    "files": [
+        ":/data/mock/conf/services/wind.json",
+        ":/data/mock/conf/services/orionxs-dcdc.json",
+        ":/data/mock/conf/services/pylontech.json",
+        ":/data/mock/conf/services/motordrive.json",
+        ":/data/mock/conf/setup-common.json"
+    ],
+    "setup": {
+        "com.victronenergy.system": {
+            "/Ac/HasAcLoads": 0,
+            "/ActiveBatteryService": "com.victronenergy.battery/512"
+        }
+    }
+}

--- a/pages/BriefPage.qml
+++ b/pages/BriefPage.qml
@@ -16,7 +16,7 @@ SwipeViewPage {
 	property real _gaugeLabelOpacity: 0
 
 	readonly property int _leftGaugeCount: (acInputGauge.active ? 1 : 0) + (dcInputGauge.active ? 1 : 0) + (solarYieldGauge.active ? 1 : 0)
-	readonly property int _rightGaugeCount: dcLoadGauge.active ? 2 : 1  // AC load gauge is always active
+	readonly property int _rightGaugeCount: (acLoadGauge.active ? 1 : 0) + (dcLoadGauge.active ? 1 : 0)
 	readonly property real _unexpandedHeight: Theme.geometry_screen_height - Theme.geometry_statusBar_height - Theme.geometry_navigationBar_height
 
 	property bool _readyToInit: state === "" && !Global.splashScreenVisible
@@ -270,8 +270,8 @@ SwipeViewPage {
 			id: acLoadGauge
 
 			width: Theme.geometry_briefPage_edgeGauge_width
-			height: Gauges.gaugeHeight(root._rightGaugeCount)
-			active: root.state !== "panelOpened"
+			height: active ? Gauges.gaugeHeight(root._rightGaugeCount) : 0
+			active: Global.system.hasAcLoads && root.state !== "panelOpened"
 
 			sourceComponent: SideMultiGauge {
 				readonly property var gaugeParams: Gauges.rightGaugeParameters(0, _rightGaugeCount, phaseModel.count > 1)
@@ -309,10 +309,11 @@ SwipeViewPage {
 			width: Theme.geometry_briefPage_edgeGauge_width
 			height: active ? Gauges.gaugeHeight(root._rightGaugeCount) : 0
 			active: Global.system.dc.hasPower && root.state !== "panelOpened"
-			sourceComponent: SideGauge {
-				readonly property var gaugeParams: Gauges.rightGaugeParameters(1, _rightGaugeCount)
 
-				// DC load gauge progresses in counter-clockwise direction (i.e. upwards).
+			sourceComponent: SideGauge {
+				readonly property var gaugeParams: Gauges.rightGaugeParameters(acLoadGauge.active ? 1 : 0, _rightGaugeCount)
+
+				// DC load gauge progresses in counter-clockwise direction (i.e. upwards)
 				direction: PathArc.Counterclockwise
 				startAngle: gaugeParams.end
 				endAngle: gaugeParams.start

--- a/pages/BriefSidePanel.qml
+++ b/pages/BriefSidePanel.qml
@@ -257,7 +257,8 @@ exported power v  0.4 |   /
 		title: qsTrId("brief_ac_loads")
 		icon.source: "qrc:/images/acloads.svg"
 		quantityLabel.dataObject: Global.system.load.ac
-		loadersActive: true
+		loadersActive: Global.system.hasAcLoads
+		visible: loadersActive
 		sideComponent: LoadGraph {
 			animationEnabled: root.animationEnabled
 			onNextValueRequested: addValue(acLoadGraphRange.averagePhaseCurrentAsRatio)

--- a/pages/OverviewPage.qml
+++ b/pages/OverviewPage.qml
@@ -381,7 +381,10 @@ SwipeViewPage {
 	}
 
 	function _resetRightWidgets() {
-		let widgets = [acLoadsWidget]
+		let widgets = []
+		if (layoutConditions.showAcLoads) {
+			widgets.push(acLoadsWidget)
+		}
 		if (Global.evChargers.model.count > 0) {
 			widgets.push(_createWidget(VenusOS.OverviewWidget_Type_Evcs))
 		}
@@ -527,6 +530,10 @@ SwipeViewPage {
 		onPvChargerCountChanged: Qt.callLater(root._resetWidgets)
 		readonly property int pvInverterCount: Global.solarInputs?.pvInverterDevices.count ?? 0
 		onPvInverterCountChanged: Qt.callLater(root._resetWidgets)
+
+		// Affects whether AcLoadsWidget is shown.
+		readonly property bool showAcLoads: Global.system?.hasAcLoads || Global.evChargers?.model.count > 0
+		onShowAcLoadsChanged: Qt.callLater(root._resetWidgets)
 
 		// Affects whether DcLoadsWidget is shown.
 		readonly property bool showDcLoads: Global.system?.dc.hasPower
@@ -827,6 +834,7 @@ SwipeViewPage {
 	AcLoadsWidget {
 		id: acLoadsWidget
 
+		visible: Global.system.hasAcLoads || Global.evChargers.model.count > 0 // the EVCS widget might connect to the AC Loads widget
 		expanded: root._expandLayout
 		animateGeometry: root._animateGeometry
 		animationEnabled: root.animationEnabled
@@ -978,18 +986,18 @@ SwipeViewPage {
 				parent: acLoadsWidget
 				location: VenusOS.WidgetConnector_Location_Left
 				offsetY: Theme.geometry_overviewPage_connector_anchor_height + Theme.geometry_overviewPage_connector_anchor_spacing
-				visible: evcsWidget.connectToCombinedAcLoads || evcsWidget.connectToSplitAcLoads
+				visible: acLoadsWidget.visible && (evcsWidget.connectToCombinedAcLoads || evcsWidget.connectToSplitAcLoads)
 			}
 			WidgetConnectorAnchor {
 				id: acLoadsToEvcsEndAnchor
 				location: VenusOS.WidgetConnector_Location_Left
 				offsetY: -(Theme.geometry_overviewPage_connector_anchor_height + Theme.geometry_overviewPage_connector_anchor_spacing)
-				visible: evcsWidget.connectToCombinedAcLoads || evcsWidget.connectToSplitAcLoads
+				visible: acLoadsWidget.visible && (evcsWidget.connectToCombinedAcLoads || evcsWidget.connectToSplitAcLoads)
 			}
 			WidgetConnector {
 				id: acLoadsToEvcsConnector
 				parent: root
-				visible: evcsWidget.connectToCombinedAcLoads || evcsWidget.connectToSplitAcLoads
+				visible: acLoadsWidget.visible && (evcsWidget.connectToCombinedAcLoads || evcsWidget.connectToSplitAcLoads)
 				startWidget: acLoadsWidget
 				startLocation: VenusOS.WidgetConnector_Location_Left
 				startOffsetY: acLoadsToEvcsStartAnchor.offsetY

--- a/pages/boat/ConsumptionGauge.qml
+++ b/pages/boat/ConsumptionGauge.qml
@@ -46,7 +46,7 @@ Column {
 		unit: Global.system.load.ac.preferredUnit
 		icon.source: "qrc:/images/acloads.svg"
 		icon.width: Theme.geometry_widgetHeader_icon_size
-		visible: !motorDriveLoad.visible // && !isNaN(value) once #2159 is resolved
+		visible: !motorDriveLoad.visible && Global.system?.hasAcLoads // && !isNaN(value) once #2159 is resolved
 	}
 
 	QuantityLabelIconRow {

--- a/pages/boat/LoadArc.qml
+++ b/pages/boat/LoadArc.qml
@@ -15,8 +15,9 @@ Column {
 	required property MotorDrive motorDrive
 
 	readonly property int _rightGaugeCount: root.gps.valid && root.motorDrive.dcConsumption.quotient.valid ? 1 // just the motor drive
-											: dcLoadGauge.active ? 2 // both AC & DC
-											: 1  // just AC. The AC load gauge is always active
+											: dcLoadGauge.active && acLoadGauge.active ? 2 // both AC & DC
+											: dcLoadGauge.active || acLoadGauge.active ? 1 // just one
+											: 0
 
 	readonly property bool showing3Phases: acLoadGauge.active && Global.system.load.ac.phases.count === 3
 
@@ -47,7 +48,7 @@ Column {
 
 		width: Theme.geometry_briefPage_edgeGauge_width
 		height: active ? Gauges.gaugeHeight(root._rightGaugeCount) : 0
-		active: !motorDriveLoadGauge.active
+		active: Global.system?.hasAcLoads && !motorDriveLoadGauge.active
 
 		sourceComponent: SideMultiGauge {
 			readonly property var gaugeParams: Gauges.rightGaugeParameters(0, _rightGaugeCount, phaseModel.count > 1)
@@ -79,7 +80,7 @@ Column {
 		height: active ? Gauges.gaugeHeight(root._rightGaugeCount) : 0
 		active: !motorDriveLoadGauge.active && Global.system.dc.hasPower
 		sourceComponent: SideGauge {
-			readonly property var gaugeParams: Gauges.rightGaugeParameters(1, _rightGaugeCount,)
+			readonly property var gaugeParams: Gauges.rightGaugeParameters(acLoadGauge.active ? 1 : 0, _rightGaugeCount, false)
 			// DC load gauge progresses in counter-clockwise direction (i.e. upwards).
 			direction: PathArc.Counterclockwise
 			startAngle: gaugeParams.end


### PR DESCRIPTION
Also hide AC Loads related gauges on the Boat and Brief pages.

Contributes to issue #2617