### PR TITLE
Firmware: improve update check toast logic

### DIFF
--- a/components/FirmwareUpdate.qml
+++ b/components/FirmwareUpdate.qml
@@ -21,7 +21,7 @@ QtObject {
 		id: updateCheckTimer
 		repeat: false
 		running: false
-		onTriggered: root._finishUpdateCheck()
+		onTriggered: root._timeoutUpdateCheck()
 	}
 
 	property VeQuickItem _stateItem: VeQuickItem {
@@ -51,8 +51,18 @@ QtObject {
 				}
 				break
 			case FirmwareUpdater.ErrorDuringChecking:
+				// If the device has no internet connectivity, its state value
+				// may be set to this value, even if the user didn't explicitly
+				// request a check for update.
+				// The `checkingForUpdate` value should only be true if a check
+				// was triggered explicitly by the user via the ListFirmwareCheckButton.
 				//% "Error while checking for firmware updates"
-				msg = qsTrId("settings_firmware_error_during_checking_for_updates")
+				let checkErrorMsg = qsTrId("settings_firmware_error_during_checking_for_updates")
+				if (root.checkingForUpdate) {
+					msg = checkErrorMsg
+				} else {
+					console.warn("/Firmware/State value set to ErrorDuringChecking by venus platform")
+				}
 				break
 			case FirmwareUpdater.Checking:
 				break
@@ -190,5 +200,11 @@ QtObject {
 		if (msg) {
 			Global.showToastNotification(VenusOS.Notification_Info, msg, 10000)
 		}
+	}
+
+	function _timeoutUpdateCheck() {
+		//% "Firmware check timed out"
+		let msg = qsTrId("settings_firmware_check_timed_out")
+		Global.showToastNotification(VenusOS.Notification_Info, msg, 10000)
 	}
 }

--- a/components/listitems/ListFirmwareCheckButton.qml
+++ b/components/listitems/ListFirmwareCheckButton.qml
@@ -16,7 +16,7 @@ ListButton {
 		   ? qsTrId("settings_firmware_checking")
 			 //% "Press to check"
 		   : qsTrId("settings_firmware_press_to_check")
-	interactive: !Global.firmwareUpdate.busy
+	interactive: !Global.firmwareUpdate.checkingForUpdate
 	writeAccessLevel: VenusOS.User_AccessType_User
 
 	onClicked: {


### PR DESCRIPTION
Previously, if the value of the firmware update state path changed to ErrorDuringChecking due to a (venus platform) backend update, a toast notification would be raised, even if the user did not trigger the check.

This commit ensures that the toast is only raised if the user triggered the check, and otherwise it simply logs the warning to the console.

This commit also ensures that the firmware update check button's busy state is bound appropriately to the "checkingForUpdate" property of the FirmwareUpdate object, which will transition to false if the check times out.

Contributes to issue #2276