### PR TITLE
Security: fix prompt text for GX password changes

### DIFF
--- a/components/dialogs/SecurityProfilePasswordDialog.qml
+++ b/components/dialogs/SecurityProfilePasswordDialog.qml
@@ -48,7 +48,7 @@ ModalDialog {
 		passwordHint.text = ""
 	}
 
-	//% "Changing the GX Password"
+	//% "Change the GX Password"
 	title: qsTrId("settings_security_profile_change_password_title")
 
 	//% "Confirm"


### PR DESCRIPTION
Fix the grammatical tense for the title.