### PR TITLE
Tank setup: add 1-decimal display and 1 Ω step for ohm sensor unit

### DIFF
--- a/pages/settings/devicelist/tank/PageTankSetup.qml
+++ b/pages/settings/devicelist/tank/PageTankSetup.qml
@@ -162,9 +162,15 @@ Page {
 
 		// The possible values here are not well defined. The doco says: "can be V, and probably also mA and R or O."
 		// At least one installation uses "cm".
+		// Resistive tank sensors (European 0-180Ω, US 240-30Ω, Custom) publish "Ω" or
+		// its ASCII equivalent "O". 1 decimal place and 1 Ω step are appropriate for
+		// resistance values in the tens-to-hundreds-of-ohms range.
 		readonly property int displayDecimals: {
 			switch (value) {
 			case "cm":
+				return 1
+			case "Ω":
+			case "O":
 				return 1
 			default:
 				return 3
@@ -175,6 +181,9 @@ Page {
 			switch (value) {
 			case "cm":
 				return 0.1
+			case "Ω":
+			case "O":
+				return 1
 			default:
 				return 0.005
 			}


### PR DESCRIPTION
## Problem

When a tank sensor publishes `/RawUnit = "Ω"` (or its ASCII equivalent `"O"`), the Setup page displays sensor values with **3 decimal places** (e.g. `190.000 Ω`, `0.000 Ω`) because the `rawUnit` object only has a special case for `"cm"` — all other units fall through to `default: return 3`.

This is inconsistent with the physical reality of resistive tank sensors:
- European standard: 0–180 Ω (integer values)
- US standard: 240–30 Ω (integer values)
- Custom: user-defined resistance range

1 decimal place (`190.0 Ω`) is sufficient precision. A `stepSize` of `1` (1 Ω) is also appropriate — `0.005` (the current default) is meaningless for resistance values in the tens or hundreds of ohms.

## Evidence

Victron's own `dbus-adc` binary and `dbus-modbus-client` publish `/RawUnit = "Ω"` for resistive tank sensors, as confirmed by the demo recorder CSV files shipped with Venus OS (`demo2_water.csv`, `demo2_blackwater.csv`, `demo2_diesel.csv`). The missing case for `"Ω"` in `PageTankSetup.qml` appears to be an oversight — the existing comment even lists `"R or O"` as known values but they were never handled.

## Fix

Add explicit `case "Ω":` and `case "O":` branches to both `displayDecimals` and `stepSize`:

- `displayDecimals` → `1`
- `stepSize` → `1`

Both `"Ω"` (Unicode U+03A9) and `"O"` (ASCII fallback used by some drivers) are handled for robustness.

## Testing

Verified on Venus OS v3.72 with a third-party ADS1115-based resistive tank sensor driver publishing `/RawUnit = "Ω"`. Before this fix: `190.000 Ω`. After: `190.0 Ω`.