### PR TITLE
ListAcInError: show error code for all energy meters, not just Fronius/CG

### DIFF
--- a/components/listitems/ListAcInError.qml
+++ b/components/listitems/ListAcInError.qml
@@ -29,15 +29,31 @@ ListText {
 				//% "No error (%1)"
 				return qsTrId("ac-in-modeldefault_no_error").arg(dataItem.value)
 			}
+		} else {
+			// Generic fallback for all other energy meters.
+			// Use /ErrorMessage from D-Bus if available; otherwise
+			// display the raw error code number (same as Fronius).
+			if (errorMessage.valid && errorMessage.value !== "") {
+				//: %1 = error description from the device, %2 = the error code number
+				//% "%1 (%2)"
+				return qsTrId("ac-in-modeldefault_error_with_message").arg(errorMessage.value).arg(dataItem.value || 0)
+			}
+			return dataItem.value || ""
 		}
 		return ""
 	}
 	preferredVisible: productId.value === ProductInfo.ProductId_PvInverter_Fronius
 			|| productId.value === ProductInfo.ProductId_EnergyMeter_CarloGavazzi
-
+			|| (dataItem.valid && dataItem.value > 0)
+			|| (errorMessage.valid && errorMessage.value !== "")
 
 	VeQuickItem {
 		id: productId
 		uid: root.bindPrefix + "/ProductId"
+	}
+
+	VeQuickItem {
+		id: errorMessage
+		uid: root.bindPrefix + "/ErrorMessage"
 	}
 }


### PR DESCRIPTION
## Summary

- The error code row in `ListAcInError.qml` is currently only visible for Fronius PV inverters and Carlo Gavazzi energy meters (hard-coded `ProductId` check). Third-party energy meter drivers (e.g. `com.victronenergy.grid` services) that publish `/ErrorCode` cannot surface errors in the device page.
- This change makes the error row visible for **any** device that publishes a non-zero `/ErrorCode`, while preserving existing Fronius and Carlo Gavazzi behaviour unchanged.
- Adds support for an optional `/ErrorMessage` D-Bus path. When a device publishes both `/ErrorCode` and `/ErrorMessage`, the GUI displays `"<message> (<code>)"` (e.g. `"Open Neutral (5)"`). Devices that only publish `/ErrorCode` get the raw numeric code displayed, matching the existing Fronius behaviour.

### Motivation

We maintain a Venus OS driver ([dbus-power-watchdog](https://github.com/TechBlueprints/dbus-power-watchdog)) for Hughes Power Watchdog energy meters. These devices report error codes (0-9) via BLE, which the driver publishes to `/ErrorCode` on its `com.victronenergy.grid` service. However, the error code is invisible on the Cerbo GX display because `ListAcInError.qml` only renders the row for two specific product IDs.

As a workaround we currently set our `/ProductId` to the Fronius value (`0xA142`) to make the error visible. This PR would let us (and other third-party drivers) use our own product ID while still having errors shown in the GUI.

### Changes

**`components/listitems/ListAcInError.qml`**

1. Added a generic `else` branch after the Fronius and Carlo Gavazzi checks — shows the raw error code for any other product
2. Extended `preferredVisible` to include `dataItem.valid && dataItem.value > 0` (non-zero error code present) and `errorMessage.valid` (device has a status message)
3. Added a `VeQuickItem` binding to `/ErrorMessage` — an optional D-Bus path that devices can publish to provide a human-readable error description

### Backward compatibility

- **Fronius**: Unchanged — still shows raw error code, always visible
- **Carlo Gavazzi**: Unchanged — still shows translated messages, always visible
- **All other devices**: Error row appears only when `/ErrorCode > 0` or `/ErrorMessage` is non-empty; hidden otherwise
- No changes to any other files

## Test plan

- [ ] Verify Fronius PV inverter error display is unchanged
- [ ] Verify Carlo Gavazzi energy meter error display is unchanged
- [ ] Verify a third-party grid meter publishing `/ErrorCode = 5` shows "5" in the error row
- [ ] Verify a third-party grid meter publishing `/ErrorCode = 5` and `/ErrorMessage = "Open Neutral"` shows "Open Neutral (5)"
- [ ] Verify a third-party grid meter publishing `/ErrorCode = 0` (no error) hides the error row
- [ ] Verify a device with no `/ErrorCode` path does not show the error row