### PR TITLE
Switches: disable control if it has any of the disabled statuses

### DIFF
--- a/components/switches/SwitchableOutputGroupCard.qml
+++ b/components/switches/SwitchableOutputGroupCard.qml
@@ -68,6 +68,7 @@ ControlCard {
 							width: Qt.binding(function() { return outputGrid.cellWidth }),
 							height: Qt.binding(function() { return outputGrid.cellHeight }),
 							switchableOutput: modelData,
+							enabled: Qt.binding(function() { return !(modelData.status & VenusOS.SwitchableOutput_Status_Disabled) })
 						})
 					} else {
 						source = ""

--- a/components/switches/delegates/SwitchableOutputCardDelegate_0.qml
+++ b/components/switches/delegates/SwitchableOutputCardDelegate_0.qml
@@ -14,7 +14,6 @@ Item {
 
 	required property SwitchableOutput switchableOutput
 
-	enabled: root.switchableOutput.status !== VenusOS.SwitchableOutput_Status_Disabled
 	focus: true
 	KeyNavigationHighlight.active: activeFocus
 

--- a/components/switches/delegates/SwitchableOutputCardDelegate_1.qml
+++ b/components/switches/delegates/SwitchableOutputCardDelegate_1.qml
@@ -14,7 +14,6 @@ Item {
 
 	required property SwitchableOutput switchableOutput
 
-	enabled: root.switchableOutput.status !== VenusOS.SwitchableOutput_Status_Disabled
 	focus: true
 	KeyNavigationHighlight.active: activeFocus
 

--- a/components/switches/delegates/SwitchableOutputCardDelegate_10.qml
+++ b/components/switches/delegates/SwitchableOutputCardDelegate_10.qml
@@ -14,7 +14,6 @@ Item {
 
 	required property SwitchableOutput switchableOutput
 
-	enabled: root.switchableOutput.status !== VenusOS.SwitchableOutput_Status_Disabled
 	focus: true
 	KeyNavigationHighlight.active: activeFocus
 

--- a/components/switches/delegates/SwitchableOutputCardDelegate_2.qml
+++ b/components/switches/delegates/SwitchableOutputCardDelegate_2.qml
@@ -14,7 +14,6 @@ FocusScope {
 
 	required property SwitchableOutput switchableOutput
 
-	enabled: root.switchableOutput.status !== VenusOS.SwitchableOutput_Status_Disabled
 	focus: true
 	KeyNavigationHighlight.active: activeFocus && !slider.activeFocus
 

--- a/components/switches/delegates/SwitchableOutputCardDelegate_3.qml
+++ b/components/switches/delegates/SwitchableOutputCardDelegate_3.qml
@@ -14,7 +14,6 @@ FocusScope {
 
 	required property SwitchableOutput switchableOutput
 
-	enabled: root.switchableOutput.status !== VenusOS.SwitchableOutput_Status_Disabled
 	focus: true
 	KeyNavigationHighlight.active: activeFocus
 

--- a/components/switches/delegates/SwitchableOutputCardDelegate_4.qml
+++ b/components/switches/delegates/SwitchableOutputCardDelegate_4.qml
@@ -14,7 +14,6 @@ FocusScope {
 
 	required property SwitchableOutput switchableOutput
 
-	enabled: root.switchableOutput.status !== VenusOS.SwitchableOutput_Status_Disabled
 	focus: true
 	KeyNavigationHighlight.active: activeFocus
 

--- a/components/switches/delegates/SwitchableOutputCardDelegate_6.qml
+++ b/components/switches/delegates/SwitchableOutputCardDelegate_6.qml
@@ -14,7 +14,6 @@ FocusScope {
 
 	required property SwitchableOutput switchableOutput
 
-	enabled: root.switchableOutput.status !== VenusOS.SwitchableOutput_Status_Disabled
 	focus: true
 	KeyNavigationHighlight.active: activeFocus
 

--- a/components/switches/delegates/SwitchableOutputCardDelegate_7.qml
+++ b/components/switches/delegates/SwitchableOutputCardDelegate_7.qml
@@ -14,7 +14,6 @@ FocusScope {
 
 	required property SwitchableOutput switchableOutput
 
-	enabled: root.switchableOutput.status !== VenusOS.SwitchableOutput_Status_Disabled
 	focus: true
 	KeyNavigationHighlight.active: activeFocus
 

--- a/components/switches/delegates/SwitchableOutputCardDelegate_8.qml
+++ b/components/switches/delegates/SwitchableOutputCardDelegate_8.qml
@@ -14,7 +14,6 @@ FocusScope {
 
 	required property SwitchableOutput switchableOutput
 
-	enabled: root.switchableOutput.status !== VenusOS.SwitchableOutput_Status_Disabled
 	focus: true
 	KeyNavigationHighlight.active: activeFocus
 

--- a/components/switches/delegates/SwitchableOutputCardDelegate_9.qml
+++ b/components/switches/delegates/SwitchableOutputCardDelegate_9.qml
@@ -14,7 +14,6 @@ FocusScope {
 
 	required property SwitchableOutput switchableOutput
 
-	enabled: root.switchableOutput.status !== VenusOS.SwitchableOutput_Status_Disabled
 	focus: true
 	KeyNavigationHighlight.active: activeFocus
 

--- a/components/switches/delegates/SwitchableOutputCardDelegate_color.qml
+++ b/components/switches/delegates/SwitchableOutputCardDelegate_color.qml
@@ -15,9 +15,7 @@ FocusScope {
 	required property SwitchableOutput switchableOutput
 	property QtObject _selectorDialog
 
-	enabled: root.switchableOutput.status !== VenusOS.SwitchableOutput_Status_Disabled
 	focus: true
-
 	KeyNavigationHighlight.active: activeFocus && !sliderScope.activeFocus && !slider.activeFocus && !colorButton.activeFocus
 
 	// When Space is pressed: focus the slider. From there, user can press Space again to enter

--- a/data/mock/conf/services/switch-controls-tester.json
+++ b/data/mock/conf/services/switch-controls-tester.json
@@ -55,7 +55,7 @@
         "/SwitchableOutput/toggle_2/Settings/ValidFunctions": 2,
         "/SwitchableOutput/toggle_2/Settings/ValidTypes": 16383,
         "/SwitchableOutput/toggle_2/State": 0,
-        "/SwitchableOutput/toggle_2/Status": 32,
+        "/SwitchableOutput/toggle_2/Status": 34,
 
         "/SwitchableOutput/toggle_3/Name": "01c. Toggle, on, disabled",
         "/SwitchableOutput/toggle_3/Settings/CustomName": "",
@@ -66,7 +66,7 @@
         "/SwitchableOutput/toggle_3/Settings/ValidFunctions": 2,
         "/SwitchableOutput/toggle_3/Settings/ValidTypes": 16383,
         "/SwitchableOutput/toggle_3/State": 1,
-        "/SwitchableOutput/toggle_3/Status": 32,
+        "/SwitchableOutput/toggle_3/Status": 41,
 
         "/SwitchableOutput/dimming_1/Dimming": 2,
         "/SwitchableOutput/dimming_1/Name": "02a. Dimming",
@@ -90,7 +90,7 @@
         "/SwitchableOutput/dimming_2/Settings/ValidFunctions": 2,
         "/SwitchableOutput/dimming_2/Settings/ValidTypes": 16383,
         "/SwitchableOutput/dimming_2/State": 1,
-        "/SwitchableOutput/dimming_2/Status": 32,
+        "/SwitchableOutput/dimming_2/Status": 36,
 
         "/SwitchableOutput/dimming_3/Dimming": 50,
         "/SwitchableOutput/dimming_3/Name": "02c. Dimming, off, disabled",


### PR DESCRIPTION
Disable control if the status bit matches 'disabled' (0x20), rather than if the status is exactly 0x20, so that the control is still disabled if the status is 0x22 (disabled tripped), 0x24 (disabled, over temperature) or 0x29 (disabled but on).

Fixes #2806

<img width="1824" height="1240" alt="image" src="https://github.com/user-attachments/assets/a9fed315-a629-4cf8-bda6-f28a8c108df4" />
