### PR TITLE
Switches: add access controls to SwitchableOutput settings

### DIFF
--- a/data/mock/conf/services/switch-controls-tester.json
+++ b/data/mock/conf/services/switch-controls-tester.json
@@ -85,6 +85,7 @@
         "/GenericInput/temp_1/Status": 0,
 
         "/SwitchableOutput/momentary_1/Name": "Out-00a. Momentary",
+        "/SwitchableOutput/momentary_1/Settings/Adjustable": 0,
         "/SwitchableOutput/momentary_1/Settings/CustomName": "",
         "/SwitchableOutput/momentary_1/Settings/Function": 2,
         "/SwitchableOutput/momentary_1/Settings/Group": "",

--- a/pages/settings/devicelist/iochannel/PageSwitchableOutput.qml
+++ b/pages/settings/devicelist/iochannel/PageSwitchableOutput.qml
@@ -11,14 +11,18 @@ Page {
 
 	required property SwitchableOutput switchableOutput
 
+	readonly property bool _writeable: !(settingsAdjustable.valid && settingsAdjustable.value === 0)
+
 	GradientListView {
 		model: VisibleItemModel {
 			ListIOChannelNameField {
 				dataItem.uid: root.switchableOutput.uid + "/Settings/CustomName"
+				interactive: _writeable
 			}
 
 			ListIOChannelGroupField {
 				dataItem.uid: root.switchableOutput.uid + "/Settings/Group"
+				interactive: _writeable
 			}
 
 			ListRadioButtonGroup {
@@ -26,6 +30,7 @@ Page {
 				text: qsTrId("page_switchable_output_switch_mode")
 				dataItem.uid: root.switchableOutput.uid + "/Settings/SwitchMode"
 				preferredVisible: dataItem.valid
+				interactive: _writeable
 				optionModel: [
 					//% "Disabled"
 					{ display: qsTrId("page_switchable_output_switch_mode_disabled"), value: 0 },
@@ -41,6 +46,7 @@ Page {
 				text: qsTrId("page_switchable_output_dim_mode")
 				dataItem.uid: root.switchableOutput.uid + "/Settings/DimMode"
 				preferredVisible: dataItem.valid
+				interactive: _writeable
 				optionModel: [
 					//% "Dimming disabled"
 					{ display: qsTrId("page_switchable_output_dim_mode_disabled"), value: 0 },
@@ -56,6 +62,7 @@ Page {
 				text: qsTrId("page_switchable_output_fuse_detection_mode")
 				dataItem.uid: root.switchableOutput.uid + "/Settings/FuseDetection"
 				preferredVisible: dataItem.valid
+				interactive: _writeable
 				optionModel: [
 					{ display: CommonWords.disabled, value: 0 },
 					{ display: CommonWords.enabled, value: 1 },
@@ -71,10 +78,12 @@ Page {
 				decimals: 0 // backend does not allow for decimal precision
 				suffix: Units.defaultUnitString(VenusOS.Units_Amp)
 				preferredVisible: dataItem.valid
+				interactive: _writeable
 			}
 
 			ListIOChannelTypeRadioButtonGroup {
 				ioChannel: root.switchableOutput
+				interactive: _writeable
 			}
 
 			ListRadioButtonGroup {
@@ -93,7 +102,7 @@ Page {
 					}
 					return options
 				}
-				interactive: optionModel.length > 1 || !root.switchableOutput.hasValidFunction
+				interactive: _writeable && (optionModel.length > 1 || !root.switchableOutput.hasValidFunction)
 
 				// Set the fallback text explicitly, in case the output Function is not supported by its
 				// ValidFunctions, which means the current Function is not one of the listed options and
@@ -103,12 +112,14 @@ Page {
 
 			ListIOChannelShowRadioButtonGroup {
 				dataItem.uid: root.switchableOutput.uid + "/Settings/ShowUIControl"
+				interactive: _writeable
 			}
 
 			ListQuantity {
 				text: CommonWords.current_amps
 				dataItem.uid: root.switchableOutput.uid + "/Current"
 				preferredVisible: dataItem.valid
+				interactive: _writeable
 				unit: VenusOS.Units_Amp
 			}
 
@@ -117,6 +128,7 @@ Page {
 				text: qsTrId("page_switchable_output_startup_state")
 				dataItem.uid: root.switchableOutput.uid + "/Settings/StartupState"
 				preferredVisible: dataItem.valid
+				interactive: _writeable
 				optionModel: [
 					{ display: CommonWords.off, value: 0 },
 					{ display: CommonWords.on, value: 1 },
@@ -130,6 +142,7 @@ Page {
 				text: qsTrId("page_switchable_output_startup_dim_level")
 				secondaryText: startupDimLevel.valid ? startupDimLevel.value === -1 ? qsTrId("page_switchable_output_startup_state_restore_from_memory") : startupDimLevel.value + "%" : ""
 				preferredVisible: startupDimLevel.valid
+				interactive: _writeable
 				onClicked: Global.pageManager.pushPage(dimStartupStateComponent, { title: text })
 
 				VeQuickItem {
@@ -149,6 +162,7 @@ Page {
 									//% "Restore dim level from memory"
 									text: qsTrId("page_switchable_output_restore_dim_level")
 									checked: startupDimLevel.valid && startupDimLevel.value === -1
+									interactive: _writeable
 									onClicked: {
 										startupDimLevel.setValue(startupDimLevel.value === -1 ? 0 : -1)
 									}
@@ -159,6 +173,7 @@ Page {
 									//% "Set startup dim level manually"
 									text: qsTrId("page_switchable_output_set_dim_level_manually")
 									checked: startupDimLevel.valid && startupDimLevel.value !== -1
+									interactive: _writeable
 									onClicked: {
 										startupDimLevel.setValue(-2)
 									}
@@ -185,6 +200,7 @@ Page {
 				text: qsTrId("page_switchable_output_polarity")
 				dataItem.uid: root.switchableOutput.uid + "/Settings/Polarity"
 				preferredVisible: dataItem.valid
+				interactive: _writeable
 				optionModel: [
 					//% "Active high / Normally open"
 					{ display: qsTrId("page_switchable_output_polarity_active_high"), value: 0 },
@@ -197,6 +213,7 @@ Page {
 				//% "Output limit min"
 				text: qsTrId("settings_dvcc_output_limit_min")
 				preferredVisible: dataItem.valid
+				interactive: _writeable
 				from: 0
 				to: 100
 				decimals: 2
@@ -208,6 +225,7 @@ Page {
 				//% "Output limit max"
 				text: qsTrId("settings_dvcc_output_limit_max")
 				preferredVisible: dataItem.valid
+				interactive: _writeable
 				from: 0
 				to: 100
 				decimals: 2
@@ -215,5 +233,10 @@ Page {
 				dataItem.uid: root.switchableOutput.uid + "/Settings/OutputLimitMax"
 			}
 		}
+	}
+
+	VeQuickItem {
+		id: settingsAdjustable
+		uid: root.switchableOutput.uid + "/Settings/Adjustable"
 	}
 }


### PR DESCRIPTION
Adds "/Settings/Adjustable" to settings, this provides a readonly 
flag for settings. Currently only protects CustomName and Group.

Contributes to #2790