### PR TITLE
Settings: fix bug in network state reporting

### DIFF
--- a/components/NetworkServices.qml
+++ b/components/NetworkServices.qml
@@ -10,7 +10,7 @@ VeQuickItem {
 	id: root
 
 	property string service
-	property string state
+	property string networkState // don't shadow VeQuickItem::state
 	property string method_
 	property string macAddress
 	property string ipAddress: ""
@@ -24,7 +24,7 @@ VeQuickItem {
 	property bool completed
 	readonly property bool hasBluetoothSupport: _hasBluetoothSupport.value
 	readonly property string mobileNetworkName: _networkName.valid ? _networkName.value + " " + Utils.simplifiedNetworkType(_networkType.value) : "--"
-	readonly property bool disconnected: state === "idle" || state === "failure"
+	readonly property bool disconnected: networkState === "idle" || networkState === "failure"
 
 	property VeQuickItem setValueItem: VeQuickItem {
 		uid: Global.venusPlatform.serviceUid + "/Network/SetValue"
@@ -86,7 +86,7 @@ VeQuickItem {
 
 		if (details) {
 			root.service = details["Service"]
-			state = details["State"]
+			networkState = details["State"]
 			method_ = details["Method"]
 			ipAddress = details["Address"]
 			macAddress = details["Mac"]

--- a/pages/settings/NetworkSettingsPageModel.qml
+++ b/pages/settings/NetworkSettingsPageModel.qml
@@ -83,7 +83,7 @@ VisibleItemModel {
 
 	ListText {
 		text: CommonWords.state
-		secondaryText: Utils.connmanServiceState(networkServices.state)
+		secondaryText: Utils.connmanServiceState(networkServices.networkState)
 	}
 
 	ListText {

--- a/pages/settings/PageSettingsConnectivity.qml
+++ b/pages/settings/PageSettingsConnectivity.qml
@@ -16,8 +16,8 @@ Page {
 			ListNavigation {
 				//% "Ethernet"
 				text: qsTrId("pagesettingsconnectivity_ethernet")
-				secondaryText: networkServices.state !== "idle" && networkServices.state !== ""
-					? (networkServices.ipAddress ? networkServices.ipAddress : Utils.connmanServiceState(networkServices.state))
+				secondaryText: networkServices.networkState !== "idle" && networkServices.networkState !== ""
+					? (networkServices.ipAddress ? networkServices.ipAddress : Utils.connmanServiceState(networkServices.networkState))
 					//% "Unplugged"
 					: qsTrId("settings_tcpip_connection_unplugged")
 				onClicked: Global.pageManager.pushPage("/pages/settings/PageSettingsEthernet.qml", {"title": text})


### PR DESCRIPTION
Don't shadow the VeQuickItem state property.

Contributes to issue #2743