### PR TITLE
Boat: ensure "Motordrive" text is not clipped

### DIFF
--- a/pages/boat/LargeCenterGauge.qml
+++ b/pages/boat/LargeCenterGauge.qml
@@ -132,6 +132,7 @@ Item {
 		MotorDriveGauges {
 			id: motorDriveGauges
 
+			width: rpmGauge.width - (2 * Theme.geometry_boatPage_motorDriveGauges_horizontalMargin)
 			topPadding: Theme.geometry_boatPage_motorDriveGauges_topPadding
 			motorDrives: root.motorDrives
 			showDcConsumption: !root.gps.valid

--- a/pages/boat/MotorDriveGauges.qml
+++ b/pages/boat/MotorDriveGauges.qml
@@ -17,25 +17,24 @@ Column {
 	spacing: Theme.geometry_boatPage_motorDriveColumn_spacing
 
 	Row {
-		id: motordriveRow
-
 		anchors.horizontalCenter: parent.horizontalCenter
 		spacing: Theme.geometry_boatPage_row_spacing
 
 		CP.ColorImage {
-			anchors {
-				right: undefined
-				verticalCenter: parent.verticalCenter
-			}
+			id: motorDriveIcon
 			width: Theme.geometry_boatPage_motordriveRow_image_width
-			height: width
+			height: Theme.geometry_boatPage_motordriveRow_image_width
 			color: Theme.color_boatPage_icon
 			source: "qrc:/images/icon_propeller_32.png"
 		}
 
 		Label {
 			anchors.verticalCenter: parent.verticalCenter
+			width: Math.min(root.width - motorDriveIcon.width, implicitWidth)
+			verticalAlignment: Text.AlignVCenter
+			minimumPixelSize: Theme.font_size_tiny
 			font.pixelSize: Theme.font_size_body2
+			fontSizeMode: Text.HorizontalFit
 			//% "Motordrive"
 			text: qsTrId("boat_page_motor_drive")
 		}

--- a/themes/geometry/FiveInch.json
+++ b/themes/geometry/FiveInch.json
@@ -535,6 +535,7 @@
     "geometry_boatPage_powerRow_rightMargin": 58,
     "geometry_boatPage_row_spacing": 4,
     "geometry_boatPage_motorDriveGauges_topPadding": 25,
+    "geometry_boatPage_motorDriveGauges_horizontalMargin": 32,
     "geometry_boatPage_motorDrive_temperaturesColumn_spacing": -5,
     "geometry_boatPage_motorDriveColumn_spacing": 5,
     "geometry_boatPage_motordriveRow_image_width": 32

--- a/themes/geometry/SevenInch.json
+++ b/themes/geometry/SevenInch.json
@@ -535,6 +535,7 @@
     "geometry_boatPage_powerRow_rightMargin": 72,
     "geometry_boatPage_row_spacing": 4,
     "geometry_boatPage_motorDriveGauges_topPadding": 8,
+    "geometry_boatPage_motorDriveGauges_horizontalMargin": 56,
     "geometry_boatPage_motorDrive_temperaturesColumn_spacing": -2,
     "geometry_boatPage_motorDriveColumn_spacing": 18,
     "geometry_boatPage_motordriveRow_image_width": 32


### PR DESCRIPTION
In some languages, the "Motordrive" text is too long to fit within the centre gauge; for example, "Accionado por motor" in Spanish. Use fontSizeMode to reduce the font size if needed.

---

Without the fix:

<img width="1824" height="1240" alt="image" src="https://github.com/user-attachments/assets/afa06fbd-ca57-4cc9-b4b0-15ae440ec3ef" />

With the fix:

<img width="1824" height="1240" alt="image" src="https://github.com/user-attachments/assets/271d46f6-3bc4-41ee-8e98-4cbb5b69c4b9" />
