### PR TITLE
Switches: indicate when /Status is invalid

### DIFF
--- a/data/mock/conf/services/switch-controls-tester.json
+++ b/data/mock/conf/services/switch-controls-tester.json
@@ -45,7 +45,7 @@
         "/GenericInput/unranged_2/Settings/ValidTypes": 15,
         "/GenericInput/unranged_2/Settings/Decimals": 3,
         "/GenericInput/unranged_2/Settings/Unit": "/Speed",
-        "/GenericInput/unranged_2/Status": 1,
+        "/GenericInput/unranged_2/Status": 0,
 
         "/GenericInput/ranged_1/Name": "In-02a. Ranged",
         "/GenericInput/ranged_1/Value": 10.234,
@@ -259,7 +259,7 @@
         "/SwitchableOutput/stepped_switch_2/Status": 9,
 
         "/SwitchableOutput/stepped_switch_3/Dimming": 1,
-        "/SwitchableOutput/stepped_switch_3/Name": "Out-04c. Stepped switch, disabled",
+        "/SwitchableOutput/stepped_switch_3/Name": "Out-04c. Stepped switch, invalid status",
         "/SwitchableOutput/stepped_switch_3/Settings/CustomName": "",
         "/SwitchableOutput/stepped_switch_3/Settings/DimmingMax": 3,
         "/SwitchableOutput/stepped_switch_3/Settings/Function": 2,
@@ -269,7 +269,6 @@
         "/SwitchableOutput/stepped_switch_3/Settings/ValidFunctions": 2,
         "/SwitchableOutput/stepped_switch_3/Settings/ValidTypes": 16383,
         "/SwitchableOutput/stepped_switch_3/State": 1,
-        "/SwitchableOutput/stepped_switch_3/Status": 32,
 
         "/SwitchableOutput/dropdown_1/Dimming": 1,
         "/SwitchableOutput/dropdown_1/Name": "Out-06a. Dropdown, 5 options",

--- a/src/enums.cpp
+++ b/src/enums.cpp
@@ -513,7 +513,9 @@ QString Enums::genericInput_statusToText(GenericInput_Status value) const
 		//% "Sensor battery low"
 		return qtTrId("generic_input_status_sensor_battery_low");
 	}
-	return QString();
+
+	//% "Unknown status"
+	return qtTrId("generic_input_unknown_status");
 }
 
 QString Enums::switchableOutput_typeToText(SwitchableOutput_Type value, const QString &channelId) const
@@ -697,14 +699,15 @@ QString Enums::switchableOutput_statusToText(SwitchableOutput_Status value, Swit
 			if (value & SwitchableOutput_Status_Disabled) {
 				//% "Not running, disabled"
 				return qtTrId("switchable_output_not_running_disabled");
-			} else {
+			} else if (value == SwitchableOutput_Status_Off) {
 				//% "Not running"
 				return qtTrId("switchable_output_not_running");
 			}
 		}
 	}
 
-	return QString::number(static_cast<int>(value));
+	//% "Unknown status"
+	return qtTrId("switchable_output_unknown_status");
 }
 
 QString Enums::tank_fluidTypeToText(Tank_Type type) const

--- a/src/iochannel.cpp
+++ b/src/iochannel.cpp
@@ -155,7 +155,7 @@ int IOChannel::status() const
 
 void IOChannel::setStatus(const QVariant &variant)
 {
-	m_status = variant.toInt();
+	m_status = variant.isValid() ? variant.toInt() : -1;
 	emit statusChanged();
 }
 

--- a/src/iochannel.h
+++ b/src/iochannel.h
@@ -173,7 +173,7 @@ protected:
 	QString m_group;
 	QString m_unitText;
 	Direction m_direction = Input;
-	int m_status = 0; // Default status is 0 (off)
+	int m_status = -1; // Default status is -1 (invalid)
 	int m_type = -1;
 	int m_unitType = Enums::Units_None;
 	int m_decimals = 0;

--- a/tests/genericinput/tst_genericinput.qml
+++ b/tests/genericinput/tst_genericinput.qml
@@ -54,7 +54,7 @@ TestCase {
 				tag: "status - invalid",
 				uid: "mock/com.victronenergy.test.a/GenericInput/0",
 				inputProperties: { "Name": "Foo" }, // status not set
-				expected: { status: 0 },
+				expected: { status: -1 },
 			},
 			{
 				tag: "status - 0",
@@ -203,7 +203,7 @@ TestCase {
 		compare(input.channelId, "")
 		compare(input.serviceUid, "")
 		compare(input.formattedName, "")
-		compare(input.status, 0)
+		compare(input.status, -1)
 		compare(input.value, 0)
 		compare(input.primaryLabel, "")
 		compare(input.rangeMin, 0)
@@ -230,7 +230,7 @@ TestCase {
 		compare(input.channelId, "")
 		compare(input.serviceUid, "")
 		compare(input.formattedName, "")
-		compare(input.status, 0)
+		compare(input.status, -1)
 		compare(input.value, 0)
 		compare(input.primaryLabel, "")
 		compare(input.rangeMin, 0)

--- a/tests/switchableoutput/tst_switchableoutput.qml
+++ b/tests/switchableoutput/tst_switchableoutput.qml
@@ -79,7 +79,7 @@ TestCase {
 				tag: "status - invalid",
 				uid: "mock/com.victronenergy.test.a/SwitchableOutput/0",
 				outputProperties: { "State": 0 }, // status not set
-				expected: { status: 0 },
+				expected: { status: -1 },
 			},
 			{
 				tag: "status - 0",
@@ -184,7 +184,7 @@ TestCase {
 		compare(output.serviceUid, "")
 		compare(output.formattedName, "")
 		compare(output.state, 0)
-		compare(output.status, 0)
+		compare(output.status, -1)
 		compare(output.dimming, 0)
 		compare(output.type, -1)
 		compare(output.group, "")
@@ -208,7 +208,7 @@ TestCase {
 		compare(output.serviceUid, "")
 		compare(output.formattedName, "")
 		compare(output.state, 0)
-		compare(output.status, 0)
+		compare(output.status, -1)
 		compare(output.dimming, 0)
 		compare(output.type, -1)
 		compare(output.group, "")


### PR DESCRIPTION
When <GenericInput|SwitchableOutput>/x/Status is an invalid value, or is not set at all, show "Unknown status" for the control in the Switch Pane.

Fixes #2872