### PR TITLE
Generic Inputs: fix custom unit display

### DIFF
--- a/components/IOChannelQuantityLabel.qml
+++ b/components/IOChannelQuantityLabel.qml
@@ -11,7 +11,7 @@ QuantityLabel {
 
 	valueText: quantityInfo.number
 	unit: Global.systemSettings.toPreferredUnit(ioChannel.unitType)
-	unitText: quantityInfo.unit === VenusOS.Units_None ? ioChannel.unitText : quantityInfo.unit
+	unitText: quantityInfo.unitType === VenusOS.Units_None ? ioChannel.unitText : quantityInfo.unit
 	precision: ioChannel.decimals
 	font.pixelSize: Theme.font_size_body2
 	precisionAdjustmentAllowed: false // Always respect the decimals setting


### PR DESCRIPTION
Fixes #2869 
---
Fixes to show the custom unit, as per here:

<img width="1824" height="1240" alt="image" src="https://github.com/user-attachments/assets/684a6719-8199-4379-8041-a282baebe005" />
