### PR TITLE
Switchable output config: Add switch to set startup dimlevel manually (Aurelia only)

### DIFF
--- a/pages/settings/devicelist/iochannel/PageSwitchableOutput.qml
+++ b/pages/settings/devicelist/iochannel/PageSwitchableOutput.qml
@@ -154,11 +154,21 @@ Page {
 									}
 								}
 
+								ListSwitch {
+									id: setDimLevelManuallySwitch
+									//% "Set startup dim level manually"
+									text: qsTrId("page_switchable_output_set_dim_level_manually")
+									checked: startupDimLevel.valid && startupDimLevel.value !== -1
+									onClicked: {
+										startupDimLevel.setValue(-2)
+									}
+								}
+
 								ListSpinBox {
 
 									//% "Startup dim level"
 									text: qsTrId("settings_dvcc_startup_dim_level")
-									preferredVisible: restoreDimLevelSwitch.visible && !restoreDimLevelSwitch.checked
+									preferredVisible: setDimLevelManuallySwitch.visible && !setDimLevelManuallySwitch.checked
 									from: 0
 									to: 100
 									suffix: "%"


### PR DESCRIPTION
Checking this switch will write `-2` to `/Settings/StartupDimming`. The Aurelia will then load the previous startup dimlevel from memory and write it back to the path. https://github.com/victronenergy/gui-v2/issues/2656