### PR TITLE
Units: display a "unit" prefix for PowerFactor values

### DIFF
--- a/components/QuantityRow.qml
+++ b/components/QuantityRow.qml
@@ -57,9 +57,14 @@ Row {
 			value: quantityObject.numberValue
 			unit: quantityObject.unit
 			precision: quantityObject.precision
-			valueText: quantityObject.textValue || quantityInfo.number
-			valueColor: quantityObject.valueColor.valid ? quantityObject.valueColor : root.valueColor
-			unitColor: Theme.color_quantityTable_quantityUnit
+			valueText: unit === VenusOS.Units_PowerFactor ? "PF" : (quantityObject.textValue || quantityInfo.number)
+			unitText: unit === VenusOS.Units_PowerFactor ? (quantityObject.textValue || quantityInfo.number) : quantityInfo.unit
+			valueColor: unit === VenusOS.Units_PowerFactor ? Theme.color_quantityTable_quantityUnit
+				: quantityObject.valueColor.valid ? quantityObject.valueColor
+				: root.valueColor
+			unitColor: unit !== VenusOS.Units_PowerFactor ? Theme.color_quantityTable_quantityUnit
+				: quantityObject.valueColor.valid ? quantityObject.valueColor
+				: root.valueColor
 
 			Rectangle {
 				id: verticalSeparator

--- a/components/QuantityTableMetrics.qml
+++ b/components/QuantityTableMetrics.qml
@@ -19,7 +19,8 @@ FontMetrics {
 
 		// Give the unit symbol some extra space on the column.
 		// Due to QTBUG-124588, use tightBoundingRect() instead of advanceWidth().
-		const maxTextRect = tightBoundingRect("99.99" + Units.defaultUnitString(unit))
+		const maxTextRect = tightBoundingRect("99.99"
+			+ (unit === VenusOS.Units_PowerFactor ? "PF" : Units.defaultUnitString(unit)))
 		return maxTextRect.width + maxTextRect.x
 	}
 


### PR DESCRIPTION
Power factor is a unitless ratio value, but displaying it as a unitless number in tables is confusing for users who don't know what the number is supposed to represent.

This commit ensures that we display power factor values with a "PF" prefix unit within tables.

Contributes to issue #2724