### PR TITLE
ProgressArc: fix transitionAngle when not visible

### DIFF
--- a/components/ProgressArc.qml
+++ b/components/ProgressArc.qml
@@ -23,7 +23,7 @@ Shape {
 	property color fillColor: "transparent"
 	property real progressAnimatedEndAngle: progress.animatedEndAngle
 
-	property real transitionAngle: visible ? startAngle + ((endAngle - startAngle) * Math.min(Math.max((isNaN(control.value) ? 0 : control.value), 0.0), 100.0) / 100.0) : 0
+	property real transitionAngle: visible ? startAngle + ((endAngle - startAngle) * Math.min(Math.max((isNaN(control.value) ? 0 : control.value), 0.0), 100.0) / 100.0) : startAngle
 
 	Arc {
 		id: remainder


### PR DESCRIPTION
## ProgressArc

There is a bug when a ProgressArc is hidden then shown again.
It used to reset `transitionAngle` to `0` when hidden which depending on the `startAngle` and `endAngle` could be out of bounds.
The UI was glitching until the animation was over and `transitionAngle` was back between `startAngle` and `endAngle`.

I discovered the issue while working on dual-motor support.
In the example below, it's hiding the main rpm arc to show two arcs (left and right rpm).

https://github.com/user-attachments/assets/6da15d83-0240-4755-954b-f8740f48080a