### PR TITLE
PageStack: fix popPage() during modal dialog rejection

### DIFF
--- a/components/PageStack.qml
+++ b/components/PageStack.qml
@@ -118,7 +118,7 @@ StackView {
 	}
 
 	function popPage(toPage, operation) {
-		if (!toPage) {
+		if (toPage === null) {
 			popAllPages(operation)
 			return
 		}

--- a/pages/settings/PageVrmDeviceInstances.qml
+++ b/pages/settings/PageVrmDeviceInstances.qml
@@ -132,7 +132,7 @@ Page {
 		id: rebootDialogComponent
 
 		ModalWarningDialog {
-			property Page toPage
+			property var toPage
 
 			//% "Reboot now?"
 			title: qsTrId("settings_vrm_device_instances_reboot_now")


### PR DESCRIPTION
Differentiate between a null toPage (result in pop-all) and an
undefined toPage (results in a pop-one).

Allow storing an undefined toPage in the reboot modal dialog
so that if the user clicks the "back" button we eventually
call popPage with the appropriate (i.e. undefined) value.

Fixes #2732