### PR TITLE
Animations: do not unnecessarily animate dialogs and history error view

### DIFF
--- a/components/SolarHistoryErrorView.qml
+++ b/components/SolarHistoryErrorView.qml
@@ -78,6 +78,7 @@ MouseArea {
 		height: root.expanded ? implicitHeight : Theme.geometry_solarHistoryErrorView_itemHeight
 
 		Behavior on height {
+			enabled: Global.animationEnabled
 			NumberAnimation {
 				duration: Theme.animation_solarHistoryErrorView_expand_duration
 			}

--- a/components/dialogs/ModalDialog.qml
+++ b/components/dialogs/ModalDialog.qml
@@ -88,12 +88,18 @@ T.Dialog {
 	// would be received. So, just enable it when the dialog is opened, if key nav is enabled.
 	focus: Global.keyNavigationEnabled
 
-	enter: Transition {
-		enabled: Global.animationEnabled
+	// Only provide transitions if animations are enabled. Ideally the transitions would always be
+	// set but with 'enabled' set to only run when needed, but due to QTBUG-142410 the enabled value
+	// is not respected.
+	enter: Global.animationEnabled ? enterTransition : null
+	exit: Global.animationEnabled ? exitTransition : null
+
+	Transition {
+		id: enterTransition
 		NumberAnimation { property: "opacity"; from: 0.0; to: 1.0; duration: Theme.animation_page_fade_duration }
 	}
-	exit: Transition {
-		enabled: Global.animationEnabled
+	Transition {
+		id: exitTransition
 		NumberAnimation {
 			loops: Qt.platform.os == "wasm" ? 0 : 1 // workaround wasm crash, see https://bugreports.qt.io/browse/QTBUG-121382
 			property: "opacity"; from: 1.0; to: 0.0; duration: Theme.animation_page_fade_duration

--- a/components/dialogs/SolarDailyHistoryDialog.qml
+++ b/components/dialogs/SolarDailyHistoryDialog.qml
@@ -58,7 +58,14 @@ T.Dialog {
 	// In case height changes when dialog is opened, update the highlight bar position.
 	onHeightChanged: root._positionHighlightBar()
 
-	enter: Transition {
+	// Only provide transitions if animations are enabled. Ideally the transitions would always be
+	// set but with 'enabled' set to only run when needed, but due to QTBUG-142410 the enabled value
+	// is not respected.
+	enter: Global.animationEnabled ? enterTransition : null
+	exit: Global.animationEnabled ? exitTransition : null
+
+	Transition {
+		id: enterTransition
 		SequentialAnimation {
 			ScriptAction {
 				script: {
@@ -71,10 +78,13 @@ T.Dialog {
 			NumberAnimation { property: "opacity"; from: 0.0; to: 1.0; duration: Theme.animation_page_fade_duration }
 		}
 	}
-	exit: Transition {
+
+	Transition {
+		id: exitTransition
 		NumberAnimation {
 			loops: Qt.platform.os == "wasm" ? 0 : 1 // workaround wasm crash, see https://bugreports.qt.io/browse/QTBUG-121382
-			property: "opacity"; from: 1.0; to: 0.0; duration: Theme.animation_page_fade_duration }
+			property: "opacity"; from: 1.0; to: 0.0; duration: Theme.animation_page_fade_duration
+		}
 	}
 
 	background: Rectangle {


### PR DESCRIPTION
Respect Global.animationEnabled. For Dialog enter/exit transitions, these properties must be assigned conditionally due to QTBUG-142410.