### PR TITLE
UI: make ESS Relay test a submenu with per-unit RelayTestOk status

### DIFF
--- a/components/CommonWords.qml
+++ b/components/CommonWords.qml
@@ -576,6 +576,10 @@ QtObject {
 	//% "VE.Bus Error"
 	readonly property string vebus_error: qsTrId("common_words_vebus_error")
 
+	//: eg. 'Phase L1, device 3 (6)', where '(6)' is the index into the list of reported values
+	//% "Phase L%1, device %2 (%3)"
+	readonly property string vebus_phase_device: qsTrId("common_words_vebus_device_phase_x_device_x_index_x")
+
 	//% "Voltage"
 	readonly property string voltage: qsTrId("common_words_voltage")
 

--- a/pages/vebusdevice/PageVeBusAdvanced.qml
+++ b/pages/vebusdevice/PageVeBusAdvanced.qml
@@ -57,6 +57,11 @@ Page {
 	}
 
 	VeQuickItem {
+		id: numberOfMultis
+		uid: root.bindPrefix + "/Devices/NumberOfMultis"
+	}
+
+	VeQuickItem {
 		id: masterHasNetworkQuality
 
 		uid: root.bindPrefix + "/Devices/0/ExtendStatus/VeBusNetworkQualityCounter"
@@ -255,18 +260,46 @@ Page {
 				preferredVisible: dataItem.valid && isMulti
 			}
 
-			ListRadioButtonGroup {
+			ListNavigation {
 				//% "ESS Relay test"
 				text: qsTrId("vebus_device_ess_relay_test")
-				dataItem.uid: root.bindPrefix + "/Devices/0/ExtendStatus/WaitingForRelayTest"
-				interactive: false
-				preferredVisible: dataItem.valid && isEssOrHub4 && isMulti
-				optionModel: [
-					//% "Completed"
-					{ display: qsTrId("vebus_device_ess_relay_test_completed"), value: 0 },
-					//% "Pending"
-					{ display: qsTrId("vebus_device_ess_relay_test_pending"), value: 1 }
-				]
+				preferredVisible: waitingForRelayTest.valid && isEssOrHub4 && isMulti
+				secondaryText: waitingForRelayTest.value === 0
+								//% "Completed"
+							 ? qsTrId("vebus_device_ess_relay_test_completed")
+								//% "Pending"
+							 : qsTrId("vebus_device_ess_relay_test_pending")
+				onClicked: Global.pageManager.pushPage(essRelayTestPage, {"title": text})
+
+				VeQuickItem {
+					id: waitingForRelayTest
+					uid: root.bindPrefix + "/Devices/0/ExtendStatus/WaitingForRelayTest"
+				}
+
+				Component {
+					id: essRelayTestPage
+
+					Page {
+						GradientListView {
+							model: VisibleItemModel {
+								SettingsColumn {
+									width: parent ? parent.width : 0
+
+									Repeater {
+										model: numberOfMultis.valid ? numberOfMultis.value : 0
+
+										ListText {
+											text: CommonWords.vebus_phase_device.arg((index % 3) + 1).arg(Math.floor(index / 3) + 1).arg(index)
+											secondaryText: dataItem.value === 1 ? CommonWords.ok : CommonWords.error
+											dataItem.uid: root.bindPrefix + "/Devices/" + index + "/ExtendStatus/RelayTestOk"
+											preferredVisible: dataItem.valid
+										}
+									}
+								}
+							}
+						}
+					}
+				}
 			}
 
 			ListNavigation {

--- a/pages/vebusdevice/PageVeBusError11Menu.qml
+++ b/pages/vebusdevice/PageVeBusError11Menu.qml
@@ -29,9 +29,7 @@ ListNavigation {
 		uid: devPrefix + "/ExtendStatus/GridRelayReport/Count"
 	}
 
-	//: eg. 'Phase L1, device 3 (6)', where '(6)' is the index into the list of reported values
-	//% "Phase L%1, device %2 (%3)"
-	text: qsTrId("vebus_device_phase_x_device_x_index_x").arg((_index % 3) + 1).arg(Math.floor(_index / 3) + 1).arg(_index)
+	text: CommonWords.vebus_phase_device.arg((_index % 3) + 1).arg(Math.floor(_index / 3) + 1).arg(_index)
 	secondaryText: counter.text + " " + code.text
 	preferredVisible: code.valid
 	onClicked:  Global.pageManager.pushPage("/pages/vebusdevice/PageVeBusError11Device.qml", {


### PR DESCRIPTION
The ESS Relay test item now navigates to a submenu listing each unit's RelayTestOk state, using the per-device Devices/{N}/ExtendStatus/RelayTestOk path. The main item retains the WaitingForRelayTest summary (Completed/Pending).

https://github.com/victronenergy/venus-private/issues/272