### PR TITLE
VRM: always prompt user to reboot after VRM device instance changes

### DIFF
--- a/components/Page.qml
+++ b/components/Page.qml
@@ -21,7 +21,10 @@ FocusScope {
 	property int topLeftButton: VenusOS.StatusBar_LeftButton_None
 	property int topRightButton: VenusOS.StatusBar_RightButton_None
 
-	property var tryPop // optional function: returns whether the page can be poppped
+	// Optional function that is called when the stack is about to pop this page. Return true if
+	// the page can be popped, or false to deny it and remain on the page.
+	// Takes one argument: the page to which the stack will be popped (null if popping all pages)
+	property var tryPop
 
 	readonly property bool __is_venus_gui_page__: true
 

--- a/components/PageStack.qml
+++ b/components/PageStack.qml
@@ -110,13 +110,20 @@ StackView {
 	}
 
 	function popAllPages(operation) {
+		if (!_canPopTo(null)) {
+			return
+		}
 		fakePopAnimation.duration = _animationDuration(operation)
 		root.state = "closed"
 	}
 
 	function popPage(toPage, operation) {
-		if (root.animating
-				|| (!!root.currentItem && !!root.currentItem.tryPop && !root.currentItem.tryPop())) {
+		if (!toPage) {
+			popAllPages(operation)
+			return
+		}
+
+		if (!_canPopTo(toPage)) {
 			return
 		}
 		root._pageUrls.pop()
@@ -170,6 +177,14 @@ StackView {
 		if (obj && !Theme.objectHasQObjectParent(obj)) {
 			obj.destroy()
 		}
+	}
+
+	function _canPopTo(toPage) {
+		if (root.animating
+				|| (!!root.currentItem && !!root.currentItem.tryPop && !root.currentItem.tryPop(toPage))) {
+			return false
+		}
+		return true
 	}
 
 	function _animationDuration(operation) {

--- a/pages/settings/PageVrmDeviceInstances.qml
+++ b/pages/settings/PageVrmDeviceInstances.qml
@@ -52,7 +52,7 @@ Page {
 	}
 
 	// If user changes the VRM instance, ask whether reboot should be done when page is popped.
-	tryPop: () => {
+	tryPop: (toPage) => {
 		// If a text field delegate in the list is currently focused, remove the focus so that it
 		// calls _changeVrmInstance() to save the new VRM instance value, before this checks
 		// whether any VRM instances have changed.
@@ -62,7 +62,7 @@ Page {
 			return true
 		}
 
-		Global.dialogLayer.open(rebootDialogComponent)
+		Global.dialogLayer.open(rebootDialogComponent, { toPage: toPage })
 		return false
 	}
 
@@ -132,6 +132,8 @@ Page {
 		id: rebootDialogComponent
 
 		ModalWarningDialog {
+			property Page toPage
+
 			//% "Reboot now?"
 			title: qsTrId("settings_vrm_device_instances_reboot_now")
 
@@ -177,7 +179,7 @@ Page {
 
 			onRejected: {
 				root.tryPop = undefined     // allow the next pop to proceed
-				Global.pageManager.popPage()
+				Global.pageManager.popPage(toPage)
 			}
 		}
 	}

--- a/src/classandvrminstancemodel.cpp
+++ b/src/classandvrminstancemodel.cpp
@@ -107,6 +107,7 @@ bool ClassAndVrmInstance::setVrmInstance(int newVrmInstance)
 		qWarning() << "Cannot set VRM instance for" << m_item->uniqueId() << "device class not set!";
 		return false;
 	}
+	m_pendingVrmInstance = newVrmInstance;
 	m_item->setValue(QStringLiteral("%1:%2").arg(m_deviceClass).arg(newVrmInstance));
 	return true;
 }
@@ -116,7 +117,10 @@ bool ClassAndVrmInstance::hasVrmInstanceChanges() const
 	// Returns true if vrmInstance has changed after initialization. This may be due to
 	// setVrmInstance() being called, or due to the /ClassAndVrmInstance being changed on the
 	// backend by some other source.
-	return m_vrmInstance != m_initialVrmInstance;
+	return m_vrmInstance != m_initialVrmInstance
+			// True if setVrmInstance() has been called but the new value has not yet been written
+			// to the backend.
+			|| m_pendingVrmInstance >= 0;
 }
 
 void ClassAndVrmInstance::classAndVrmInstanceChanged(QVariant variant)
@@ -127,6 +131,7 @@ void ClassAndVrmInstance::classAndVrmInstanceChanged(QVariant variant)
 
 	m_deviceClass.clear();
 	m_vrmInstance = -1;
+	m_pendingVrmInstance = -1;
 	if (variant.isValid()) {
 		const QStringList classAndInstance = variant.toString().split(':');
 		bool instanceOk = false;

--- a/src/classandvrminstancemodel.h
+++ b/src/classandvrminstancemodel.h
@@ -72,6 +72,7 @@ private:
 	VeQItem *m_item = nullptr;
 	BaseDevice *m_device = nullptr;
 	int m_vrmInstance = -1;
+	int m_pendingVrmInstance = -1;
 	int m_initialVrmInstance = -1;
 };
 


### PR DESCRIPTION
The VRM Device Instances page should show a reboot prompt dialog if the page is popped after a VRM device instance is changed. There were two bugs here:

1. The dialog was not shown if the user changed an instance then immediately clicked a breadcrumb to go to the previous page, without first pressing Enter in the text field to "accept". This was because the new instance had not yet been written to the backend, and thus hasVrmInstanceChanges() unexpectedly returned false. Fix this by changing hasVrmInstanceChanges() to return true if a pending
change has not yet been written.

2. It was also not shown if the user clicked the first breadcrumb ("Settings") instead of the second "VRM" breadcrumb. This was because PageStack.qml only called the tryPop() function in the single-page-pop case, but not when popping all pages. Fix this by calling tryPop() from popAllPages(), and pass the destination page to tryPop() so that the VRM Device Instances page can pop to the correct page when the reboot prompt dialog is cancelled.

Fixes #2712
