### PR TITLE
Boat: minor fixes

### DIFF
--- a/data/mock/page-conf/BoatPageConfig.qml
+++ b/data/mock/page-conf/BoatPageConfig.qml
@@ -125,7 +125,7 @@ Item {
 				MockManager.setValue(serviceUid + "/DeviceInstance", deviceInstance)
 				MockManager.setValue(serviceUid + "/ProductName", config.motorDrives[i].productName ?? "Motor drive %1".arg(deviceInstance))
 				MockManager.setValue(serviceUid + "/Motor/Direction", Math.floor(Math.random() * 3))
-				MockManager.setValue(serviceUid + "/Motor/RPM", Math.round(Math.random() * MockManager.value(Global.systemSettings.serviceUid + "/Settings/Gui/Gauges/MotorDrive/RPM/Max")))
+				MockManager.setValue(serviceUid + "/Motor/RPM", Math.random() * MockManager.value(Global.systemSettings.serviceUid + "/Settings/Gui/Gauges/MotorDrive/RPM/Max"))
 				MockManager.setValue(serviceUid + "/Motor/Temperature", Math.random() * 100)
 				MockManager.setValue(serviceUid + "/Coolant/Temperature", Math.random() * 100)
 				MockManager.setValue(serviceUid + "/Controller/Temperature", Math.random() * 100)

--- a/pages/boat/LargeCenterGauge.qml
+++ b/pages/boat/LargeCenterGauge.qml
@@ -108,7 +108,7 @@ Item {
 			verticalAlignment: Text.AlignVCenter
 			horizontalAlignment: Text.AlignHCenter
 			color: Theme.color_font_primary
-			font.pixelSize: motorDriveGauges.visible || rpmLabel.visible
+			font.pixelSize: motorDriveGauges.visible || rpmLabel.visible || dualRpmLabels.visible
 							? Theme.font_boatPage_speed_pixelSize
 							: Theme.font_boatPage_speed_pixelSize_large
 			font.weight: Font.Medium

--- a/pages/boat/LargeCenterGauge.qml
+++ b/pages/boat/LargeCenterGauge.qml
@@ -114,7 +114,7 @@ Item {
 			font.weight: Font.Medium
 			fontSizeMode: Text.HorizontalFit
 			visible: root.activeDataSource === root.gps
-			text: root.gps.numerator >= 10.0 ? Math.round(root.gps.numerator) : Units.formatNumber(root.gps.numerator, 1)
+			text: Units.formatNumber(root.gps.numerator, Math.round(root.gps.numerator * 10) >= 100 ? 0 : 1)
 			height: font.pixelSize
 		}
 
@@ -257,7 +257,7 @@ Item {
 			}
 			verticalAlignment: Text.AlignVCenter
 			font.pixelSize: Theme.font_size_body3
-			text: Math.abs(root.motorDrives.leftMotorDrive.rpm._numerator.value)
+			text: Units.formatNumber(Math.abs(root.motorDrives.leftMotorDrive.rpm._numerator.value))
 		}
 
 		Rectangle {
@@ -284,7 +284,7 @@ Item {
 			}
 			verticalAlignment: Text.AlignVCenter
 			font.pixelSize: Theme.font_size_body3
-			text: Math.abs(root.motorDrives.rightMotorDrive.rpm._numerator.value)
+			text: Units.formatNumber(Math.abs(root.motorDrives.rightMotorDrive.rpm._numerator.value))
 		}
 	}
 


### PR DESCRIPTION
Minor issues came up during testing of 3.70~85.

- Speed precision logic was unreliable as it relied on a float comparison and could cause the UI to show `10.0` while it should have shown `10`.
- In the unlikely scenario that boat RPMs are floats, in dual drive it wouldn't display with a precision of 0.
- Font size of the speed value was incorrect in dual drive pushing the unit label too far down.

## Speed precision issue

<img width="797" height="477" alt="Screenshot 2026-02-12 at 09 18 14" src="https://github.com/user-attachments/assets/2318e53b-43d9-45e8-8b02-9ccb0f1e714d" />

## RPMs precision in dual drive

<img width="797" height="477" alt="Screenshot 2026-02-12 at 09 39 00" src="https://github.com/user-attachments/assets/09e030a5-8d66-4119-b05e-ace4c22b2dcc" />

## Speed font size in dual drive

Before  
<img width="797" height="477" alt="Screenshot 2026-02-12 at 09 20 42" src="https://github.com/user-attachments/assets/9772bc6d-1ed4-4a56-b71a-2610a29ed9f0" />

After  
<img width="797" height="477" alt="Screenshot 2026-02-12 at 09 23 37" src="https://github.com/user-attachments/assets/cc6956f8-fe12-4778-b1d9-64f16d0a482f" />
