### PR TITLE
Switches: basic slider should always respect /Settings/Decimals

### DIFF
--- a/components/switches/delegates/SwitchableOutputCardDelegate_7.qml
+++ b/components/switches/delegates/SwitchableOutputCardDelegate_7.qml
@@ -55,6 +55,7 @@ FocusScope {
 			value: slider.value // already in the display unit
 			unitType: Global.systemSettings.toPreferredUnit(root.switchableOutput.unitType)
 			precision: root.switchableOutput.decimals
+			precisionAdjustmentAllowed: false // Always respect the decimals setting
 		}
 	}
 


### PR DESCRIPTION
units.cpp may adjust the displayed number of decimals at particular thresholds. Avoid doing this for the basic slider quantity label, and always respect the /Settings/Decimals value.