### PR TITLE
Tank: allow removing custom tank shape points

### DIFF
--- a/pages/settings/devicelist/tank/PageTankShape.qml
+++ b/pages/settings/devicelist/tank/PageTankShape.qml
@@ -103,7 +103,7 @@ Page {
 
 					MouseArea {
 						anchors.centerIn: parent
-						height: pointDelegate.height - 2*Theme.geometry_closeButton_margins
+						height: pointDelegate.height
 						width: height
 						onClicked: {
 							let pointList = pointsListView.model


### PR DESCRIPTION
The "minus" icon button was unclickable due to its size being reduced too much by close button margins.  This commit ensures that the button will fill the parent delegate height, making it easy to click.

Contributes to issue #2202