### PR TITLE
Boat: center TTG value

### DIFF
--- a/pages/boat/TimeToGo.qml
+++ b/pages/boat/TimeToGo.qml
@@ -25,6 +25,7 @@ Column {
 	Row {
 		id: timeToGo
 
+		anchors.horizontalCenter: parent.horizontalCenter
 		spacing: Theme.geometry_boatPage_timeToGo_rowSpacing
 
 		component TimeToGoQuantityLabel : QuantityLabel {


### PR DESCRIPTION
When the value is smaller than the label it was not centered.

Before:  
<img width="797" height="477" alt="Screenshot 2026-02-16 at 09 21 42" src="https://github.com/user-attachments/assets/91083122-85bd-46fe-a842-58eb00dd3883" />

After:  
<img width="797" height="477" alt="Screenshot 2026-02-16 at 09 22 12" src="https://github.com/user-attachments/assets/487b1d4c-dda9-41c0-ac61-8c85615954aa" />