### PR TITLE
Add an ESS system reason number for peak shaving

### DIFF
--- a/components/SystemReason.qml
+++ b/components/SystemReason.qml
@@ -29,6 +29,7 @@ QtObject {
 	readonly property alias slowCharge: _slowCharge
 	readonly property alias userChargeLimited: _userChargeLimited
 	readonly property alias userDischargeLimited: _userDischargeLimited
+	readonly property alias peakShaving: _peakShaving
 
 	// Flags to monitor
 	readonly property list<VeQuickItem> flagItems: [
@@ -38,7 +39,8 @@ QtObject {
 		VeQuickItem { id: _dischargeDisabled;		uid: serviceUid + "/SystemState/DischargeDisabled" },
 		VeQuickItem { id: _slowCharge;				uid: serviceUid + "/SystemState/SlowCharge" },
 		VeQuickItem { id: _userChargeLimited;		uid: serviceUid + "/SystemState/UserChargeLimited" },
-		VeQuickItem { id: _userDischargeLimited;	uid: serviceUid + "/SystemState/UserDischargeLimited" }
+		VeQuickItem { id: _userDischargeLimited;	uid: serviceUid + "/SystemState/UserDischargeLimited" },
+		VeQuickItem { id: _peakShaving;				uid: serviceUid + "/SystemState/PeakShaving" }
 	]
 
 	function descriptionText() { // not used yet, will be needed for the new battery charging/discharge design


### PR DESCRIPTION
Nothing ground-breaking here, it just adds a `#8` indicator on the screen when the system is discharging the battery to shave a peak.

https://github.com/victronenergy/venus-private/issues/538