### PR TITLE
Integrations: add EEBus Devices page

### DIFF
--- a/cmake/ModuleMock_Sources.cmake
+++ b/cmake/ModuleMock_Sources.cmake
@@ -34,6 +34,7 @@ SET(VictronMock_QML_MODULE_RESOURCES
     data/mock/conf/services/dcsystem2.json
     data/mock/conf/services/dse-genset.json
     data/mock/conf/services/digitalinput-alarm.json
+    data/mock/conf/services/eebus.json
     data/mock/conf/services/em-acload.json
     data/mock/conf/services/em-evcharger-input.json
     data/mock/conf/services/em-evcharger-output.json

--- a/cmake/ModuleVenus_Sources.cmake
+++ b/cmake/ModuleVenus_Sources.cmake
@@ -402,6 +402,8 @@ set (VictronVenusOS_QML_MODULE_SOURCES
     pages/settings/PageSettingsDocumentation.qml
     pages/settings/PageSettingsDvcc.qml
     pages/settings/PageSettingsDynamicEss.qml
+    pages/settings/PageSettingsEebus.qml
+    pages/settings/PageSettingsEebusDevice.qml
     pages/settings/PageSettingsEthernet.qml
     pages/settings/PageSettingsFirmware.qml
     pages/settings/PageSettingsFirmwareOffline.qml

--- a/components/listitems/ListLink.qml
+++ b/components/listitems/ListLink.qml
@@ -25,12 +25,13 @@ import Victron.VenusOS
 ListSetting {
 	id: root
 
+	property int mode: Qt.platform.os === "wasm" ? VenusOS.ListLink_Mode_LinkButton : VenusOS.ListLink_Mode_QRCode
 	property string url
 	readonly property string formattedUrl: "<font color=\"%1\">%2</font>".arg(Theme.color_font_primary).arg(url)
 
 	function click() {
 		if (root.clickable) {
-			if (Qt.platform.os === "wasm") {
+			if (root.mode === VenusOS.ListLink_Mode_LinkButton) {
 				BackendConnection.openUrl(root.url)
 			} else {
 				Global.dialogLayer.open(largeQrCodeComponent)
@@ -90,7 +91,7 @@ ListSetting {
 
 			//% "Open link"
 			text: qsTrId("listlink_open_link")
-			visible: Qt.platform.os === "wasm"
+			visible: root.mode === VenusOS.ListLink_Mode_LinkButton
 			rightPadding: arrowIcon.width + root.spacing
 
 			CP.ColorImage {
@@ -115,7 +116,7 @@ ListSetting {
 
 			//% "Show QR code"
 			text: qsTrId("listlink_show_qr_code")
-			visible: Qt.platform.os !== "wasm"
+			visible: root.mode === VenusOS.ListLink_Mode_QRCode
 			down: root.clickable && (pressed || checked)
 			enabled: root.clickable
 			focusPolicy: Qt.NoFocus
@@ -130,12 +131,12 @@ ListSetting {
 
 		ListPressArea {
 			anchors.fill: parent
-			enabled: root.interactive && Qt.platform.os === "wasm"
+			enabled: root.interactive && root.mode === VenusOS.ListLink_Mode_LinkButton
 			onClicked: root.click()
 		}
 	}
 
-	caption: Qt.platform.os === "wasm" ? ""
+	caption: root.mode === VenusOS.ListLink_Mode_LinkButton ? ""
 		  //: %1 = url text
 		  //% "Open the QR code to scan it with your portable device.<br />Or insert the link: %1"
 		: qsTrId("listlink_scan_qr_code").arg(formattedUrl)

--- a/data/mock/conf/maximal.json
+++ b/data/mock/conf/maximal.json
@@ -6,6 +6,7 @@
         ":/data/mock/conf/services/dcsystem2.json",
         ":/data/mock/conf/services/digitalinput-alarm.json",
         ":/data/mock/conf/services/dse-genset.json",
+        ":/data/mock/conf/services/eebus.json",
         ":/data/mock/conf/services/em-acload.json",
         ":/data/mock/conf/services/em-evcharger-input.json",
         ":/data/mock/conf/services/em-evcharger-output.json",

--- a/data/mock/conf/services/eebus.json
+++ b/data/mock/conf/services/eebus.json
@@ -1,0 +1,18 @@
+{
+    "com.victronenergy.settings": {
+        "/Settings/Services/Eebus": 1
+    },
+    "com.victronenergy.eebus": {
+        "/Devices/NIBE_123456789_4712/AutoAccept": 0,
+        "/Devices/NIBE_123456789_4712/Brand": "NIBE",
+        "/Devices/NIBE_123456789_4712/Host": "local.",
+        "/Devices/NIBE_123456789_4712/Model": "HeatPump",
+        "/Devices/NIBE_123456789_4712/Name": "NIBE-123456789-4712",
+        "/Devices/NIBE_123456789_4712/Ski": "42d98f9b82ef2f51799f379c5e82765e87685d8a",
+        "/Devices/NIBE_123456789_4712/Trusted": 1,
+        "/Devices/NIBE_123456789_4712/Type": "HeatGenerationSystem",
+        "/LocalSki": "efada28e50e86401fa9ef4790a14dcb0224a01ed",
+        "/PairingQrCode": "SHIP;SKI:efada28e50e86401fa9ef4790a14dcb0224a01ed;ID:VE-GX-f208hff3h02;BRAND:VictronEnergy;TYPE:EnergyManagementSystem;MODEL:VenusOS;SERIAL:12345678;ENDSHIP;",
+        "/TrustedSkis": "[\"42d98f9b82ef2f51799f379c5e82765e87685d8a\"]"
+    }
+}

--- a/pages/settings/PageSettingsEebus.qml
+++ b/pages/settings/PageSettingsEebus.qml
@@ -1,0 +1,118 @@
+/*
+** Copyright (C) 2026 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+Page {
+	id: root
+
+	readonly property string serviceUid: BackendConnection.serviceUidForType("eebus")
+
+	VeQItemSortTableModel {
+		id: channelModel
+		dynamicSortFilter: true
+		filterFlags: VeQItemSortTableModel.FilterInvalid
+		filterRole: VeQItemTableModel.UniqueIdRole
+		filterRegExp: "\/Devices\/(?:\\w+)\/Trusted$"
+		model: VeQItemTableModel {
+			uids: [ root.serviceUid + "/Devices" ]
+			flags: VeQItemTableModel.AddAllChildren | VeQItemTableModel.AddNonLeaves | VeQItemTableModel.DontAddItem
+		}
+	}
+
+	VeQItemSortTableModel {
+		id: sortedChannelModel
+
+		filterRole: VeQItemTableModel.ValueRole
+		sortColumn: childValues.sortValueColumn
+		dynamicSortFilter: true
+
+		model: VeQItemChildModel {
+			id: childValues
+			model: channelModel
+			sortDelegate: VeQItemSortDelegate {
+				id: channelSortDelegate
+
+				readonly property string deviceUid: buddy.itemParent()?.uid ?? ""
+				readonly property string name: nameItem.valid ? nameItem.value : ""
+
+				sortValue: buddy.valid ? "" : name
+
+				VeQuickItem {
+					id: nameItem
+					uid: channelSortDelegate.deviceUid + "/Name"
+				}
+			}
+		}
+	}
+
+	GradientListView {
+		id: eebusListView
+
+		header: SettingsColumn {
+			width: parent?.width ?? 0
+
+			ListSwitch {
+				id: enable
+				text: CommonWords.enable
+				dataItem.uid: Global.systemSettings.serviceUid + "/Settings/Services/Eebus"
+			}
+
+			ListText {
+				//% "Local SKI"
+				text: qsTrId("eebus_local_ski")
+				dataItem.uid: root.serviceUid + "/LocalSki"
+				preferredVisible: dataItem.valid
+			}
+
+			ListLink {
+				//% "QR Code for pairing"
+				text: qsTrId("eebus_pairing_qr_code")
+				url: pairingQRCode.valid ? pairingQRCode.value : ""
+				caption: ""
+				mode: VenusOS.ListLink_Mode_QRCode
+				preferredVisible: pairingQRCode.valid
+
+				VeQuickItem {
+					id: pairingQRCode
+					uid: root.serviceUid + "/PairingQrCode"
+				}
+			}
+
+			SectionHeader {
+				text: CommonWords.discovered_devices
+				opacity: eebusListView.count > 0 ? 1 : 0
+			}
+		}
+		model: sortedChannelModel
+		delegate: ListNavigation {
+			id: listDelegate
+
+			required property VeQItem item
+			readonly property string uid: item.itemParent().uid
+
+			text: name.valid ? name.value : ""
+			secondaryText: trusted.valid && trusted.value === 1
+				//% "Trusted"
+				? qsTrId("eebus_trusted")
+				//% "Untrusted"
+				: qsTrId("eebus_untrusted")
+
+			onClicked: Global.pageManager.pushPage("/pages/settings/PageSettingsEebusDevice.qml",
+												   { bindPrefix: listDelegate.uid, title: text })
+
+			VeQuickItem {
+				id: name
+				uid: listDelegate.uid + "/Name"
+			}
+
+			VeQuickItem {
+				id: trusted
+				uid: listDelegate.uid + "/Trusted"
+			}
+		}
+	}
+}

--- a/pages/settings/PageSettingsEebusDevice.qml
+++ b/pages/settings/PageSettingsEebusDevice.qml
@@ -1,0 +1,58 @@
+/*
+** Copyright (C) 2026 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+Page {
+	id: root
+
+	required property string bindPrefix
+
+	GradientListView {
+		model: VisibleItemModel {
+			ListSwitch {
+				//% "Trusted"
+				text: qsTrId("eebus_device_trusted")
+				dataItem.uid: root.bindPrefix + "/Trusted"
+				writeAccessLevel: VenusOS.User_AccessType_User
+			}
+
+			ListText {
+				text: CommonWords.manufacturer
+				dataItem.uid: root.bindPrefix + "/Brand"
+			}
+
+			ListText {
+				text: CommonWords.model_name
+				dataItem.uid: root.bindPrefix + "/Model"
+			}
+
+			ListText {
+				//% "Host"
+				text: qsTrId("eebus_device_host")
+				dataItem.uid: root.bindPrefix + "/Host"
+			}
+
+			ListText {
+				//% "SKI"
+				text: qsTrId("eebus_device_ski")
+				dataItem.uid: root.bindPrefix + "/Ski"
+			}
+
+			ListText {
+				text: CommonWords.type
+				dataItem.uid: root.bindPrefix + "/Type"
+			}
+
+			ListSwitch {
+				//% "Auto Accept"
+				text: qsTrId("eebus_device_auto_accept")
+				dataItem.uid: root.bindPrefix + "/AutoAccept"
+				interactive: false
+			}
+		}
+	}
+}

--- a/pages/settings/PageSettingsIntegrations.qml
+++ b/pages/settings/PageSettingsIntegrations.qml
@@ -58,6 +58,12 @@ Page {
 			}
 
 			ListNavigation {
+				//% "EEBus Devices"
+				text: qsTrId("pagesettingsintegrations_eebus_devices")
+				onClicked: Global.pageManager.pushPage("/pages/settings/PageSettingsEebus.qml", {"title": text})
+			}
+
+			ListNavigation {
 				//% "Bluetooth Sensors"
 				text: qsTrId("pagesettingsintegrations_bluetooth_sensors")
 				preferredVisible: !!hasBluetoothSupport.value

--- a/src/enums.h
+++ b/src/enums.h
@@ -930,6 +930,12 @@ public:
 	};
 	Q_ENUM(ListItem_BottomContentSizeMode)
 
+	enum ListLink_Mode {
+		ListLink_Mode_LinkButton,
+		ListLink_Mode_QRCode
+	};
+	Q_ENUM(ListLink_Mode)
+
 	enum ModificationChecks_Action {
 		ModificationChecks_Action_Idle,
 		ModificationChecks_Action_StartCheck,


### PR DESCRIPTION
Contributes to: https://github.com/victronenergy/gui-v2/issues/2918

For the upcoming EEBus service, we are adding a way to manage it and its devices from the UI.

Requirements are:
- new menu on the integrations page. ("EEBus Devices")
- a way to enable/disable the service.
- show the service's SKI.
- show the service's pairing QR code.
- show the discovered devices.
- a sub page per discovered device with all of its information.
- a way to set a device as trusted.

<img width="800" height="480" alt="Screenshot 2026-04-13 at 09 35 44" src="https://github.com/user-attachments/assets/54739dbe-d2ae-4dff-b7d8-0f929a20b8e0" />

<img width="800" height="480" alt="Screenshot 2026-04-13 at 09 35 53" src="https://github.com/user-attachments/assets/2d2b6221-4134-44c2-96d8-ce4bc796ceaf" />

<img width="800" height="480" alt="Screenshot 2026-04-13 at 09 36 21" src="https://github.com/user-attachments/assets/29eda161-b642-4642-934b-5268635d4975" />