### PR TITLE
Switches: fix basic slider decimals and tests

### DIFF
--- a/data/mock/conf/services/switch-controls-tester.json
+++ b/data/mock/conf/services/switch-controls-tester.json
@@ -345,10 +345,11 @@
         "/SwitchableOutput/basic_slider_3/Status": 32,
 
         "/SwitchableOutput/basic_slider_4/Dimming": 10,
-        "/SwitchableOutput/basic_slider_4/Name": "Out-07d. Basic slider: speed",
+        "/SwitchableOutput/basic_slider_4/Name": "Out-07d. Basic slider: speed, step=0.1",
         "/SwitchableOutput/basic_slider_4/Settings/Unit": "/Speed",
         "/SwitchableOutput/basic_slider_4/Settings/DimmingMin": -100,
         "/SwitchableOutput/basic_slider_4/Settings/DimmingMax": 100,
+        "/SwitchableOutput/basic_slider_4/Settings/StepSize": 0.1,
         "/SwitchableOutput/basic_slider_4/Settings/CustomName": "",
         "/SwitchableOutput/basic_slider_4/Settings/Function": 2,
         "/SwitchableOutput/basic_slider_4/Settings/Group": "",

--- a/src/iochannel.cpp
+++ b/src/iochannel.cpp
@@ -258,7 +258,7 @@ int IOChannel::decimals() const
 
 void IOChannel::setDecimals(const QVariant &variant)
 {
-	m_decimalsVariant = variant.toInt();
+	m_decimalsVariant = variant;
 	updateDecimals();
 }
 

--- a/tests/switchableoutput/tst_switchableoutput.qml
+++ b/tests/switchableoutput/tst_switchableoutput.qml
@@ -559,43 +559,55 @@ TestCase {
 			{
 				tag: "Decimals=0",
 				uid: "mock/com.victronenergy.test.a/SwitchableOutput/0",
-				outputProperties: { "/Settings/Decimals": 0 },
+				outputProperties: { "Settings/Decimals": 0 },
 				decimals: 0,
 			},
 			{
 				tag: "StepSize=0",
 				uid: "mock/com.victronenergy.test.a/SwitchableOutput/0",
-				outputProperties: { "/Settings/StepSize": 0 },
+				outputProperties: { "Settings/StepSize": 0 },
 				decimals: 0,
 			},
 			{
 				tag: "Decimals=1",
 				uid: "mock/com.victronenergy.test.a/SwitchableOutput/0",
-				outputProperties: { "/Settings/Decimals": 1 },
+				outputProperties: { "Settings/Decimals": 1 },
 				decimals: 1,
 			},
 			{
 				tag: "StepSize=1",
 				uid: "mock/com.victronenergy.test.a/SwitchableOutput/0",
-				outputProperties: { "/Settings/StepSize": 1 },
+				outputProperties: { "Settings/StepSize": 1 },
+				decimals: 0,
+			},
+			{
+				tag: "StepSize=0.1",
+				uid: "mock/com.victronenergy.test.a/SwitchableOutput/0",
+				outputProperties: { "Settings/StepSize": 0.1 },
 				decimals: 1,
+			},
+			{
+				tag: "StepSize=1.23",
+				uid: "mock/com.victronenergy.test.a/SwitchableOutput/0",
+				outputProperties: { "Settings/StepSize": 1.23 },
+				decimals: 2,
 			},
 			{
 				tag: "Decimals=0, StepSize=0",
 				uid: "mock/com.victronenergy.test.a/SwitchableOutput/0",
-				outputProperties: { "/Settings/Decimals": 0, "/Settings/StepSize": 0 },
+				outputProperties: { "Settings/Decimals": 0, "Settings/StepSize": 0 },
 				decimals: 0,
 			},
 			{
-				tag: "Decimals=0, StepSize=1",
+				tag: "Decimals=0, StepSize=1.23",
 				uid: "mock/com.victronenergy.test.a/SwitchableOutput/0",
-				outputProperties: { "/Settings/Decimals": 0, "/Settings/StepSize": 1 },
-				decimals: 0, // Decimals override
+				outputProperties: { "Settings/Decimals": 1, "Settings/StepSize": 1.23 },
+				decimals: 1, // Decimals override
 			},
 			{
 				tag: "Decimals=1, StepSize=0",
 				uid: "mock/com.victronenergy.test.a/SwitchableOutput/0",
-				outputProperties: { "/Settings/Decimals": 1, "/Settings/StepSize": 0 },
+				outputProperties: { "Settings/Decimals": 1, "Settings/StepSize": 0 },
 				decimals: 1, // Decimals override
 			},
 		]
@@ -606,7 +618,7 @@ TestCase {
 
 		setOutputProperties(data.uid, data.outputProperties)
 		output.uid = data.uid
-		compare(output.decimals, output.decimals)
+		compare(output.decimals, data.decimals)
 
 		// Clean up
 		output.uid = ""


### PR DESCRIPTION
Set the decimals variant without calling QVariant::toInt(), otherwise it is set to a valid QVariant(0) variant.

Fix the decimals/stepsize tests: actually check the expected output, add additional step size tests, and fix the test input paths so that values are set correctly.

Fixes #2866