### PR TITLE
Tanks: correctly show status in Devices list

### DIFF
--- a/data/mock/conf/services/tank-blackwater-error-state.json
+++ b/data/mock/conf/services/tank-blackwater-error-state.json
@@ -16,7 +16,7 @@
         "/DeviceInstance": 30,
         "/FilterLength": 10,
         "/FluidType": 5,
-        "/Level": 89,
+        "/Level": null,
         "/Mgmt/Connection": "Tank Level input 2",
         "/Mgmt/ProcessName": "dbus-adc",
         "/Mgmt/ProcessVersion": "1.32",

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_tank.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_tank.qml
@@ -9,12 +9,12 @@ import Victron.VenusOS
 DeviceListDelegate {
 	id: root
 
-	readonly property string statusText: level.valid ? "" : (status.valid ? Global.tanks.statusToText(status.value) : "--")
+	readonly property string statusText: level.valid ? "" : (status.valid ? Global.tanks.statusToText(status.value) : "")
 
 	quantityModel: QuantityObjectModel {
 		filterType: QuantityObjectModel.HasValue
 
-		QuantityObject { object: root; key: "statusText"; unit: VenusOS.Units_None }
+		QuantityObject { object: root; key: root.statusText ? "statusText" : ""; unit: VenusOS.Units_None }
 		QuantityObject { object: temperature; unit: Global.systemSettings.temperatureUnit }
 		QuantityObject { object: remaining; unit: Global.systemSettings.volumeUnit }
 		QuantityObject { object: level; unit: VenusOS.Units_Percentage }


### PR DESCRIPTION
When the status text is empty, ensure the QuantityObject is invalid, else it will attempt to show a number like "0.0". Also, do not show "--" when the status is not valid; just omit the status text altogether.

Update the mock Black Water tank to have an invalid /Level, so that it will show the "Error" status text as expected. Normally, if a tank is in an error state, it will not have a level set.

Fixes #2874