### PR TITLE
Settings: update Device List delegate when device is disconnected

### DIFF
--- a/src/runtimedevicemodel.cpp
+++ b/src/runtimedevicemodel.cpp
@@ -62,7 +62,7 @@ QVariant RuntimeDeviceModel::data(const QModelIndex &index, int role) const
 	switch (role)
 	{
 	case DeviceRole:
-		return m_devices.at(row).device ? QVariant::fromValue<BaseDevice *>(m_devices.at(row).device) : QVariant();
+		return QVariant::fromValue<BaseDevice *>(m_devices.at(row).device);
 	case CachedDeviceNameRole:
 		return m_devices.at(row).cachedName;
 	case ConnectedRole:

--- a/tests/runtimedevicemodel/tst_runtimedevicemodel.qml
+++ b/tests/runtimedevicemodel/tst_runtimedevicemodel.qml
@@ -42,7 +42,7 @@ TestCase {
 		// Disconnect them; the entries should still be there, but with connected=false.
 		for (i = 0 ; i < devices.length; ++i) {
 			MockManager.removeValue(devices[i].uid)
-			compare(RuntimeDeviceModel.data(RuntimeDeviceModel.index(i, 0), RuntimeDeviceModel.DeviceRole), undefined)
+			compare(RuntimeDeviceModel.data(RuntimeDeviceModel.index(i, 0), RuntimeDeviceModel.DeviceRole), null)
 			compare(RuntimeDeviceModel.data(RuntimeDeviceModel.index(i, 0), RuntimeDeviceModel.CachedDeviceNameRole), devices[i].productName)
 			compare(RuntimeDeviceModel.data(RuntimeDeviceModel.index(i, 0), RuntimeDeviceModel.ConnectedRole), false)
 			compare(RuntimeDeviceModel.deviceAt(i), null)
@@ -115,7 +115,7 @@ TestCase {
 		// Disconnect, and verify the custom name is still there as the cached name.
 		for (i = 0 ; i < devices.length; ++i) {
 			MockManager.removeValue(devices[i].uid)
-			compare(RuntimeDeviceModel.data(RuntimeDeviceModel.index(i, 0), RuntimeDeviceModel.DeviceRole), undefined)
+			compare(RuntimeDeviceModel.data(RuntimeDeviceModel.index(i, 0), RuntimeDeviceModel.DeviceRole), null)
 			compare(RuntimeDeviceModel.data(RuntimeDeviceModel.index(i, 0), RuntimeDeviceModel.CachedDeviceNameRole), devices[i].customName)
 			compare(RuntimeDeviceModel.data(RuntimeDeviceModel.index(i, 0), RuntimeDeviceModel.ConnectedRole), false)
 		}


### PR DESCRIPTION
Always return a valid QVariant for the 'device' role. Otherwise, if an invalid QVariant is returned for a BaseDevice-type role, the value assignment to the 'required property BaseDevice device' in the DeviceListPage ListView delegate fails (silently), because a QVariant has been assigned to a BaseDevice property.

With this fix, the 'device' property in the DeviceListPage delegate will now update to a null device as expected when the device is disconnected, which means the delegate's onDeviceChanged() is also triggered as expected to load the DisconnectedDeviceDelegate.

Fixes #2827