### PR TITLE
MotorDrive: consolidate device list page

### DIFF
--- a/cmake/ModuleVenus_Sources.cmake
+++ b/cmake/ModuleVenus_Sources.cmake
@@ -197,6 +197,7 @@ set (VictronVenusOS_QML_MODULE_SOURCES
     components/listitems/ListInfoLabel.qml
     components/listitems/ListInverterChargerModeButton.qml
     components/listitems/ListLink.qml
+    components/listitems/ListMotorDriveGear.qml
     components/listitems/ListMqttAccessSwitch.qml
     components/listitems/ListMountStateButton.qml
     components/listitems/ListAcInPositionRadioButtonGroup.qml

--- a/components/listitems/ListMotorDriveGear.qml
+++ b/components/listitems/ListMotorDriveGear.qml
@@ -1,0 +1,61 @@
+/*
+** Copyright (C) 2025 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+ListItem {
+	id: root
+
+	readonly property alias dataItem: dataItem
+
+	VeQuickItem {
+		id: dataItem
+	}
+
+	content.children: [
+		Row {
+			id: gearRow
+
+			spacing: Theme.geometry_listItem_content_spacing
+			visible: dataItem.valid
+
+			GearIndicator {
+				gear: VenusOS.MotorDriveGear_Forward
+				text: "F" // intentionally not translated
+			}
+
+			GearIndicator {
+				gear: VenusOS.MotorDriveGear_Neutral
+				text: "N" // intentionally not translated
+			}
+
+			GearIndicator {
+				gear: VenusOS.MotorDriveGear_Reverse
+				text: "R" // intentionally not translated
+			}
+		}
+	]
+
+	component GearIndicator : Item {
+		required property int gear
+		property alias text: gearLabel.text
+
+		width: gearLabel.width
+		height: gearLabel.height
+
+		Label {
+			id: gearLabel
+
+			anchors {
+				horizontalCenter: parent.horizontalCenter
+				bottom: parent.bottom
+			}
+			color: dataItem.value === parent.gear ? Theme.color_font_primary : Theme.color_font_secondary
+			font.pixelSize: Theme.font_size_body2
+			horizontalAlignment: Text.AlignHCenter
+		}
+	}
+}

--- a/data/mock/MotorDrivesImpl.qml
+++ b/data/mock/MotorDrivesImpl.qml
@@ -62,6 +62,7 @@ Item {
 				VeQuickItem { uid: root.motorDriveUid + "/Motor/Temperature" }
 				VeQuickItem { uid: root.motorDriveUid + "/Coolant/Temperature" }
 				VeQuickItem { uid: root.motorDriveUid + "/Controller/Temperature" }
+				VeQuickItem { uid: root.motorDriveUid + "/Motor/Torque" }
 			}
 			MockDataRangeAnimator {
 				active: Global.mainView && Global.mainView.mainViewVisible

--- a/data/mock/conf/services/motordrive.json
+++ b/data/mock/conf/services/motordrive.json
@@ -17,6 +17,7 @@
         "/Motor/Direction": 2,
         "/Motor/RPM": 1411,
         "/Motor/Temperature": 23,
+        "/Motor/Torque": 85,
         "/N2kDeviceInstance": 0,
         "/N2kUniqueNumber": 655188,
         "/ProductId": 45155,

--- a/pages/settings/devicelist/PageMotorDrive.qml
+++ b/pages/settings/devicelist/PageMotorDrive.qml
@@ -17,6 +17,33 @@ DevicePage {
 	serviceUid: bindPrefix
 
 	settingsModel: VisibleItemModel {
+		ListQuantityGroup {
+			text: CommonWords.dc
+			model: QuantityObjectModel {
+				filterType: QuantityObjectModel.HasValue
+
+				QuantityObject { object: dcVoltage; unit: VenusOS.Units_Volt_DC}
+				QuantityObject { object: dcCurrent; unit: VenusOS.Units_Amp }
+				QuantityObject { object: dcPower; unit: VenusOS.Units_Watt }
+			}
+			preferredVisible: dcVoltage.valid || dcCurrent.valid || dcPower.valid
+
+			VeQuickItem {
+				id: dcVoltage
+				uid: root.bindPrefix + "/Dc/0/Voltage"
+			}
+
+			VeQuickItem {
+				id: dcCurrent
+				uid: root.bindPrefix + "/Dc/0/Current"
+			}
+
+			VeQuickItem {
+				id: dcPower
+				uid: root.bindPrefix + "/Dc/0/Power"
+			}
+		}
+
 		ListQuantity {
 			//% "Motor RPM"
 			text: qsTrId("devicelist_motordrive_motorrpm")
@@ -25,32 +52,25 @@ DevicePage {
 			preferredVisible: dataItem.valid
 		}
 
+		ListMotorDriveGear {
+			//% "Motor Direction"
+			text: qsTrId("devicelist_motordrive_motordirection")
+			dataItem.uid: root.bindPrefix + "/Motor/Direction"
+			preferredVisible: dataItem.valid
+		}
+
+		ListQuantity {
+			//% "Motor Torque"
+			text: qsTrId("devicelist_motordrive_motortorque")
+			dataItem.uid: root.bindPrefix + "/Motor/Torque"
+			unit: VenusOS.Units_NewtonMeter
+			preferredVisible: dataItem.valid
+		}
+
 		ListTemperature {
 			//% "Motor Temperature"
 			text: qsTrId("devicelist_motordrive_motortemperature")
 			dataItem.uid: root.bindPrefix + "/Motor/Temperature"
-			preferredVisible: dataItem.valid
-		}
-
-		ListQuantity {
-			text: CommonWords.power_watts
-			dataItem.uid: root.bindPrefix + "/Dc/0/Power"
-			unit: VenusOS.Units_Watt
-			preferredVisible: dataItem.valid
-		}
-
-		ListQuantity {
-			text: CommonWords.voltage
-			dataItem.uid: root.bindPrefix + "/Dc/0/Voltage"
-			unit: VenusOS.Units_Volt_DC
-			preferredVisible: dataItem.valid
-		}
-
-		ListQuantity {
-			text: CommonWords.current_amps
-			dataItem.uid: root.bindPrefix + "/Dc/0/Current"
-			unit: VenusOS.Units_Amp
-			precision: 2
 			preferredVisible: dataItem.valid
 		}
 

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_motordrive.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_motordrive.qml
@@ -12,6 +12,7 @@ DeviceListDelegate {
 	quantityModel: QuantityObjectModel {
 		filterType: QuantityObjectModel.HasValue
 		QuantityObject { object: motorRpm; unit: VenusOS.Units_RevolutionsPerMinute }
+		QuantityObject { object: dcPower; unit: VenusOS.Units_Watt }
 	}
 
 	onClicked: {
@@ -22,5 +23,10 @@ DeviceListDelegate {
 	VeQuickItem {
 		id: motorRpm
 		uid: root.device.serviceUid + "/Motor/RPM"
+	}
+
+	VeQuickItem {
+		id: dcPower
+		uid: root.device.serviceUid + "/Dc/0/Power"
 	}
 }

--- a/src/enums.h
+++ b/src/enums.h
@@ -96,7 +96,8 @@ public:
 		Units_Altitude_Foot,
 		Units_PartsPerMillion,
 		Units_MicrogramPerCubicMeter,
-		Units_Lux
+		Units_Lux,
+		Units_NewtonMeter,
 	};
 	Q_ENUM(Units_Type)
 

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -124,6 +124,7 @@ int Units::defaultUnitPrecision(VenusOS::Enums::Units_Type unit) const
 	case VenusOS::Enums::Units_Altitude_Metre:         // fall through
 	case VenusOS::Enums::Units_Altitude_Foot:          // fall through
 	case VenusOS::Enums::Units_PartsPerMillion:        // fall through
+	case VenusOS::Enums::Units_NewtonMeter:            // fall through
 		return 0;
 	default:
 		// VoltAmpere
@@ -210,6 +211,8 @@ QString Units::defaultUnitString(VenusOS::Enums::Units_Type unit, int formatHint
 		return QStringLiteral("µg/m³");
 	case VenusOS::Enums::Units_Lux:
 		return QStringLiteral("lux");
+	case VenusOS::Enums::Units_NewtonMeter:
+		return QStringLiteral("Nm");
 	default:
 		qWarning() << "No unit label known for unit:" << unit;
 		return QString();


### PR DESCRIPTION
- Reorder MotorDrive page's items.
- Add Torque and Direction.

The order was consolidated by importance and in relevance with the boat page order of importance.
The DC values were consolidated into one list item.

<img width="798" height="482" alt="Screenshot 2025-12-09 at 17 06 28" src="https://github.com/user-attachments/assets/aeb65797-6ad9-4212-a69a-447afd435be4" />

- Add Power to device list motordrive delegate.

<img width="798" height="482" alt="Screenshot 2025-12-09 at 17 10 19" src="https://github.com/user-attachments/assets/993e399e-388e-4ad2-9571-3c0ec7bfaa30" />
