### PR TITLE
Firmware Updates: fix bugs in UI after performing update check

### DIFF
--- a/components/listitems/ListFirmwareCheckButton.qml
+++ b/components/listitems/ListFirmwareCheckButton.qml
@@ -11,7 +11,7 @@ ListButton {
 
 	property int updateType
 
-	secondaryText: Global.firmwareUpdate.state === FirmwareUpdater.Checking
+	secondaryText: Global.firmwareUpdate.checkingForUpdate
 			 //% "Checking..."
 		   ? qsTrId("settings_firmware_checking")
 			 //% "Press to check"


### PR DESCRIPTION
- don't restart the timeout timer in idle state
- stop the timeout timer if the backend transitions to an error state
- increase the check request timeout time interval
- increase the asynchronous time allowed for the update file version to be deserialised after the backend state updates
- handle the case where the user performs an update check, changes the image feed, and then performs another update check which results in the previously-valid value becoming invalid.

Contributes to issue #2745