### PR TITLE
ESS: add grid meter required setting

### DIFF
--- a/pages/settings/PageSettingsHub4.qml
+++ b/pages/settings/PageSettingsHub4.qml
@@ -67,6 +67,28 @@ Page {
 		}
 
 		ListRadioButtonGroup {
+			//% "Grid meter required"
+			text: qsTrId("settings_ess_grid_meter_required")
+			dataItem.uid: Global.systemSettings.serviceUid + "/Settings/CGwacs/GridMeterRequired"
+			preferredVisible: withoutGridMeter.currentIndex === 0
+				&& essMode.value !== VenusOS.Ess_Hub4ModeState_Disabled
+			optionModel: [
+				{
+					display: CommonWords.yes,
+					value: 1,
+					//% "A grid meter must be present for ESS operation. If not available, the system will switch to pass-through."
+					caption: qsTrId("settings_ess_grid_meter_required_caption")
+				},
+				{
+					display: CommonWords.no,
+					value: 0,
+					//% "The system will use a grid meter when present, but fall back to internal measurements if the connection to the grid meter is lost."
+					caption: qsTrId("settings_ess_grid_meter_optional_caption")
+				},
+			]
+		}
+
+		ListRadioButtonGroup {
 			//% "Self-consumption from battery"
 			text: qsTrId("settings_ess_self_consumption_battery")
 			dataItem.uid: Global.systemSettings.serviceUid + "/Settings/CGwacs/BatteryUse"


### PR DESCRIPTION
Adds a new setting below Grid metering to configure whether a grid meter is required for ESS operation. When set to Yes, the system will switch to pass-through if the grid meter is unavailable. When set to No, the system will fall back to internal measurements.

https://github.com/victronenergy/venus-private/issues/595