### PR TITLE
VE.Bus: show AC-in 2 measurements when AC-in 1 is not available

### DIFF
--- a/data/common/AcInput.qml
+++ b/data/common/AcInput.qml
@@ -37,21 +37,18 @@ Device {
 			}
 			switch (root.serviceType) {
 			case "vebus":
-				// Multi/Quattro can only measure its active input, i.e. when both:
-				// - system /Ac/In/<x>/Connected=1 for this input
-				// - this input matches the vebus /Ac/ActiveIn value
-				if (root.inputInfo.connected
-						&& _activeInput.valid
-						&& root.inputInfo.inputIndex === _activeInput.value) {
+				// Multi/Quattro can only measure its active input, so if connected=true, then we
+				// know this is the active input. Do not attempt to match inputInfo.inputIndex
+				// against the value of system /Ac/ActiveIn/ActiveInput, as those do not match if
+				// the first vebus input is disconnected.
+				if (root.inputInfo.connected) {
 					return root.serviceUid + "/Ac/ActiveIn"
 				}
 				break
 			case "acsystem":
 				// Multi RS is like the vebus case; it can only measure its active input.
-				if (root.inputInfo.connected
-						&& _activeInput.valid
-						&& root.inputInfo.inputIndex === _activeInput.value) {
-					return "%1/Ac/In/%2".arg(root.serviceUid).arg(_activeInput.value + 1)
+				if (root.inputInfo.connected) {
+					return "%1/Ac/In/%2".arg(root.serviceUid).arg(root.inputInfo.inputIndex + 1)
 				}
 				break
 			case "grid":
@@ -76,13 +73,6 @@ Device {
 			}
 			return ""
 		}
-	}
-
-	// The currently-active input on vebus or acsystem. 0 = ACin-1, 1 = ACin-2, 240 is none (inverting).
-	readonly property VeQuickItem _activeInput: VeQuickItem {
-		uid: root.inputInfo && root.inputInfo.valid && (root.serviceType === "vebus" || root.serviceType === "acsystem")
-			 ? root.serviceUid + "/Ac/ActiveIn/ActiveInput"
-			 : ""
 	}
 
 	// StatusCode is only valid for genset devices

--- a/data/mock/SystemAcImpl.qml
+++ b/data/mock/SystemAcImpl.qml
@@ -114,9 +114,9 @@ Item {
 					phaseAcOutCurrent = Units.sumRealNumbers(phaseAcOutCurrent, acService.acOut["currentL" + (phaseIndex + 1)].value)
 					if (updateGaugeRanges) {
 						const inputCurrent = (phaseAcInCurrent || 0) + (phaseAcOutCurrent || 0)
-						if (acService.activeInput === 1) {
+						if (acService.index === 0) {
 							acIn1MaxCurrent = Math.max(acIn1MaxCurrent, inputCurrent)
-						} else if (acService.activeInput === 2) {
+						} else if (acService.index === 1) {
 							acIn2MaxCurrent = Math.max(acIn2MaxCurrent, inputCurrent)
 						} else {
 							noAcInMaxCurrent = Math.max(noAcInMaxCurrent, inputCurrent)
@@ -171,11 +171,9 @@ Item {
 		delegate: QtObject {
 			id: acService
 
+			required property int index
 			required property string uid
 			readonly property string serviceType: BackendConnection.serviceTypeFromUid(uid)
-			readonly property int activeInput: _activeInput.value === VenusOS.AcInputs_InputSource_Inverting ? -1
-						: !_activeInput.valid ? 1
-						: _activeInput.value + 1
 			property bool completed
 
 			readonly property string phaseCountUid: (acService.serviceType === "vebus" || acService.serviceType === "acsystem")
@@ -190,7 +188,7 @@ Item {
 				powerKey: "P"
 				currentKey: "I"
 				bindPrefix: acService.serviceType === "vebus" ? acService.uid + "/Ac/ActiveIn"
-					: acService.serviceType === "acsystem" ? acService.uid + "/Ac/In/%1".arg(activeInput.value + 1)
+					: acService.serviceType === "acsystem" ? acService.uid + "/Ac/In/%1".arg(index + 1)
 					: acService.serviceType === "charger" ? acService.uid + "/Ac/In"
 					: "" // no AC-in for inverters
 				_phaseCount.uid: acService.phaseCountUid
@@ -220,11 +218,6 @@ Item {
 						Qt.callLater(acServiceObjects.updateConsumption)
 					}
 				}
-			}
-			readonly property VeQuickItem _activeInput: VeQuickItem {
-				uid: acService.serviceType === "vebus" || acService.serviceType === "acsystem"
-					 ? acService.uid + "/Ac/ActiveIn/ActiveInput"
-					 : ""
 			}
 		}
 		onObjectAdded: (index, acService) => {
@@ -271,8 +264,7 @@ Item {
 					if (acInput.serviceType === "vebus") {
 						MockManager.setValue(acInput.serviceUid + "/Ac/ActiveIn/P", totalPower)
 					} else if (acInput.serviceType === "acsystem") {
-						const activeInput = MockManager.value(acInput.serviceUid + "/Ac/ActiveIn/ActiveInput")
-						MockManager.setValue(acInput.serviceUid + "/Ac/%1/P".arg(activeInput + 1), totalPower)
+						MockManager.setValue(acInput.serviceUid + "/Ac/%1/P".arg(index + 1), totalPower)
 					}
 				}
 			}

--- a/data/mock/page-conf/BriefAndOverviewPageConfig.qml
+++ b/data/mock/page-conf/BriefAndOverviewPageConfig.qml
@@ -416,12 +416,8 @@ Item {
 		}
 		inputInfo.serviceInfoChanged() // force AcInputs.qml to update the acInput object now, so phases can be set
 
-		// Set the active input for vebus/acsystem inputs
 		const input = Global.acInputs["input" + (inputInfo.inputIndex + 1)]
 		if (input) {
-			if (!!inputInfoConfig.connected && input._activeInput.uid) {
-				input._activeInput.setValue(inputInfo.inputIndex)
-			}
 			// Set phase data
 			const objectAcConn = input._phaseMeasurements
 			const phaseCount = inputInfoConfig.phaseCount ?? 1


### PR DESCRIPTION
When determining whether an AC input is connected on vebus/acsystem, just look at /Ac/In/<input-index>/Connected on the system service, and ignore the value of /Ac/ActiveIn/ActiveInput on the vebus/acsystem service. The /ActiveInput path specifies whether AC-in1 or AC-in2 is connected, but this value does not always align with the input index in the system /Ac/In/<input-index> path. In any case it is not necessary to check the /ActiveInput value, as vebus/acsystem services can only have one active AC input at a time.

This was causing a bug where the measurements for the AC-in 2 would not be shown if AC-in 1 was not connected, as /ActiveInput=1 in this case, so it was assumed AC-in 1 was the active input, rather than AC-in 2.

Fixes #1805