### PR TITLE
UI: ensure various timers still run when animations are disabled

### DIFF
--- a/Global.qml
+++ b/Global.qml
@@ -13,7 +13,7 @@ QtObject {
 	property var pageManager
 	property var mainView
 	property var firmwareUpdate
-	property bool applicationActive: true
+	property bool applicationActive: true // i.e. not in Idle mode
 	property bool keyNavigationEnabled
 
 	readonly property bool backendReady: BackendConnection.state === BackendConnection.Ready
@@ -25,7 +25,8 @@ QtObject {
 	property var dialogLayer
 	property var notificationLayer
 	property bool displayCpuUsage
-	readonly property bool animationEnabled: (systemSettings?.animationEnabled ?? true) && BackendConnection.applicationVisible
+	readonly property bool animationEnabled: (systemSettings?.animationEnabled ?? true) && BackendConnection.applicationVisible && !ScreenBlanker.blanked
+	readonly property bool timersEnabled: BackendConnection.applicationVisible && !ScreenBlanker.blanked
 
 	// data sources
 	property var acInputs

--- a/Main.qml
+++ b/Main.qml
@@ -177,7 +177,7 @@ Window {
 
 	Timer {
 		id: appIdleTimer
-		running: !Global.splashScreenVisible
+		running: !Global.splashScreenVisible && Global.timersEnabled
 		interval: 60000
 		onTriggered: {
 			Global.applicationActive = false

--- a/components/Led.qml
+++ b/components/Led.qml
@@ -53,7 +53,7 @@ Item {
 
 			Timer {
 				interval: 500
-				running: dataItem.value > 0
+				running: dataItem.value > 0 && Global.timersEnabled
 				repeat: true
 				onTriggered: root._pulse = !root._pulse
 			}

--- a/components/LoadGraph.qml
+++ b/components/LoadGraph.qml
@@ -37,7 +37,7 @@ Item {
 
 	Timer {
 		id: pausedAnimationTimer
-		running: !root.animationEnabled
+		running: !root.animationEnabled // even if !Global.timersEnabled, to avoid discontinuities
 		repeat: true
 		interval: Theme.geometry_briefPage_sidePanel_loadGraph_intervalMs
 		onTriggered: {

--- a/components/ObjectAcConnection.qml
+++ b/components/ObjectAcConnection.qml
@@ -65,7 +65,7 @@ QtObject {
 	// changes too often on system with more than one phase
 	readonly property Timer _totalPowerTimer: Timer {
 		interval: 1000
-		running: BackendConnection.applicationVisible && root.hasPower
+		running: root.hasPower && Global.timersEnabled
 		repeat: true
 		onTriggered: {
 			_power = (powerL1.value || 0) + (powerL2.value || 0) + (powerL3.value || 0)

--- a/components/SolarYieldGauge.qml
+++ b/components/SolarYieldGauge.qml
@@ -56,7 +56,7 @@ Item {
 		property var sampledAverages: []
 		property var _activeSamples: []
 
-		running: true
+		running: true // even if !Global.timersEnabled, to avoid discontinuities
 		repeat: true
 		interval: 30 * 1000
 		onTriggered: {

--- a/data/SystemSettings.qml
+++ b/data/SystemSettings.qml
@@ -313,7 +313,7 @@ QtObject {
 			interval: 60000
 			repeat: true
 			triggeredOnStart: true
-			running: BackendConnection.applicationVisible
+			running: BackendConnection.applicationVisible // even if !Global.timersEnabled, in case screen blank duration is short
 			onTriggered: root.time.getValue(true)   // force value refresh
 		}
 	}

--- a/pages/MainView.qml
+++ b/pages/MainView.qml
@@ -107,7 +107,8 @@ FocusScope {
 	}
 
 	// Revert to the start page when the application has been inactive for the period of time
-	// specified by the startPageTimeout.
+	// specified by the startPageTimeout.  Note that the timer should be running
+	// even if !Global.timersEnabled as the screen blank duration might be very short.
 	Timer {
 		running: !!Global.systemSettings
 				 && Global.systemSettings.startPageConfiguration.hasStartPage

--- a/pages/settings/PageCanbusStatus.qml
+++ b/pages/settings/PageCanbusStatus.qml
@@ -70,7 +70,7 @@ Page {
 
 	Timer {
 		interval: 1000
-		running: root.animationEnabled
+		running: Global.timersEnabled
 		repeat: true
 		triggeredOnStart: true
 

--- a/pages/settings/PageGeneratorRuntimeService.qml
+++ b/pages/settings/PageGeneratorRuntimeService.qml
@@ -120,7 +120,7 @@ Page {
 				preferredVisible: dataItem.valid && dataItem.value > 0
 
 				Timer {
-					running: parent.preferredVisible && root.animationEnabled
+					running: parent.preferredVisible && Global.timersEnabled
 					repeat: true
 					interval: 1000
 					onTriggered: {

--- a/pages/settings/PageSettingsLogger.qml
+++ b/pages/settings/PageSettingsLogger.qml
@@ -158,7 +158,7 @@ Page {
 
 				Timer {
 					interval: 1000
-					running: parent.visible && root.animationEnabled
+					running: parent.visible && Global.timersEnabled
 					repeat: true
 					triggeredOnStart: true
 					onTriggered: parent.secondaryText = root.timeAgo(parent.dataItem.value)
@@ -356,7 +356,7 @@ Page {
 
 				Timer {
 					interval: 1000
-					running: !!parent.dataItem.value && root.animationEnabled
+					running: !!parent.dataItem.value && Global.timersEnabled
 					repeat: true
 					triggeredOnStart: true
 					onTriggered: parent.secondaryText = root.timeAgo(parent.dataItem.value)

--- a/pages/settings/PageSettingsWifi.qml
+++ b/pages/settings/PageSettingsWifi.qml
@@ -150,7 +150,7 @@ Page {
 	Timer {
 		id: scanTimer
 		interval: 10000
-		running: root.animationEnabled
+		running: Global.timersEnabled
 		repeat: true
 		triggeredOnStart: true
 		onTriggered: scanItem.setValue(1)

--- a/pages/settings/PageTzInfo.qml
+++ b/pages/settings/PageTzInfo.qml
@@ -75,7 +75,7 @@ Page {
 		interval: 10000
 		repeat: true
 		triggeredOnStart: true
-		running: BackendConnection.applicationVisible
+		running: BackendConnection.applicationVisible // even if !Global.timersEnabled
 		onTriggered: Global.systemSettings.time.getValue(true)
 	}
 

--- a/pages/settings/debug/PageSettingsDemo.qml
+++ b/pages/settings/debug/PageSettingsDemo.qml
@@ -165,7 +165,7 @@ Page {
 				}
 
 				Timer {
-					running: root.isCurrentPage
+					running: root.isCurrentPage && Global.timersEnabled
 					interval: 3000
 					repeat: true
 					onTriggered: customDataObject.voltage = Math.random()


### PR DESCRIPTION
    The user can manually disable animations, in order to reduce
    gui-v2's CPU usage.  Timers should NOT use animationEnabled
    in their running condition, but instead should depend on
    the application being visible and not screen-blanked.

    In some cases, screen blank status should not be taken into
    account, in case the screen blank duration is very short, and
    the functionality triggered by the timer is important; ensure
    we mark such cases for future maintainers.

    Contributes to issue #2801