### PR TITLE
Switches: change the color wheel type immediately

### DIFF
--- a/components/ColorSelector.qml
+++ b/components/ColorSelector.qml
@@ -14,7 +14,7 @@ Item {
 	id: root
 
 	required property ColorDimmerData colorDimmerData
-	readonly property int outputType: colorDimmerData.outputType
+	property int outputType
 
 	readonly property color currentColor: colorSwatch.color
 

--- a/components/SettingSync.qml
+++ b/components/SettingSync.qml
@@ -8,6 +8,13 @@ import Victron.VenusOS
 
 /*
 	Writes a value to a setting, and indicates whether the new value has been written.
+
+	This allows the UI to show the value that has been saved to a VeQuickItem, even if the value
+	change is not reflected in the backend yet. To do this, bind to the 'expectedValue' property.
+
+	Ideally this type would not be required in future, as VeQuickItem already has some handling for
+	locally-written values and the state property that indicates whether a value has been
+	synchronized, but those features are not currently supported by the MQTT producer.
 */
 QtObject {
 	id: root


### PR DESCRIPTION
If the user changes between RGB and CCT color types, update the UI immediately to reflect the change, even if the change has not yet been saved to the backend. This makes the UI look more responsive.