### PR TITLE
Units: modify displayed precision adjustment logic

### DIFF
--- a/components/QuantityLabel.qml
+++ b/components/QuantityLabel.qml
@@ -20,6 +20,7 @@ Item {
 	property alias unitText: unitLabel.text
 	property int alignment: Qt.AlignHCenter
 	property alias precision: quantityInfo.precision
+	property alias precisionAdjustmentAllowed: quantityInfo.precisionAdjustmentAllowed
 	property alias formatHints: quantityInfo.formatHints
 	property alias leftPadding: digitRow.leftPadding
 	property alias rightPadding: digitRow.rightPadding

--- a/components/listitems/core/ListQuantity.qml
+++ b/components/listitems/core/ListQuantity.qml
@@ -15,6 +15,7 @@ ListItem {
 	property alias unit: quantityLabel.unit
 	property alias unitColor: quantityLabel.unitColor
 	property alias precision: quantityLabel.precision
+	property alias precisionAdjustmentAllowed: quantityLabel.precisionAdjustmentAllowed
 
 	content.children: [
 		QuantityLabel {

--- a/pages/vebusdevice/PageMicrogrid.qml
+++ b/pages/vebusdevice/PageMicrogrid.qml
@@ -23,6 +23,7 @@ Page {
 	component MicrogridListQuantity: ListQuantity {
 		textFormat: Text.RichText
 		precision: 2
+		precisionAdjustmentAllowed: false
 	}
 
 	component ListValueRange: ListText {
@@ -44,6 +45,7 @@ Page {
 			unitType: parent && parent.unitType ? parent.unitType : VenusOS.Units_None
 			value: dataItemFrom.valid ? dataItemFrom.value : NaN
 			precision: 2
+			precisionAdjustmentAllowed: false
 		}
 
 		QuantityInfo {
@@ -52,6 +54,7 @@ Page {
 			unitType: parent && parent.unitType ? parent.unitType : VenusOS.Units_None
 			value: dataItemTo.valid ? dataItemTo.value : NaN
 			precision: 2
+			precisionAdjustmentAllowed: false
 		}
 
 		VeQuickItem {

--- a/src/quantityinfo.cpp
+++ b/src/quantityinfo.cpp
@@ -25,7 +25,7 @@ QuantityInfo::~QuantityInfo()
 
 void QuantityInfo::update() {
 	// Pass the previous value to allow hysteresis
-	quantity = qobject_cast<Units*>(Units::instance(nullptr, nullptr))->getDisplayTextWithHysteresis(unitType, value, quantity.scale, precision, unitMatchValue, formatHints);
+	quantity = qobject_cast<Units*>(Units::instance(nullptr, nullptr))->getDisplayTextWithHysteresis(unitType, value, quantity.scale, precision, precisionAdjustmentAllowed, unitMatchValue, formatHints);
 	if (m_number != quantity.number) {
 		m_number = quantity.number;
 		emit numberChanged();

--- a/src/quantityinfo.h
+++ b/src/quantityinfo.h
@@ -28,6 +28,7 @@ class QuantityInfo : public QObject
 	Q_PROPERTY(qreal value MEMBER value NOTIFY valueChanged FINAL)
 	Q_PROPERTY(qreal unitMatchValue MEMBER unitMatchValue NOTIFY unitMatchValueChanged FINAL)
 	Q_PROPERTY(int precision MEMBER precision NOTIFY precisionChanged FINAL)
+	Q_PROPERTY(bool precisionAdjustmentAllowed MEMBER precisionAdjustmentAllowed NOTIFY precisionAdjustmentAllowedChanged FINAL)
 	Q_PROPERTY(Victron::VenusOS::Enums::Units_Type unitType MEMBER unitType NOTIFY inputChanged FINAL)
 	Q_PROPERTY(int formatHints MEMBER formatHints NOTIFY formatHintsChanged FINAL)
 
@@ -47,6 +48,7 @@ signals:
 	void inputChanged();
 	void valueChanged();
 	void precisionChanged();
+	void precisionAdjustmentAllowedChanged();
 	void unitMatchValueChanged();
 	void formatHintsChanged();
 private:
@@ -60,6 +62,7 @@ private:
 	qreal value = qQNaN();
 	Victron::VenusOS::Enums::Units_Type unitType = Victron::VenusOS::Enums::Units_None;
 	int precision = -1;
+	bool precisionAdjustmentAllowed = true;
 	qreal unitMatchValue = qQNaN();
 	bool completed = false;
 	int formatHints = 0;

--- a/src/units.h
+++ b/src/units.h
@@ -68,6 +68,7 @@ public:
 		VenusOS::Enums::Units_Type unit,
 		qreal value,
 		int precision = -1,
+		bool precisionAdjustmentAllowed = true,
 		qreal unitMatchValue = qQNaN()) const;
 
 	quantityInfo getDisplayTextWithHysteresis(
@@ -75,6 +76,7 @@ public:
 		qreal value,
 		VenusOS::Enums::Units_Scale previousScale,
 		int precision = -1,
+		bool precisionAdjustmentAllowed = true,
 		qreal unitMatchValue = qQNaN(),
 		int formatHints = 0) const;
 

--- a/tests/units/tst_units.qml
+++ b/tests/units/tst_units.qml
@@ -269,7 +269,7 @@ TestCase {
 		compare(quantity.unit, "TWh")
 
 		// choose scale based on different anchor value
-		quantity = Units.getDisplayText(unit, 19567890123, -1, 123456789)
+		quantity = Units.getDisplayText(unit, 19567890123, -1, true, 123456789)
 		compare(quantity.number, "19568")
 		compare(quantity.unit, "GWh")
 	}


### PR DESCRIPTION
Previously, when the units of a value was scaled up, we did not increase the displayed precision.  Thus, a value with precision 0 such as 12345 W would be scaled up to 12.345 kW and then trimmed to 12 kW due to the specified precision.

This commit adjusts the logic to allow increasing the precision so long as the total number of digits is less than 4. That is, 12345 W will now be displayed as 12.35 kW.

Previously, the decimal point character seemed to have been considered to take up a "digit" when calculating whether to trim the precision in some cases (e.g. for precision 2 values with 2 non-decimal digits, precision was trimmed to just 1).

This commit removes that consideration, which allows removal of some unnecessary special-casing for Volts unit values.

Contributes to issue #2705