### PR TITLE
 Networking: add the possibility to disable the link local interface

### DIFF
--- a/pages/settings/NetworkSettingsPageModel.qml
+++ b/pages/settings/NetworkSettingsPageModel.qml
@@ -170,6 +170,14 @@ VisibleItemModel {
 		saveInput: function() { networkServices.setServiceProperty("Nameserver", textField.text) }
 	}
 
+	ListSwitch {
+		//% "Enable Link-local"
+		text: qsTrId("settings_tcpip_ethernet_linklocal_enabled")
+		dataItem.uid: Global.systemSettings.serviceUid + "/Settings/Services/EthernetLinkLocal"
+		preferredVisible: !networkServices.wifi
+		writeAccessLevel: VenusOS.User_AccessType_User
+	}
+
 	ListText {
 		id: linklocal
 


### PR DESCRIPTION
Having the link local interface enabled can trigger network issue with switches with MAC security enabled. See https://github.com/victronenergy/venus/issues/1511. A bit late to the show, but we promised to look at this more than half a year ago. (and for gui-v2 it is a trivial change) 

venus v3.70\~86 supports the setting, but the link local address won't get updated
venus v3.70\~87 (yet to build) will update the link local address