### PR TITLE
Switches: allow channel direction configuration and move switches into Outputs page

### DIFF
--- a/components/DevicePage.qml
+++ b/components/DevicePage.qml
@@ -23,10 +23,6 @@ Page {
 	property alias settingsModel: settingsListView.model
 	property alias settingsDelegate: settingsListView.delegate
 
-	// True if a "Switches" item should be shown in the footer (if /SwitchableOutput entries are
-	// present on the service).
-	property bool showSwitches: true
-
 	// Additional settings to be loaded by PageDeviceInfo.
 	property Component extraDeviceInfo
 
@@ -45,9 +41,10 @@ Page {
 			topPadding: ListView.view.count > 0 ? spacing : 0
 
 			ListNavigation {
-				//% "Switches"
-				text: qsTrId("device_page_switches")
-				preferredVisible: root.showSwitches && switchableOutputModel.count > 0
+				//: Settings page for switchable outputs
+				//% "Outputs"
+				text: qsTrId("device_page_outputs")
+				preferredVisible: switchableOutputModel.count > 0
 				onClicked: {
 					Global.pageManager.pushPage(switchableOutputPageComponent, { title: text })
 				}
@@ -55,7 +52,7 @@ Page {
 				IOChannelProxyModel {
 					id: switchableOutputModel
 					sourceModel: VeQItemTableModel {
-						uids: root.showSwitches ? [ root.serviceUid + "/SwitchableOutput" ] : []
+						uids: [ root.serviceUid + "/SwitchableOutput" ]
 						flags: VeQItemTableModel.AddChildren | VeQItemTableModel.AddNonLeaves | VeQItemTableModel.DontAddItem
 					}
 				}

--- a/data/mock/conf/services/smartswitch.json
+++ b/data/mock/conf/services/smartswitch.json
@@ -11,6 +11,10 @@
         "/Settings/Vecan/vecan1/VenusUniqueId": 1
     },
     "com.victronenergy.switch.smartswitch_123": {
+        "/Channel/0/Direction": -1,
+        "/Channel/1/Direction": 0,
+        "/Channel/2/Direction": 0,
+        "/Channel/3/Direction": 0,
         "/Connected": 1,
         "/CustomName": "",
         "/DeviceInstance": 0,

--- a/pages/settings/devicelist/PageSwitch.qml
+++ b/pages/settings/devicelist/PageSwitch.qml
@@ -97,12 +97,4 @@ DevicePage {
 			}
 		}
 	}
-	settingsModel: IOChannelProxyModel {
-		sourceModel: VeQItemTableModel {
-			uids: [ root.serviceUid + "/SwitchableOutput" ]
-			flags: VeQItemTableModel.AddChildren | VeQItemTableModel.AddNonLeaves | VeQItemTableModel.DontAddItem
-		}
-	}
-	settingsDelegate: SwitchableOutputListDelegate {}
-	showSwitches: false
 }

--- a/pages/settings/devicelist/PageSwitch.qml
+++ b/pages/settings/devicelist/PageSwitch.qml
@@ -38,6 +38,64 @@ DevicePage {
 			unit: VenusOS.Units_Volt_DC
 			precision: 1
 		}
+
+		ListNavigation {
+			//% "Channel configuration"
+			text: qsTrId("settings_switch_channel_configuration")
+			preferredVisible: channelModel.rowCount > 0
+			onClicked: Global.pageManager.pushPage(channelConfigPageComponent, { title: text })
+
+			VeQItemTableModel {
+				id: channelModel
+				uids: [ root.serviceUid + "/Channel" ]
+				flags: VeQItemTableModel.AddChildren | VeQItemTableModel.AddNonLeaves | VeQItemTableModel.DontAddItem
+			}
+
+			Component {
+				id: channelConfigPageComponent
+
+				Page {
+					GradientListView {
+						model: channelModel
+						delegate: ListRadioButtonGroup {
+							id: channelDirection
+
+							required property string uid
+							required property string id
+
+							// Contains <service>/SwitchableOutput/<x> or <service>/GenericInput/<x>
+							// depending on the direction of the channel.
+							readonly property string inputOrOutputUid: dataItem.value !== 0 && dataItem.value !== 1 ? ""
+									: "%1/%2/%3".arg(root.device.serviceUid)
+										.arg(dataItem.value === 0 ? "SwitchableOutput" : "GenericInput")
+										.arg(id)
+
+							text: channelCustomName.value || channelName.value || id
+							dataItem.uid: uid + "/Direction"
+							optionModel: [
+								{ display: CommonWords.unknown_status, value: -1, readOnly: true },
+								//: Configure channel to use "input" direction
+								//% "Input"
+								{ display: qsTrId("settings_switch_channel_input"), value: 1 },
+								//: Configure channel to use "output" direction
+								//% "Output"
+								{ display: qsTrId("settings_switch_channel_output"), value: 0 },
+							]
+
+							VeQuickItem {
+								id: channelName
+								uid: channelDirection.inputOrOutputUid ? channelDirection.inputOrOutputUid + "/Name" : ""
+							}
+
+							VeQuickItem {
+								id: channelCustomName
+								uid: channelDirection.inputOrOutputUid ? channelDirection.inputOrOutputUid + "/Settings/CustomName" : ""
+							}
+						}
+					}
+				}
+			}
+		}
 	}
 	settingsModel: IOChannelProxyModel {
 		sourceModel: VeQItemTableModel {


### PR DESCRIPTION
Provides channel configuration settings in [Device] > Channel configuration > [Channel] as follows:

<img width="1824" height="1240" alt="image" src="https://github.com/user-attachments/assets/8bc460c1-afe4-4503-85e5-46d992f3d37c" />
<img width="1824" height="1240" alt="image" src="https://github.com/user-attachments/assets/763c21fb-d7f0-402c-a847-929382566d46" />
<img width="1824" height="1240" alt="image" src="https://github.com/user-attachments/assets/de7f267d-3dbd-43c7-a0c4-ce7565eff604" />
