### PR TITLE
Switches: improve quantity displays for dimmable controls

### DIFF
--- a/components/switches/GenericInputCardDelegateHeader.qml
+++ b/components/switches/GenericInputCardDelegateHeader.qml
@@ -11,7 +11,7 @@ IOChannelCardDelegateHeader {
 
 	required property GenericInput genericInput
 
-	formattedName: genericInput.formattedName
+	ioChannel: genericInput
 	statusText: VenusOS.genericInput_statusToText(genericInput.status)
 	statusVisible: genericInput.status !== VenusOS.GenericInput_Status_On
 	statusColor: {

--- a/components/switches/IOChannelCardDelegateHeader.qml
+++ b/components/switches/IOChannelCardDelegateHeader.qml
@@ -10,33 +10,41 @@ import Victron.VenusOS
 RowLayout {
 	id: root
 
-	required property string formattedName
+	required property IOChannel ioChannel
 	required property string statusText
-	property string secondaryTitle
 	property bool statusVisible
 	property color statusColor: Theme.color_red
 
+	// If quantityValue or quantityText is set, the QuantityLabel is displayed.
+	property real quantityValue: NaN
+	property int quantityUnit: -1 // If -1, will use the IOChannel unit
+	property string quantityText // If set, this overrides the displayed quantityValue
+	property color quantityColor: Theme.color_font_primary
+
+	spacing: Theme.geometry_iochannel_label_margin
+
 	Label {
 		Layout.fillWidth: true
-		Layout.alignment: Qt.AlignBaseline
-		bottomPadding: Theme.geometry_iochannel_label_margin
-		rightPadding: Theme.geometry_iochannel_label_margin
-		text: root.formattedName
+		Layout.bottomMargin: Theme.geometry_iochannel_label_margin
+		text: root.ioChannel.formattedName
 		elide: Text.ElideMiddle // don't elide right, as it may obscure a trailing channel id
 	}
 
-	Label {
-		id: secondaryTitleLabel
-		Layout.alignment: Qt.AlignBaseline
-		bottomPadding: Theme.geometry_iochannel_label_margin
-		text: root.secondaryTitle
-		font.pixelSize: Theme.font_size_body2
+	IOChannelQuantityLabel {
+		Layout.bottomMargin: Theme.geometry_iochannel_label_margin
+		ioChannel: root.ioChannel
+		value: root.quantityValue
+		valueColor: root.quantityColor
+		valueText: root.quantityText || quantityInfo.number
+		unit: root.quantityUnit >= 0 ? root.quantityUnit : Global.systemSettings.toPreferredUnit(ioChannel.unitType)
+		unitColor: root.quantityColor
+		visible: !root.statusVisible && (root.quantityText.length > 0 || !isNaN(root.quantityValue))
 	}
 
 	Rectangle {
 		id: statusRect
 
-		Layout.bottomMargin: Theme.geometry_iochannel_label_margin
+		Layout.bottomMargin: Theme.geometry_iochannel_statusBackground_bottomPadding
 		Layout.maximumWidth: parent.width / 2
 		Layout.minimumWidth: statusLabel.implicitWidth
 		Layout.alignment: Qt.AlignRight

--- a/components/switches/SwitchableOutputCardDelegateHeader.qml
+++ b/components/switches/SwitchableOutputCardDelegateHeader.qml
@@ -12,7 +12,11 @@ IOChannelCardDelegateHeader {
 
 	required property SwitchableOutput switchableOutput
 
-	formattedName: switchableOutput.formattedName
+	ioChannel: switchableOutput
+	quantityColor: (switchableOutput.hasValidState && switchableOutput.state === 0)
+				   || (switchableOutput.status & VenusOS.SwitchableOutput_Status_Disabled)
+			? Theme.color_font_secondary
+			: Theme.color_font_primary
 	statusText: VenusOS.switchableOutput_statusToText(switchableOutput.status, switchableOutput.type)
 	statusVisible: !(switchableOutput.status === VenusOS.SwitchableOutput_Status_Off
 			|| switchableOutput.status === VenusOS.SwitchableOutput_Status_On

--- a/components/switches/delegates/SwitchableOutputCardDelegate_2.qml
+++ b/components/switches/delegates/SwitchableOutputCardDelegate_2.qml
@@ -42,6 +42,8 @@ FocusScope {
 			rightMargin: Theme.geometry_controlCard_button_margins
 		}
 		switchableOutput: root.switchableOutput
+		quantityValue: slider.value
+		quantityUnit: VenusOS.Units_Percentage
 	}
 
 	SwitchableOutputDimmableSlider {

--- a/components/switches/delegates/SwitchableOutputCardDelegate_3.qml
+++ b/components/switches/delegates/SwitchableOutputCardDelegate_3.qml
@@ -48,14 +48,13 @@ FocusScope {
 			rightMargin: Theme.geometry_controlCard_button_margins
 		}
 		switchableOutput: root.switchableOutput
-		secondaryTitle: measurementItem.valid
-			? "%1%2/<font color=\"%3\">%4</font>%5"
+		quantityText: measurementItem.valid
+			? "%1/<font color=\"%2\">%3</font>"
 					.arg(slider.value.toFixed(root.switchableOutput.decimals))
-					.arg(Units.degreesSymbol)
 					.arg(Theme.color_font_secondary)
 					.arg(measurementItem.value.toFixed(root.switchableOutput.decimals))
-					.arg(Global.systemSettings.temperatureUnitSuffix)
-			: slider.value.toFixed(root.switchableOutput.decimals) + Global.systemSettings.temperatureUnitSuffix
+			: slider.value.toFixed(root.switchableOutput.decimals)
+		quantityUnit: Global.systemSettings.toPreferredUnit(Global.systemSettings.temperatureUnit)
 	}
 
 	VeQuickItem {

--- a/components/switches/delegates/SwitchableOutputCardDelegate_7.qml
+++ b/components/switches/delegates/SwitchableOutputCardDelegate_7.qml
@@ -48,15 +48,7 @@ FocusScope {
 			rightMargin: Theme.geometry_controlCard_button_margins
 		}
 		switchableOutput: root.switchableOutput
-		secondaryTitle: quantityInfo.number + (quantityInfo.unit || root.switchableOutput.unitText)
-
-		QuantityInfo {
-			id: quantityInfo
-			value: slider.value // already in the display unit
-			unitType: Global.systemSettings.toPreferredUnit(root.switchableOutput.unitType)
-			decimals: root.switchableOutput.decimals
-			formatHints: Units.NoDecimalAdjustment // Always respect the decimals setting
-		}
+		quantityValue: slider.value // already in the display unit
 	}
 
 	SwitchableOutputSlider {

--- a/components/switches/delegates/SwitchableOutputCardDelegate_color.qml
+++ b/components/switches/delegates/SwitchableOutputCardDelegate_color.qml
@@ -49,6 +49,8 @@ FocusScope {
 			rightMargin: Theme.geometry_controlCard_button_margins
 		}
 		switchableOutput: root.switchableOutput
+		quantityValue: currentColorDimmerData.color.hsvValue * 100 // convert from 0-1 range to 0-100%
+		quantityUnit: VenusOS.Units_Percentage
 	}
 
 	FocusScope {

--- a/src/switchableoutput.cpp
+++ b/src/switchableoutput.cpp
@@ -79,11 +79,21 @@ int SwitchableOutput::state() const
 	return m_state.toInt();
 }
 
+bool SwitchableOutput::hasValidState() const
+{
+	return m_hasValidState;
+}
+
 void SwitchableOutput::setState(const QVariant &variant)
 {
+	const bool prevHasState = m_hasValidState;
 	m_state = variant;
+	m_hasValidState = variant.isValid();
 	updateAllowedInGroupModel();
 	emit stateChanged();
+	if (prevHasState != hasValidState()) {
+		emit hasStateChanged();
+	}
 }
 
 qreal SwitchableOutput::dimming() const

--- a/src/switchableoutput.h
+++ b/src/switchableoutput.h
@@ -33,6 +33,7 @@ class SwitchableOutput : public IOChannel
 	Q_OBJECT
 	QML_ELEMENT
 	Q_PROPERTY(int state READ state NOTIFY stateChanged FINAL)
+	Q_PROPERTY(bool hasValidState READ hasValidState NOTIFY hasStateChanged FINAL)
 	Q_PROPERTY(qreal dimming READ dimming NOTIFY dimmingChanged FINAL)
 	Q_PROPERTY(int function READ function NOTIFY functionChanged FINAL)
 	Q_PROPERTY(int validFunctions READ validFunctions NOTIFY validFunctionsChanged FINAL)
@@ -45,6 +46,9 @@ public:
 	// Whether the Function is a supported Type value, and matches the ValidFunctions.
 	bool hasValidFunction() const;
 
+	// True if /State is available.
+	bool hasValidState() const;
+
 	// Output/channel operational paths
 	int state() const;
 	qreal dimming() const;
@@ -55,6 +59,7 @@ public:
 
 Q_SIGNALS:
 	void stateChanged();
+	void hasStateChanged();
 	void dimmingChanged();
 	void functionChanged();
 	void validFunctionsChanged();
@@ -80,6 +85,7 @@ private:
 	QVariant m_function;
 	QString m_stepSizeString;
 	int m_validFunctions = 0;
+	bool m_hasValidState = false;
 	bool m_hasValidFunction = false;
 };
 

--- a/themes/geometry/FiveInch.json
+++ b/themes/geometry/FiveInch.json
@@ -296,6 +296,7 @@
     "geometry_iochannel_status_horizontalPadding": 8,
     "geometry_iochannel_status_radius": 10,
     "geometry_iochannel_status_minimum_width": 48,
+    "geometry_iochannel_statusBackground_bottomPadding": 4,
 
     "geometry_colorWheelDialog_width": 754,
     "geometry_colorWheelDialog_height": 448,

--- a/themes/geometry/SevenInch.json
+++ b/themes/geometry/SevenInch.json
@@ -296,6 +296,7 @@
     "geometry_iochannel_status_horizontalPadding": 8,
     "geometry_iochannel_status_radius": 10,
     "geometry_iochannel_status_minimum_width": 48,
+    "geometry_iochannel_statusBackground_bottomPadding": 4,
 
     "geometry_colorWheelDialog_width": 754,
     "geometry_colorWheelDialog_height": 448,


### PR DESCRIPTION
Replace the control secondary label with a QuantityLabel, so that quantities can be displayed in the switch delegate in a standard manner.

Add quantity displays for Dimmable and RGB/RGBW/CCT controls, and show the quantity in the secondary colour when the output state is off (or status is disabled).

For Temperature controls, when the /Measurement is shown, omit the degree symbol from the first number in the quantity text.

Fixes #2891, #2912


<img width="1824" height="1240" alt="image" src="https://github.com/user-attachments/assets/8fdcb362-1097-4ecb-85dc-65450917ba53" />
<img width="1824" height="1240" alt="image" src="https://github.com/user-attachments/assets/d905d22a-2b04-4174-acfb-f6070871bf91" />
<img width="1824" height="1240" alt="image" src="https://github.com/user-attachments/assets/51ef9c42-2b7b-4003-9aae-835a9045e063" />
