### PR TITLE
Languages: add Japanese

### DIFF
--- a/cmake/BuildRequirements.cmake
+++ b/cmake/BuildRequirements.cmake
@@ -19,7 +19,7 @@ if(QT_KNOWN_POLICY_QTP0001)
 endif()
 
 # Supported languages / translation catalogues.
-list(APPEND TS_CODES "af" "ar" "cs" "da" "de" "es" "fr" "it" "nl" "pl" "pt" "ro" "ru" "sv" "th" "tr" "uk" "zh_CN")
+list(APPEND TS_CODES "af" "ar" "cs" "da" "de" "es" "fr" "it" "ja" "nl" "pl" "pt" "ro" "ru" "sv" "th" "tr" "uk" "zh_CN")
 qt_standard_project_setup(REQUIRES ${REQUIRED_QT_VERSION}
     I18N_SOURCE_LANGUAGE en # optional - this is the default
     I18N_TRANSLATED_LANGUAGES ${TS_CODES}

--- a/i18n/venus-gui-v2_ja.ts
+++ b/i18n/venus-gui-v2_ja.ts
@@ -1,0 +1,12999 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja">
+  <context>
+    <name></name>
+    <message id="page_switchable_output_switch_mode_disabled">
+      <location filename="../../pages/settings/devicelist/iochannel/PageSwitchableOutput.qml" line="36"/>
+      <source>Disabled</source>
+      <translation>無効</translation>
+    </message>
+    <message id="common_words_inverter_overload">
+      <location filename="../../components/CommonWords.qml" line="284"/>
+      <source>Inverter overload</source>
+      <translation>コンディショナー過負荷状態</translation>
+    </message>
+    <message id="ev_power">
+      <location filename="../../pages/ev/EvPage.qml" line="64"/>
+      <source>Power</source>
+      <extracomment>Electric power, as measured in Watts</extracomment>
+      <translation>電力</translation>
+    </message>
+    <message id="generic_input_label_off">
+      <location filename="../../src/genericinput.cpp" line="112"/>
+      <source>Off</source>
+      <extracomment>Digital input state</extracomment>
+      <translation>オフ</translation>
+    </message>
+    <message id="common_words_auto">
+      <location filename="../../components/CommonWords.qml" line="83"/>
+      <source>Auto</source>
+      <translation>自動</translation>
+    </message>
+    <message id="common_words_high_battery_voltage">
+      <location filename="../../components/CommonWords.qml" line="242"/>
+      <source>High battery voltage</source>
+      <translation>バッテリー高電圧</translation>
+    </message>
+    <message id="overview_widget_inverter_title">
+      <location filename="../../components/widgets/InverterChargerWidget.qml" line="32"/>
+      <source>Inverter / Charger</source>
+      <translation>インバーター / チャージャー</translation>
+    </message>
+    <message id="common_words_low_battery_voltage">
+      <location filename="../../components/CommonWords.qml" line="293"/>
+      <source>Low battery voltage</source>
+      <translation>バッテリー低電圧</translation>
+    </message>
+    <message id="switchable_output_function_manual">
+      <location filename="../../src/enums.cpp" line="593"/>
+      <source>Manual</source>
+      <translation>手動</translation>
+    </message>
+    <message id="pagesettingsboatpage_none">
+      <location filename="../../pages/settings/PageSettingsBoatPage.qml" line="35"/>
+      <source>None</source>
+      <extracomment>Indicates no phase</extracomment>
+      <translation>なし</translation>
+    </message>
+    <message id="ev_position">
+      <location filename="../../pages/ev/EvPage.qml" line="141"/>
+      <source>Position</source>
+      <extracomment>EVCS AC input/output position</extracomment>
+      <translation>ポジション</translation>
+    </message>
+    <message id="generic_input_primaryLabel_speed">
+      <location filename="../../src/genericinput.cpp" line="164"/>
+      <source>Speed</source>
+      <extracomment>A speed measurement value</extracomment>
+      <translation>速度</translation>
+    </message>
+    <message id="common_words_state">
+      <location filename="../../components/CommonWords.qml" line="516"/>
+      <source>State</source>
+      <translation>状態</translation>
+    </message>
+    <message id="settings_firmware_installing">
+      <location filename="../../components/FirmwareUpdate.qml" line="114"/>
+      <source>Installing %1...</source>
+      <extracomment>%1 = firmware version</extracomment>
+      <translation>%1をインストール中...</translation>
+    </message>
+    <message id="splash_view_unknown_error">
+      <location filename="../../components/SplashView.qml" line="329"/>
+      <source>Unknown error</source>
+      <translation>不明なエラー:</translation>
+    </message>
+    <message id="controlcard_inverter_charger_ess_minimum_soc">
+      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="106"/>
+      <source>Minimum SOC</source>
+      <translation>最小SOC</translation>
+    </message>
+    <message id="common_words_enter_password">
+      <location filename="../../components/CommonWords.qml" line="197"/>
+      <source>Enter password</source>
+      <translation>パスワードを入力</translation>
+    </message>
+    <message id="settings_firmware_press_to_check">
+      <location filename="../../components/listitems/ListFirmwareCheckButton.qml" line="18"/>
+      <source>Press to check</source>
+      <translation>押して確認</translation>
+    </message>
+    <message id="common_words_grid">
+      <location filename="../../components/CommonWords.qml" line="233"/>
+      <source>Grid</source>
+      <translation>系統電源</translation>
+    </message>
+    <message id="overview_widget_solaryield_title">
+      <location filename="../../components/widgets/SolarYieldWidget.qml" line="26"/>
+      <source>Solar yield</source>
+      <translation>太陽光発電量</translation>
+    </message>
+    <message id="inverters_state_externalccontrol">
+      <location filename="../../data/System.qml" line="186"/>
+      <source>External control</source>
+      <translation>外部コントロール</translation>
+    </message>
+    <message id="levels_page_tanks">
+      <location filename="../../pages/LevelsPage.qml" line="61"/>
+      <source>Tanks</source>
+      <translation>タンク</translation>
+    </message>
+    <message id="levels_page_environment">
+      <location filename="../../pages/LevelsPage.qml" line="63"/>
+      <source>Environment</source>
+      <translation>環境</translation>
+    </message>
+    <message id="settings_general">
+      <location filename="../../pages/SettingsPage.qml" line="48"/>
+      <source>General</source>
+      <translation>一般</translation>
+    </message>
+    <message id="pagesettingssupportstate_firmware">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="342"/>
+      <source>Firmware</source>
+      <translation>ファームウェア</translation>
+    </message>
+    <message id="pagesettingsgeneral_date_and_time">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="222"/>
+      <source>Date &amp; Time</source>
+      <translation>日時</translation>
+    </message>
+    <message id="settings_dvcc_dvcc">
+      <location filename="../../pages/settings/DvccCommonSettings.qml" line="17"/>
+      <source>DVCC</source>
+      <translation>DVCC</translation>
+    </message>
+    <message id="common_words_ess">
+      <location filename="../../components/CommonWords.qml" line="212"/>
+      <source>ESS</source>
+      <translation>ESS</translation>
+    </message>
+    <message id="pagesettingsconnectivity_ethernet">
+      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="32"/>
+      <source>Ethernet</source>
+      <translation>Ethernet</translation>
+    </message>
+    <message id="pagesettingsconnectivity_wifi">
+      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="44"/>
+      <source>Wi-Fi</source>
+      <translation>WiFi</translation>
+    </message>
+    <message id="settings_units_gps">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="65"/>
+      <source>GPS</source>
+      <extracomment>GPS units</extracomment>
+      <translation>GPS</translation>
+    </message>
+    <message id="switchable_output_function_tankpump">
+      <location filename="../../src/enums.cpp" line="596"/>
+      <source>Tank pump</source>
+      <translation>タンクポンプ</translation>
+    </message>
+    <message id="controlcard_generator_subcard_button_manual_stop">
+      <location filename="../../components/GeneratorManualControlButton.qml" line="34"/>
+      <source>Manual Stop</source>
+      <translation>手動停止</translation>
+    </message>
+    <message id="controlcard_generator_subcard_button_manual_start">
+      <location filename="../../components/GeneratorManualControlButton.qml" line="37"/>
+      <source>Manual Start</source>
+      <translation>手動開始</translation>
+    </message>
+    <message id="evcs_autostart">
+      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="22"/>
+      <source>Autostart</source>
+      <translation>自動開始</translation>
+    </message>
+    <message id="settings_access_level">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="67"/>
+      <source>Access level</source>
+      <translation>アクセスレベル</translation>
+    </message>
+    <message id="settings_access_user">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="72"/>
+      <source>User</source>
+      <translation>ユーザー</translation>
+    </message>
+    <message id="settings_access_user_installer">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="74"/>
+      <source>User &amp; Installer</source>
+      <translation>ユーザーと設置者</translation>
+    </message>
+    <message id="settings_access_superuser">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="76"/>
+      <source>Superuser</source>
+      <translation>スーパーユーザー</translation>
+    </message>
+    <message id="settings_access_service">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="78"/>
+      <source>Service</source>
+      <translation>サービス</translation>
+    </message>
+    <message id="settings_dvcc_switch_reset_vebus_after_disabling_dvcc">
+      <location filename="../../pages/settings/DvccCommonSettings.qml" line="23"/>
+      <source>Make sure to also reset the VE.Bus system after disabling DVCC</source>
+      <translation>DVCCを無効にした後、VE.Busシステムもリセットしてください</translation>
+    </message>
+    <message id="settings_dvcc_limit_charge_current">
+      <location filename="../../pages/settings/DvccCommonSettings.qml" line="37"/>
+      <source>Limit charge current</source>
+      <translation>充電電流を制限</translation>
+    </message>
+    <message id="settings_dvcc_max_charge_current">
+      <location filename="../../pages/settings/DvccCommonSettings.qml" line="49"/>
+      <source>Maximum charge current</source>
+      <translation>最大充電電流</translation>
+    </message>
+    <message id="generator_condition_use_value_to_start_stop">
+      <location filename="../../pages/settings/GeneratorCondition.qml" line="23"/>
+      <source>Use %1 value to start/stop</source>
+      <translation>開始/停止に%1の値を使用</translation>
+    </message>
+    <message id="generator_condition_start_when_property_is_higher_than">
+      <location filename="../../pages/settings/GeneratorCondition.qml" line="30"/>
+      <source>Start when %1 is higher than</source>
+      <translation>%1がより高い場合に開始</translation>
+    </message>
+    <message id="generator_condition_start_when_property_is_lower_than">
+      <location filename="../../pages/settings/GeneratorCondition.qml" line="33"/>
+      <source>Start when %1 is lower than</source>
+      <translation>%1がより低い場合に開始</translation>
+    </message>
+    <message id="generator_condition_stop_when_property_is_higher_than">
+      <location filename="../../pages/settings/GeneratorCondition.qml" line="38"/>
+      <source>Stop when %1 is higher than</source>
+      <translation>%1がより高い場合に停止</translation>
+    </message>
+    <message id="generator_condition_stop_when_property_is_lower_than">
+      <location filename="../../pages/settings/GeneratorCondition.qml" line="41"/>
+      <source>Stop when %1 is lower than</source>
+      <translation>%1がより低い場合に停止</translation>
+    </message>
+    <message id="settings_fronius_remove_ip_address">
+      <location filename="../../pages/settings/IpAddressListView.qml" line="84"/>
+      <source>Remove IP address?</source>
+      <translation>IPアドレスを削除しますか？</translation>
+    </message>
+    <message id="settings_dvcc_max">
+      <location filename="../../pages/settings/PageChargeCurrentLimits.qml" line="71"/>
+      <source>Max: %1</source>
+      <translation>最大: %1</translation>
+    </message>
+    <message id="settings_deviceinfo_connection">
+      <location filename="../../pages/settings/PageDeviceInfo.qml" line="24"/>
+      <source>Connection</source>
+      <translation>接続</translation>
+    </message>
+    <message id="settings_deviceinfo_product">
+      <location filename="../../pages/settings/PageDeviceInfo.qml" line="31"/>
+      <source>Product</source>
+      <translation>製品</translation>
+    </message>
+    <message id="iochannel_name">
+      <location filename="../../components/listitems/ListIOChannelNameField.qml" line="11"/>
+      <source>Name</source>
+      <translation>名前</translation>
+    </message>
+    <message id="settings_deviceinfo_product_id">
+      <location filename="../../pages/settings/PageDeviceInfo.qml" line="49"/>
+      <source>Product ID</source>
+      <translation>製品ID</translation>
+    </message>
+    <message id="settings_deviceinfo_hardware_version">
+      <location filename="../../pages/settings/PageDeviceInfo.qml" line="63"/>
+      <source>Hardware version</source>
+      <translation>ハードウエアバージョン</translation>
+    </message>
+    <message id="settings_deviceinfo_device_name">
+      <location filename="../../pages/settings/PageDeviceInfo.qml" line="84"/>
+      <source>Device name</source>
+      <translation>デバイス名</translation>
+    </message>
+    <message id="settings_remote_switch_control_disabled">
+      <location filename="../../components/listitems/ListGeneratorError.qml" line="17"/>
+      <source>Remote switch control disabled</source>
+      <translation>リモートスイッチ制御が無効</translation>
+    </message>
+    <message id="settings_generator_in_fault_condition">
+      <location filename="../../components/listitems/ListGeneratorError.qml" line="19"/>
+      <source>Generator in fault condition</source>
+      <translation>発電機が故障状態</translation>
+    </message>
+    <message id="settings_generator_not_detected">
+      <location filename="../../components/listitems/ListGeneratorError.qml" line="21"/>
+      <source>Generator not detected at AC input</source>
+      <translation>AC入力で発電機が検出されません</translation>
+    </message>
+    <message id="settings_page_run_time_and_service_accumulated_running_time">
+      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="141"/>
+      <source>Accumulated running time since last test run</source>
+      <translation>最終テスト運転からの累積運転時間</translation>
+    </message>
+    <message id="settings_page_run_time_and_service_time_to_next_test_run">
+      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="117"/>
+      <source>Time to next test run</source>
+      <translation>次のテスト運転までの時間</translation>
+    </message>
+    <message id="settings_page_run_time_and_service_running_now">
+      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="134"/>
+      <source>Running now</source>
+      <translation>現在稼働中</translation>
+    </message>
+    <message id="common_words_manual_start">
+      <location filename="../../components/CommonWords.qml" line="318"/>
+      <source>Manual start</source>
+      <translation>手動開始</translation>
+    </message>
+    <message id="page_generator_conditions_start_generator">
+      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="74"/>
+      <source>Start generator</source>
+      <translation>発電機を開始</translation>
+    </message>
+    <message id="settings_page_run_time_and_service_daily_run_time">
+      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="70"/>
+      <source>Daily run time</source>
+      <translation>1日の運転時間</translation>
+    </message>
+    <message id="common_words_value_must_be_greater_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="577"/>
+      <source>Value must be greater than stop value</source>
+      <translation>値は停止値より大きくする必要があります</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="580"/>
+      <source>Value must be lower than start value</source>
+      <translation>値は開始値より小さくする必要があります</translation>
+    </message>
+    <message id="settings_minmax_acout_max_power">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="124"/>
+      <source>AC output</source>
+      <translation>AC出力</translation>
+    </message>
+    <message id="page_generator_ac_load_use_ac_load">
+      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="25"/>
+      <source>Use AC Load to start/stop</source>
+      <translation>開始/停止にAC負荷を使用</translation>
+    </message>
+    <message id="page_generator_ac_load_measurement">
+      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="31"/>
+      <source>Measurement</source>
+      <translation>測定</translation>
+    </message>
+    <message id="total_consumption">
+      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="35"/>
+      <source>Total consumption</source>
+      <translation>総消費量</translation>
+    </message>
+    <message id="total_ac_out">
+      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="37"/>
+      <source>Inverter total AC out</source>
+      <translation>インバーターAC出力合計</translation>
+    </message>
+    <message id="ac_out_highest_phase">
+      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="39"/>
+      <source>Inverter AC out highest phase</source>
+      <translation>インバーターAC出力最高位相</translation>
+    </message>
+    <message id="start_when_power_is_higher_than">
+      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="46"/>
+      <source>Start when power is higher than</source>
+      <translation>電力がより高い場合に開始</translation>
+    </message>
+    <message id="stop_when_power_is_lower_than">
+      <location filename="../../pages/settings/PageGeneratorAcLoad.qml" line="78"/>
+      <source>Stop when power is lower than</source>
+      <translation>電力がより低い場合に停止</translation>
+    </message>
+    <message id="settings_system_battery_monitor">
+      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="23"/>
+      <source>Battery monitor</source>
+      <translation>バッテリーモニター</translation>
+    </message>
+    <message id="settings_system_unavailable_monitor">
+      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="26"/>
+      <source>Unavailable monitor, set another</source>
+      <translation>モニターが利用できません、別のものを設定してください</translation>
+    </message>
+    <message id="page_generator_conditions_on_loss_of_communication">
+      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="68"/>
+      <source>On loss of communication</source>
+      <translation>通信喪失時</translation>
+    </message>
+    <message id="page_generator_conditions_stop_generator">
+      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="72"/>
+      <source>Stop generator</source>
+      <translation>発電機を停止</translation>
+    </message>
+    <message id="page_generator_conditions_keep_generator_running">
+      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="76"/>
+      <source>Keep generator running</source>
+      <translation>発電機を稼働し続ける</translation>
+    </message>
+    <message id="page_generator_conditions_stop_generator_when_ac_input_available">
+      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="82"/>
+      <source>Stop generator when AC-input is available</source>
+      <translation>AC入力が利用可能な場合に発電機を停止</translation>
+    </message>
+    <message id="page_generator_conditions_battery_soc">
+      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="105"/>
+      <source>Battery SOC</source>
+      <translation>バッテリーSOC</translation>
+    </message>
+    <message id="settings_inverter_high_temperature">
+      <location filename="../../data/Generators.qml" line="83"/>
+      <source>Inverter high temperature</source>
+      <translation>インバーター高温</translation>
+    </message>
+    <message id="page_generator_conditions_start_on_high_temperature_warning">
+      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="141"/>
+      <source>Start on high temperature warning</source>
+      <translation>高温警告時に開始</translation>
+    </message>
+    <message id="page_generator_conditions_start_on_overload_warning">
+      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="150"/>
+      <source>Start on overload warning</source>
+      <translation>過負荷警告時に開始</translation>
+    </message>
+    <message id="generator_periodic_run">
+      <location filename="../../data/Generators.qml" line="65"/>
+      <source>Periodic run</source>
+      <translation>定期運転</translation>
+    </message>
+    <message id="run_interval">
+      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="25"/>
+      <source>Run interval</source>
+      <translation>運転間隔</translation>
+    </message>
+    <message id="page_generator_test_run_days">
+      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="28"/>
+      <source>%1 day(s)</source>
+      <translation>%1日</translation>
+    </message>
+    <message id="page_generator_test_run_skip_run">
+      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="36"/>
+      <source>Skip run if has been running for</source>
+      <translation>運転していた場合、実行をスキップ</translation>
+    </message>
+    <message id="page_generator_test_run_start_always">
+      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="40"/>
+      <source>Start always</source>
+      <translation>常に開始</translation>
+    </message>
+    <message id="page_generator_test_run_run_interval_start_date">
+      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="52"/>
+      <source>Run interval start date</source>
+      <translation>運転間隔開始日</translation>
+    </message>
+    <message id="page_generator_test_run_run_duration">
+      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="63"/>
+      <source>Run duration (hh:mm)</source>
+      <translation>運転時間 (時:分)</translation>
+    </message>
+    <message id="page_generator_test_run_run_until_fully_charged">
+      <location filename="../../pages/settings/PageGeneratorTestRun.qml" line="72"/>
+      <source>Run until battery is fully charged</source>
+      <translation>バッテリーが完全に充電されるまで運転</translation>
+    </message>
+    <message id="settings_gps_ok_fix">
+      <location filename="../../pages/settings/PageGps.qml" line="26"/>
+      <source>GPS OK (fix)</source>
+      <translation>GPS OK (測位完了)</translation>
+    </message>
+    <message id="settings_gps_ok_no_fix">
+      <location filename="../../pages/settings/PageGps.qml" line="29"/>
+      <source>GPS connected, but no GPS fix</source>
+      <translation>GPS接続済み、ただし測位未完了</translation>
+    </message>
+    <message id="settings_gps_not_connected">
+      <location filename="../../pages/settings/PageGps.qml" line="32"/>
+      <source>No GPS connected</source>
+      <translation>GPS未接続</translation>
+    </message>
+    <message id="settings_gps_latitude">
+      <location filename="../../pages/settings/PageGps.qml" line="38"/>
+      <source>Latitude</source>
+      <translation>緯度</translation>
+    </message>
+    <message id="settings_gps_longitude">
+      <location filename="../../pages/settings/PageGps.qml" line="45"/>
+      <source>Longitude</source>
+      <translation>経度</translation>
+    </message>
+    <message id="settings_gps_speed_kmh">
+      <location filename="../../pages/settings/PageGps.qml" line="60"/>
+      <source>%1 km/h</source>
+      <extracomment>GPS speed data, in kilometers per hour</extracomment>
+      <translation>%1 km/h</translation>
+    </message>
+    <message id="settings_gps_speed_mph">
+      <location filename="../../pages/settings/PageGps.qml" line="64"/>
+      <source>%1 mph</source>
+      <extracomment>GPS speed data, in miles per hour</extracomment>
+      <translation>%1 mph</translation>
+    </message>
+    <message id="settings_gps_speed_kt">
+      <location filename="../../pages/settings/PageGps.qml" line="68"/>
+      <source>%1 kt</source>
+      <extracomment>GPS speed data, in knots</extracomment>
+      <translation>%1 kt</translation>
+    </message>
+    <message id="settings_gps_speed_ms">
+      <location filename="../../pages/settings/PageGps.qml" line="72"/>
+      <source>%1 m/s</source>
+      <extracomment>GPS speed data, in meters per second</extracomment>
+      <translation>%1 m/s</translation>
+    </message>
+    <message id="settings_gps_course">
+      <location filename="../../pages/settings/PageGps.qml" line="79"/>
+      <source>Course</source>
+      <translation>進行方向</translation>
+    </message>
+    <message id="settings_gps_altitude">
+      <location filename="../../pages/settings/PageGps.qml" line="87"/>
+      <source>Altitude</source>
+      <translation>高度</translation>
+    </message>
+    <message id="settings_gps_num_satellites">
+      <location filename="../../pages/settings/PageGps.qml" line="96"/>
+      <source>Number of satellites</source>
+      <translation>衛星数</translation>
+    </message>
+    <message id="settings_ess_debug_grid_setpoint">
+      <location filename="../../pages/settings/PageHub4Debug.qml" line="15"/>
+      <source>Grid Setpoint</source>
+      <translation>電力網の設定値</translation>
+    </message>
+    <message id="settings_ess_debug_ac_in_setpoint">
+      <location filename="../../pages/settings/PageHub4Debug.qml" line="48"/>
+      <source>AC-In setpoint</source>
+      <translation>AC入力設定値</translation>
+    </message>
+    <message id="settings_ess_debug_limits_i">
+      <location filename="../../pages/settings/PageHub4Debug.qml" line="76"/>
+      <source>Limits (I)</source>
+      <translation>制限 (I)</translation>
+    </message>
+    <message id="settings_ess_debug_limits_p">
+      <location filename="../../pages/settings/PageHub4Debug.qml" line="100"/>
+      <source>Limits (P)</source>
+      <translation>制限 (P)</translation>
+    </message>
+    <message id="settings_batteries_battery_visible">
+      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="15"/>
+      <source>Visible</source>
+      <translation>表示</translation>
+    </message>
+    <message id="settings_batteries_battery_hidden">
+      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="17"/>
+      <source>Hidden</source>
+      <translation>非表示</translation>
+    </message>
+    <message id="settings_batteries_battery_auxiliary_measurement">
+      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="62"/>
+      <source>%1 (Auxiliary measurement)</source>
+      <translation>%1 (補助測定値)</translation>
+    </message>
+    <message id="settings_batteries_battery_output">
+      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="64"/>
+      <source>%1 (Output %2)</source>
+      <translation>%1 (出力 %2)</translation>
+    </message>
+    <message id="settings_briefview_center_active_battery_monitor">
+      <location filename="../../components/listitems/ListBriefCenterDetails.qml" line="27"/>
+      <source>Active battery monitor</source>
+      <translation>アクティブバッテリーモニター</translation>
+    </message>
+    <message id="settings_system_enter_user_defined_name">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="50"/>
+      <source>Enter name</source>
+      <translation>名前を入力</translation>
+    </message>
+    <message id="settings_continuous_scan">
+      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="46"/>
+      <source>Continuous scanning</source>
+      <translation>連続スキャン</translation>
+    </message>
+    <message id="settings_io_bluetooth_adapters">
+      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="59"/>
+      <source>Bluetooth adapters</source>
+      <translation>Bluetoothアダプター</translation>
+    </message>
+    <message id="settings_pincode">
+      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="42"/>
+      <source>Pincode</source>
+      <translation>PINコード</translation>
+    </message>
+    <message id="settings_bluetooth_remove_existing_pairing_info">
+      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="52"/>
+      <source>It might be necessary to remove existing pairing information before connecting.</source>
+      <translation>接続する前に、既存のペアリング情報を削除する必要がある場合があります。</translation>
+    </message>
+    <message id="settings_cgwacs_phase_type">
+      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="63"/>
+      <source>Phase type</source>
+      <translation>相タイプ</translation>
+    </message>
+    <message id="settings_single_phase">
+      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="68"/>
+      <source>Single phase</source>
+      <translation>単相</translation>
+    </message>
+    <message id="settings_multi_phase">
+      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="70"/>
+      <source>Multi phase</source>
+      <translation>多相</translation>
+    </message>
+    <message id="settings_pv_inverter_on_phase_2">
+      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="77"/>
+      <source>PV inverter on phase 2</source>
+      <translation>フェーズ2のPVインバーター</translation>
+    </message>
+    <message id="settings_cgwacs_pv_inverter_l2_position">
+      <location filename="../../pages/settings/PageSettingsCGwacs.qml" line="87"/>
+      <source>PV inverter on phase 2 Position</source>
+      <translation>フェーズ2のPVインバーター位置</translation>
+    </message>
+    <message id="settings_canbus_profile">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="46"/>
+      <source>CAN-bus profile</source>
+      <translation>CANバスプロファイル</translation>
+    </message>
+    <message id="settings_canbus_vecan_and_can_bus_bms">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="42"/>
+      <source>VE.Can &amp; CAN-bus BMS (250 kbit/s)</source>
+      <translation>VE.Can &amp; CANバスBMS (250 kbit/s)</translation>
+    </message>
+    <message id="settings_oceanvolt">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="66"/>
+      <source>Oceanvolt (250 kbit/s)</source>
+      <translation>Oceanvolt (250 kbit/s)</translation>
+    </message>
+    <message id="settings_rvc">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="72"/>
+      <source>RV-C (250 kbit/s)</source>
+      <translation>RV-C (250 kbit/s)</translation>
+    </message>
+    <message id="settings_up_bu_no_services">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="78"/>
+      <source>Up, but no services (250 kbit/s)</source>
+      <translation>起動済み、ただしサービスなし (250 kbit/s)</translation>
+    </message>
+    <message id="common_words_devices">
+      <location filename="../../components/CommonWords.qml" line="172"/>
+      <source>Devices</source>
+      <translation>デバイス</translation>
+    </message>
+    <message id="settings_canbus_nmea2000out">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="67"/>
+      <source>NMEA2000-out</source>
+      <translation>NMEA2000出力</translation>
+    </message>
+    <message id="settings_canbus_unique_id_select">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="94"/>
+      <source>Unique identity number selector</source>
+      <translation>固有識別番号セレクター</translation>
+    </message>
+    <message id="settings_canbus_unique_id_wait">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="106"/>
+      <source>Please wait, changing and checking the unique number takes a while</source>
+      <translation>しばらくお待ちください。固有番号の変更と確認には時間がかかります。</translation>
+    </message>
+    <message id="settings_canbus_unique_id_vecan_description">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="99"/>
+      <source>Above selector sets which block of unique identity numbers to use for the NAME Unique Identity Numbers in the PGN 60928 NAME field. Change only when using multiple GX Devices in one VE.Can network.</source>
+      <translation>上記のセレクターは、PGN 60928 NAMEフィールドのNAME固有識別番号に使用する固有識別番号のブロックを設定します。1つのVE.Canネットワークで複数のGXデバイスを使用する場合にのみ変更してください。</translation>
+    </message>
+    <message id="settings_canbus_unique_id_rvc_description">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="102"/>
+      <source>Above selector sets which block of unique identity numbers to use for the Serial number in the DGN 60928 ADDRESS_CLAIM field. Change only when using multiple GX Devices in one RV-C network.</source>
+      <translation>上記のセレクターは、DGN 60928 ADDRESS_CLAIMフィールドのシリアル番号に使用する固有識別番号のブロックを設定します。1つのRV-Cネットワークで複数のGXデバイスを使用する場合にのみ変更してください。</translation>
+    </message>
+    <message id="settings_canbus_unique_id_choose">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="123"/>
+      <source>Check Unique id numbers</source>
+      <translation>固有ID番号を確認</translation>
+    </message>
+    <message id="settings_canbus_unique_id_conflict">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="132"/>
+      <source>There is another device connected with this unique number, please select a new number.</source>
+      <translation>この固有番号で別のデバイスが接続されています。新しい番号を選択してください。</translation>
+    </message>
+    <message id="settings_canbus_unique_id_ok">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="135"/>
+      <source>OK: No other device is connected with this unique number.</source>
+      <translation>OK: この固有番号で他のデバイスは接続されていません。</translation>
+    </message>
+    <message id="common_words_network_status">
+      <location filename="../../components/CommonWords.qml" line="362"/>
+      <source>Network status</source>
+      <translation>ネットワークステータス</translation>
+    </message>
+    <message id="settings_adaptive_brightness">
+      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="20"/>
+      <source>Adaptive brightness</source>
+      <translation>自動輝度調整</translation>
+    </message>
+    <message id="settings_brightness">
+      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="28"/>
+      <source>Brightness</source>
+      <translation>明るさ</translation>
+    </message>
+    <message id="settings_display_off_time">
+      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="36"/>
+      <source>Display off time</source>
+      <translation>ディスプレイオフ時間</translation>
+    </message>
+    <message id="settings_displayoff_10sec">
+      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="42"/>
+      <source>10 sec</source>
+      <translation>10秒</translation>
+    </message>
+    <message id="settings_displayoff_30sec">
+      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="44"/>
+      <source>30 sec</source>
+      <translation>30秒</translation>
+    </message>
+    <message id="settings_1_min">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="115"/>
+      <source>1 min</source>
+      <translation>1分</translation>
+    </message>
+    <message id="settings_10_min">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="119"/>
+      <source>10 min</source>
+      <translation>10分</translation>
+    </message>
+    <message id="settings_30_min">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="123"/>
+      <source>30 min</source>
+      <translation>30分</translation>
+    </message>
+    <message id="settings_startpage_timeout_never">
+      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="14"/>
+      <source>Never</source>
+      <translation>決してなし</translation>
+    </message>
+    <message id="settings_display_dark_mode">
+      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="65"/>
+      <source>Dark</source>
+      <extracomment>Dark colors mode</extracomment>
+      <translation>ダーク</translation>
+    </message>
+    <message id="settings_display_light_mode">
+      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="68"/>
+      <source>Light</source>
+      <extracomment>Light colors mode</extracomment>
+      <translation>ライト</translation>
+    </message>
+    <message id="settings_language">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="150"/>
+      <source>Language</source>
+      <translation>言語</translation>
+    </message>
+    <message id="settings_language_changing_language">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="202"/>
+      <source>Changing language</source>
+      <translation>言語の変更</translation>
+    </message>
+    <message id="settings_units_energy">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="40"/>
+      <source>Electrical power display</source>
+      <translation>電力表示</translation>
+    </message>
+    <message id="settings_units_watts">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="44"/>
+      <source>Power (Watts)</source>
+      <translation>電力 (ワット)</translation>
+    </message>
+    <message id="settings_units_amps">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="47"/>
+      <source>Current (Amps)</source>
+      <translation>電流 (アンペア)</translation>
+    </message>
+    <message id="settings_briefview_level">
+      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="176"/>
+      <source>Level %1</source>
+      <extracomment>Level number</extracomment>
+      <translation>レベル %1</translation>
+    </message>
+    <message id="settings_units_celsius">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="21"/>
+      <source>Celsius</source>
+      <translation>℃</translation>
+    </message>
+    <message id="settings_units_fahrenheit">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="23"/>
+      <source>Fahrenheit</source>
+      <translation>°F</translation>
+    </message>
+    <message id="settings_dvcc_instructions">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="18"/>
+      <source>&lt;b&gt;CAUTION:&lt;/b&gt; Read the manual before adjusting.</source>
+      <translation>&lt;b&gt;注意:&lt;/b&gt; 調整する前にマニュアルを読んでください。</translation>
+    </message>
+    <message id="settings_dvcc_limit_managed_battery_charge_voltage">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="39"/>
+      <source>Limit managed battery charge voltage</source>
+      <translation>管理バッテリー充電電圧の制限</translation>
+    </message>
+    <message id="settings_dvcc_max_charge_voltage">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="51"/>
+      <source>Maximum charge voltage</source>
+      <translation>最大充電電圧</translation>
+    </message>
+    <message id="settings_dvcc_shared_voltage_sense">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="61"/>
+      <source>SVS - Shared voltage sense</source>
+      <translation>SVS - 共有電圧検出</translation>
+    </message>
+    <message id="settings_dvcc_shared_temp_sense">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="70"/>
+      <source>STS - Shared temperature sense</source>
+      <translation>STS - 共有温度検出</translation>
+    </message>
+    <message id="settings_tank_unavailable_sensor">
+      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="70"/>
+      <source>Unavailable sensor, set another</source>
+      <translation>センサーが利用できません。別のセンサーを設定してください。</translation>
+    </message>
+    <message id="settings_dvcc_used_sensor">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="120"/>
+      <source>Used sensor</source>
+      <translation>使用中センサー</translation>
+    </message>
+    <message id="settings_dvcc_shared_current_sense">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="131"/>
+      <source>SCS - Shared current sense</source>
+      <translation>SCS - 共有電流検出</translation>
+    </message>
+    <message id="settings_dvcc_scs_status">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="138"/>
+      <source>SCS status</source>
+      <translation>SCSステータス</translation>
+    </message>
+    <message id="settings_dvcc_scs_disabled_external_control">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="146"/>
+      <source>Disabled (external control)</source>
+      <translation>無効 (外部制御)</translation>
+    </message>
+    <message id="settings_dvcc_scs_disabled_no_chargers">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="148"/>
+      <source>Disabled (no chargers)</source>
+      <translation>無効 (充電器なし)</translation>
+    </message>
+    <message id="settings_dvcc_scs_disabled_no_battery_monitor">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="150"/>
+      <source>Disabled (no battery monitor)</source>
+      <translation>無効 (バッテリーモニターなし)</translation>
+    </message>
+    <message id="settings_dvcc_auto_selection">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="160"/>
+      <source>Automatic selection</source>
+      <translation>自動選択</translation>
+    </message>
+    <message id="settings_dvcc_no_bms_control">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="162"/>
+      <source>No BMS control</source>
+      <translation>BMS制御なし</translation>
+    </message>
+    <message id="settings_dvcc_controlling_bms">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="166"/>
+      <source>Controlling BMS</source>
+      <translation>BMSを制御中</translation>
+    </message>
+    <message id="settings_dvcc_unavailable_bms">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="172"/>
+      <source>Unavailable, set another</source>
+      <extracomment>Shown when BMS instance is invalid</extracomment>
+      <translation>利用できません。別のものを設定してください。</translation>
+    </message>
+    <message id="settings_dvcc_auto_selected">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="202"/>
+      <source>Auto selected</source>
+      <translation>自動選択済み</translation>
+    </message>
+    <message id="settings_build_date_time">
+      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="27"/>
+      <source>Build date/time</source>
+      <translation>ビルド日時</translation>
+    </message>
+    <message id="settings_online_updates">
+      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="35"/>
+      <source>Online updates</source>
+      <translation>オンラインアップデート</translation>
+    </message>
+    <message id="settings_install_firmware_from_sd_usb">
+      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="43"/>
+      <source>Install firmware from SD/USB</source>
+      <translation>SD/USBからファームウェアをインストール</translation>
+    </message>
+    <message id="settings_stored_backup_firmware">
+      <location filename="../../pages/settings/PageSettingsFirmware.qml" line="51"/>
+      <source>Stored backup firmware</source>
+      <translation>保存済みバックアップファームウェア</translation>
+    </message>
+    <message id="settings_firmware_check_for_updates_on_sd_usb">
+      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="19"/>
+      <source>Check for updates on SD/USB</source>
+      <translation>SD/USBでアップデートを確認</translation>
+    </message>
+    <message id="settings_firmware_found">
+      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="27"/>
+      <source>Firmware found</source>
+      <translation>ファームウェアが見つかりました</translation>
+    </message>
+    <message id="settings_firmware_offline_installing">
+      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="32"/>
+      <source>Installing %1</source>
+      <extracomment>%1 = firmware version</extracomment>
+      <translation>%1をインストール中</translation>
+    </message>
+    <message id="settings_firmware_online_press_to_update_to">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="90"/>
+      <source>Press to update to %1</source>
+      <extracomment>%1 = firmware version</extracomment>
+      <translation>押して%1にアップデート</translation>
+    </message>
+    <message id="settings_firmware_build_date_time">
+      <location filename="../../pages/settings/PageSettingsFirmwareOffline.qml" line="50"/>
+      <source>Firmware build date/time</source>
+      <translation>ファームウェアビルド日時</translation>
+    </message>
+    <message id="settings_auto_update">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="19"/>
+      <source>Auto update</source>
+      <translation>自動アップデート</translation>
+    </message>
+    <message id="settings_firmware_check_only">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="25"/>
+      <source>Check only</source>
+      <translation>確認のみ</translation>
+    </message>
+    <message id="settings_firmware_check_and_download_only">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="27"/>
+      <source>Check and download only</source>
+      <translation>確認とダウンロードのみ</translation>
+    </message>
+    <message id="settings_firmware_check_and_update">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="29"/>
+      <source>Check and update</source>
+      <translation>確認と更新</translation>
+    </message>
+    <message id="settings_update_feed">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="35"/>
+      <source>Update feed</source>
+      <translation>更新フィード</translation>
+    </message>
+    <message id="common_words_image_type">
+      <location filename="../../components/CommonWords.qml" line="267"/>
+      <source>Image type</source>
+      <translation>画像タイプ</translation>
+    </message>
+    <message id="iochannel_invert_normal">
+      <location filename="../../pages/settings/devicelist/iochannel/PageGenericInput.qml" line="40"/>
+      <source>Normal</source>
+      <extracomment>The firmware type for normal images</extracomment>
+      <translation>普通</translation>
+    </message>
+    <message id="common_words_firmware_type_large">
+      <location filename="../../components/CommonWords.qml" line="220"/>
+      <source>Large</source>
+      <extracomment>The firmware type for large images</extracomment>
+      <translation>大</translation>
+    </message>
+    <message id="settings_firmware_check_for_updates">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="68"/>
+      <source>Check for updates</source>
+      <translation>アップデートを確認</translation>
+    </message>
+    <message id="settings_firmware_update_available">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="76"/>
+      <source>Update available</source>
+      <translation>更新が利用可能です</translation>
+    </message>
+    <message id="settings_firmware_online_installing_progress">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="82"/>
+      <source>Installing %1 %2%</source>
+      <extracomment>Firmware update progress. %1 = firmware version, %2 = current update progress</extracomment>
+      <translation>%1 をインストール中 %2%%</translation>
+    </message>
+    <message id="settings_firmware_update_build_date_time">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="109"/>
+      <source>Update build date/time</source>
+      <translation>ビルド日時更新</translation>
+    </message>
+    <message id="page_settings_fronius_inverters">
+      <location filename="../../pages/settings/PageSettingsFronius.qml" line="30"/>
+      <source>Inverters</source>
+      <translation>インバーター</translation>
+    </message>
+    <message id="page_settings_fronius_find_pv_inverters">
+      <location filename="../../pages/settings/PageSettingsFronius.qml" line="36"/>
+      <source>Find PV inverters</source>
+      <translation>PVインバーターを検索</translation>
+    </message>
+    <message id="page_settings_fronius_detected_ip_addresses">
+      <location filename="../../pages/settings/PageSettingsFronius.qml" line="44"/>
+      <source>Detected IP addresses</source>
+      <translation>検出されたIPアドレス</translation>
+    </message>
+    <message id="page_settings_shelly_add_ip_address_manually">
+      <location filename="../../pages/settings/PageSettingsShelly.qml" line="111"/>
+      <source>Add IP address manually</source>
+      <translation>IPアドレスを手動追加</translation>
+    </message>
+    <message id="page_settings_fronius_tcp_port">
+      <location filename="../../pages/settings/PageSettingsFronius.qml" line="56"/>
+      <source>TCP port</source>
+      <translation>TCPポート</translation>
+    </message>
+    <message id="page_settings_fronius_inverter_multiphase">
+      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="36"/>
+      <source>Multiphase</source>
+      <translation>多相</translation>
+    </message>
+    <message id="page_settings_fronius_inverter_l1">
+      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="46"/>
+      <source>L1</source>
+      <translation>L1</translation>
+    </message>
+    <message id="page_settings_fronius_inverter_l2">
+      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="48"/>
+      <source>L2</source>
+      <translation>L2</translation>
+    </message>
+    <message id="page_settings_fronius_inverter_l3">
+      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="50"/>
+      <source>L3</source>
+      <translation>L3</translation>
+    </message>
+    <message id="page_settings_fronius_inverter_split_phase">
+      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="52"/>
+      <source>Split-phase (L1+L2)</source>
+      <translation>分割相 (L1+L2)</translation>
+    </message>
+    <message id="page_settings_fronius_inverter_show">
+      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="59"/>
+      <source>Show</source>
+      <translation>表示</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_mp">
+      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="46"/>
+      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="102"/>
+      <source>AC-In1 MP</source>
+      <translation>AC入力1 MP</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_l1">
+      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="108"/>
+      <source>AC-In1 L%1</source>
+      <translation>AC入力1 L%1</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in1_unknown">
+      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="112"/>
+      <source>AC-In1 --</source>
+      <translation>AC入力1 --</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_out_mp">
+      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="64"/>
+      <source>AC-Out MP</source>
+      <translation>AC出力 MP</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_out_l">
+      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="70"/>
+      <source>AC-Out L%1</source>
+      <translation>AC出力 L%1</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_out_phase_unknown">
+      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="74"/>
+      <source>AC-Out --</source>
+      <translation>AC出力 --</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in2_mp">
+      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="83"/>
+      <source>AC-In2 MP</source>
+      <translation>AC入力2 MP</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in2_l1">
+      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="89"/>
+      <source>AC-In2 L%1</source>
+      <translation>AC入力2 L%1</translation>
+    </message>
+    <message id="page_setting_fronius_inverters_ac_in2_phase_unknown">
+      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="93"/>
+      <source>AC-In2 --</source>
+      <translation>AC入力2 --</translation>
+    </message>
+    <message id="settings_remote_support">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="299"/>
+      <source>Remote support</source>
+      <translation>リモートサポート</translation>
+    </message>
+    <message id="settings_remote_support_tunnel">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="305"/>
+      <source>Remote support tunnel</source>
+      <translation>リモートサポートトンネル</translation>
+    </message>
+    <message id="settings_remote_ip_and_support">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="314"/>
+      <source>Remote support IP and port</source>
+      <translation>リモートサポートIPとポート</translation>
+    </message>
+    <message id="reboot_button_reboot_now">
+      <location filename="../../components/listitems/ListRebootButton.qml" line="15"/>
+      <source>Reboot now</source>
+      <translation>今すぐ再起動</translation>
+    </message>
+    <message id="settings_audible_alarm">
+      <location filename="../../pages/settings/PageSettingsAlarmsAndFeedback.qml" line="18"/>
+      <source>Audible alarm</source>
+      <translation>音声アラーム</translation>
+    </message>
+    <message id="settings_demo_mode">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="264"/>
+      <source>Demo mode</source>
+      <translation>デモモード</translation>
+    </message>
+    <message id="page_settings_demo_ess">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="271"/>
+      <source>ESS demo</source>
+      <translation>ESSデモ</translation>
+    </message>
+    <message id="page_settings_demo_1">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="273"/>
+      <source>Boat/Motorhome demo 1</source>
+      <translation>ボート/モーターホームデモ1</translation>
+    </message>
+    <message id="page_settings_demo_2">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="275"/>
+      <source>Boat/Motorhome demo 2</source>
+      <translation>ボート/モーターホームデモ2</translation>
+    </message>
+    <message id="settings_demo_mode_caption">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="279"/>
+      <source>Starting demo mode will change some settings and the user interface will be unresponsive for a moment.</source>
+      <translation>デモモードを開始すると、設定が一部変更され、UIが一時的に応答しなくなります。</translation>
+    </message>
+    <message id="page_settings_generator_conditions">
+      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="34"/>
+      <source>Conditions</source>
+      <translation>条件</translation>
+    </message>
+    <message id="page_settings_generator_minimum_run_time">
+      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="40"/>
+      <source>Minimum run time</source>
+      <translation>最小稼働時間</translation>
+    </message>
+    <message id="page_settings_generator_warm_up_time">
+      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="66"/>
+      <source>Warm-up time</source>
+      <translation>ウォームアップ時間</translation>
+    </message>
+    <message id="page_settings_generator_cool_down_time">
+      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="77"/>
+      <source>Cool-down time</source>
+      <translation>クールダウン時間</translation>
+    </message>
+    <message id="page_settings_generator_detect_generator_at_ac_input">
+      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="105"/>
+      <source>Detect generator at AC input</source>
+      <translation>AC入力で発電機を検出</translation>
+    </message>
+    <message id="page_settings_generator_detect_generator_not_set">
+      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="113"/>
+      <source>None of the AC inputs is set to generator. Go to the system setup page and set the correct AC input to generator in order to enable this functionality.</source>
+      <translation>AC入力がいずれも発電機に設定されていません。この機能を有効にするには、システム設定ページで正しいAC入力を発電機に設定してください。</translation>
+    </message>
+    <message id="page_settings_generator_detect_generator_set">
+      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="117"/>
+      <source>An alarm will be triggered when no power from the generator is detected at the inverter AC input. Make sure that the correct AC input is set to generator on the system setup page.</source>
+      <translation>インバーターのAC入力で発電機からの電力が検出されない場合、アラームが作動します。システム設定ページで正しいAC入力が発電機に設定されていることを確認してください。</translation>
+    </message>
+    <message id="page_settings_generator_quiet_hours_start_time">
+      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="173"/>
+      <source>Quiet hours start time</source>
+      <translation>静音時間開始</translation>
+    </message>
+    <message id="page_settings_generator_quiet_hours_end_time">
+      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="181"/>
+      <source>Quiet hours end time</source>
+      <translation>静音時間終了</translation>
+    </message>
+    <message id="page_settings_generator_run_time_and_service">
+      <location filename="../../components/PageGensetModel.qml" line="349"/>
+      <location filename="../../pages/settings/PageGenerator.qml" line="118"/>
+      <source>Run time and service</source>
+      <translation>稼働時間とサービス</translation>
+    </message>
+    <message id="page_settings_run_time_and_service_reset_daily_run_time_counters">
+      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="90"/>
+      <source>Reset daily run time counters</source>
+      <translation>日次稼働時間カウンターをリセット</translation>
+    </message>
+    <message id="page_settings_run_time_and_service_runtime_counter_reset">
+      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="100"/>
+      <source>The daily runtime counter has been reset</source>
+      <translation>日次稼働時間カウンターはリセットされました</translation>
+    </message>
+    <message id="page_settings_run_time_and_service_runtime_counter_cant_reset_while_running">
+      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="103"/>
+      <source>It is not possible to modify the counters while the generator is running</source>
+      <translation>発電機稼働中はカウンターを修正できません</translation>
+    </message>
+    <message id="page_settings_generator_service_interval">
+      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="160"/>
+      <source>Generator service interval (hours)</source>
+      <translation>発電機サービス間隔 (時間)</translation>
+    </message>
+    <message id="page_settings_run_time_and_service_service_time_interval">
+      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="168"/>
+      <source>Service time interval set to %1h. Use the 'Reset service timer' button to reset the service timer.</source>
+      <translation>サービス時間間隔は%1hに設定されました。「サービスタイマーをリセット」ボタンでタイマーをリセットしてください。</translation>
+    </message>
+    <message id="page_settings_run_time_and_service_reset_service_timer">
+      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="179"/>
+      <source>Reset service timer</source>
+      <translation>サービスタイマーをリセット</translation>
+    </message>
+    <message id="settings_gps_format">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="71"/>
+      <source>Format</source>
+      <extracomment>Format of reported GPS data</extracomment>
+      <translation>形式</translation>
+    </message>
+    <message id="settings_gps_format_dms_example">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="77"/>
+      <source>52° 20' 41.6" N, 5° 13' 12.3" E</source>
+      <extracomment>Example of GPS data in the 'Degrees, Minutes, Seconds' format</extracomment>
+      <translation>52° 20' 41.6" N, 5° 13' 12.3" E</translation>
+    </message>
+    <message id="settings_gps_format_dd_example">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="80"/>
+      <source>52.34489, 5.22008</source>
+      <extracomment>Example of GPS data in the 'Decimal Degrees' format</extracomment>
+      <translation>52.34489, 5.22008</translation>
+    </message>
+    <message id="settings_gps_format_dm_example">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="83"/>
+      <source>52° 20.693 N, 5° 13.205 E</source>
+      <extracomment>Example of GPS data in the 'Degrees Minutes' format</extracomment>
+      <translation>52° 20.693 N, 5° 13.205 E</translation>
+    </message>
+    <message id="settings_gps_speed_unit">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="90"/>
+      <source>Speed Unit</source>
+      <extracomment>Speed unit for reported GPS data</extracomment>
+      <translation>速度単位</translation>
+    </message>
+    <message id="settings_gps_format_mph">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="99"/>
+      <source>Miles per hour</source>
+      <translation>マイル/時</translation>
+    </message>
+    <message id="settings_gps_format_kt">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="101"/>
+      <source>Knots</source>
+      <translation>ノット</translation>
+    </message>
+    <message id="page_settings_gsm_internet">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="52"/>
+      <source>Internet</source>
+      <translation>インターネット</translation>
+    </message>
+    <message id="page_settings_gsm_carrier">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="61"/>
+      <source>Carrier</source>
+      <translation>キャリア</translation>
+    </message>
+    <message id="page_settings_gsm_error_message">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="93"/>
+      <source>It may be necessary to configure the APN settings below in this page, contact your operator for details.
+If that doesn't work, check sim-card in a phone to make sure that there is credit and/or it is registered to be used for data.</source>
+      <translation>このページで下記のAPN設定が必要になる場合があります。詳細については、ご契約の通信事業者にお問い合わせください。
+それでも機能しない場合は、SIMカードを電話で確認し、残高があること、またはデータ通信用に登録されていることを確認してください。</translation>
+    </message>
+    <message id="page_settings_gsm_allow_roaming">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="99"/>
+      <source>Allow roaming</source>
+      <translation>ローミングを許可</translation>
+    </message>
+    <message id="page_settings_gsm_sim_status">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="106"/>
+      <source>Sim status</source>
+      <translation>SIM ステータス</translation>
+    </message>
+    <message id="page_settings_gsm_sim_not_inserted">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="111"/>
+      <source>SIM not inserted</source>
+      <translation>SIM未挿入</translation>
+    </message>
+    <message id="page_settings_gsm_pin_required">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="114"/>
+      <source>PIN required</source>
+      <translation>PINが必要</translation>
+    </message>
+    <message id="page_settings_gsm_puk_required">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="117"/>
+      <source>PUK required</source>
+      <translation>PUKが必要</translation>
+    </message>
+    <message id="page_settings_gsm_sim_failure">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="120"/>
+      <source>SIM failure</source>
+      <translation>SIMエラー</translation>
+    </message>
+    <message id="page_settings_gsm_sim_busy">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="123"/>
+      <source>SIM busy</source>
+      <translation>SIM使用中</translation>
+    </message>
+    <message id="page_settings_gsm_wrong_sim">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="126"/>
+      <source>Wrong SIM</source>
+      <translation>誤ったSIM</translation>
+    </message>
+    <message id="page_settings_gsm_wrong_pin">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="129"/>
+      <source>Wrong PIN</source>
+      <translation>PINが間違っています</translation>
+    </message>
+    <message id="page_settings_gsm_pin">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="198"/>
+      <source>PIN</source>
+      <translation>バッテリー</translation>
+    </message>
+    <message id="page_settings_gsm_apn">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="214"/>
+      <source>APN</source>
+      <translation>APN</translation>
+    </message>
+    <message id="page_settings_gsm_default">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="216"/>
+      <source>Default</source>
+      <translation>デフォルト</translation>
+    </message>
+    <message id="page_settings_gsm_use_default_apn">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="230"/>
+      <source>Use default APN</source>
+      <translation>デフォルトAPNを使用</translation>
+    </message>
+    <message id="page_settings_gsm_apn_name">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="242"/>
+      <source>APN name</source>
+      <translation>APN名</translation>
+    </message>
+    <message id="page_settings_gsm_use_authentication">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="256"/>
+      <source>Use authentication</source>
+      <translation>認証を使用</translation>
+    </message>
+    <message id="page_settings_gsm_user_name">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="271"/>
+      <source>User name</source>
+      <translation>ユーザー名</translation>
+    </message>
+    <message id="page_settings_gsm_imei">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="286"/>
+      <source>IMEI</source>
+      <translation>IMEI</translation>
+    </message>
+    <message id="settings_ess_battery_life_self_consumption">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="15"/>
+      <source>Self-consumption</source>
+      <translation>自家消費</translation>
+    </message>
+    <message id="settings_ess_no_ess_assistant">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="22"/>
+      <source>No ESS Assistant found</source>
+      <translation>ESSアシスタントが見つかりません</translation>
+    </message>
+    <message id="settings_ess_grid_metering">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="58"/>
+      <source>Grid metering</source>
+      <translation>系統計量</translation>
+    </message>
+    <message id="settings_ess_external_meter">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="63"/>
+      <source>External meter</source>
+      <translation>外部メーター</translation>
+    </message>
+    <message id="settings_ess_inverter_charger">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="65"/>
+      <source>Inverter/Charger</source>
+      <translation>インバーター/チャージャー</translation>
+    </message>
+    <message id="settings_ess_multiphase_regulation">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="106"/>
+      <source>Multiphase regulation</source>
+      <translation>多相規制</translation>
+    </message>
+    <message id="settings_ess_phase_compensation">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="113"/>
+      <source>Total of all phases</source>
+      <translation>すべての相の合計</translation>
+    </message>
+    <message id="settings_ess_individual_phase">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="115"/>
+      <source>Individual phase</source>
+      <translation>個別相</translation>
+    </message>
+    <message id="settings_ess_multiphase_split_notif">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="121"/>
+      <source>Each phase is regulated to individually achieve the grid setpoint (system efficiency is decreased).
+
+CAUTION: Use only if required by the utility provider.</source>
+      <translation>各相が個別に系統設定点に達するように調整されます（システム効率は低下します）。
+
+注意：電力会社から要求された場合にのみ使用してください。</translation>
+    </message>
+    <message id="settings_ess_multiphase_total_notif">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="124"/>
+      <source>The total of all phases is intelligently regulated to achieve the grid setpoint (system efficiency is optimised).
+
+Use unless prohibited by the utility provider.</source>
+      <translation>すべての相の合計がインテリジェントに調整され、系統設定点に達するようにします（システム効率が最適化されます）。
+
+電力会社によって禁止されていない限り使用してください。</translation>
+    </message>
+    <message id="settings_rs_ess_min_soc">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="40"/>
+      <source>Minimum SOC (unless grid fails)</source>
+      <translation>最低SOC（系統障害時を除く）</translation>
+    </message>
+    <message id="settings_rs_active_soc_limit">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="57"/>
+      <source>Active SOC limit</source>
+      <translation>アクティブなSOC制限</translation>
+    </message>
+    <message id="settings_ess_peak_shaving">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="267"/>
+      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="48"/>
+      <source>Peak shaving</source>
+      <translation>ピークカット</translation>
+    </message>
+    <message id="settings_ess_above_minimum_soc_only">
+      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="53"/>
+      <source>Above minimum SOC only</source>
+      <translation>最低SOC以上の場合のみ</translation>
+    </message>
+    <message id="iochannel_showui_always">
+      <location filename="../../components/listitems/ListIOChannelShowRadioButtonGroup.qml" line="18"/>
+      <source>Always</source>
+      <translation>常に</translation>
+    </message>
+    <message id="settings_ess_battery_life_discharge_disabled">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="173"/>
+      <source>Discharge disabled</source>
+      <translation>放電無効</translation>
+    </message>
+    <message id="settings_ess_battery_life_slow_charge">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="175"/>
+      <source>Slow charge</source>
+      <translation>スロー充電</translation>
+    </message>
+    <message id="ev_charging_state_sustain">
+      <location filename="../../pages/ev/EvPage.qml" line="88"/>
+      <source>Sustain</source>
+      <translation>持続</translation>
+    </message>
+    <message id="inverters_state_recharge">
+      <location filename="../../data/System.qml" line="195"/>
+      <source>Recharge</source>
+      <translation>再充電</translation>
+    </message>
+    <message id="settings_ess_limit_charge_power">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="187"/>
+      <source>Limit charge power</source>
+      <translation>充電電力制限</translation>
+    </message>
+    <message id="settings_ess_max_charge_power">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="205"/>
+      <source>Maximum charge power</source>
+      <translation>最大充電電力</translation>
+    </message>
+    <message id="settings_ess_limit_inverter_power">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="218"/>
+      <source>Limit inverter power</source>
+      <translation>インバーター電力制限</translation>
+    </message>
+    <message id="settings_ess_max_inverter_power">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="236"/>
+      <source>Maximum inverter power</source>
+      <translation>最大インバーター電力</translation>
+    </message>
+    <message id="settings_ess_grid_setpoint">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="247"/>
+      <source>Grid setpoint</source>
+      <translation>電力網の設定値</translation>
+    </message>
+    <message id="settings_ess_grid_feed_in">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="256"/>
+      <source>Grid feed-in</source>
+      <translation>系統への売電</translation>
+    </message>
+    <message id="settings_ess_ac_coupled_pv">
+      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="20"/>
+      <source>AC-coupled PV - feed in excess</source>
+      <translation>AC結合型PV - 余剰分を売電</translation>
+    </message>
+    <message id="settings_ess_dc_coupled_pv">
+      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="30"/>
+      <source>DC-coupled PV - feed in excess</source>
+      <translation>DC結合型PV - 余剰分を売電</translation>
+    </message>
+    <message id="settings_ess_limit_system_feed_in">
+      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="45"/>
+      <source>Limit system feed-in</source>
+      <translation>システムフィードインを制限</translation>
+    </message>
+    <message id="settings_ess_max_feed_in">
+      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="61"/>
+      <source>Maximum feed-in</source>
+      <translation>最大フィードイン</translation>
+    </message>
+    <message id="settings_ess_feed_in_limiting_active">
+      <location filename="../../pages/settings/PageSettingsHub4Feedin.qml" line="73"/>
+      <source>Feed-in limiting active</source>
+      <translation>売電制限が有効</translation>
+    </message>
+    <message id="digitalinputs_type_pulsemeter">
+      <location filename="../../src/enums.cpp" line="295"/>
+      <source>Pulse meter</source>
+      <translation>パルスメーター</translation>
+    </message>
+    <message id="digitalinputs_type_dooralarm">
+      <location filename="../../src/enums.cpp" line="298"/>
+      <source>Door alarm</source>
+      <translation>ドアアラーム</translation>
+    </message>
+    <message id="switchable_output_bilge_pump">
+      <location filename="../../src/enums.cpp" line="561"/>
+      <source>Bilge pump</source>
+      <translation>ビルジポンプ</translation>
+    </message>
+    <message id="digitalinputs_type_bilgealarm">
+      <location filename="../../src/enums.cpp" line="304"/>
+      <source>Bilge alarm</source>
+      <translation>ビルジ警報</translation>
+    </message>
+    <message id="digitalinputs_type_burglaralarm">
+      <location filename="../../src/enums.cpp" line="307"/>
+      <source>Burglar alarm</source>
+      <translation>盗難警報</translation>
+    </message>
+    <message id="digitalinputs_type_smokealarm">
+      <location filename="../../src/enums.cpp" line="310"/>
+      <source>Smoke alarm</source>
+      <translation>煙警報</translation>
+    </message>
+    <message id="digitalinputs_type_firealarm">
+      <location filename="../../src/enums.cpp" line="313"/>
+      <source>Fire alarm</source>
+      <translation>火災警報</translation>
+    </message>
+    <message id="digitalinputs_type_co2alarm">
+      <location filename="../../src/enums.cpp" line="316"/>
+      <source>CO2 alarm</source>
+      <translation>CO2警報</translation>
+    </message>
+    <message id="pagesettingssupportstate_signal_k">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="457"/>
+      <source>Signal K</source>
+      <translation>Signal K</translation>
+    </message>
+    <message id="pagesettingssupportstate_node_red">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="471"/>
+      <source>Node-RED</source>
+      <translation>Node-RED</translation>
+    </message>
+    <message id="settings_large_enabled_safe_mode">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="258"/>
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="263"/>
+      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="24"/>
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="475"/>
+      <source>Enabled (safe mode)</source>
+      <translation>有効（セーフモード）</translation>
+    </message>
+    <message id="settings_logging_time_ago_deferred">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="22"/>
+      <source>Deferred by %1s</source>
+      <extracomment>%1 = number of seconds</extracomment>
+      <translation>%1sにより延期されました</translation>
+    </message>
+    <message id="settings_vrm_portal_id">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="87"/>
+      <source>VRM Portal ID</source>
+      <translation>VRMポータルID</translation>
+    </message>
+    <message id="settings_log_interval">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="112"/>
+      <source>Log interval</source>
+      <translation>ログ間隔</translation>
+    </message>
+    <message id="settings_5_min">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="117"/>
+      <source>5 min</source>
+      <translation>5分</translation>
+    </message>
+    <message id="settings_15_min">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="121"/>
+      <source>15 min</source>
+      <translation>15分</translation>
+    </message>
+    <message id="settings_1_hr">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="125"/>
+      <source>1 hour</source>
+      <translation>1時間</translation>
+    </message>
+    <message id="settings_2_hr">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="127"/>
+      <source>2 hours</source>
+      <translation>2時間</translation>
+    </message>
+    <message id="settings_4_hr">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="129"/>
+      <source>4 hours</source>
+      <translation>4時間</translation>
+    </message>
+    <message id="settings_12_hr">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="131"/>
+      <source>12 hours</source>
+      <translation>12時間</translation>
+    </message>
+    <message id="settings_1_day">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="133"/>
+      <source>1 day</source>
+      <translation>1日</translation>
+    </message>
+    <message id="settings_https_enabled">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="143"/>
+      <source>Use secure connection (HTTPS)</source>
+      <translation>セキュア接続（HTTPS）を使用</translation>
+    </message>
+    <message id="ev_last_contact">
+      <location filename="../../pages/ev/EvPage.qml" line="115"/>
+      <source>Last contact</source>
+      <translation>最終接続</translation>
+    </message>
+    <message id="settings_connection_error_150">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="211"/>
+      <source>#150 Unexpected response text</source>
+      <translation>#150 予期しない応答テキスト</translation>
+    </message>
+    <message id="settings_connection_error_151">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="214"/>
+      <source>#151 Unexpected HTTP response</source>
+      <translation>#151 予期しないHTTP応答</translation>
+    </message>
+    <message id="settings_connection_error_152">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="217"/>
+      <source>#152 Connection timeout</source>
+      <translation>#152 接続タイムアウト</translation>
+    </message>
+    <message id="settings_connection_error_153">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="220"/>
+      <source>#153 Connection error</source>
+      <translation>#153 接続エラー</translation>
+    </message>
+    <message id="settings_connection_error_154">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="223"/>
+      <source>#154 DNS failure</source>
+      <translation>#154 DNS障害</translation>
+    </message>
+    <message id="settings_connection_error_155">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="226"/>
+      <source>#155 Routing error</source>
+      <translation>#155 ルーティングエラー</translation>
+    </message>
+    <message id="settings_connection_error_156">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="229"/>
+      <source>#156 VRM unavailable</source>
+      <translation>#156 VRMが利用できません</translation>
+    </message>
+    <message id="settings_connection_error_157">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="232"/>
+      <source>#159 Unknown error</source>
+      <translation>#159 不明なエラー</translation>
+    </message>
+    <message id="settings_vrm_error_message">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="249"/>
+      <source>Error message: 
+%1</source>
+      <translation>エラーメッセージ:
+%1</translation>
+    </message>
+    <message id="settings_no_contact_reboot">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="274"/>
+      <source>Reboot device when no contact</source>
+      <translation>接続がない場合にデバイスを再起動</translation>
+    </message>
+    <message id="settings_vrm_no_contact_reset_delay">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="284"/>
+      <source>No contact reset delay (hh:mm)</source>
+      <translation>接続なしリセット遅延 (hh:mm)</translation>
+    </message>
+    <message id="settings_vrm_storage_location">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="290"/>
+      <source>Storage location</source>
+      <translation>保存場所</translation>
+    </message>
+    <message id="settings_vrm_no_buffer_active">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="292"/>
+      <source>No buffer active</source>
+      <translation>バッファはアクティブではありません</translation>
+    </message>
+    <message id="settings_vrm_internal_storage">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="295"/>
+      <source>Internal storage</source>
+      <translation>内部ストレージ</translation>
+    </message>
+    <message id="settings_vrm_transferring">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="297"/>
+      <source>Transferring</source>
+      <translation>転送中</translation>
+    </message>
+    <message id="settings_vrm_external_storage">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="299"/>
+      <source>External storage</source>
+      <translation>外部ストレージ</translation>
+    </message>
+    <message id="settings_vrm_no_space_error">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="313"/>
+      <source>No space left on storage</source>
+      <translation>ストレージの空き容量がありません</translation>
+    </message>
+    <message id="settings_vrm_io_error">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="315"/>
+      <source>IO error</source>
+      <translation>IOエラー</translation>
+    </message>
+    <message id="settings_vrm_mount_error">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="317"/>
+      <source>Mount error</source>
+      <translation>マウントエラー</translation>
+    </message>
+    <message id="settings_vrm_storage_contains_firmware_error">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="319"/>
+      <source>Contains firmware image. Not using.</source>
+      <translation>ファームウェアイメージが含まれています。使用しません。</translation>
+    </message>
+    <message id="settings_vrm_storage_not_writable_error">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="321"/>
+      <source>SD card / USB stick not writable</source>
+      <translation>SDカード/USBスティックに書き込みできません</translation>
+    </message>
+    <message id="settings_vrm_free_disk_space">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="330"/>
+      <source>Free disk space</source>
+      <translation>ディスク空き容量</translation>
+    </message>
+    <message id="settings_vrm_byte">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="333"/>
+      <source>byte</source>
+      <translation>バイト</translation>
+    </message>
+    <message id="settings_vrm_bytes">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="335"/>
+      <source>bytes</source>
+      <translation>バイト</translation>
+    </message>
+    <message id="settings_vrm_stored_records">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="343"/>
+      <source>Stored records</source>
+      <translation>保存されているレコード</translation>
+    </message>
+    <message id="settings_vrm_records_count">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="346"/>
+      <source>%1 records</source>
+      <translation>%1件のレコード</translation>
+    </message>
+    <message id="settings_vrm_oldest_record_age">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="354"/>
+      <source>Oldest record age</source>
+      <translation>最古のレコードの経過時間</translation>
+    </message>
+    <message id="settings_modbus_no_errors">
+      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="56"/>
+      <source>No errors reported</source>
+      <translation>エラーは報告されていません</translation>
+    </message>
+    <message id="settings_modbus_time_of_last_error">
+      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="63"/>
+      <source>Time of last error</source>
+      <translation>最終エラー発生日時</translation>
+    </message>
+    <message id="settings_modbus_available_services">
+      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="49"/>
+      <source>Available services</source>
+      <translation>利用可能なサービス</translation>
+    </message>
+    <message id="settings_relay_function_relay1">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="48"/>
+      <source>Function (Relay 1)</source>
+      <translation>機能（リレー1）</translation>
+    </message>
+    <message id="page_switchable_output_function">
+      <location filename="../../pages/settings/devicelist/iochannel/PageSwitchableOutput.qml" line="91"/>
+      <source>Function</source>
+      <translation>機能</translation>
+    </message>
+    <message id="settings_relay_alarm_relay">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="56"/>
+      <source>Alarm relay</source>
+      <translation>アラームリレー</translation>
+    </message>
+    <message id="settings_relay_normally_open">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="83"/>
+      <source>Normally open</source>
+      <translation>常時開</translation>
+    </message>
+    <message id="settings_relay_normally_closed">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="85"/>
+      <source>Normally closed</source>
+      <translation>常時閉</translation>
+    </message>
+    <message id="settings_relay_function_relay2">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="93"/>
+      <source>Function (Relay 2)</source>
+      <translation>機能（リレー2）</translation>
+    </message>
+    <message id="settings_relay_temp_control_rules">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="119"/>
+      <source>Temperature control rules</source>
+      <translation>温度制御ルール</translation>
+    </message>
+    <message id="settings_relay_activate_on_temp">
+      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="107"/>
+      <source>Relay activation on temperature</source>
+      <translation>温度によるリレー作動</translation>
+    </message>
+    <message id="settings_relay_no_temperature_relay">
+      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="131"/>
+      <source>No relay is configured to be activated by temperature. Go to the relay settings page located in the main settings menu and set the relay function to "Temperature".</source>
+      <translation>温度で起動するリレーは設定されていません。メイン設定メニューにあるリレー設定ページに移動し、リレー機能を「温度」に設定してください。</translation>
+    </message>
+    <message id="settings_firmware_version_switch_option">
+      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="51"/>
+      <source>This option allows you to switch between the current and the previous firmware version. No internet or sdcard needed.</source>
+      <translation>このオプションを使用すると、現在のファームウェアバージョンと以前のファームウェアバージョンを切り替えることができます。インターネット接続やSDカードは不要です。</translation>
+    </message>
+    <message id="settings_firmware_current_version">
+      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="94"/>
+      <source>Firmware %1 (%2)</source>
+      <extracomment>%1 = current firmware version, %2 = current firmware build number</extracomment>
+      <translation>ファームウェア %1 (%2)</translation>
+    </message>
+    <message id="settings_firmware_press_to_boot">
+      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="62"/>
+      <source>Press to boot</source>
+      <translation>起動するには押してください</translation>
+    </message>
+    <message id="settings_firmware_rebooting_to">
+      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="80"/>
+      <source>Rebooting to %1</source>
+      <extracomment>%1 = backup version</extracomment>
+      <translation>%1 に再起動中</translation>
+    </message>
+    <message id="settings_firmware_switching_not_possible">
+      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="84"/>
+      <source>Switching firmware version is not possible when auto update is set to "Check and update". Set auto update to "Disabled" or "Check only" to enable this option.</source>
+      <translation>自動更新が「確認と更新」に設定されている場合、ファームウェアバージョンの切り替えはできません。このオプションを有効にするには、自動更新を「無効」または「確認のみ」に設定してください。</translation>
+    </message>
+    <message id="settings_firmware_backup_not_available">
+      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="101"/>
+      <source>Backup firmware not available</source>
+      <translation>バックアップファームウェアが利用できません</translation>
+    </message>
+    <message id="settings_services_canbus_over_tcpip_debug">
+      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="120"/>
+      <source>CAN-bus over TCP/IP (Debug)</source>
+      <translation>TCP/IP経由のCANバス (デバッグ)</translation>
+    </message>
+    <message id="settings_system_shore_power">
+      <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="21"/>
+      <source>Shore power</source>
+      <translation>陸電</translation>
+    </message>
+    <message id="settings_system_name_vehicle">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="19"/>
+      <source>Vehicle</source>
+      <translation>車両</translation>
+    </message>
+    <message id="nav_boat">
+      <location filename="../../pages/boat/BoatPage.qml" line="14"/>
+      <source>Boat</source>
+      <extracomment>The 'Boat' page</extracomment>
+      <translation>ボート</translation>
+    </message>
+    <message id="settings_system_name">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="26"/>
+      <source>System name</source>
+      <translation>システム名</translation>
+    </message>
+    <message id="settings_tcpip_auto">
+      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="103"/>
+      <source>Automatic</source>
+      <translation>自動</translation>
+    </message>
+    <message id="settings_system_name_user_defined">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="41"/>
+      <source>User defined</source>
+      <translation>ユーザー定義</translation>
+    </message>
+    <message id="settings_system_user_defined_name">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="48"/>
+      <source>User-defined name</source>
+      <translation>ユーザー定義名</translation>
+    </message>
+    <message id="settings_system_ac_input_1">
+      <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="42"/>
+      <source>AC input 1</source>
+      <translation>AC入力1</translation>
+    </message>
+    <message id="settings_system_ac_input_2">
+      <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="51"/>
+      <source>AC input 2</source>
+      <translation>AC入力2</translation>
+    </message>
+    <message id="settings_system_monitor_for_grid_failure">
+      <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="93"/>
+      <source>Monitor for grid failure</source>
+      <translation>グリッド故障の監視</translation>
+    </message>
+    <message id="settings_system_monitor_for_shore_disconnect">
+      <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="95"/>
+      <source>Monitor for shore disconnect</source>
+      <translation>陸電切断の監視</translation>
+    </message>
+    <message id="settings_system_auto_selected">
+      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="48"/>
+      <source>Auto-selected</source>
+      <translation>自動選択</translation>
+    </message>
+    <message id="settings_system_status_sync_vebus_soc_with_battery">
+      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="16"/>
+      <source>Synchronize VE.Bus SOC with battery</source>
+      <translation>VE.Bus SOCをバッテリーと同期</translation>
+    </message>
+    <message id="settings_system_status_solar_charger_vebus">
+      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="23"/>
+      <source>Use solar charger current to improve VE.Bus SOC</source>
+      <translation>ソーラー充電器電流を使用してVE.Bus SOCを改善</translation>
+    </message>
+    <message id="settings_system_status_solar_charger_voltage_control">
+      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="30"/>
+      <source>Solar charger voltage control</source>
+      <translation>ソーラー充電器電圧制御</translation>
+    </message>
+    <message id="settings_system_status_solar_charger_current_control">
+      <location filename="../../pages/settings/PageSettingsSystemStatus.qml" line="37"/>
+      <source>Solar charger current control</source>
+      <translation>ソーラー充電器電流制御</translation>
+    </message>
+    <message id="common_words_bms_control">
+      <location filename="../../components/CommonWords.qml" line="104"/>
+      <source>BMS control</source>
+      <translation>BMSコントロール</translation>
+    </message>
+    <message id="settings_pump_function_not_enabled">
+      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="38"/>
+      <source>Tank pump start/stop function is not enabled. Go to relay settings and set function to "Tank pump".</source>
+      <translation>タンクポンプの開始/停止機能は有効になっていません。リレー設定に移動し、機能を「タンクポンプ」に設定してください。</translation>
+    </message>
+    <message id="settings_pump_state">
+      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="47"/>
+      <source>Pump state</source>
+      <translation>ポンプの状態</translation>
+    </message>
+    <message id="settings_tank_sensor">
+      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="67"/>
+      <source>Tank sensor</source>
+      <translation>タンクセンサー</translation>
+    </message>
+    <message id="settings_tank_start_level">
+      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="90"/>
+      <source>Start level</source>
+      <translation>開始レベル</translation>
+    </message>
+    <message id="settings_tank_stop_level">
+      <location filename="../../pages/settings/PageSettingsTankPump.qml" line="99"/>
+      <source>Stop level</source>
+      <translation>停止レベル</translation>
+    </message>
+    <message id="settings_tcpip_connection_lost">
+      <location filename="../../pages/settings/PageSettingsEthernet.qml" line="24"/>
+      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="33"/>
+      <source>Connection lost</source>
+      <translation>接続が切れた</translation>
+    </message>
+    <message id="settings_tcpip_connection_unplugged">
+      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="36"/>
+      <location filename="../../pages/settings/PageSettingsEthernet.qml" line="26"/>
+      <location filename="../../pages/settings/PageSettingsTcpIp.qml" line="35"/>
+      <source>Unplugged</source>
+      <translation>アンプラグド</translation>
+    </message>
+    <message id="settings_tcpip_hidden">
+      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="21"/>
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="138"/>
+      <source>[Hidden]</source>
+      <translation>[非表示]</translation>
+    </message>
+    <message id="settings_tcpip_connect_to_network">
+      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="44"/>
+      <source>Connect to network?</source>
+      <translation>ネットワークに接続しますか？</translation>
+    </message>
+    <message id="settings_tcpip_connect">
+      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="46"/>
+      <source>Connect</source>
+      <translation>接続</translation>
+    </message>
+    <message id="settings_tcpip_forget_network">
+      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="57"/>
+      <source>Forget network?</source>
+      <translation>ネットワークを削除しますか？</translation>
+    </message>
+    <message id="settings_tcpip_forget">
+      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="59"/>
+      <source>Forget</source>
+      <translation>無視</translation>
+    </message>
+    <message id="settings_tcpip_forget_confirm">
+      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="71"/>
+      <source>Are you sure that you want to forget this network?</source>
+      <translation>このネットワークを削除してもよろしいですか？</translation>
+    </message>
+    <message id="settings_tcpip_mac_address">
+      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="91"/>
+      <source>MAC address</source>
+      <translation>MACアドレス</translation>
+    </message>
+    <message id="settings_tcpip_ip_config">
+      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="99"/>
+      <source>IP configuration</source>
+      <translation>IP設定</translation>
+    </message>
+    <message id="settings_tcpip_fixed">
+      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="109"/>
+      <source>Fixed</source>
+      <translation>固定</translation>
+    </message>
+    <message id="settings_tcpip_netmask">
+      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="147"/>
+      <source>Netmask</source>
+      <translation>ネットマスク</translation>
+    </message>
+    <message id="settings_tcpip_gateway">
+      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="156"/>
+      <source>Gateway</source>
+      <translation>ゲートウエイ</translation>
+    </message>
+    <message id="settings_tcpip_dns_server">
+      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="166"/>
+      <source>DNS server</source>
+      <translation>DNSサーバー</translation>
+    </message>
+    <message id="settings_tcpip_link_local">
+      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="185"/>
+      <source>Link-local IP address</source>
+      <translation>リンクローカルIPアドレス</translation>
+    </message>
+    <message id="settings_vecan_instance_zero_warning">
+      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="36"/>
+      <source>Careful, for ESS systems, as well as systems with a managed battery, the CAN-bus device instance must remain configured to 0. See GX manual for more information.</source>
+      <translation>注意：ESSシステム、および管理バッテリーを搭載したシステムでは、CANバスデバイスインスタンスは0に設定されたままでなければなりません。詳細については、GXマニュアルを参照してください。</translation>
+    </message>
+    <message id="settings_vecan_nad">
+      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="53"/>
+      <source>Network Address</source>
+      <translation>ネットワークアドレス</translation>
+    </message>
+    <message id="settings_vecan_devices">
+      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="16"/>
+      <source>VE.CAN devices</source>
+      <translation>VE.CANデバイス</translation>
+    </message>
+    <message id="settings_wifi_no_access_points">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="128"/>
+      <source>No access points</source>
+      <translation>アクセスポイントなし</translation>
+    </message>
+    <message id="settings_wifi_no_wifi_adapter_connected">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="130"/>
+      <source>No Wi-Fi adapter connected</source>
+      <translation>Wi-Fiアダプターが接続されていません</translation>
+    </message>
+    <message id="settings_wifi_create_ap">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="35"/>
+      <source>Create access point</source>
+      <translation>アクセスポイントを作成</translation>
+    </message>
+    <message id="settings_wifi_networks">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="120"/>
+      <source>Wi-Fi networks</source>
+      <translation>Wi-Fiネットワーク</translation>
+    </message>
+    <message id="settings_wifi_disable_ap_are_you_sure">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="60"/>
+      <source>Are you sure that you want to disable the access point?</source>
+      <translation>アクセスポイントを無効にしてもよろしいですか？</translation>
+    </message>
+    <message id="settings_tz_date_time_utc">
+      <location filename="../../pages/settings/PageTzInfo.qml" line="88"/>
+      <source>Date/Time UTC</source>
+      <translation>日付/時刻 UTC</translation>
+    </message>
+    <message id="settings_tz_date_time_local">
+      <location filename="../../pages/settings/PageTzInfo.qml" line="115"/>
+      <source>Date/Time local</source>
+      <translation>日付/時刻 ローカル</translation>
+    </message>
+    <message id="settings_tz_time_zone">
+      <location filename="../../pages/settings/PageTzInfo.qml" line="140"/>
+      <source>Time zone</source>
+      <translation>タイムゾーン</translation>
+    </message>
+    <message id="settings_tz_africa">
+      <location filename="../../pages/settings/PageTzInfo.qml" line="235"/>
+      <source>Africa</source>
+      <translation>アフリカ</translation>
+    </message>
+    <message id="settings_tz_america">
+      <location filename="../../pages/settings/PageTzInfo.qml" line="241"/>
+      <source>America</source>
+      <translation>アメリカ</translation>
+    </message>
+    <message id="settings_tz_asia">
+      <location filename="../../pages/settings/PageTzInfo.qml" line="259"/>
+      <source>Asia</source>
+      <translation>アジア</translation>
+    </message>
+    <message id="settings_tz_atlantic">
+      <location filename="../../pages/settings/PageTzInfo.qml" line="265"/>
+      <source>Atlantic</source>
+      <translation>大西洋</translation>
+    </message>
+    <message id="settings_tz_ustralia">
+      <location filename="../../pages/settings/PageTzInfo.qml" line="271"/>
+      <source>Australia</source>
+      <translation>オーストラリア</translation>
+    </message>
+    <message id="settings_tz_europe">
+      <location filename="../../pages/settings/PageTzInfo.qml" line="277"/>
+      <source>Europe</source>
+      <translation>ヨーロッパ</translation>
+    </message>
+    <message id="settings_tz_indian">
+      <location filename="../../pages/settings/PageTzInfo.qml" line="283"/>
+      <source>Indian</source>
+      <translation>インド洋</translation>
+    </message>
+    <message id="settings_tz_pacific">
+      <location filename="../../pages/settings/PageTzInfo.qml" line="289"/>
+      <source>Pacific</source>
+      <translation>太平洋</translation>
+    </message>
+    <message id="settings_vrm_device_instances_unconnected">
+      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="88"/>
+      <source>Unconnected %1</source>
+      <extracomment>Name for an unconnected device. %1 = type of device</extracomment>
+      <translation>未接続 %1</translation>
+    </message>
+    <message id="settings_vrm_device_instances_reboot_now">
+      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="138"/>
+      <source>Reboot now?</source>
+      <translation>今すぐ再起動しますか？</translation>
+    </message>
+    <message id="settings_vrm_device_instances_reboot_now_description">
+      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="141"/>
+      <source>VRM instance changes will not be applied until the device is rebooted.</source>
+      <translation>VRMインスタンスの変更は、デバイスが再起動されるまで適用されません。</translation>
+    </message>
+    <message id="settings_vrm_device_instances_rebooting">
+      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="161"/>
+      <source>Device is rebooting...</source>
+      <translation>デバイスを再起動しています...</translation>
+    </message>
+    <message id="settings_vrm_device_instances_rebooted">
+      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="164"/>
+      <source>Device has been rebooted.</source>
+      <translation>デバイスが再起動されました。</translation>
+    </message>
+    <message id="settings_accharger_low_battery_voltage_alarm">
+      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="100"/>
+      <source>Low battery voltage alarm</source>
+      <translation>低バッテリー電圧アラーム</translation>
+    </message>
+    <message id="settings_accharger_high_battery_voltage_alarm">
+      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="109"/>
+      <source>High battery voltage alarm</source>
+      <translation>バッテリー高電圧アラーム</translation>
+    </message>
+    <message id="common_words_last_error">
+      <location filename="../../components/CommonWords.qml" line="663"/>
+      <source>Last error</source>
+      <extracomment>Details of last error</extracomment>
+      <translation>最後のエラー</translation>
+    </message>
+    <message id="common_words_2nd_last_error">
+      <location filename="../../components/CommonWords.qml" line="666"/>
+      <source>2nd last error</source>
+      <extracomment>Details of 2nd last error</extracomment>
+      <translation>最後から2番目のエラー</translation>
+    </message>
+    <message id="common_words_3rd_last_error">
+      <location filename="../../components/CommonWords.qml" line="669"/>
+      <source>3rd last error</source>
+      <extracomment>Details of 3rd last error</extracomment>
+      <translation>最後から3番目のエラー</translation>
+    </message>
+    <message id="common_words_4th_last_error">
+      <location filename="../../components/CommonWords.qml" line="672"/>
+      <source>4th last error</source>
+      <extracomment>Details of 4th last error</extracomment>
+      <translation>最後から4番目のエラー</translation>
+    </message>
+    <message id="charger_networked">
+      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="22"/>
+      <source>Networked</source>
+      <translation>ネットワーク接続済み</translation>
+    </message>
+    <message id="charger_mode_setting">
+      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="37"/>
+      <source>Mode setting</source>
+      <translation>モード設定</translation>
+    </message>
+    <message id="systemsettings_networkstatus_standalone">
+      <location filename="../../data/SystemSettings.qml" line="175"/>
+      <source>Standalone</source>
+      <extracomment>Network status: Standalone</extracomment>
+      <translation>スタンドアローン</translation>
+    </message>
+    <message id="charger_charge">
+      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="48"/>
+      <source>Charge</source>
+      <translation>充電</translation>
+    </message>
+    <message id="charger_charge_hub_1">
+      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="54"/>
+      <source>Charge &amp; HUB-1</source>
+      <translation>充電 &amp; HUB-1</translation>
+    </message>
+    <message id="charger_bms">
+      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="57"/>
+      <source>BMS</source>
+      <translation>BMS</translation>
+    </message>
+    <message id="charger_charge_bms">
+      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="60"/>
+      <source>Charge &amp; BMS</source>
+      <translation>充電 &amp; BMS</translation>
+    </message>
+    <message id="charger_ext_control_bms">
+      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="63"/>
+      <source>Ext. Control &amp; BMS</source>
+      <translation>外部制御 &amp; BMS</translation>
+    </message>
+    <message id="charger_charge_hub_1_bms">
+      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="66"/>
+      <source>Charge, Hub-1 &amp; BMS</source>
+      <translation>充電、Hub-1 &amp; BMS</translation>
+    </message>
+    <message id="charger_master_setting">
+      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="77"/>
+      <source>Master setting</source>
+      <translation>マスター設定</translation>
+    </message>
+    <message id="systemsettings_networkstatus_slave">
+      <location filename="../../data/SystemSettings.qml" line="159"/>
+      <source>Slave</source>
+      <extracomment>Network status: Slave</extracomment>
+      <translation>スレーブ</translation>
+    </message>
+    <message id="charger_group_master">
+      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="88"/>
+      <source>Group master</source>
+      <translation>グループマスター</translation>
+    </message>
+    <message id="charger_charge_master">
+      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="91"/>
+      <source>Charge master</source>
+      <translation>充電マスター</translation>
+    </message>
+    <message id="charger_group_charge_master">
+      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="94"/>
+      <source>Group &amp; Charge master</source>
+      <translation>グループ &amp; 充電マスター</translation>
+    </message>
+    <message id="charger_charge_voltage">
+      <location filename="../../pages/solar/PageSolarParallelOperation.qml" line="105"/>
+      <source>Charge voltage</source>
+      <translation>充電電圧</translation>
+    </message>
+    <message id="common_words_reset">
+      <location filename="../../components/CommonWords.qml" line="459"/>
+      <source>Reset</source>
+      <extracomment>Reset the BMS control</extracomment>
+      <translation>リセット</translation>
+    </message>
+    <message id="solarcharger_load">
+      <location filename="../../pages/solar/PageSolarCharger.qml" line="233"/>
+      <source>Load</source>
+      <translation>負荷</translation>
+    </message>
+    <message id="charger_networked_operation">
+      <location filename="../../pages/solar/PageSolarCharger.qml" line="288"/>
+      <source>Networked operation</source>
+      <translation>ネットワーク運用</translation>
+    </message>
+    <message id="charger_history_table_view">
+      <location filename="../../pages/solar/SolarHistoryPage.qml" line="29"/>
+      <source>Table view</source>
+      <translation>テーブル表示</translation>
+    </message>
+    <message id="charger_history_chart">
+      <location filename="../../pages/solar/SolarHistoryPage.qml" line="31"/>
+      <source>Chart</source>
+      <translation>チャート</translation>
+    </message>
+    <message id="listitems_alarm_level_warning">
+      <location filename="../../components/listitems/core/ListAlarm.qml" line="21"/>
+      <source>Warning</source>
+      <extracomment>Voltage alarm is at "Warning" level</extracomment>
+      <translation>警告</translation>
+    </message>
+    <message id="generic_input_label_alarm">
+      <location filename="../../src/genericinput.cpp" line="126"/>
+      <source>Alarm</source>
+      <extracomment>Relay function is 'alarm'</extracomment>
+      <translation>アラーム</translation>
+    </message>
+    <message id="generic_input_primaryLabel_volume">
+      <location filename="../../src/genericinput.cpp" line="172"/>
+      <source>Volume</source>
+      <extracomment>The volume (as a percentage) for this tank shape point</extracomment>
+      <translation>容量</translation>
+    </message>
+    <message id="tank_status_short_circuited">
+      <location filename="../../data/Tanks.qml" line="177"/>
+      <source>Short circuited</source>
+      <translation>短絡</translation>
+    </message>
+    <message id="tank_status_reverse_polarity">
+      <location filename="../../data/Tanks.qml" line="180"/>
+      <source>Reverse polarity</source>
+      <translation>逆極性</translation>
+    </message>
+    <message id="evcs_charging_stations">
+      <location filename="../../pages/evcs/EvChargerListPage.qml" line="13"/>
+      <source>EV Charging Stations</source>
+      <translation>EV充電ステーション</translation>
+    </message>
+    <message id="evcs_session">
+      <location filename="../../pages/evcs/EvChargerPage.qml" line="47"/>
+      <source>Session</source>
+      <translation>セッション</translation>
+    </message>
+    <message id="evcs_charging_time">
+      <location filename="../../pages/evcs/EvChargerPage.qml" line="54"/>
+      <source>Time</source>
+      <extracomment>Charging time for the EV charger</extracomment>
+      <translation>時間</translation>
+    </message>
+    <message id="evcs_charge_mode">
+      <location filename="../../pages/evcs/EvChargerPage.qml" line="125"/>
+      <source>Charge mode</source>
+      <translation>充電モード</translation>
+    </message>
+    <message id="evcs_manual_caption">
+      <location filename="../../data/EvChargers.qml" line="30"/>
+      <source>Start and stop the process yourself. Use this for quick charges and close monitoring.</source>
+      <translation>充電プロセスを手動で開始・停止します。急速充電や厳密な監視に適しています。</translation>
+    </message>
+    <message id="evcs_auto_caption">
+      <location filename="../../data/EvChargers.qml" line="36"/>
+      <source>Starts and stops based on the battery charge level. Optimal for overnight and extended charges to avoid overcharging.</source>
+      <translation>バッテリーの充電レベルに基づいて開始・停止します。過充電を避けるため、夜間や長時間の充電に最適です。</translation>
+    </message>
+    <message id="evcs_scheduled_caption">
+      <location filename="../../data/EvChargers.qml" line="42"/>
+      <source>Lower electricity rates during off-peak hours or if you want to ensure that your EV is fully charged and ready to go at a specific time.</source>
+      <translation>オフピーク時間帯の電気料金を節約したい場合や、特定の時間までにEVを完全に充電して準備を整えたい場合に利用します。</translation>
+    </message>
+    <message id="evcs_enable_charging">
+      <location filename="../../pages/evcs/EvChargerPage.qml" line="140"/>
+      <source>Enable charging</source>
+      <translation>充電を有効にする</translation>
+    </message>
+    <message id="evcs_lock_charger_display">
+      <location filename="../../pages/evcs/EvChargerSetupPage.qml" line="28"/>
+      <source>Lock charger display</source>
+      <translation>充電器ディスプレイをロック</translation>
+    </message>
+    <message id="settings_rvc_source_address">
+      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="36"/>
+      <source>Source Address</source>
+      <translation>ソースアドレス</translation>
+    </message>
+    <message id="settings_rvc_configuration">
+      <location filename="../../pages/settings/PageSettingsRvcDevice.qml" line="65"/>
+      <source>Configuration</source>
+      <translation>設定</translation>
+    </message>
+    <message id="settings_rvc_line_instance_num">
+      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="19"/>
+      <source>Line instance #%1</source>
+      <extracomment>%1 = number of this line instance</extracomment>
+      <translation>ラインインスタンス #%1</translation>
+    </message>
+    <message id="settings_rvc_line_instance">
+      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="21"/>
+      <source>Line instance</source>
+      <translation>ラインインスタンス</translation>
+    </message>
+    <message id="settings_rvc_charger_instance">
+      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="33"/>
+      <source>Charger instance</source>
+      <translation>充電器インスタンス</translation>
+    </message>
+    <message id="settings_rvc_inverter_instance">
+      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="40"/>
+      <source>Inverter instance</source>
+      <translation>インバーターインスタンス</translation>
+    </message>
+    <message id="settings_rvc_dc_source_#_instance">
+      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="81"/>
+      <source>DC source #%1 instance</source>
+      <extracomment>%1 = number of this DC source</extracomment>
+      <translation>DCソース #%1 インスタンス</translation>
+    </message>
+    <message id="settings_rvc_dc_source_instance">
+      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="83"/>
+      <source>DC source instance</source>
+      <translation>DCソースインスタンス</translation>
+    </message>
+    <message id="settings_rvc_dc_source_#_priority">
+      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="93"/>
+      <source>DC source #%1 priority</source>
+      <extracomment>%1 = number of this DC source</extracomment>
+      <translation>DCソース #%1 優先度</translation>
+    </message>
+    <message id="settings_rvc_dc_source_priority">
+      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="95"/>
+      <source>DC source priority</source>
+      <translation>DCソース優先度</translation>
+    </message>
+    <message id="settings_rvc_tank_instance">
+      <location filename="../../pages/settings/PageSettingsRvcDeviceConfiguration.qml" line="105"/>
+      <source>Tank instance</source>
+      <translation>タンクインスタンス</translation>
+    </message>
+    <message id="settings_rvc_devices">
+      <location filename="../../pages/settings/PageSettingsRvcDevices.qml" line="15"/>
+      <source>RV-C devices</source>
+      <translation>RV-C デバイス</translation>
+    </message>
+    <message id="settings_page_debug_enable_fps_visualizer">
+      <location filename="../../pages/settings/debug/PageDebug.qml" line="49"/>
+      <source>Enable frame-rate visualizer</source>
+      <translation>フレームレートビジュアライザーを有効にする</translation>
+    </message>
+    <message id="devicelist_unsupported">
+      <location filename="../../pages/settings/devicelist/delegates/DeviceListDelegate_unsupported.qml" line="14"/>
+      <source>Unsupported</source>
+      <extracomment>Device is not supported</extracomment>
+      <translation>非対応</translation>
+    </message>
+    <message id="devicelist_remove_disconnected_devices">
+      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="125"/>
+      <source>Remove disconnected devices</source>
+      <translation>切断されたデバイスを削除</translation>
+    </message>
+    <message id="devicelist_unsupporteddevices_found">
+      <location filename="../../pages/settings/devicelist/PageUnsupportedDevice.qml" line="22"/>
+      <source>Unsupported device found</source>
+      <translation>非対応デバイスが検出されました</translation>
+    </message>
+    <message id="batterysettingrelay_relay_function">
+      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="26"/>
+      <source>Relay function</source>
+      <translation>リレー機能</translation>
+    </message>
+    <message id="batterysettingrelay_charger_or_generator_start_stop">
+      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="33"/>
+      <source>Charger or generator start/stop</source>
+      <translation>充電器または発電機の開始/停止</translation>
+    </message>
+    <message id="common_words_manual_control">
+      <location filename="../../components/CommonWords.qml" line="315"/>
+      <source>Manual control</source>
+      <translation>手動制御</translation>
+    </message>
+    <message id="batterysettingrelay_always_open_dont_use_the_relay">
+      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="37"/>
+      <source>Always open (don't use the relay)</source>
+      <translation>常に開放 (リレーを使用しない)</translation>
+    </message>
+    <message id="batterysettingrelay_low_state_of_charge_setting_note">
+      <location filename="../../pages/settings/devicelist/battery/BatterySettingsRelayModel.qml" line="51"/>
+      <source>Note that changing the Low state-of-charge setting also changes the Time-to-go discharge floor setting in the battery menu.</source>
+      <translation>低充電状態設定を変更すると、バッテリーメニュー内の放電下限までの時間設定も変更されることに注意してください。</translation>
+    </message>
+    <message id="lynxdistributor_fuse_blown">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="63"/>
+      <source>Fuse blown</source>
+      <translation>フューズ溶断</translation>
+    </message>
+    <message id="batterydiagnostics_status_leds">
+      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="25"/>
+      <source>Status LEDs</source>
+      <translation>ステータスLED</translation>
+    </message>
+    <message id="batterydiagnostics_main_switch">
+      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="57"/>
+      <source>Main Switch</source>
+      <translation>メインスイッチ</translation>
+    </message>
+    <message id="batterydiagnostics_heater">
+      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="64"/>
+      <source>Heater</source>
+      <translation>ヒーター</translation>
+    </message>
+    <message id="batterydiagnostics_internal_fan">
+      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="71"/>
+      <source>Internal Fan</source>
+      <translation>内部ファン</translation>
+    </message>
+    <message id="batterydiagnostics_warning_flags">
+      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="78"/>
+      <source>Warning Flags</source>
+      <translation>警告フラグ</translation>
+    </message>
+    <message id="batterydiagnostics_alarm_flags">
+      <location filename="../../pages/settings/devicelist/battery/Page48TlDiagnostics.qml" line="84"/>
+      <source>Alarm Flags</source>
+      <translation>アラームフラグ</translation>
+    </message>
+    <message id="common_words_switch">
+      <location filename="../../components/CommonWords.qml" line="539"/>
+      <source>Switch</source>
+      <extracomment>Change the battery mode</extracomment>
+      <translation>スイッチ</translation>
+    </message>
+    <message id="devicelist_battery_initializing">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="43"/>
+      <source>Initializing</source>
+      <translation>初期化中</translation>
+    </message>
+    <message id="devicelist_battery_shutdown">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="54"/>
+      <source>Shutdown</source>
+      <extracomment>Status is 'Shutdown'</extracomment>
+      <translation>シャットダウン</translation>
+    </message>
+    <message id="devicelist_battery_updating">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="58"/>
+      <source>Updating</source>
+      <extracomment>Status is 'Updating'</extracomment>
+      <translation>更新中</translation>
+    </message>
+    <message id="devicelist_battery_going_to_run">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="64"/>
+      <source>Going to run</source>
+      <extracomment>Status is 'Going to run'</extracomment>
+      <translation>実行予定</translation>
+    </message>
+    <message id="devicelist_battery_pre_charging">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="68"/>
+      <source>Pre-Charging</source>
+      <extracomment>Status is 'Pre-Charging'</extracomment>
+      <translation>プレチャージ</translation>
+    </message>
+    <message id="devicelist_battery_contactor_check">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="72"/>
+      <source>Contactor check</source>
+      <extracomment>Status is 'Contactor check'</extracomment>
+      <translation>接触子の確認</translation>
+    </message>
+    <message id="batteryalarms_state_of_health">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="66"/>
+      <source>State of health</source>
+      <translation>健全性</translation>
+    </message>
+    <message id="common_words_battery_temperature">
+      <location filename="../../components/CommonWords.qml" line="98"/>
+      <source>Battery temperature</source>
+      <translation>バッテリー温度</translation>
+    </message>
+    <message id="battery_air_temp">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="197"/>
+      <source>Air temperature</source>
+      <translation>気温</translation>
+    </message>
+    <message id="battery_starter_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="204"/>
+      <source>Starter voltage</source>
+      <translation>スターター電圧</translation>
+    </message>
+    <message id="battery_buss_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="252"/>
+      <source>Bus voltage</source>
+      <translation>バス電圧</translation>
+    </message>
+    <message id="battery_top_section_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="220"/>
+      <source>Top section voltage</source>
+      <translation>上部セクション電圧</translation>
+    </message>
+    <message id="battery_bottom_section_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="228"/>
+      <source>Bottom section voltage</source>
+      <translation>下部セクション電圧</translation>
+    </message>
+    <message id="battery_mid_point_deviation">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="236"/>
+      <source>Mid-point deviation</source>
+      <translation>中間点偏差</translation>
+    </message>
+    <message id="battery_consumed_amphours">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="244"/>
+      <source>Consumed AmpHours</source>
+      <translation>消費アンペアアワー</translation>
+    </message>
+    <message id="battery_time_to_go">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="260"/>
+      <source>Time-to-go</source>
+      <translation>残り時間</translation>
+    </message>
+    <message id="battery_details">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="291"/>
+      <source>Details</source>
+      <translation>詳細</translation>
+    </message>
+    <message id="battery_module_level_alarms">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="315"/>
+      <source>Module level alarms</source>
+      <translation>モジュールレベルアラーム</translation>
+    </message>
+    <message id="battery_settings_diagnostics">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="350"/>
+      <source>Diagnostics</source>
+      <translation>診断</translation>
+    </message>
+    <message id="battery_settings_fuses">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="375"/>
+      <source>Fuses</source>
+      <translation>ヒューズ</translation>
+    </message>
+    <message id="battery_settings_io">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="391"/>
+      <source>IO</source>
+      <translation>IO</translation>
+    </message>
+    <message id="pagesettingsgeneral_system">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="108"/>
+      <source>System</source>
+      <translation>システム</translation>
+    </message>
+    <message id="battery_settings_parameters">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="421"/>
+      <source>Parameters</source>
+      <translation>パラメーター</translation>
+    </message>
+    <message id="battery_redetect_battery">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="446"/>
+      <source>Redetect Battery</source>
+      <translation>バッテリーを再検出</translation>
+    </message>
+    <message id="vebus_device_press_to_redetect">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="217"/>
+      <source>Press to redetect</source>
+      <translation>押して再検出</translation>
+    </message>
+    <message id="battery_redetecting_the_battery_note">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="455"/>
+      <source>Redetecting the battery may take up time 60 seconds. Meanwhile the name of the battery may be incorrect.</source>
+      <translation>バッテリーの再検出には最大60秒かかる場合があります。その間、バッテリー名が正しく表示されないことがあります。</translation>
+    </message>
+    <message id="batteryalarms_high_charge_current">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="38"/>
+      <source>High charge current</source>
+      <translation>高充電電流</translation>
+    </message>
+    <message id="batteryalarms_high_discharge_current">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="52"/>
+      <source>High discharge current</source>
+      <translation>高放電電流</translation>
+    </message>
+    <message id="evchargers_status_low_state_of_charge">
+      <location filename="../../data/EvChargers.qml" line="70"/>
+      <source>Low SOC</source>
+      <translation>低SOC</translation>
+    </message>
+    <message id="batteryalarms_low_starter_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="73"/>
+      <source>Low starter voltage</source>
+      <translation>スターター低電圧</translation>
+    </message>
+    <message id="batteryalarms_high_starter_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="80"/>
+      <source>High starter voltage</source>
+      <translation>スターター高電圧</translation>
+    </message>
+    <message id="batteryalarms_battery_temperature_sensor">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="99"/>
+      <source>Battery temperature sensor</source>
+      <translation>バッテリー温度センサー</translation>
+    </message>
+    <message id="batteryalarms_mid_point_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="106"/>
+      <source>Mid-point voltage</source>
+      <translation>中点電圧</translation>
+    </message>
+    <message id="batteryalarms_high_internal_temperature">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="120"/>
+      <source>High internal temperature</source>
+      <translation>内部高温</translation>
+    </message>
+    <message id="batteryalarms_low_charge_temperature">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="127"/>
+      <source>Low charge temperature</source>
+      <translation>低充電温度</translation>
+    </message>
+    <message id="batteryalarms_high_charge_temperature">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="134"/>
+      <source>High charge temperature</source>
+      <translation>高充電温度</translation>
+    </message>
+    <message id="batteryalarms_internal_failure">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="141"/>
+      <source>Internal failure</source>
+      <translation>内部故障</translation>
+    </message>
+    <message id="batteryalarms_circuit_breaker_tripped">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="148"/>
+      <source>Circuit breaker tripped</source>
+      <translation>回路ブレーカー作動</translation>
+    </message>
+    <message id="batteryalarms_cell_imbalance">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="155"/>
+      <source>Cell imbalance</source>
+      <translation>セル不均衡</translation>
+    </message>
+    <message id="batteryalarms_low_cell_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="162"/>
+      <source>Low cell voltage</source>
+      <translation>低セル電圧</translation>
+    </message>
+    <message id="batterydetails_lowest_cell_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="19"/>
+      <source>Lowest cell voltage</source>
+      <translation>最小セル電圧</translation>
+    </message>
+    <message id="batterydetails_highest_cell_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="29"/>
+      <source>Highest cell voltage</source>
+      <translation>最大セル電圧</translation>
+    </message>
+    <message id="batterydetails_minimum_cell_temperature">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="39"/>
+      <source>Minimum cell temperature</source>
+      <translation>最小セル温度</translation>
+    </message>
+    <message id="batterydetails_maximum_cell_temperature">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="49"/>
+      <source>Maximum cell temperature</source>
+      <translation>最大セル温度</translation>
+    </message>
+    <message id="batterydetails_modules">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="69"/>
+      <source>Battery modules</source>
+      <translation>バッテリーモジュール</translation>
+    </message>
+    <message id="devicelist_batterydetails_modules_online">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="62"/>
+      <source>%1 online</source>
+      <extracomment>%1 = number of battery modules that are online</extracomment>
+      <translation>%1 がオンライン</translation>
+    </message>
+    <message id="devicelist_batterydetails_modules_offline">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="66"/>
+      <source>%1 offline</source>
+      <extracomment>%1 = number of battery modules that are offline</extracomment>
+      <translation>%1 がオフライン</translation>
+    </message>
+    <message id="batterydetails_number_of_modules_blocking_charge_discharge">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="79"/>
+      <source>Number of modules blocking charge / discharge</source>
+      <translation>充電/放電をブロックしているモジュールの数</translation>
+    </message>
+    <message id="batterydetails_installed_available_capacity">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="89"/>
+      <source>Installed / Available capacity</source>
+      <translation>設置済み/利用可能な容量</translation>
+    </message>
+    <message id="batteryalarms_deepest_discharge">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="19"/>
+      <source>Deepest discharge</source>
+      <translation>過重放電</translation>
+    </message>
+    <message id="batteryhistory_last_discharge">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="27"/>
+      <source>Last discharge</source>
+      <translation>最後の放電</translation>
+    </message>
+    <message id="batteryhistory_average_discharge">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="35"/>
+      <source>Average discharge</source>
+      <translation>平均放電</translation>
+    </message>
+    <message id="batteryhistory_total_charge_cycles">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="43"/>
+      <source>Total charge cycles</source>
+      <translation>合計充電サイクル</translation>
+    </message>
+    <message id="batteryhistory_number_of_full_discharges">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="50"/>
+      <source>Number of full discharges</source>
+      <translation>完全放電回数</translation>
+    </message>
+    <message id="batteryhistory_cumulative_ah_drawn">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="57"/>
+      <source>Cumulative Ah drawn</source>
+      <translation>累積消費Ah</translation>
+    </message>
+    <message id="batteryhistory_minimum_cell_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="79"/>
+      <source>Minimum cell voltage</source>
+      <translation>最小セル電圧</translation>
+    </message>
+    <message id="batteryhistory_maximum_cell_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="88"/>
+      <source>Maximum cell voltage</source>
+      <translation>最大セル電圧</translation>
+    </message>
+    <message id="batteryhistory_time_since_last_full_charge">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="97"/>
+      <source>Time since last full charge</source>
+      <translation>最後のフル充電以来の時間</translation>
+    </message>
+    <message id="batteryhistory_synchronisation_count">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="104"/>
+      <source>Synchronisation count</source>
+      <translation>同期回数</translation>
+    </message>
+    <message id="batteryhistory_low_starter_bat_voltage_alarms">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="123"/>
+      <source>Low starter battery voltage alarms</source>
+      <translation>低始動バッテリー電圧アラーム</translation>
+    </message>
+    <message id="batteryhistory_minimum_starter_bat_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="137"/>
+      <source>Minimum starter battery voltage</source>
+      <translation>最小始動バッテリー電圧</translation>
+    </message>
+    <message id="batteryhistory_maximum_starter_bat_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="145"/>
+      <source>Maximum starter battery voltage</source>
+      <translation>最大始動バッテリー電圧</translation>
+    </message>
+    <message id="batteryhistory_discharged_energy">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="165"/>
+      <source>Discharged energy</source>
+      <translation>放電エネルギー</translation>
+    </message>
+    <message id="batteryhistory_charged_energy">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="173"/>
+      <source>Charged energy</source>
+      <translation>充電エネルギー</translation>
+    </message>
+    <message id="batteryparameters_charge_voltage_limit_cvl">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="18"/>
+      <source>Charge Voltage Limit (CVL)</source>
+      <translation>充電電圧制限 (CVL)</translation>
+    </message>
+    <message id="batteryparameters_charge_current_limit_ccl">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="25"/>
+      <source>Charge Current Limit (CCL)</source>
+      <translation>充電電流制限 (CCL)</translation>
+    </message>
+    <message id="batteryparameters_discharge_current_limit_dcl">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="32"/>
+      <source>Discharge Current Limit (DCL)</source>
+      <translation>放電電流制限 (DCL)</translation>
+    </message>
+    <message id="batteryparameters_low_voltage_disconnect_always_ignored">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="39"/>
+      <source>Low Voltage Disconnect (always ignored)</source>
+      <translation>低電圧切断 (常に無視)</translation>
+    </message>
+    <message id="batterysettings_battery_bank">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="38"/>
+      <source>Battery bank</source>
+      <translation>バッテリーバンク</translation>
+    </message>
+    <message id="batterysettings_relay_on_battery_monitor">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="56"/>
+      <source>Relay (on battery monitor)</source>
+      <translation>リレー (バッテリーモニター上)</translation>
+    </message>
+    <message id="batterysettings_restore_factory_defaults">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="66"/>
+      <source>Restore factory defaults</source>
+      <translation>工場出荷時設定に復元</translation>
+    </message>
+    <message id="vebus_backup_press_to_restore">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="391"/>
+      <source>Press to restore</source>
+      <translation>押して復元</translation>
+    </message>
+    <message id="batterysettings_confirm_restore_factory_defaults">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="79"/>
+      <source>Restore factory defaults?</source>
+      <translation>工場出荷時設定に復元しますか？</translation>
+    </message>
+    <message id="batterysettings_bluetooth_enabled">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettings.qml" line="93"/>
+      <source>Bluetooth Enabled</source>
+      <translation>Bluetooth 有効</translation>
+    </message>
+    <message id="batterysettingsbattery_nominal_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="24"/>
+      <source>Nominal Voltage</source>
+      <translation>公称電圧</translation>
+    </message>
+    <message id="batterysettingsbattery_12_volt">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="28"/>
+      <source>12 Volt</source>
+      <translation>12 ボルト</translation>
+    </message>
+    <message id="batterysettingsbattery_24_volt">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="30"/>
+      <source>24 Volt</source>
+      <translation>24 ボルト</translation>
+    </message>
+    <message id="batterysettingsbattery_48_volt">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="32"/>
+      <source>48 Volt</source>
+      <translation>48ボルト</translation>
+    </message>
+    <message id="devicelist_tanksetup_capacity">
+      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="18"/>
+      <source>Capacity</source>
+      <translation>定員</translation>
+    </message>
+    <message id="batterysettingsbattery_charged_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="48"/>
+      <source>Charged voltage</source>
+      <translation>充電済み電圧</translation>
+    </message>
+    <message id="batterysettingsbattery_tail_current">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="59"/>
+      <source>Tail current</source>
+      <translation>テール電流</translation>
+    </message>
+    <message id="batterysettingsbattery_charged_detection_time">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="70"/>
+      <source>Charged detection time</source>
+      <translation>充電検知時間</translation>
+    </message>
+    <message id="batterysettingsbattery_peukert_exponent">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="79"/>
+      <source>Peukert exponent</source>
+      <translation>ポイカート指数</translation>
+    </message>
+    <message id="batterysettingsbattery_charge_efficiency_factor">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="89"/>
+      <source>Charge efficiency factor</source>
+      <translation>充電効率要因</translation>
+    </message>
+    <message id="batterysettingsbattery_current_threshold">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="98"/>
+      <source>Current threshold</source>
+      <translation>電流しきい値</translation>
+    </message>
+    <message id="batterysettingsbattery_time_to_go_averaging_period">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="109"/>
+      <source>Time-to-go averaging period</source>
+      <translation>残り時間平均計算期間</translation>
+    </message>
+    <message id="batterysettingsbattery_time_to_go_discharge_floor">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="129"/>
+      <source>Time-to-go discharge floor</source>
+      <translation>放電下限までの残り時間</translation>
+    </message>
+    <message id="batterysettingsbattery_current_offset">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="138"/>
+      <source>Current offset</source>
+      <translation>電流オフセット</translation>
+    </message>
+    <message id="batterysettingsbattery_synchronise_state_of_charge_to_100%">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="145"/>
+      <source>Synchronise state-of-charge to 100%</source>
+      <translation>充電率を100%に同期</translation>
+    </message>
+    <message id="batterysettingsbattery_press_to_sync">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="147"/>
+      <source>Press to sync</source>
+      <translation>押して同期</translation>
+    </message>
+    <message id="batterysettingsbattery_calibrate_zero_current">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="160"/>
+      <source>Calibrate zero current</source>
+      <translation>ゼロ電流を校正</translation>
+    </message>
+    <message id="batterysettingsbattery_press_to_set_to_0">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="162"/>
+      <source>Press to set to 0</source>
+      <translation>押して0に設定</translation>
+    </message>
+    <message id="batterylynxdistibutor_distributor">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="37"/>
+      <source>Distributor %1</source>
+      <translation>分電器 %1</translation>
+    </message>
+    <message id="lynxdistributor_no_power_on_busbar">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="46"/>
+      <source>No power on busbar</source>
+      <translation>バスバーに電源がありません</translation>
+    </message>
+    <message id="lynxdistributor_count_fuses_blown" numerus="yes">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="61"/>
+      <source>%n fuse(s) blown</source>
+      <extracomment>%n = number of fuses that have blown</extracomment>
+      <translation>
+        <numerusform>%n個のヒューズが切れています</numerusform>
+      </translation>
+    </message>
+    <message id="lynxdistributor_no_information_available">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="84"/>
+      <source>No information available, see previous page for Distributor status.</source>
+      <translation>情報がありません。ディストリビューターのステータスについては前のページを参照してください。</translation>
+    </message>
+    <message id="lynxdistributor_fuse_name">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="91"/>
+      <source>Fuse %1</source>
+      <extracomment>%1 = name of this fuse</extracomment>
+      <translation>フューズ%1</translation>
+    </message>
+    <message id="lynxdistributor_not_used">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="97"/>
+      <source>Not used</source>
+      <translation>未使用</translation>
+    </message>
+    <message id="lynxdistributor_blown">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxDistributorList.qml" line="102"/>
+      <source>Blown</source>
+      <translation>溶断</translation>
+    </message>
+    <message id="lynxiondiagnostics_shutdowns_due_error">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxIonDiagnostics.qml" line="18"/>
+      <source>Shutdowns due error</source>
+      <translation>エラーによるシャットダウン</translation>
+    </message>
+    <message id="lynxionio_system_switch">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="18"/>
+      <source>System Switch</source>
+      <translation>システムスイッチ</translation>
+    </message>
+    <message id="lynxionio_external_relay">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="38"/>
+      <source>External relay</source>
+      <translation>外部リレー</translation>
+    </message>
+    <message id="lynxionio_programmable_contact">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxIonIo.qml" line="46"/>
+      <source>Programmable Contact</source>
+      <translation>プログラマブル接点</translation>
+    </message>
+    <message id="common_words_batteries">
+      <location filename="../../components/CommonWords.qml" line="57"/>
+      <source>Batteries</source>
+      <translation>バッテリー</translation>
+    </message>
+    <message id="lynxionsystem_parallel">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="30"/>
+      <source>Parallel</source>
+      <translation>並列</translation>
+    </message>
+    <message id="lynxionsystem_series">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="36"/>
+      <source>Series</source>
+      <translation>直列</translation>
+    </message>
+    <message id="lynxionsystem_min_max_cell_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="48"/>
+      <source>Min/max cell voltage</source>
+      <translation>最小/最大セル電圧</translation>
+    </message>
+    <message id="lynxionsystem_min_max_cell_temperature">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="68"/>
+      <source>Min/max cell temperature</source>
+      <translation>最小/最大セル温度</translation>
+    </message>
+    <message id="battery_status_balancing">
+      <location filename="../../src/enums.cpp" line="78"/>
+      <source>Balancing</source>
+      <translation>バランシング</translation>
+    </message>
+    <message id="settings_switch_channel_output">
+      <location filename="../../pages/settings/devicelist/PageSwitch.qml" line="82"/>
+      <source>Output</source>
+      <extracomment>DC output measurement values</extracomment>
+      <translation>出力</translation>
+    </message>
+    <message id="alternator_wakespeed_field_drive">
+      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="68"/>
+      <source>Field drive</source>
+      <translation>フィールドドライブ</translation>
+    </message>
+    <message id="alternator_wakespeed_engine_speed">
+      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="91"/>
+      <source>Engine speed</source>
+      <translation>エンジン回転数</translation>
+    </message>
+    <message id="dcmeter_aux_voltage">
+      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterModel.qml" line="37"/>
+      <source>Aux voltage</source>
+      <translation>補助電圧</translation>
+    </message>
+    <message id="dcmeter_alarms_no_alarms">
+      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="17"/>
+      <source>No alarms</source>
+      <translation>アラームなし</translation>
+    </message>
+    <message id="dcmeter_alarms_low_voltage">
+      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="31"/>
+      <source>Low voltage</source>
+      <translation>低電圧</translation>
+    </message>
+    <message id="dcmeter_alarms_high_voltage">
+      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="40"/>
+      <source>High voltage</source>
+      <translation>高電圧</translation>
+    </message>
+    <message id="dcmeter_alarms_low_aux_voltage">
+      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="49"/>
+      <source>Low aux voltage</source>
+      <translation>補助低電圧</translation>
+    </message>
+    <message id="dcmeter_alarms_high_aux_voltage">
+      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterAlarms.qml" line="58"/>
+      <source>High aux voltage</source>
+      <translation>補助高電圧</translation>
+    </message>
+    <message id="dcmeter_history_low_aux_voltage_alarms">
+      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="57"/>
+      <source>Low aux voltage alarms</source>
+      <translation>補助電圧低アラーム</translation>
+    </message>
+    <message id="dcmeter_history_high_aux_voltage_alarms">
+      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="64"/>
+      <source>High aux voltage alarms</source>
+      <translation>補助電圧高アラーム</translation>
+    </message>
+    <message id="dcmeter_history_minimum_aux_voltage">
+      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="71"/>
+      <source>Minimum aux voltage</source>
+      <translation>最小補助電圧</translation>
+    </message>
+    <message id="dcmeter_history_maximum_aux_voltage">
+      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="79"/>
+      <source>Maximum aux voltage</source>
+      <translation>最大補助電圧</translation>
+    </message>
+    <message id="dcmeter_history_produced_energy">
+      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="99"/>
+      <source>Produced energy</source>
+      <translation>生産エネルギー</translation>
+    </message>
+    <message id="dcmeter_history_consumed_energy">
+      <location filename="../../pages/settings/devicelist/dc-in/PageDcMeterHistory.qml" line="107"/>
+      <source>Consumed energy</source>
+      <translation>消費エネルギー</translation>
+    </message>
+    <message id="devicelist_tankalarm_enable_alarm">
+      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="18"/>
+      <source>Enable alarm</source>
+      <translation>アラームを有効にする</translation>
+    </message>
+    <message id="devicelist_tankalarm_active_level">
+      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="24"/>
+      <source>Active level</source>
+      <translation>作動レベル</translation>
+    </message>
+    <message id="devicelist_tankalarm_restore_level">
+      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="33"/>
+      <source>Restore level</source>
+      <translation>復元レベル</translation>
+    </message>
+    <message id="devicelist_tankalarm_delay">
+      <location filename="../../pages/settings/devicelist/tank/PageTankAlarm.qml" line="42"/>
+      <source>Delay</source>
+      <translation>遅延</translation>
+    </message>
+    <message id="devicelist_tanksensor_level">
+      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="29"/>
+      <source>Level</source>
+      <translation>レベル</translation>
+    </message>
+    <message id="devicelist_tanksensor_remaining">
+      <location filename="../../pages/settings/devicelist/tank/PageTankSensor.qml" line="36"/>
+      <source>Remaining</source>
+      <translation>残り</translation>
+    </message>
+    <message id="temperature_sensor_battery">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="112"/>
+      <source>Sensor battery</source>
+      <translation>センサーバッテリー</translation>
+    </message>
+    <message id="devicelist_tanksetup_sensor_type">
+      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="31"/>
+      <source>Sensor type</source>
+      <translation>センサータイプ</translation>
+    </message>
+    <message id="devicelist_tanksetup_standard">
+      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="44"/>
+      <source>Standard</source>
+      <translation>デフォルト</translation>
+    </message>
+    <message id="devicelist_tanksetup_european_(0_to_180_ohm)">
+      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="49"/>
+      <source>European (0 to 180 Ohm)</source>
+      <translation>欧州式 (0～180オーム)</translation>
+    </message>
+    <message id="devicelist_tanksetup_us_(240_to_30_ohm)">
+      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="51"/>
+      <source>US (240 to 30 Ohm)</source>
+      <translation>米国式 (240～30オーム)</translation>
+    </message>
+    <message id="devicelist_tanksetup_custom">
+      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="53"/>
+      <source>Custom</source>
+      <translation>カスタム</translation>
+    </message>
+    <message id="devicelist_tanksetup_sensor_value_when_empty">
+      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="59"/>
+      <source>Sensor value when empty</source>
+      <translation>空の場合のセンサー値</translation>
+    </message>
+    <message id="devicelist_tanksetup_fluid_type">
+      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="79"/>
+      <source>Fluid type</source>
+      <translation>流体タイプ</translation>
+    </message>
+    <message id="devicelist_tanksetup_butane_ratio">
+      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="88"/>
+      <source>Butane ratio</source>
+      <translation>ブタン比率</translation>
+    </message>
+    <message id="devicelist_tanksetup_custom_shape">
+      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="98"/>
+      <source>Custom shape</source>
+      <translation>カスタム形状</translation>
+    </message>
+    <message id="devicelist_tanksetup_averaging_time">
+      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="114"/>
+      <source>Averaging time</source>
+      <translation>平均時間</translation>
+    </message>
+    <message id="devicelist_tanksetup_sensor_value">
+      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="122"/>
+      <source>Sensor value</source>
+      <translation>センサー値</translation>
+    </message>
+    <message id="devicelist_tankshape_empty">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="83"/>
+      <source>No custom shape defined. You may define one with up to ten points. Note that 0% and 100% are implied.</source>
+      <translation>カスタム形状が定義されていません。最大10ポイントで定義できます。なお、0%と100%は自動的に適用されます。</translation>
+    </message>
+    <message id="devicelist_tankshape_point">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="102"/>
+      <source>Point %1</source>
+      <extracomment>%1 = the point number</extracomment>
+      <translation>ポイント %1</translation>
+    </message>
+    <message id="devicelist_tankshape_add_point">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="199"/>
+      <source>Add point</source>
+      <translation>ポイントを追加</translation>
+    </message>
+    <message id="devicelist_tankshape_sensor_level">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="225"/>
+      <source>Sensor level</source>
+      <extracomment>The sensor level (as a percentage) for this tank shape point</extracomment>
+      <translation>センサーレベル</translation>
+    </message>
+    <message id="devicelist_tankshape_duplicate_sensor_level">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="331"/>
+      <source>Duplicate sensor level values are not allowed.</source>
+      <translation>センサーレベル値の重複は許可されていません。</translation>
+    </message>
+    <message id="devicelist_tankshape_volume_not_increasing">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="337"/>
+      <source>Volume values must be increasing.</source>
+      <translation>容量値は増加させてください。</translation>
+    </message>
+    <message id="cycle_history_watchdog">
+      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="41"/>
+      <source>Watchdog</source>
+      <translation>ウォッチドッグ</translation>
+    </message>
+    <message id="ac-in-setup_unlocked_(kvarh)">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="41"/>
+      <source>Unlocked (kVARh)</source>
+      <translation>ロック解除済み (kVARh)</translation>
+    </message>
+    <message id="ac-in-setup_unlocked_(2)">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="44"/>
+      <source>Unlocked (2)</source>
+      <translation>ロック解除済み (2)</translation>
+    </message>
+    <message id="ac-in-setup_unlocked_(1)">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="47"/>
+      <source>Unlocked (1)</source>
+      <translation>ロック解除済み (1)</translation>
+    </message>
+    <message id="ac-in-setup_locked">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="50"/>
+      <source>Locked</source>
+      <translation>ロック</translation>
+    </message>
+    <message id="ac-in-setup_phase_configuration">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="113"/>
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="144"/>
+      <source>Phase configuration</source>
+      <translation>フェーズ構成</translation>
+    </message>
+    <message id="ac-in-setup_switch_position">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="129"/>
+      <source>Switch position</source>
+      <translation>スイッチ位置</translation>
+    </message>
+    <message id="ac-in-setup_two_phase">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="151"/>
+      <source>2-phase</source>
+      <translation>2相</translation>
+    </message>
+    <message id="ac-in-setup_three_phase">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="153"/>
+      <source>3-phase</source>
+      <translation>三相</translation>
+    </message>
+    <message id="ac-in-genset_ac">
+      <location filename="../../components/PageGensetModel.qml" line="218"/>
+      <source>AC</source>
+      <translation>AC</translation>
+    </message>
+    <message id="ac-in-genset_engine">
+      <location filename="../../components/PageGensetModel.qml" line="256"/>
+      <source>Engine</source>
+      <translation>エンジン</translation>
+    </message>
+    <message id="devicelist_motordrive_coolanttemperature">
+      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="79"/>
+      <source>Coolant temperature</source>
+      <oldsource>Coolant Temperature</oldsource>
+      <translation>冷却水温度</translation>
+    </message>
+    <message id="ac-in-genset_exhaust_temperature">
+      <location filename="../../components/PageGensetModel.qml" line="308"/>
+      <source>Exhaust temperature</source>
+      <translation>排気温度</translation>
+    </message>
+    <message id="ac-in-genset_winding_temperature">
+      <location filename="../../components/PageGensetModel.qml" line="315"/>
+      <source>Winding temperature</source>
+      <translation>巻線温度</translation>
+    </message>
+    <message id="ac-in-genset_starter_battery_voltage">
+      <location filename="../../components/PageGensetModel.qml" line="329"/>
+      <source>Starter battery voltage</source>
+      <translation>スターターバッテリー電圧</translation>
+    </message>
+    <message id="ac-in-genset_number_of_starts">
+      <location filename="../../components/PageGensetModel.qml" line="337"/>
+      <source>Number of starts</source>
+      <translation>始動回数</translation>
+    </message>
+    <message id="ac-in-modeldefault_front_selector_locked">
+      <location filename="../../components/listitems/ListAcInError.qml" line="26"/>
+      <source>Front selector locked (%1)</source>
+      <extracomment>%1 = the error number</extracomment>
+      <translation>前面セレクターがロックされています (%1)</translation>
+    </message>
+    <message id="ac-in-modeldefault_no_error">
+      <location filename="../../components/listitems/ListAcInError.qml" line="30"/>
+      <source>No error (%1)</source>
+      <extracomment>%1 = the error number</extracomment>
+      <translation>エラーなし (%1)</translation>
+    </message>
+    <message id="ac-in-modeldefault_ac_totals">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="88"/>
+      <source>AC Totals</source>
+      <translation>AC合計値</translation>
+    </message>
+    <message id="ac-in-modeldefault_energy_x">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="122"/>
+      <source>Energy L%1</source>
+      <extracomment>%1 = phase number (1-3)</extracomment>
+      <translation>エネルギー L%1</translation>
+    </message>
+    <message id="ac-in-modeldefault_phase_sequence">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="160"/>
+      <source>Phase Sequence</source>
+      <translation>相シーケンス</translation>
+    </message>
+    <message id="ac-in-modeldefault_phase_sequence_l3_first">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="166"/>
+      <source>L1-L3-L2</source>
+      <extracomment>Phase sequence L1-L3-L2</extracomment>
+      <translation>L1-L3-L2</translation>
+    </message>
+    <message id="ac-in-modeldefault_phase_sequence_ordered">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="169"/>
+      <source>L1-L2-L3</source>
+      <extracomment>Phase sequence L1-L2-L3</extracomment>
+      <translation>L1-L2-L3</translation>
+    </message>
+    <message id="ac-in-modeldefault_data_manager_version">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcIn.qml" line="35"/>
+      <source>Data manager version</source>
+      <translation>データマネージャーバージョン</translation>
+    </message>
+    <message id="smappee_ct_list_type">
+      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTList.qml" line="31"/>
+      <source>%1: %2</source>
+      <extracomment>%1 = device number, %2 = device type</extracomment>
+      <translation>%1: %2</translation>
+    </message>
+    <message id="smappeect_title">
+      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="18"/>
+      <source>CT %1</source>
+      <extracomment>%1 = CT device number</extracomment>
+      <translation>CT %1</translation>
+    </message>
+    <message id="smappeect_flashing_led_indicates_this_ct">
+      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeCTSetup.qml" line="62"/>
+      <source>Flashing LED indicates this CT</source>
+      <translation>点滅するLEDがこのCTを示します</translation>
+    </message>
+    <message id="smappee_device_list_bus_devices">
+      <location filename="../../pages/settings/devicelist/ac-in/PageSmappeeDeviceList.qml" line="15"/>
+      <source>Smappee bus devices</source>
+      <translation>Smappeeバスデバイス</translation>
+    </message>
+    <message id="common_words_setting_disabled_when_dmc_connected">
+      <location filename="../../components/CommonWords.qml" line="689"/>
+      <source>This setting is disabled when a Digital Multi Control is connected.</source>
+      <oldsource>This setting is disabled when a Digital Multi Control is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
+      <translation>デジタルマルチコントロールが接続されている場合、この設定は無効になります。</translation>
+    </message>
+    <message id="common_words_setting_disabled_when_bms_connected">
+      <location filename="../../components/CommonWords.qml" line="678"/>
+      <source>This setting is disabled when a VE.Bus BMS is connected.</source>
+      <oldsource>This setting is disabled when a VE.Bus BMS is connected. If it was recently disconnected execute 'Redetect system' that is available below on this menu.</oldsource>
+      <translation>VE.Bus BMSが接続されている場合、この設定は無効になります。</translation>
+    </message>
+    <message id="settings_multirs_ac_in_phase">
+      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="151"/>
+      <source>AC in %1</source>
+      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+      <translation>AC入力 %1</translation>
+    </message>
+    <message id="common_words_dc">
+      <location filename="../../components/CommonWords.qml" line="161"/>
+      <source>DC</source>
+      <translation>DC</translation>
+    </message>
+    <message id="iochannel_invert_inverted">
+      <location filename="../../pages/settings/devicelist/iochannel/PageGenericInput.qml" line="42"/>
+      <source>Inverted</source>
+      <translation>反転</translation>
+    </message>
+    <message id="digitalinput_invert_alarm_logic">
+      <location filename="../../pages/settings/devicelist/PageDigitalInput.qml" line="60"/>
+      <source>Invert alarm logic</source>
+      <translation>アラームロジックを反転</translation>
+    </message>
+    <message id="page_meteo_irradiance">
+      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="42"/>
+      <source>Irradiance</source>
+      <translation>照射</translation>
+    </message>
+    <message id="page_meteo_cell_temperature">
+      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="51"/>
+      <source>Cell temperature</source>
+      <translation>セル温度</translation>
+    </message>
+    <message id="page_meteo_external_temperature_1">
+      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="60"/>
+      <source>External temperature (1)</source>
+      <translation>外部温度 (1)</translation>
+    </message>
+    <message id="page_meteo_external_temperature">
+      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="62"/>
+      <source>External temperature</source>
+      <translation>外部温度</translation>
+    </message>
+    <message id="page_meteo_external_temperature_2">
+      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="73"/>
+      <source>External temperature (2)</source>
+      <translation>外部温度 (2)</translation>
+    </message>
+    <message id="page_meteo_wind_speed">
+      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="81"/>
+      <source>Wind speed</source>
+      <translation>風速</translation>
+    </message>
+    <message id="page_meteo_settings_auto_detect">
+      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="17"/>
+      <source>Auto-detect</source>
+      <translation>自動検出</translation>
+    </message>
+    <message id="page_meteo_settings_wind_speed_sensor">
+      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="24"/>
+      <source>Wind speed sensor</source>
+      <translation>風速センサー</translation>
+    </message>
+    <message id="page_meteo_settings_external_temperature_sensor">
+      <location filename="../../pages/settings/devicelist/PageMeteoSettings.qml" line="31"/>
+      <source>External temperature sensor</source>
+      <translation>外部温度センサー</translation>
+    </message>
+    <message id="pulsecounter_aggregate">
+      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounter.qml" line="22"/>
+      <source>Aggregate</source>
+      <translation>集計</translation>
+    </message>
+    <message id="pulsecounter_setup_multiplier">
+      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="27"/>
+      <source>Multiplier</source>
+      <translation>乗数</translation>
+    </message>
+    <message id="pulsecounter_setup_reset_counter">
+      <location filename="../../pages/settings/devicelist/pulsemeter/PagePulseCounterSetup.qml" line="35"/>
+      <source>Reset counter</source>
+      <translation>カウンターをリセット</translation>
+    </message>
+    <message id="generic_input_status_sensor_battery_low">
+      <location filename="../../src/enums.cpp" line="514"/>
+      <source>Sensor battery low</source>
+      <translation>センサーのバッテリー残量低下</translation>
+    </message>
+    <message id="temperature_humidity">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="54"/>
+      <source>Humidity</source>
+      <translation>湿度</translation>
+    </message>
+    <message id="temperature_pressure">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="62"/>
+      <source>Pressure</source>
+      <translation>圧力</translation>
+    </message>
+    <message id="temperature_offset">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="43"/>
+      <source>Offset</source>
+      <translation>オフセット</translation>
+    </message>
+    <message id="temperature_scale">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="52"/>
+      <source>Scale</source>
+      <translation>スケール</translation>
+    </message>
+    <message id="temperature_sensor_voltage">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensorSetup.qml" line="63"/>
+      <source>Sensor voltage</source>
+      <translation>センサー電圧</translation>
+    </message>
+    <message id="settings_multirs_total_pv_power">
+      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="205"/>
+      <source>Total PV Power</source>
+      <translation>PV合計電力</translation>
+    </message>
+    <message id="common_words_product_page">
+      <location filename="../../components/CommonWords.qml" line="442"/>
+      <source>Product page</source>
+      <translation>製品ページ</translation>
+    </message>
+    <message id="vebus_device_ac_sensor_x_y">
+      <location filename="../../pages/vebusdevice/PageAcSensor.qml" line="19"/>
+      <source>AC sensor %1 %2</source>
+      <translation>ACセンサー %1 %2</translation>
+    </message>
+    <message id="vebus_mk3_new_version_available">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="37"/>
+      <source>A new MK3 version is available.
+NOTE: The update might temporarily stop the system.</source>
+      <translation>新しいMK3バージョンが利用可能です。
+注記：アップデートにより、システムが一時的に停止する場合があります。</translation>
+    </message>
+    <message id="vebus_device_update_the_mk3">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="43"/>
+      <source>Update the MK3</source>
+      <translation>MK3をアップデート</translation>
+    </message>
+    <message id="vebus_device_press_to_update">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="45"/>
+      <source>Press to update</source>
+      <translation>押してアップデート</translation>
+    </message>
+    <message id="vebus_device_updating_the_mk3">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="50"/>
+      <source>Updating the MK3, values will reappear after the update is complete</source>
+      <translation>MK3をアップデート中。アップデート完了後、値が再表示されます。</translation>
+    </message>
+    <message id="vebus_device_charging_the_battery_to_100">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="93"/>
+      <source>Charging the battery to 100%</source>
+      <translation>バッテリーを100%まで充電中</translation>
+    </message>
+    <message id="vebus_device_in_progress">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="80"/>
+      <source>In progress</source>
+      <translation>進行中</translation>
+    </message>
+    <message id="vebus_device_press_to_stop">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="87"/>
+      <source>Press to stop</source>
+      <translation>押して停止</translation>
+    </message>
+    <message id="vebus_device_press_to_start">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="127"/>
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="90"/>
+      <source>Press to start</source>
+      <translation>押して開始</translation>
+    </message>
+    <message id="vebus_device_charge_the_battery_to_100">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="96"/>
+      <source>Charge the battery to 100%</source>
+      <translation>バッテリーを100%まで充電</translation>
+    </message>
+    <message id="vebus_device_return_to_normal_operation">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="105"/>
+      <source>The system will return to normal operation, prioritizing renewable energy.
+Do you want to continue?</source>
+      <translation>システムは再生可能エネルギーを優先する通常動作に戻ります。
+続行しますか？</translation>
+    </message>
+    <message id="vebus_device_use_shore_power">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="126"/>
+      <source>Shore power will be used when available and the "Solar &amp; wind priority" option will be ignored.
+Do you want to continue?</source>
+      <translation>利用可能な場合は商用電源が使用され、「太陽光・風力優先」オプションは無視されます。
+続行しますか？</translation>
+    </message>
+    <message id="ebus_device_use_shore_power_once">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="131"/>
+      <source>Shore power will be used to complete a full battery charge for one time.
+After the charging process is complete, the system will return to normal operation, prioritizing solar and wind energy.
+Do you want to continue?</source>
+      <translation>バッテリーを一度だけ完全に充電するために商用電源が使用されます。
+充電プロセス完了後、システムは太陽光・風力エネルギーを優先する通常動作に戻ります。
+続行しますか？</translation>
+    </message>
+    <message id="vebus_device_page_dc_voltage">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="159"/>
+      <source>DC Voltage</source>
+      <translation>DC電圧</translation>
+    </message>
+    <message id="vebus_device_page_dc_current">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="166"/>
+      <source>DC Current</source>
+      <translation>DC電流</translation>
+    </message>
+    <message id="vebus_device_page_advanced">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="206"/>
+      <source>Advanced</source>
+      <translation>高度</translation>
+    </message>
+    <message id="common_words_alarm_setup">
+      <location filename="../../components/CommonWords.qml" line="68"/>
+      <source>Alarm setup</source>
+      <translation>アラーム設定</translation>
+    </message>
+    <message id="vebus_device_bms_not_found">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="240"/>
+      <source>A BMS assistant is installed configured for a VE.Bus BMS, but the VE.Bus BMS is not found!</source>
+      <translation>VE.Bus BMS用に設定されたBMSアシスタントがインストールされていますが、VE.Bus BMSが見つかりません！</translation>
+    </message>
+    <message id="vebus_device_vebus_bms">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="246"/>
+      <source>VE.Bus BMS</source>
+      <translation>VE.Bus BMS</translation>
+    </message>
+    <message id="vebus_device_warning">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="102"/>
+      <source>Warning: Activating equalization in an ESS system with solar chargers can cause charging the battery at high voltage with a too high current.</source>
+      <translation>警告：ソーラーチャージャーを備えたESSシステムで均等化を有効にすると、バッテリーが高電圧かつ過電流で充電される可能性があります。</translation>
+    </message>
+    <message id="vebus_device_switch_to_float">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="106"/>
+      <source>The system will automatically switch over to float once the Equalization charge has been completed.</source>
+      <translation>均等化充電が完了すると、システムは自動的にフロート充電に切り替わります。</translation>
+    </message>
+    <message id="vebus_device_interrupt_equalization">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="113"/>
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="165"/>
+      <source>Interrupt equalization</source>
+      <translation>均等化を中断</translation>
+    </message>
+    <message id="vebus_device_equalization">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="115"/>
+      <source>Equalization</source>
+      <translation>均等化</translation>
+    </message>
+    <message id="vebus_device_interrupting">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="119"/>
+      <source>Interrupting...</source>
+      <translation>中断中...</translation>
+    </message>
+    <message id="vebus_device_starting">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="122"/>
+      <source>Starting...</source>
+      <translation>起動中...</translation>
+    </message>
+    <message id="vebus_device_press_to_interrupt">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="125"/>
+      <source>Press to interrupt</source>
+      <translation>押して中断</translation>
+    </message>
+    <message id="vebus_device_interrupt_and_restart_absorption">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="169"/>
+      <source>Interrupt and restart absorption</source>
+      <translation>中断して吸収充電を再開</translation>
+    </message>
+    <message id="vebus_device_interrupt_and_go_to_float">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="175"/>
+      <source>Interrupt and go to float</source>
+      <translation>中断してフロートに移行</translation>
+    </message>
+    <message id="vebus_device_interrupt">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="181"/>
+      <source>Interrupt</source>
+      <translation>中断</translation>
+    </message>
+    <message id="vebus_device_do_not_interrupt">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="187"/>
+      <source>Do not interrupt</source>
+      <translation>中断しない</translation>
+    </message>
+    <message id="vebus_device_redectect_vebus_system">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="212"/>
+      <source>Redetect VE.Bus system</source>
+      <translation>VE.Busシステムを再検出</translation>
+    </message>
+    <message id="vebus_device_redetecting">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="215"/>
+      <source>Redetecting...</source>
+      <translation>再検出中...</translation>
+    </message>
+    <message id="vebus_device_restart_vebus_system">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="224"/>
+      <source>Restart VE.Bus system</source>
+      <translation>VE.Busシステムを再起動</translation>
+    </message>
+    <message id="vebus_device_restarting">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="227"/>
+      <source>Restarting...</source>
+      <translation>再起動中...</translation>
+    </message>
+    <message id="vebus_device_press_to_restart">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="229"/>
+      <source>Press to restart</source>
+      <translation>押して再起動</translation>
+    </message>
+    <message id="vebus_device_ac_input_1_ignored">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="249"/>
+      <source>AC input 1 ignored</source>
+      <translation>AC入力 1 無視</translation>
+    </message>
+    <message id="vebus_device_ac_input_2_ignored">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="257"/>
+      <source>AC input 2 ignored</source>
+      <translation>AC入力 2 無視</translation>
+    </message>
+    <message id="vebus_device_ess_relay_test">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="265"/>
+      <source>ESS Relay test</source>
+      <translation>ESSリレーテスト</translation>
+    </message>
+    <message id="cycle_history_completed">
+      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="31"/>
+      <source>Completed</source>
+      <translation>完了</translation>
+    </message>
+    <message id="common_words_pending">
+      <location filename="../../components/CommonWords.qml" line="413"/>
+      <source>Pending</source>
+      <translation>待機中</translation>
+    </message>
+    <message id="vebus_diagnostics">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="317"/>
+      <source>VE.Bus diagnostics</source>
+      <translation>VE.Bus診断</translation>
+    </message>
+    <message id="vebus_veice_network_quality_counter">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="336"/>
+      <source>Network quality counter Phase L%1, device %2 (%3)</source>
+      <translation>ネットワーク品質カウンター 相L%1、デバイス%2 (%3)</translation>
+    </message>
+    <message id="vebus_device_error_8_11_report">
+      <location filename="../../pages/vebusdevice/PageVeBusAlarms.qml" line="62"/>
+      <source>VE.Bus Error 8 / 11 report</source>
+      <translation>VE.Busエラー8/11レポート</translation>
+    </message>
+    <message id="alarm_level_alarm_only">
+      <location filename="../../components/listitems/ListAlarmLevelRadioButtonGroup.qml" line="13"/>
+      <source>Alarm only</source>
+      <translation>アラームのみ</translation>
+    </message>
+    <message id="alarm_level_alarms_and_warnings">
+      <location filename="../../components/listitems/ListAlarmLevelRadioButtonGroup.qml" line="15"/>
+      <source>Alarms &amp; warnings</source>
+      <translation>アラームと警告</translation>
+    </message>
+    <message id="vebus_device_bms_error">
+      <location filename="../../pages/vebusdevice/PageVeBusBms.qml" line="31"/>
+      <source>BMS Error</source>
+      <translation>BMSエラー</translation>
+    </message>
+    <message id="vebus_device_serial_numbers">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="291"/>
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="295"/>
+      <source>Serial numbers</source>
+      <translation>シリアル番号</translation>
+    </message>
+    <message id="vebus_device_last_vebus_error_11_report">
+      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="33"/>
+      <source>Last VE.Bus Error 11 report #%1</source>
+      <translation>最新のVE.Busエラー11レポート #%1</translation>
+    </message>
+    <message id="vebus_device_bf_safety_test_in_progress">
+      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="40"/>
+      <source>BF safety test in progress</source>
+      <translation>BF安全テスト進行中</translation>
+    </message>
+    <message id="vebus_device_bf_safety_test_ok">
+      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="47"/>
+      <source>BF safety test OK</source>
+      <translation>BF安全テストOK</translation>
+    </message>
+    <message id="vebus_device_ac0_ac1_mismatch">
+      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="59"/>
+      <source>AC0 /AC1 mismatch</source>
+      <translation>AC0/AC1の不一致</translation>
+    </message>
+    <message id="vebus_device_communication_error">
+      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="66"/>
+      <source>Communication error</source>
+      <translation>通信エラー</translation>
+    </message>
+    <message id="vebus_device_ground_relay_error">
+      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="73"/>
+      <source>GND Relay Error</source>
+      <translation>GNDリレーエラー</translation>
+    </message>
+    <message id="vebus_device_umains_mismatch">
+      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="80"/>
+      <source>UMains mismatch</source>
+      <translation>UMainsの不一致</translation>
+    </message>
+    <message id="vebus_device_period_time_mismatch">
+      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="87"/>
+      <source>Period Time mismatch</source>
+      <translation>周期時間の不一致</translation>
+    </message>
+    <message id="vebus_device_drive_of_bf_relay_mismatch">
+      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="94"/>
+      <source>Drive of BF relay mismatch</source>
+      <translation>BFリレー駆動の不一致</translation>
+    </message>
+    <message id="vebus_device_error_pe2_open">
+      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="101"/>
+      <source>Error: PE2 open</source>
+      <translation>エラー: PE2オープン</translation>
+    </message>
+    <message id="vebus_device_error_pe2_closed">
+      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="108"/>
+      <source>Error: PE2 closed</source>
+      <translation>エラー: PE2クローズ</translation>
+    </message>
+    <message id="vebus_device_failing_step">
+      <location filename="../../pages/vebusdevice/PageVeBusError11Device.qml" line="115"/>
+      <source>Failing step: %1</source>
+      <translation>失敗ステップ: %1</translation>
+    </message>
+    <message id="common_words_vebus_device_phase_x_device_x_index_x">
+      <location filename="../../components/CommonWords.qml" line="590"/>
+      <source>Phase L%1, device %2 (%3)</source>
+      <extracomment>eg. 'Phase L1, device 3 (6)', where '(6)' is the index into the list of reported values</extracomment>
+      <translation>相L%1、デバイス%2 (%3)</translation>
+    </message>
+    <message id="vebus_error_11_reporting_requires_v454">
+      <location filename="../../pages/vebusdevice/PageVeBusError11View.qml" line="25"/>
+      <source>VE.Bus Error 11 reporting requires minimum VE.Bus firmware version 454.</source>
+      <translation>VE.Busエラー11の報告には、VE.Busファームウェアバージョン454以降が必要です。</translation>
+    </message>
+    <message id="vebus_quirks">
+      <location filename="../../pages/vebusdevice/PageVeBusKwhCounters.qml" line="22"/>
+      <source>VE.Bus Quirks</source>
+      <translation>VE.Busの特性</translation>
+    </message>
+    <message id="vebus_ac_sensor_energy">
+      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="10"/>
+      <source>energy</source>
+      <translation>エネルギー</translation>
+    </message>
+    <message id="vebus_ac_sensor_power">
+      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="12"/>
+      <source>power</source>
+      <translation>電力</translation>
+    </message>
+    <message id="vebus_ac_sensor_voltage">
+      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="14"/>
+      <source>voltage</source>
+      <translation>電圧</translation>
+    </message>
+    <message id="vebus_ac_sensor_current">
+      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="16"/>
+      <source>current</source>
+      <translation>電流</translation>
+    </message>
+    <message id="vebus_ac_sensor_location">
+      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="18"/>
+      <source>location</source>
+      <translation>所在地</translation>
+    </message>
+    <message id="vebus_ac_sensor_phase">
+      <location filename="../../pages/vebusdevice/VeBusAcSensorModel.qml" line="20"/>
+      <source>phase</source>
+      <translation>相</translation>
+    </message>
+    <message id="vebus_device_active_ac_input">
+      <location filename="../../components/listitems/ListActiveAcInput.qml" line="21"/>
+      <source>Active AC Input</source>
+      <translation>アクティブAC入力</translation>
+    </message>
+    <message id="vebus_device_high_dc_ripple">
+      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="15"/>
+      <source>High DC ripple</source>
+      <translation>高DCリップル</translation>
+    </message>
+    <message id="vebus_device_high_dc_voltage">
+      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="17"/>
+      <source>High DC voltage</source>
+      <translation>DC高電圧</translation>
+    </message>
+    <message id="vebus_device_high_dc_current">
+      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="19"/>
+      <source>High DC current</source>
+      <translation>高DC電流</translation>
+    </message>
+    <message id="vebus_device_temperature_sense_error">
+      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="23"/>
+      <source>Temperature sense error</source>
+      <translation>温度検知エラー</translation>
+    </message>
+    <message id="vebus_device_voltage_sense_error">
+      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmSettingsModel.qml" line="25"/>
+      <source>Voltage sense error</source>
+      <translation>電圧検知エラー</translation>
+    </message>
+    <message id="rssystemalarms_overload">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="48"/>
+      <source>Overload</source>
+      <extracomment>Alarm configuration when 'overload' state is triggered</extracomment>
+      <translation>過負荷</translation>
+    </message>
+    <message id="common_words_alarm_setting_dc_ripple">
+      <location filename="../../components/CommonWords.qml" line="65"/>
+      <source>DC ripple</source>
+      <extracomment>Alarm configuration when 'DC ripple' state is triggered</extracomment>
+      <translation>DCリップル</translation>
+    </message>
+    <message id="vebus_device_voltage_sensor">
+      <location filename="../../pages/vebusdevice/VeBusDeviceAlarmStatusModel.qml" line="16"/>
+      <source>Voltage Sensor</source>
+      <translation>電圧センサー</translation>
+    </message>
+    <message id="rssystemalarms_phase_rotation">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="27"/>
+      <source>Phase rotation</source>
+      <translation>フェーズローテーション</translation>
+    </message>
+    <message id="vebus_device_vebus_version">
+      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="11"/>
+      <source>VE.Bus version</source>
+      <translation>VE.Busバージョン</translation>
+    </message>
+    <message id="vebus_device_mk2_device">
+      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="13"/>
+      <source>MK2 device</source>
+      <translation>MK2デバイス</translation>
+    </message>
+    <message id="vebus_device_mk2_version">
+      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="15"/>
+      <source>MK2 version</source>
+      <translation>MK2バージョン</translation>
+    </message>
+    <message id="vebus_device_multi_control_version">
+      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="17"/>
+      <source>Multi Control version</source>
+      <translation>マルチコントロールバージョン</translation>
+    </message>
+    <message id="vebus_device_bms_version">
+      <location filename="../../pages/vebusdevice/VeBusDeviceInfoModel.qml" line="19"/>
+      <source>VE.Bus BMS version</source>
+      <translation>VE.Bus BMSバージョン</translation>
+    </message>
+    <message id="ess_unless_grid_fails">
+      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="32"/>
+      <source>Unless grid fails</source>
+      <extracomment>Shown below the minimum state of charge, as configured by the user</extracomment>
+      <translation>系統停電が発生しない限り</translation>
+    </message>
+    <message id="common_words_ac_in">
+      <location filename="../../components/CommonWords.qml" line="14"/>
+      <source>AC In</source>
+      <translation>AC入力</translation>
+    </message>
+    <message id="common_words_ac_input">
+      <location filename="../../components/CommonWords.qml" line="17"/>
+      <source>AC Input</source>
+      <translation>AC入力</translation>
+    </message>
+    <message id="common_words_ac_input_role">
+      <location filename="../../components/CommonWords.qml" line="27"/>
+      <source>Role</source>
+      <extracomment>The role for an AC input (grid meter, genset, acload, etc.)</extracomment>
+      <translation>役割</translation>
+    </message>
+    <message id="common_words_ac_load">
+      <location filename="../../components/CommonWords.qml" line="30"/>
+      <source>AC load</source>
+      <translation>AC負荷</translation>
+    </message>
+    <message id="common_words_ac_out">
+      <location filename="../../components/CommonWords.qml" line="33"/>
+      <source>AC Out</source>
+      <translation>AC OUT</translation>
+    </message>
+    <message id="common_words_ac_output">
+      <location filename="../../components/CommonWords.qml" line="36"/>
+      <source>AC Output</source>
+      <translation>AC出力</translation>
+    </message>
+    <message id="common_words_ac_phase_x">
+      <location filename="../../components/CommonWords.qml" line="40"/>
+      <source>AC Phase L%1</source>
+      <extracomment>%1 = phase number (1-3)</extracomment>
+      <translation>AC相L%1</translation>
+    </message>
+    <message id="common_words_ac_sensor_x">
+      <location filename="../../components/CommonWords.qml" line="43"/>
+      <source>AC Sensor %1</source>
+      <translation>ACセンサー%1</translation>
+    </message>
+    <message id="common_words_ac_sensor">
+      <location filename="../../components/CommonWords.qml" line="46"/>
+      <source>AC Sensors</source>
+      <translation>ACセンサー</translation>
+    </message>
+    <message id="common_words_active">
+      <location filename="../../components/CommonWords.qml" line="50"/>
+      <source>Active</source>
+      <extracomment>Status is 'active'</extracomment>
+      <translation>有効</translation>
+    </message>
+    <message id="common_words_alarm_status">
+      <location filename="../../components/CommonWords.qml" line="71"/>
+      <source>Alarm status</source>
+      <translation>アラームステータス</translation>
+    </message>
+    <message id="common_words_alarms">
+      <location filename="../../components/CommonWords.qml" line="74"/>
+      <source>Alarms</source>
+      <translation>アラーム</translation>
+    </message>
+    <message id="common_words_allow_to_charge">
+      <location filename="../../components/CommonWords.qml" line="77"/>
+      <source>Allow to charge</source>
+      <translation>充電を許可</translation>
+    </message>
+    <message id="common_words_allow_to_discharge">
+      <location filename="../../components/CommonWords.qml" line="80"/>
+      <source>Allow to discharge</source>
+      <translation>放電を許可</translation>
+    </message>
+    <message id="common_words_automatic_scanning">
+      <location filename="../../components/CommonWords.qml" line="86"/>
+      <source>Automatic scanning</source>
+      <translation>自動スキャン</translation>
+    </message>
+    <message id="gauges_battery">
+      <location filename="../../components/Gauges.js" line="17"/>
+      <source>Battery</source>
+      <translation>バッテリー</translation>
+    </message>
+    <message id="common_words_battery_current">
+      <location filename="../../components/CommonWords.qml" line="95"/>
+      <source>Battery current</source>
+      <translation>バッテリー電流</translation>
+    </message>
+    <message id="common_words_battery_voltage">
+      <location filename="../../components/CommonWords.qml" line="101"/>
+      <source>Battery voltage</source>
+      <translation>バッテリー電圧</translation>
+    </message>
+    <message id="common_words_charge_current">
+      <location filename="../../components/CommonWords.qml" line="124"/>
+      <source>Charge current</source>
+      <translation>充電電流</translation>
+    </message>
+    <message id="ev_charging_state_charging">
+      <location filename="../../pages/ev/EvPage.qml" line="85"/>
+      <source>Charging</source>
+      <extracomment>"Charging" state</extracomment>
+      <translation>充電中</translation>
+    </message>
+    <message id="common_words_clear_error_action">
+      <location filename="../../components/CommonWords.qml" line="132"/>
+      <source>Clear error</source>
+      <extracomment>Action to clear an error state</extracomment>
+      <translation>エラーをクリア</translation>
+    </message>
+    <message id="generic_input_label_closed">
+      <location filename="../../src/genericinput.cpp" line="122"/>
+      <source>Closed</source>
+      <extracomment>Status is 'closed'</extracomment>
+      <translation>閉</translation>
+    </message>
+    <message id="evchargers_status_connected">
+      <location filename="../../data/EvChargers.qml" line="53"/>
+      <source>Connected</source>
+      <translation>接続済</translation>
+    </message>
+    <message id="temperature_slider_current">
+      <location filename="../../components/controls/TemperatureSlider.qml" line="164"/>
+      <source>Current</source>
+      <extracomment>Electric current, as measured in Amps</extracomment>
+      <translation>電流</translation>
+    </message>
+    <message id="common_words_current_transformers">
+      <location filename="../../components/CommonWords.qml" line="152"/>
+      <source>Current transformers</source>
+      <translation>変流器</translation>
+    </message>
+    <message id="common_words_custom_name">
+      <location filename="../../components/CommonWords.qml" line="155"/>
+      <source>Custom name</source>
+      <translation>カスタム名</translation>
+    </message>
+    <message id="common_words_debug">
+      <location filename="../../components/CommonWords.qml" line="165"/>
+      <source>Debug</source>
+      <extracomment>Title for a menu item which displays debugging information</extracomment>
+      <translation>デバッグ</translation>
+    </message>
+    <message id="common_words_device">
+      <location filename="../../components/CommonWords.qml" line="169"/>
+      <source>Device</source>
+      <extracomment>Title for device information</extracomment>
+      <translation>デバイス</translation>
+    </message>
+    <message id="ev_charging_state_discharging">
+      <location filename="../../pages/ev/EvPage.qml" line="94"/>
+      <source>Discharging</source>
+      <extracomment>Battery mode</extracomment>
+      <translation>放電中</translation>
+    </message>
+    <message id="wifimodel_disconnected">
+      <location filename="../../components/WifiModel.qml" line="28"/>
+      <source>Disconnected</source>
+      <translation>切断された状態</translation>
+    </message>
+    <message id="common_words_enable">
+      <location filename="../../components/CommonWords.qml" line="187"/>
+      <source>Enable</source>
+      <translation>有効</translation>
+    </message>
+    <message id="common_words_enabled">
+      <location filename="../../components/CommonWords.qml" line="190"/>
+      <source>Enabled</source>
+      <translation>有効</translation>
+    </message>
+    <message id="common_words_energy">
+      <location filename="../../components/CommonWords.qml" line="194"/>
+      <source>Energy</source>
+      <extracomment>Amount of charged energy</extracomment>
+      <translation>エネルギー</translation>
+    </message>
+    <message id="pvinverter_statusCode_error">
+      <location filename="../../src/enums.cpp" line="412"/>
+      <source>Error</source>
+      <extracomment>PV inverter status code</extracomment>
+      <translation>エラー</translation>
+    </message>
+    <message id="common_words_error_colon">
+      <location filename="../../components/CommonWords.qml" line="203"/>
+      <source>Error:</source>
+      <translation>エラー:</translation>
+    </message>
+    <message id="common_words_error_code">
+      <location filename="../../components/CommonWords.qml" line="206"/>
+      <source>Error code</source>
+      <translation>エラーコード</translation>
+    </message>
+    <message id="common_words_firmware_version">
+      <location filename="../../components/CommonWords.qml" line="223"/>
+      <source>Firmware version</source>
+      <translation>ファームウェアバージョン</translation>
+    </message>
+    <message id="digitalinputs_type_generator">
+      <location filename="../../src/enums.cpp" line="319"/>
+      <source>Generator</source>
+      <translation>オルタネーター</translation>
+    </message>
+    <message id="common_words_high_battery_temperature">
+      <location filename="../../components/CommonWords.qml" line="239"/>
+      <source>High battery temperature</source>
+      <translation>バッテリー高温</translation>
+    </message>
+    <message id="common_words_high_level_alarm">
+      <location filename="../../components/CommonWords.qml" line="246"/>
+      <source>High level alarm</source>
+      <extracomment>An alarm that triggers when the level is too high</extracomment>
+      <translation>高レベルアラーム</translation>
+    </message>
+    <message id="common_words_high_starter_battery_voltage">
+      <location filename="../../components/CommonWords.qml" line="249"/>
+      <source>High starter battery voltage</source>
+      <translation>スターターバッテリー電圧高</translation>
+    </message>
+    <message id="common_words_high_temperature">
+      <location filename="../../components/CommonWords.qml" line="252"/>
+      <source>High temperature</source>
+      <translation>高温</translation>
+    </message>
+    <message id="common_words_high_voltage_alarms">
+      <location filename="../../components/CommonWords.qml" line="255"/>
+      <source>High voltage alarms</source>
+      <translation>高電圧アラーム</translation>
+    </message>
+    <message id="common_words_history">
+      <location filename="../../components/CommonWords.qml" line="258"/>
+      <source>History</source>
+      <translation>履歴</translation>
+    </message>
+    <message id="common_words_x_hours">
+      <location filename="../../components/CommonWords.qml" line="261"/>
+      <source>%1 Hour(s)</source>
+      <translation>%1時間</translation>
+    </message>
+    <message id="battery_mode_idle">
+      <location filename="../../src/enums.cpp" line="27"/>
+      <source>Idle</source>
+      <extracomment>Battery mode</extracomment>
+      <translation>アイドル</translation>
+    </message>
+    <message id="scheduled_charge_inactive">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="70"/>
+      <source>Inactive</source>
+      <extracomment>Status is 'inactive'</extracomment>
+      <translation>非アクティブ</translation>
+    </message>
+    <message id="common_words_ip_address">
+      <location filename="../../components/CommonWords.qml" line="287"/>
+      <source>IP address</source>
+      <translation>IPアドレス</translation>
+    </message>
+    <message id="common_words_low_battery_temperature">
+      <location filename="../../components/CommonWords.qml" line="290"/>
+      <source>Low battery temperature</source>
+      <translation>バッテリー低温度</translation>
+    </message>
+    <message id="common_words_low_level_alarm">
+      <location filename="../../components/CommonWords.qml" line="297"/>
+      <source>Low level alarm</source>
+      <extracomment>An alarm that triggers when the level is too low</extracomment>
+      <translation>低レベルアラーム</translation>
+    </message>
+    <message id="common_words_low_starter_battery_voltage">
+      <location filename="../../components/CommonWords.qml" line="300"/>
+      <source>Low starter battery voltage</source>
+      <translation>スターターバッテリー電圧低</translation>
+    </message>
+    <message id="common_words_low_state_of_charge">
+      <location filename="../../components/CommonWords.qml" line="303"/>
+      <source>Low state-of-charge</source>
+      <translation>充電状態低</translation>
+    </message>
+    <message id="common_words_low_temperature">
+      <location filename="../../components/CommonWords.qml" line="306"/>
+      <source>Low temperature</source>
+      <translation>低温</translation>
+    </message>
+    <message id="common_words_low_voltage_alarms">
+      <location filename="../../components/CommonWords.qml" line="309"/>
+      <source>Low voltage alarms</source>
+      <translation>低電圧アラーム</translation>
+    </message>
+    <message id="common_words_manufacturer">
+      <location filename="../../components/CommonWords.qml" line="324"/>
+      <source>Manufacturer</source>
+      <translation>製造元</translation>
+    </message>
+    <message id="common_words_maximum_temperature">
+      <location filename="../../components/CommonWords.qml" line="337"/>
+      <source>Maximum temperature</source>
+      <translation>最高温度</translation>
+    </message>
+    <message id="common_words_maximum_voltage">
+      <location filename="../../components/CommonWords.qml" line="340"/>
+      <source>Maximum voltage</source>
+      <translation>最大電圧</translation>
+    </message>
+    <message id="common_words_minimum_temperature">
+      <location filename="../../components/CommonWords.qml" line="350"/>
+      <source>Minimum temperature</source>
+      <translation>最低温度</translation>
+    </message>
+    <message id="common_words_minimum_voltage">
+      <location filename="../../components/CommonWords.qml" line="353"/>
+      <source>Minimum voltage</source>
+      <translation>最小電圧</translation>
+    </message>
+    <message id="common_words_mode">
+      <location filename="../../components/CommonWords.qml" line="356"/>
+      <source>Mode</source>
+      <translation>モード</translation>
+    </message>
+    <message id="common_words_model_name">
+      <location filename="../../components/CommonWords.qml" line="359"/>
+      <source>Model name</source>
+      <translation>モデル名</translation>
+    </message>
+    <message id="generic_input_label_no">
+      <location filename="../../src/genericinput.cpp" line="116"/>
+      <source>No</source>
+      <extracomment>Digital input state</extracomment>
+      <translation>いいえ</translation>
+    </message>
+    <message id="microgrid_error_none">
+      <location filename="../../src/enums.cpp" line="784"/>
+      <source>No error</source>
+      <translation>エラーなし</translation>
+    </message>
+    <message id="acInputs_not_available">
+      <location filename="../../data/AcInputs.qml" line="109"/>
+      <source>Not available</source>
+      <translation>利用不可</translation>
+    </message>
+    <message id="common_words_not_connected">
+      <location filename="../../components/CommonWords.qml" line="381"/>
+      <source>Not connected</source>
+      <translation>未接続</translation>
+    </message>
+    <message id="common_words_offline">
+      <location filename="../../components/CommonWords.qml" line="391"/>
+      <source>Offline</source>
+      <translation>オフライン</translation>
+    </message>
+    <message id="generic_input_label_ok">
+      <location filename="../../src/genericinput.cpp" line="124"/>
+      <source>OK</source>
+      <extracomment>Voltage alarm is at "OK" level</extracomment>
+      <translation>OK</translation>
+    </message>
+    <message id="generic_input_label_on">
+      <location filename="../../src/genericinput.cpp" line="114"/>
+      <source>On</source>
+      <extracomment>Digital input state</extracomment>
+      <translation>オン</translation>
+    </message>
+    <message id="common_words_online">
+      <location filename="../../components/CommonWords.qml" line="400"/>
+      <source>Online</source>
+      <translation>オンライン</translation>
+    </message>
+    <message id="generic_input_label_open">
+      <location filename="../../src/genericinput.cpp" line="120"/>
+      <source>Open</source>
+      <extracomment>Status is 'open'</extracomment>
+      <translation>開く</translation>
+    </message>
+    <message id="common_words_password">
+      <location filename="../../components/CommonWords.qml" line="416"/>
+      <source>Password</source>
+      <translation>パスワード</translation>
+    </message>
+    <message id="common_words_phase">
+      <location filename="../../components/CommonWords.qml" line="423"/>
+      <source>Phase</source>
+      <translation>相</translation>
+    </message>
+    <message id="common_words_press_to_clear">
+      <location filename="../../components/CommonWords.qml" line="433"/>
+      <source>Press to clear</source>
+      <translation>押してクリア</translation>
+    </message>
+    <message id="common_words_press_to_reset">
+      <location filename="../../components/CommonWords.qml" line="436"/>
+      <source>Press to reset</source>
+      <translation>押してリセット</translation>
+    </message>
+    <message id="common_words_press_to_scan">
+      <location filename="../../components/CommonWords.qml" line="439"/>
+      <source>Press to scan</source>
+      <translation>押してスキャン</translation>
+    </message>
+    <message id="common_words_pv_inverter">
+      <location filename="../../components/CommonWords.qml" line="445"/>
+      <source>PV Inverter</source>
+      <translation>PVインバータ</translation>
+    </message>
+    <message id="common_words_pv_power">
+      <location filename="../../components/CommonWords.qml" line="449"/>
+      <source>PV Power</source>
+      <extracomment>Photovoltaic power (for a solar charger or tracker)</extracomment>
+      <translation>PV電力</translation>
+    </message>
+    <message id="common_words_quiet_hours">
+      <location filename="../../components/CommonWords.qml" line="452"/>
+      <source>Quiet hours</source>
+      <translation></translation>
+    </message>
+    <message id="common_words_relay">
+      <location filename="../../components/CommonWords.qml" line="456"/>
+      <source>Relay</source>
+      <extracomment>Relay switch</extracomment>
+      <translation>リレー</translation>
+    </message>
+    <message id="common_words_reboot">
+      <location filename="../../components/CommonWords.qml" line="465"/>
+      <source>Reboot</source>
+      <translation>再起動</translation>
+    </message>
+    <message id="common_words_remove">
+      <location filename="../../components/CommonWords.qml" line="468"/>
+      <source>Remove</source>
+      <translation>削除</translation>
+    </message>
+    <message id="generic_input_label_running">
+      <location filename="../../src/genericinput.cpp" line="130"/>
+      <source>Running</source>
+      <extracomment>Status = "running"</extracomment>
+      <translation>実行中</translation>
+    </message>
+    <message id="common_words_scanning">
+      <location filename="../../components/CommonWords.qml" line="475"/>
+      <source>Scanning %1%</source>
+      <translation></translation>
+    </message>
+    <message id="common_words_serial_number">
+      <location filename="../../components/CommonWords.qml" line="478"/>
+      <source>Serial number</source>
+      <translation>シリアル番号</translation>
+    </message>
+    <message id="nav_settings">
+      <location filename="../../pages/SettingsPage.qml" line="18"/>
+      <source>Settings</source>
+      <translation>設定</translation>
+    </message>
+    <message id="common_words_setup">
+      <location filename="../../components/CommonWords.qml" line="484"/>
+      <source>Setup</source>
+      <translation></translation>
+    </message>
+    <message id="common_words_signal_strength">
+      <location filename="../../components/CommonWords.qml" line="487"/>
+      <source>Signal strength</source>
+      <translation></translation>
+    </message>
+    <message id="pvinverter_statusCode_standby">
+      <location filename="../../src/enums.cpp" line="404"/>
+      <source>Standby</source>
+      <extracomment>PV inverter status code</extracomment>
+      <translation>スタンバイ</translation>
+    </message>
+    <message id="common_words_start_after_condition_reached_for">
+      <location filename="../../components/CommonWords.qml" line="504"/>
+      <source>Start after the condition is reached for</source>
+      <translation></translation>
+    </message>
+    <message id="common_words_start_time">
+      <location filename="../../components/CommonWords.qml" line="507"/>
+      <source>Start time</source>
+      <translation>開始時間</translation>
+    </message>
+    <message id="common_words_start_value_during_quiet_hours">
+      <location filename="../../components/CommonWords.qml" line="510"/>
+      <source>Start value during quiet hours</source>
+      <translation></translation>
+    </message>
+    <message id="common_words_start_when_warning_is_active_for">
+      <location filename="../../components/CommonWords.qml" line="513"/>
+      <source>Start when warning is active for</source>
+      <translation></translation>
+    </message>
+    <message id="common_words_state_of_charge">
+      <location filename="../../components/CommonWords.qml" line="519"/>
+      <source>State of charge</source>
+      <translation>充電レベル</translation>
+    </message>
+    <message id="common_words_status">
+      <location filename="../../components/CommonWords.qml" line="522"/>
+      <source>Status</source>
+      <translation>ステータス</translation>
+    </message>
+    <message id="pvinverter_statusCode_startup">
+      <location filename="../../src/enums.cpp" line="396"/>
+      <source>Startup (%1)</source>
+      <extracomment>Status = "start up". %1 = the startup status number</extracomment>
+      <translation></translation>
+    </message>
+    <message id="common_words_stop_value_during_quiet_hours">
+      <location filename="../../components/CommonWords.qml" line="529"/>
+      <source>Stop value during quiet hours</source>
+      <translation></translation>
+    </message>
+    <message id="common_words_stop_after_the_condition_is_reached_for">
+      <location filename="../../components/CommonWords.qml" line="532"/>
+      <source>Stop after the condition is reached for</source>
+      <translation></translation>
+    </message>
+    <message id="generic_input_label_stopped">
+      <location filename="../../src/genericinput.cpp" line="128"/>
+      <source>Stopped</source>
+      <extracomment>Digital input state</extracomment>
+      <translation>停止</translation>
+    </message>
+    <message id="generic_input_primaryLabel_temperature">
+      <location filename="../../src/genericinput.cpp" line="168"/>
+      <source>Temperature</source>
+      <translation>温度</translation>
+    </message>
+    <message id="common_words_temperature_sensor">
+      <location filename="../../components/CommonWords.qml" line="545"/>
+      <source>Temperature sensor</source>
+      <translation></translation>
+    </message>
+    <message id="common_words_today">
+      <location filename="../../components/CommonWords.qml" line="551"/>
+      <source>Today</source>
+      <translation>本日</translation>
+    </message>
+    <message id="common_words_total">
+      <location filename="../../components/CommonWords.qml" line="554"/>
+      <source>Total</source>
+      <translation>合計</translation>
+    </message>
+    <message id="common_words_tracker">
+      <location filename="../../components/CommonWords.qml" line="561"/>
+      <source>Tracker</source>
+      <extracomment>Solar tracker</extracomment>
+      <translation>トラッカー</translation>
+    </message>
+    <message id="iochannel_type_buttongroup_type">
+      <location filename="../../components/listitems/ListIOChannelTypeRadioButtonGroup.qml" line="15"/>
+      <source>Type</source>
+      <translation>タイプ</translation>
+    </message>
+    <message id="common_words_unique_id_number">
+      <location filename="../../components/CommonWords.qml" line="567"/>
+      <source>Unique Identity Number</source>
+      <translation></translation>
+    </message>
+    <message id="ev_charging_state_unknown">
+      <location filename="../../pages/ev/EvPage.qml" line="100"/>
+      <source>Unknown</source>
+      <translation>不明</translation>
+    </message>
+    <message id="common_words_vebus_error">
+      <location filename="../../components/CommonWords.qml" line="586"/>
+      <source>VE.Bus Error</source>
+      <translation>VE.Busエラー</translation>
+    </message>
+    <message id="common_words_voltage">
+      <location filename="../../components/CommonWords.qml" line="593"/>
+      <source>Voltage</source>
+      <translation>電圧</translation>
+    </message>
+    <message id="common_words_vrm_instance">
+      <location filename="../../components/CommonWords.qml" line="596"/>
+      <source>VRM instance</source>
+      <translation></translation>
+    </message>
+    <message id="common_words_when_warning_is_cleared_stop_after">
+      <location filename="../../components/CommonWords.qml" line="599"/>
+      <source>When warning is cleared stop after</source>
+      <translation></translation>
+    </message>
+    <message id="generic_input_label_yes">
+      <location filename="../../src/genericinput.cpp" line="118"/>
+      <source>Yes</source>
+      <extracomment>Digital input state</extracomment>
+      <translation>はい</translation>
+    </message>
+    <message id="common_words_yesterday">
+      <location filename="../../components/CommonWords.qml" line="605"/>
+      <source>Yesterday</source>
+      <translation>昨日</translation>
+    </message>
+    <message id="common_words_yield_kwh">
+      <location filename="../../components/CommonWords.qml" line="609"/>
+      <source>Yield</source>
+      <extracomment>Solar charger yield, in kWh (kilowatt hours)</extracomment>
+      <translation>歩留まり</translation>
+    </message>
+    <message id="dateselectordialog_set_date">
+      <location filename="../../components/dialogs/DateSelectorDialog.qml" line="17"/>
+      <source>Set date</source>
+      <translation></translation>
+    </message>
+    <message id="controlcard_generator_startdialog_start_now">
+      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="13"/>
+      <source>Start Now</source>
+      <translation>今すぐ起動</translation>
+    </message>
+    <message id="controlcard_generator_startdialog_timed_run">
+      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="52"/>
+      <source>Timed run</source>
+      <translation></translation>
+    </message>
+    <message id="controlcard_generator_stopdialog_stop_now">
+      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="13"/>
+      <source>Stop Now</source>
+      <translation></translation>
+    </message>
+    <message id="controlcard_generator_stopdialog_total_run_time">
+      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="62"/>
+      <source>Total Run Time</source>
+      <translation></translation>
+    </message>
+    <message id="controlcard_generator_stopdialog_set_time">
+      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="81"/>
+      <source>Set Time %1</source>
+      <extracomment>%1 = the total time (in hours, minutes, seconds) that the generator will run for, as set by the user</extracomment>
+      <translation></translation>
+    </message>
+    <message id="controlcard_generator_stopdialog_description">
+      <location filename="../../components/dialogs/GeneratorStopDialog.qml" line="97"/>
+      <source>Generator will keep running if an autostart condition is met.</source>
+      <translation></translation>
+    </message>
+    <message id="controlcard_inverter_charger_mode">
+      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="32"/>
+      <source>Inverter / Charger mode</source>
+      <translation></translation>
+    </message>
+    <message id="modaldialog_set">
+      <location filename="../../components/dialogs/ModalDialog.qml" line="36"/>
+      <source>Set</source>
+      <translation>設定済み</translation>
+    </message>
+    <message id="common_words_cancel">
+      <location filename="../../components/CommonWords.qml" line="121"/>
+      <source>Cancel</source>
+      <translation>キャンセル</translation>
+    </message>
+    <message id="settings_vrm_device_instances_close">
+      <location filename="../../pages/settings/PageVrmDeviceInstances.qml" line="147"/>
+      <source>Close</source>
+      <translation>終了</translation>
+    </message>
+    <message id="timeselectordialog_set_time">
+      <location filename="../../components/dialogs/TimeSelectorDialog.qml" line="19"/>
+      <source>Set time</source>
+      <translation>時間設定</translation>
+    </message>
+    <message id="deviceinstanceswap_already_assigned">
+      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="86"/>
+      <source>Already in use</source>
+      <translation></translation>
+    </message>
+    <message id="deviceinstanceswap_swap_error">
+      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="89"/>
+      <source>Swap error</source>
+      <translation></translation>
+    </message>
+    <message id="deviceinstanceswap_swap_completed">
+      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="91"/>
+      <source>Swap complete</source>
+      <translation></translation>
+    </message>
+    <message id="deviceinstanceswap_busy">
+      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="97"/>
+      <source>Swapping device instances...</source>
+      <translation></translation>
+    </message>
+    <message id="deviceinstanceswap_already_assigned_description_with_name">
+      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="102"/>
+      <source>Device instance %1 is already used by '%3'. Swap device instances and assign that to %2?</source>
+      <extracomment>%1 and %2 are unique device instance numbers, %3 = another device's name</extracomment>
+      <translation></translation>
+    </message>
+    <message id="deviceinstanceswap_already_assigned_description">
+      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="109"/>
+      <source>Device instance %1 is already used by another device of the same type. Swap device instances and assign that to %2?</source>
+      <extracomment>%1 and %2 are unique device instance numbers</extracomment>
+      <translation></translation>
+    </message>
+    <message id="deviceinstanceswap_timed_out">
+      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="117"/>
+      <source>Cannot swap device instances: operation timed out.</source>
+      <translation></translation>
+    </message>
+    <message id="deviceinstanceswap_active_on_reboot">
+      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="119"/>
+      <source>New device instances will be active on reboot.</source>
+      <translation></translation>
+    </message>
+    <message id="deviceinstanceswap_swap">
+      <location filename="../../components/dialogs/VrmInstanceSwapDialog.qml" line="126"/>
+      <source>Swap</source>
+      <extracomment>Confirm that the two devices' instance number should be swapped.</extracomment>
+      <translation></translation>
+    </message>
+    <message id="pagesettingssupportstate_firmware_online_check_failed">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="145"/>
+      <source>Error while checking for firmware updates</source>
+      <translation></translation>
+    </message>
+    <message id="settings_firmware_downloading_and_installing">
+      <location filename="../../components/FirmwareUpdate.qml" line="110"/>
+      <source>Downloading and installing firmware %1...</source>
+      <extracomment>%1 = firmware version</extracomment>
+      <translation></translation>
+    </message>
+    <message id="settings_firmware_installing_firmware">
+      <location filename="../../components/FirmwareUpdate.qml" line="117"/>
+      <source>Installing firmware...</source>
+      <translation></translation>
+    </message>
+    <message id="settings_firmware_error_during_installation">
+      <location filename="../../components/FirmwareUpdate.qml" line="123"/>
+      <source>Error during firmware installation</source>
+      <translation></translation>
+    </message>
+    <message id="settings_firmware_no_newer_version_available">
+      <location filename="../../components/FirmwareUpdate.qml" line="240"/>
+      <source>No newer version available</source>
+      <translation></translation>
+    </message>
+    <message id="settings_firmware_no_firmware_found">
+      <location filename="../../components/FirmwareUpdate.qml" line="243"/>
+      <source>No firmware found</source>
+      <translation></translation>
+    </message>
+    <message id="tank_type_fuel">
+      <location filename="../../src/enums.cpp" line="718"/>
+      <source>Fuel</source>
+      <translation>燃料</translation>
+    </message>
+    <message id="tank_type_fresh_water">
+      <location filename="../../src/enums.cpp" line="721"/>
+      <source>Fresh water</source>
+      <translation>淡水</translation>
+    </message>
+    <message id="tank_type_waste_water">
+      <location filename="../../src/enums.cpp" line="724"/>
+      <source>Waste water</source>
+      <translation>廃水</translation>
+    </message>
+    <message id="tank_type_live_well">
+      <location filename="../../src/enums.cpp" line="727"/>
+      <source>Live well</source>
+      <translation>生け簀</translation>
+    </message>
+    <message id="tank_type_oil">
+      <location filename="../../src/enums.cpp" line="730"/>
+      <source>Oil</source>
+      <translation>オイル</translation>
+    </message>
+    <message id="tank_type_black_water">
+      <location filename="../../src/enums.cpp" line="733"/>
+      <source>Black water</source>
+      <translation></translation>
+    </message>
+    <message id="tank_type_gasoline">
+      <location filename="../../src/enums.cpp" line="736"/>
+      <source>Gasoline</source>
+      <translation>ガソリン</translation>
+    </message>
+    <message id="tank_type_diesel">
+      <location filename="../../src/enums.cpp" line="739"/>
+      <source>Diesel</source>
+      <translation>ディーゼル</translation>
+    </message>
+    <message id="tank_type_lpg">
+      <location filename="../../src/enums.cpp" line="742"/>
+      <source>LPG</source>
+      <translation>LPG</translation>
+    </message>
+    <message id="tank_type_lng">
+      <location filename="../../src/enums.cpp" line="745"/>
+      <source>LNG</source>
+      <translation>LNG</translation>
+    </message>
+    <message id="tank_type_hydraulic_oil">
+      <location filename="../../src/enums.cpp" line="748"/>
+      <source>Hydraulic oil</source>
+      <translation>作動油</translation>
+    </message>
+    <message id="tank_type_raw_water">
+      <location filename="../../src/enums.cpp" line="751"/>
+      <source>Raw water</source>
+      <translation>生水</translation>
+    </message>
+    <message id="listItem_no_access">
+      <location filename="../../components/listitems/core/ListSetting.qml" line="78"/>
+      <source>Setting locked for access level</source>
+      <translation></translation>
+    </message>
+    <message id="settings_access_incorrect_password">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="85"/>
+      <source>Incorrect password</source>
+      <translation></translation>
+    </message>
+    <message id="welcome_brief_title">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="81"/>
+      <source>Brief</source>
+      <extracomment>The 'Brief' page</extracomment>
+      <translation></translation>
+    </message>
+    <message id="welcome_overview_title">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="90"/>
+      <source>Overview</source>
+      <translation>概要</translation>
+    </message>
+    <message id="nav_levels">
+      <location filename="../../pages/LevelsPage.qml" line="19"/>
+      <source>Levels</source>
+      <translation></translation>
+    </message>
+    <message id="common_words_notifications">
+      <location filename="../../components/CommonWords.qml" line="385"/>
+      <source>Notifications</source>
+      <extracomment>The 'Notifications' page</extracomment>
+      <translation>通知</translation>
+    </message>
+    <message id="utils_formatTimestamp_now">
+      <location filename="../../components/Utils.js" line="258"/>
+      <source>now</source>
+      <extracomment>Indicates an event happened very recently</extracomment>
+      <translation></translation>
+    </message>
+    <message id="utils_formatTimestamp_min_ago">
+      <location filename="../../components/Utils.js" line="263"/>
+      <source>%1m ago</source>
+      <extracomment>Indicates an even happened some minutes before now. %1 = the number of minutes in the past</extracomment>
+      <translation></translation>
+    </message>
+    <message id="utils_formatTimestamp_hours_min_ago">
+      <location filename="../../components/Utils.js" line="270"/>
+      <source>%1h %2m ago</source>
+      <extracomment>Indicates an even happened some hours and minutes before now. %1 = number of hours in the past, %2 = number of minutes in the past</extracomment>
+      <translation></translation>
+    </message>
+    <message id="cgwacs_battery_schedule_every_day">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="17"/>
+      <source>Every day</source>
+      <translation>毎日</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_weekdays">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="19"/>
+      <source>Weekdays</source>
+      <translation></translation>
+    </message>
+    <message id="cgwacs_battery_schedule_weekends">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="21"/>
+      <source>Weekends</source>
+      <translation>週末</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_monday">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="25"/>
+      <source>Monday</source>
+      <translation>月曜日</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_tuesday">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="27"/>
+      <source>Tuesday</source>
+      <translation>火曜日</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_wednesday">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="29"/>
+      <source>Wednesday</source>
+      <translation>水曜日</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_thursday">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="31"/>
+      <source>Thursday</source>
+      <translation>木曜日</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_friday">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="33"/>
+      <source>Friday</source>
+      <translation>金曜日</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_saturday">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="35"/>
+      <source>Saturday</source>
+      <translation>土曜日</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_sunday">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="37"/>
+      <source>Sunday</source>
+      <translation>日曜日</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_format_no_soc">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="70"/>
+      <source>%1 %2 (%3)</source>
+      <translation></translation>
+    </message>
+    <message id="cgwacs_battery_schedule_format_soc">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="73"/>
+      <source>%1 %2 (%3 or %4%)</source>
+      <translation></translation>
+    </message>
+    <message id="cgwacs_battery_schedule_name">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="79"/>
+      <source>Schedule %1</source>
+      <translation></translation>
+    </message>
+    <message id="cgwacs_battery_schedule_day">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="128"/>
+      <source>Day</source>
+      <translation></translation>
+    </message>
+    <message id="cgwacs_battery_schedule_day_not_set">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="132"/>
+      <source>Not set</source>
+      <translation>未設定</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_soc_limit">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="155"/>
+      <source>SOC limit</source>
+      <translation></translation>
+    </message>
+    <message id="cgwacs_battery_schedule_self_consumption_above_limit">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="166"/>
+      <source>Self-consumption above limit</source>
+      <translation></translation>
+    </message>
+    <message id="settings_multirs_pv">
+      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="186"/>
+      <source>PV</source>
+      <translation></translation>
+    </message>
+    <message id="cgwacs_battery_schedule_pv_and_battery">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="173"/>
+      <source>PV &amp; Battery</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingssupportstate_firmware_checking">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="142"/>
+      <source>Checking...</source>
+      <translation>チェック...</translation>
+    </message>
+    <message id="list_alarm_state">
+      <location filename="../../components/listitems/ListAlarmState.qml" line="11"/>
+      <source>Alarm state</source>
+      <translation></translation>
+    </message>
+    <message id="clear_history_button_clear_history">
+      <location filename="../../components/listitems/ListClearHistoryButton.qml" line="15"/>
+      <source>Clear History</source>
+      <translation></translation>
+    </message>
+    <message id="clear_history_button_clearing">
+      <location filename="../../components/listitems/ListClearHistoryButton.qml" line="19"/>
+      <source>Clearing</source>
+      <translation></translation>
+    </message>
+    <message id="settings_dvcc_switch_forced_on">
+      <location filename="../../components/listitems/core/ListSwitchForced.qml" line="19"/>
+      <source>Forced on</source>
+      <translation></translation>
+    </message>
+    <message id="settings_dvcc_switch_forced_off">
+      <location filename="../../components/listitems/core/ListSwitchForced.qml" line="22"/>
+      <source>Forced off</source>
+      <translation></translation>
+    </message>
+    <message id="list_relay_state">
+      <location filename="../../components/listitems/ListRelayState.qml" line="11"/>
+      <source>Relay state</source>
+      <translation>リレーの状態</translation>
+    </message>
+    <message id="common_words_batteryhistory_reset_history_on_the_monitor_itself">
+      <location filename="../../components/CommonWords.qml" line="462"/>
+      <source>Reset history on the monitor itself</source>
+      <translation></translation>
+    </message>
+    <message id="components_mount_state_press_to_eject">
+      <location filename="../../components/listitems/ListMountStateButton.qml" line="17"/>
+      <source>Press to eject</source>
+      <translation></translation>
+    </message>
+    <message id="components_mount_state_ejecting">
+      <location filename="../../components/listitems/ListMountStateButton.qml" line="21"/>
+      <source>Ejecting, please wait</source>
+      <translation></translation>
+    </message>
+    <message id="components_mount_state_no_storage_found">
+      <location filename="../../components/listitems/ListMountStateButton.qml" line="24"/>
+      <source>No storage found</source>
+      <translation></translation>
+    </message>
+    <message id="components_mount_state_microsd_usb">
+      <location filename="../../components/listitems/ListMountStateButton.qml" line="29"/>
+      <source>microSD / USB</source>
+      <translation></translation>
+    </message>
+    <message id="settings_relay_title_type_only">
+      <location filename="../../components/listitems/ListTemperatureRelay.qml" line="28"/>
+      <source>%1 temperature sensor</source>
+      <extracomment>%1 = temperature sensor type</extracomment>
+      <translation></translation>
+    </message>
+    <message id="settings_relay_title_type_and_number">
+      <location filename="../../components/listitems/ListTemperatureRelay.qml" line="32"/>
+      <source>%1 temperature sensor (%2)</source>
+      <extracomment>%1 = temperature sensor type, %2 = input number of the sensor</extracomment>
+      <translation></translation>
+    </message>
+    <message id="settings_relay_title_number_only">
+      <location filename="../../components/listitems/ListTemperatureRelay.qml" line="41"/>
+      <source>Temperature sensor (%1)</source>
+      <extracomment>%1 = input number of the sensor</extracomment>
+      <translation></translation>
+    </message>
+    <message id="settings_relay_no_actions">
+      <location filename="../../components/listitems/ListTemperatureRelay.qml" line="52"/>
+      <source>No actions</source>
+      <translation></translation>
+    </message>
+    <message id="settings_relay_c0_desc">
+      <location filename="../../components/listitems/ListTemperatureRelay.qml" line="57"/>
+      <source>C1: %1, %2</source>
+      <extracomment>%1 = Relay 1 activation value, %2 = Relay 1 deactivation value</extracomment>
+      <translation></translation>
+    </message>
+    <message id="settings_relay_c1_desc">
+      <location filename="../../components/listitems/ListTemperatureRelay.qml" line="62"/>
+      <source>C2: %1, %2</source>
+      <extracomment>%1 = Relay 2 activation value, %2 = Relay 2 deactivation value</extracomment>
+      <translation></translation>
+    </message>
+    <message id="settings_relay_equal_values_warning">
+      <location filename="../../components/TemperatureRelaySettings.qml" line="23"/>
+      <source>Warning: Activation and deactivation temperatures are set to the same value. This will lead the condition to be ignored.</source>
+      <translation></translation>
+    </message>
+    <message id="settings_relay_condition">
+      <location filename="../../components/TemperatureRelaySettings.qml" line="35"/>
+      <source>Condition %1</source>
+      <translation></translation>
+    </message>
+    <message id="settings_relay_function_disabled">
+      <location filename="../../components/TemperatureRelaySettings.qml" line="41"/>
+      <source>Function disabled</source>
+      <translation></translation>
+    </message>
+    <message id="settings_relay_none">
+      <location filename="../../components/TemperatureRelaySettings.qml" line="52"/>
+      <source>None (Disable)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_relay1">
+      <location filename="../../components/TemperatureRelaySettings.qml" line="54"/>
+      <source>Relay 1</source>
+      <translation></translation>
+    </message>
+    <message id="settings_relay2">
+      <location filename="../../components/TemperatureRelaySettings.qml" line="56"/>
+      <source>Relay 2</source>
+      <translation></translation>
+    </message>
+    <message id="settings_relay_invalid_temp_config_warning">
+      <location filename="../../components/TemperatureRelaySettings.qml" line="60"/>
+      <source>Warning: The above selected relay is not configured for temperature, this condition will be ignored.</source>
+      <translation></translation>
+    </message>
+    <message id="settings_relay_activation_value">
+      <location filename="../../components/TemperatureRelaySettings.qml" line="67"/>
+      <source>Activation value</source>
+      <translation></translation>
+    </message>
+    <message id="components_volumeunit_title">
+      <location filename="../../components/listitems/ListVolumeUnitRadioButtonGroup.qml" line="11"/>
+      <source>Volume unit</source>
+      <translation></translation>
+    </message>
+    <message id="components_volumeunit_gallons_us">
+      <location filename="../../components/listitems/ListVolumeUnitRadioButtonGroup.qml" line="19"/>
+      <source>Gallons (US)</source>
+      <translation></translation>
+    </message>
+    <message id="components_volumeunit_gallons_imperial">
+      <location filename="../../components/listitems/ListVolumeUnitRadioButtonGroup.qml" line="21"/>
+      <source>Gallons (Imperial)</source>
+      <translation></translation>
+    </message>
+    <message id="charger_history_box_min_voltage">
+      <location filename="../../components/SolarDetailBox.qml" line="58"/>
+      <source>Min Voltage</source>
+      <translation>最小電圧</translation>
+    </message>
+    <message id="charger_history_max_voltage">
+      <location filename="../../components/SolarHistoryTableView.qml" line="84"/>
+      <source>Max Voltage</source>
+      <translation>最大電圧</translation>
+    </message>
+    <message id="charger_history_box_max_current">
+      <location filename="../../components/SolarDetailBox.qml" line="70"/>
+      <source>Max Current</source>
+      <translation></translation>
+    </message>
+    <message id="charger_history_charge_time">
+      <location filename="../../components/SolarDetailBox.qml" line="121"/>
+      <source>Charge time</source>
+      <extracomment>Statistics for battery charging time</extracomment>
+      <translation></translation>
+    </message>
+    <message id="solarchargers_state_bulk">
+      <location filename="../../src/enums.cpp" line="437"/>
+      <source>Bulk</source>
+      <translation>バルク</translation>
+    </message>
+    <message id="charger_history_box_abs">
+      <location filename="../../components/SolarDetailBox.qml" line="142"/>
+      <source>Abs</source>
+      <extracomment>Battery: time spent in 'Absorption' mode</extracomment>
+      <translation>吸収</translation>
+    </message>
+    <message id="solarchargers_state_float">
+      <location filename="../../src/enums.cpp" line="443"/>
+      <source>Float</source>
+      <translation>フロート</translation>
+    </message>
+    <message id="timeselector_hr">
+      <location filename="../../components/TimeSelector.qml" line="33"/>
+      <source>hr</source>
+      <translation></translation>
+    </message>
+    <message id="charger_history_errors_occurred">
+      <location filename="../../components/SolarHistoryErrorView.qml" line="97"/>
+      <source>%1 error(s) occurred</source>
+      <translation></translation>
+    </message>
+    <message id="charger_history_errors_last">
+      <location filename="../../components/SolarHistoryErrorView.qml" line="121"/>
+      <source>Last</source>
+      <extracomment>Details of last error</extracomment>
+      <translation>負荷</translation>
+    </message>
+    <message id="charger_history_errors_2nd_last">
+      <location filename="../../components/SolarHistoryErrorView.qml" line="124"/>
+      <source>2nd last</source>
+      <extracomment>Details of 2nd last error</extracomment>
+      <translation></translation>
+    </message>
+    <message id="charger_history_errors_3rd_last">
+      <location filename="../../components/SolarHistoryErrorView.qml" line="127"/>
+      <source>3rd last</source>
+      <extracomment>Details of 3rd last error</extracomment>
+      <translation></translation>
+    </message>
+    <message id="charger_history_errors_4th_last">
+      <location filename="../../components/SolarHistoryErrorView.qml" line="130"/>
+      <source>4th last</source>
+      <extracomment>Details of 4th last error</extracomment>
+      <translation></translation>
+    </message>
+    <message id="charger_history_max_power">
+      <location filename="../../components/SolarHistoryTableView.qml" line="86"/>
+      <source>Max Power</source>
+      <translation></translation>
+    </message>
+    <message id="splash_view_unable_to_connect">
+      <location filename="../../components/SplashView.qml" line="281"/>
+      <source>Unable to connect</source>
+      <translation>接続できません</translation>
+    </message>
+    <message id="splash_view_reconnecting">
+      <location filename="../../components/SplashView.qml" line="283"/>
+      <source>Disconnected, attempting to reconnect</source>
+      <translation></translation>
+    </message>
+    <message id="utils_connman_connecting">
+      <location filename="../../components/Utils.js" line="288"/>
+      <source>Connecting</source>
+      <translation>接続中</translation>
+    </message>
+    <message id="splash_view_connected">
+      <location filename="../../components/SplashView.qml" line="288"/>
+      <source>Connected, awaiting broker messages</source>
+      <translation></translation>
+    </message>
+    <message id="splash_view_initializing">
+      <location filename="../../components/SplashView.qml" line="290"/>
+      <source>Connected, receiving broker messages</source>
+      <translation></translation>
+    </message>
+    <message id="splash_view_ready">
+      <location filename="../../components/SplashView.qml" line="299"/>
+      <source>Connected, loading user interface</source>
+      <translation></translation>
+    </message>
+    <message id="splash_view_invalid_protocol_version">
+      <location filename="../../components/SplashView.qml" line="315"/>
+      <source>Invalid protocol version</source>
+      <translation></translation>
+    </message>
+    <message id="splash_view_client_id_rejected">
+      <location filename="../../components/SplashView.qml" line="317"/>
+      <source>Client ID rejected</source>
+      <translation></translation>
+    </message>
+    <message id="splash_view_server_unavailable">
+      <location filename="../../components/SplashView.qml" line="319"/>
+      <source>Broker service not available</source>
+      <translation></translation>
+    </message>
+    <message id="splash_view_bad_username_or_password">
+      <location filename="../../components/SplashView.qml" line="321"/>
+      <source>Bad username or password</source>
+      <translation></translation>
+    </message>
+    <message id="splash_view_not_authorized">
+      <location filename="../../components/SplashView.qml" line="323"/>
+      <source>Client not authorized</source>
+      <translation></translation>
+    </message>
+    <message id="splash_view_transport_invalid">
+      <location filename="../../components/SplashView.qml" line="325"/>
+      <source>Transport connection error</source>
+      <translation></translation>
+    </message>
+    <message id="splash_view_protocol_violation">
+      <location filename="../../components/SplashView.qml" line="327"/>
+      <source>Protocol violation error</source>
+      <translation></translation>
+    </message>
+    <message id="splash_view_mqtt5_error">
+      <location filename="../../components/SplashView.qml" line="331"/>
+      <source>MQTT protocol level 5 error</source>
+      <translation></translation>
+    </message>
+    <message id="common_words_silence_alarm">
+      <location filename="../../components/CommonWords.qml" line="490"/>
+      <source>Silence alarm</source>
+      <translation></translation>
+    </message>
+    <message id="vebus_device_page_total_power">
+      <location filename="../../components/ThreePhaseQuantityTable.qml" line="47"/>
+      <source>Total Power</source>
+      <translation>総合力</translation>
+    </message>
+    <message id="timeselector_min">
+      <location filename="../../components/TimeSelector.qml" line="69"/>
+      <source>min</source>
+      <translation>最小</translation>
+    </message>
+    <message id="utils_format_days_hours">
+      <location filename="../../components/Utils.js" line="186"/>
+      <source>%1d %2h</source>
+      <translation>%1d %2h</translation>
+    </message>
+    <message id="utils_format_hours_min">
+      <location filename="../../components/Utils.js" line="191"/>
+      <source>%1h %2m</source>
+      <translation>%1h %2m</translation>
+    </message>
+    <message id="utils_format_min_sec">
+      <location filename="../../components/Utils.js" line="224"/>
+      <source>%1m %2s</source>
+      <translation>%1m %2s</translation>
+    </message>
+    <message id="utils_format_min">
+      <location filename="../../components/Utils.js" line="226"/>
+      <source>%1m</source>
+      <translation>%1m</translation>
+    </message>
+    <message id="utils_format_sec">
+      <location filename="../../components/Utils.js" line="230"/>
+      <source>%1s</source>
+      <translation>%1s</translation>
+    </message>
+    <message id="utils_zero_minutes">
+      <location filename="../../components/Utils.js" line="232"/>
+      <source>0m</source>
+      <translation></translation>
+    </message>
+    <message id="utils_connman_failure">
+      <location filename="../../components/Utils.js" line="285"/>
+      <source>Failure</source>
+      <translation>失敗</translation>
+    </message>
+    <message id="utils_connman_retrieving_ip_address">
+      <location filename="../../components/Utils.js" line="291"/>
+      <source>Retrieving IP address</source>
+      <translation>IPアドレスの取得中</translation>
+    </message>
+    <message id="utils_connman_disconnect">
+      <location filename="../../components/Utils.js" line="298"/>
+      <source>Disconnect</source>
+      <translation>切断</translation>
+    </message>
+    <message id="overview_widget_acloads_title">
+      <location filename="../../components/widgets/AcLoadsWidget.qml" line="17"/>
+      <source>AC Loads</source>
+      <translation></translation>
+    </message>
+    <message id="overview_widget_dcloads_title">
+      <location filename="../../components/widgets/DcLoadsWidget.qml" line="13"/>
+      <source>DC Loads</source>
+      <translation></translation>
+    </message>
+    <message id="overview_widget_evcs_title">
+      <location filename="../../components/widgets/EvcsWidget.qml" line="23"/>
+      <source>EVCS</source>
+      <extracomment>Abbreviation of Electric Vehicle Charging Station</extracomment>
+      <translation>EV充電器</translation>
+    </message>
+    <message id="acInputs_shore">
+      <location filename="../../data/AcInputs.qml" line="116"/>
+      <source>Shore</source>
+      <translation></translation>
+    </message>
+    <message id="acInputs_current_limit_grid">
+      <location filename="../../data/AcInputs.qml" line="142"/>
+      <source>Grid current limit</source>
+      <translation></translation>
+    </message>
+    <message id="acInputs_current_limit_generator">
+      <location filename="../../data/AcInputs.qml" line="145"/>
+      <source>Generator current limit</source>
+      <translation></translation>
+    </message>
+    <message id="acInputs_current_limit_shore">
+      <location filename="../../data/AcInputs.qml" line="148"/>
+      <source>Shore current limit</source>
+      <translation></translation>
+    </message>
+    <message id="page_generator_stopping">
+      <location filename="../../data/Generators.qml" line="44"/>
+      <source>Stopping</source>
+      <translation></translation>
+    </message>
+    <message id="utils_format_time_to_go">
+      <location filename="../../components/Utils.js" line="135"/>
+      <source>%1 to go</source>
+      <extracomment>%1 = time remaining, e.g. '3h 2m'</extracomment>
+      <translation></translation>
+    </message>
+    <message id="tank_description">
+      <location filename="../../data/common/TankDescription.qml" line="24"/>
+      <location filename="../../src/device.cpp" line="134"/>
+      <source>%1 tank (%2)</source>
+      <extracomment>Tank desription. %1 = tank type (e.g. Fuel, Fresh water), %2 = tank device instance (a number)</extracomment>
+      <translation></translation>
+    </message>
+    <message id="dcMeter_ac_charger">
+      <location filename="../../src/enums.cpp" line="209"/>
+      <source>AC charger</source>
+      <translation>AC チャージャー</translation>
+    </message>
+    <message id="dcMeter_alternator">
+      <location filename="../../src/enums.cpp" line="212"/>
+      <source>Alternator</source>
+      <translation>オルタネーター</translation>
+    </message>
+    <message id="dcMeter_dc_system">
+      <location filename="../../src/enums.cpp" line="221"/>
+      <source>DC system</source>
+      <translation>DCシステム</translation>
+    </message>
+    <message id="dcMeter_fuelcell">
+      <location filename="../../src/enums.cpp" line="230"/>
+      <source>Fuel cell</source>
+      <translation>燃料電池</translation>
+    </message>
+    <message id="dcMeter_shaft_generator">
+      <location filename="../../src/enums.cpp" line="248"/>
+      <source>Shaft generator</source>
+      <translation>シャフト発電機</translation>
+    </message>
+    <message id="dcMeter_water_generator">
+      <location filename="../../src/enums.cpp" line="254"/>
+      <source>Water generator</source>
+      <translation>水力発電機</translation>
+    </message>
+    <message id="generic_input_label_low">
+      <location filename="../../src/genericinput.cpp" line="108"/>
+      <source>Low</source>
+      <extracomment>Digital input state</extracomment>
+      <translation>低</translation>
+    </message>
+    <message id="generic_input_label_high">
+      <location filename="../../src/genericinput.cpp" line="110"/>
+      <source>High</source>
+      <extracomment>Digital input state</extracomment>
+      <translation>高</translation>
+    </message>
+    <message id="ess_state_keep_batteries_charged">
+      <location filename="../../data/Ess.qml" line="20"/>
+      <source>Keep batteries charged</source>
+      <translation>バッテリーを充電し続ける</translation>
+    </message>
+    <message id="evchargers_status_charged">
+      <location filename="../../data/EvChargers.qml" line="58"/>
+      <source>Charged</source>
+      <translation>充電済み</translation>
+    </message>
+    <message id="evchargers_status_waiting_for_sun">
+      <location filename="../../data/EvChargers.qml" line="61"/>
+      <source>Waiting for sun</source>
+      <translation>太陽を待機中</translation>
+    </message>
+    <message id="evchargers_status_waiting_for_rfid">
+      <location filename="../../data/EvChargers.qml" line="64"/>
+      <source>Waiting for RFID</source>
+      <translation>RFIDを待機中</translation>
+    </message>
+    <message id="evchargers_status_waiting_for_start">
+      <location filename="../../data/EvChargers.qml" line="67"/>
+      <source>Waiting for start</source>
+      <translation>開始を待機中</translation>
+    </message>
+    <message id="evchargers_status_ground_test_error">
+      <location filename="../../data/EvChargers.qml" line="73"/>
+      <source>Ground test error</source>
+      <translation></translation>
+    </message>
+    <message id="evchargers_status_cp_input_test_error">
+      <location filename="../../data/EvChargers.qml" line="79"/>
+      <source>CP input test error</source>
+      <translation></translation>
+    </message>
+    <message id="evchargers_status_residual_current_detected">
+      <location filename="../../data/EvChargers.qml" line="82"/>
+      <source>Residual current detected</source>
+      <translation>残留電流が検知されました</translation>
+    </message>
+    <message id="evchargers_status_undervoltage_detected">
+      <location filename="../../data/EvChargers.qml" line="85"/>
+      <source>Undervoltage detected</source>
+      <translation>電圧不足が検知されました</translation>
+    </message>
+    <message id="evchargers_status_overvoltage_detected">
+      <location filename="../../data/EvChargers.qml" line="88"/>
+      <source>Overvoltage detected</source>
+      <translation>過電圧検出</translation>
+    </message>
+    <message id="evchargers_status_overheating_detected">
+      <location filename="../../data/EvChargers.qml" line="91"/>
+      <source>Overheating detected</source>
+      <translation>過熱が検知されました</translation>
+    </message>
+    <message id="evchargers_status_charging_limit">
+      <location filename="../../data/EvChargers.qml" line="94"/>
+      <source>Charging limit</source>
+      <translation>充電限界</translation>
+    </message>
+    <message id="evchargers_status_start_charging">
+      <location filename="../../data/EvChargers.qml" line="97"/>
+      <source>Start charging</source>
+      <translation>充電開始</translation>
+    </message>
+    <message id="inverters_state_scheduledcharge">
+      <location filename="../../data/System.qml" line="198"/>
+      <source>Scheduled</source>
+      <translation>予定分</translation>
+    </message>
+    <message id="page_generator_warm_up">
+      <location filename="../../data/Generators.qml" line="38"/>
+      <source>Warm-up</source>
+      <translation></translation>
+    </message>
+    <message id="page_generator_cool_down">
+      <location filename="../../data/Generators.qml" line="41"/>
+      <source>Cool-down</source>
+      <translation></translation>
+    </message>
+    <message id="generator_manually_started">
+      <location filename="../../data/Generators.qml" line="62"/>
+      <source>Manually started</source>
+      <translation></translation>
+    </message>
+    <message id="notifications_toast_short_text">
+      <location filename="../../data/mock/MockShortcuts.qml" line="66"/>
+      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi.</source>
+      <translation></translation>
+    </message>
+    <message id="notifications_toast_long_text">
+      <location filename="../../data/mock/MockShortcuts.qml" line="68"/>
+      <source>Mollitia quis est quas deleniti quibusdam explicabo quasi. Voluptatem qui quia et consequuntur.</source>
+      <translation></translation>
+    </message>
+    <message id="pvinverters_statusCode_boot_loading">
+      <location filename="../../src/enums.cpp" line="408"/>
+      <source>Boot loading</source>
+      <extracomment>PV inverter status code</extracomment>
+      <translation>ブートローディング</translation>
+    </message>
+    <message id="pvinverter_statusCode_running_mppt">
+      <location filename="../../src/enums.cpp" line="416"/>
+      <source>Running (MPPT)</source>
+      <extracomment>PV inverter status code</extracomment>
+      <translation></translation>
+    </message>
+    <message id="pvinverter_running_throttled">
+      <location filename="../../src/enums.cpp" line="420"/>
+      <source>Running (Throttled)</source>
+      <extracomment>PV inverter status code</extracomment>
+      <translation></translation>
+    </message>
+    <message id="solarchargers_state_fault">
+      <location filename="../../src/enums.cpp" line="434"/>
+      <source>Fault</source>
+      <translation>故障</translation>
+    </message>
+    <message id="solarchargers_state_absorption">
+      <location filename="../../src/enums.cpp" line="440"/>
+      <source>Absorption</source>
+      <translation>吸収</translation>
+    </message>
+    <message id="solarchargers_state_storage">
+      <location filename="../../src/enums.cpp" line="446"/>
+      <source>Storage</source>
+      <translation>ストレージ</translation>
+    </message>
+    <message id="solarchargers_state_equalize">
+      <location filename="../../src/enums.cpp" line="449"/>
+      <source>Equalize</source>
+      <translation>均等化</translation>
+    </message>
+    <message id="inverters_state_aes_mode">
+      <location filename="../../data/System.qml" line="128"/>
+      <source>AES mode</source>
+      <translation></translation>
+    </message>
+    <message id="inverters_state_faultcondition">
+      <location filename="../../data/System.qml" line="131"/>
+      <source>Fault condition</source>
+      <translation></translation>
+    </message>
+    <message id="inverters_state_bulkcharging">
+      <location filename="../../data/System.qml" line="134"/>
+      <source>Bulk charging</source>
+      <translation></translation>
+    </message>
+    <message id="inverters_state_absorptioncharging">
+      <location filename="../../data/System.qml" line="137"/>
+      <source>Absorption charging</source>
+      <translation></translation>
+    </message>
+    <message id="inverters_state_floatcharging">
+      <location filename="../../data/System.qml" line="140"/>
+      <source>Float charging</source>
+      <translation></translation>
+    </message>
+    <message id="inverters_state_storagemode">
+      <location filename="../../data/System.qml" line="143"/>
+      <source>Storage mode</source>
+      <translation>ストレージモード</translation>
+    </message>
+    <message id="inverters_state_equalisationcharging">
+      <location filename="../../data/System.qml" line="146"/>
+      <source>Equalization charging</source>
+      <translation></translation>
+    </message>
+    <message id="inverters_state_passthru">
+      <location filename="../../data/System.qml" line="149"/>
+      <source>Pass-thru</source>
+      <translation></translation>
+    </message>
+    <message id="inverters_state_inverting">
+      <location filename="../../data/System.qml" line="152"/>
+      <source>Inverting</source>
+      <translation>変換</translation>
+    </message>
+    <message id="inverters_state_assisting">
+      <location filename="../../data/System.qml" line="155"/>
+      <source>Assisting</source>
+      <translation>補助中</translation>
+    </message>
+    <message id="inverters_state_powersupplymode">
+      <location filename="../../data/System.qml" line="158"/>
+      <source>Power supply mode</source>
+      <translation>電源モード</translation>
+    </message>
+    <message id="ev_charging_state_wake_up">
+      <location filename="../../pages/ev/EvPage.qml" line="91"/>
+      <source>Wake up</source>
+      <translation></translation>
+    </message>
+    <message id="inverters_state_repeatedabsorption">
+      <location filename="../../data/System.qml" line="168"/>
+      <source>Repeated absorption</source>
+      <translation>反復吸収</translation>
+    </message>
+    <message id="inverters_state_autoequalize">
+      <location filename="../../data/System.qml" line="171"/>
+      <source>Auto equalize</source>
+      <translation></translation>
+    </message>
+    <message id="inverters_state_battery_safe">
+      <location filename="../../data/System.qml" line="174"/>
+      <source>Battery safe</source>
+      <translation>BatterySafe</translation>
+    </message>
+    <message id="inverters_state_loaddetect">
+      <location filename="../../data/System.qml" line="177"/>
+      <source>Load detect</source>
+      <translation></translation>
+    </message>
+    <message id="inverters_state_blocked">
+      <location filename="../../data/System.qml" line="180"/>
+      <source>Blocked</source>
+      <translation>阻止された状態</translation>
+    </message>
+    <message id="inverters_state_test">
+      <location filename="../../data/System.qml" line="183"/>
+      <source>Test</source>
+      <translation>テスト</translation>
+    </message>
+    <message id="settings_rs_ess_dess">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="97"/>
+      <source>Dynamic ESS</source>
+      <translation></translation>
+    </message>
+    <message id="systemsettings_networkstatus_group_master">
+      <location filename="../../data/SystemSettings.qml" line="163"/>
+      <source>Group Master</source>
+      <extracomment>Network status: Group Master</extracomment>
+      <translation></translation>
+    </message>
+    <message id="systemsettings_networkstatus_instance_master">
+      <location filename="../../data/SystemSettings.qml" line="167"/>
+      <source>Instance Master</source>
+      <extracomment>Network status: Instance Master</extracomment>
+      <translation></translation>
+    </message>
+    <message id="systemsettings_networkstatus_group_and_instance_master">
+      <location filename="../../data/SystemSettings.qml" line="171"/>
+      <source>Group &amp; Instance Master</source>
+      <extracomment>Network status: Group &amp; Instance Master</extracomment>
+      <translation></translation>
+    </message>
+    <message id="systemsettings_networkstatus_standalone_and_group_master">
+      <location filename="../../data/SystemSettings.qml" line="179"/>
+      <source>Standalone &amp; Group Master</source>
+      <extracomment>Network status: Standalone &amp; Group Master</extracomment>
+      <translation></translation>
+    </message>
+    <message id="inverterCharger_mode_charger_only">
+      <location filename="../../data/InverterChargers.qml" line="45"/>
+      <source>Charger only</source>
+      <translation>チャージャーのみ</translation>
+    </message>
+    <message id="inverterCharger_mode_inverter_only">
+      <location filename="../../data/InverterChargers.qml" line="48"/>
+      <source>Inverter only</source>
+      <translation>インバーターのみ</translation>
+    </message>
+    <message id="charger_alarms_short_circuit_alarm">
+      <location filename="../../pages/solar/PageSolarCharger.qml" line="311"/>
+      <source>Short circuit alarm</source>
+      <translation>短絡アラーム</translation>
+    </message>
+    <message id="settings_wifi_disable_ap">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="58"/>
+      <source>Disable Access Point</source>
+      <translation></translation>
+    </message>
+    <message id="settings_ess_use_this_option_for_systems_no_peak_shaving">
+      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="56"/>
+      <source>Use this option in systems that do not perform peak shaving.</source>
+      <translation></translation>
+    </message>
+    <message id="ac-in-genset_auto_start_functionality">
+      <location filename="../../components/PageGensetModel.qml" line="75"/>
+      <source>Auto start functionality</source>
+      <translation></translation>
+    </message>
+    <message id="page_settings_run_time_and_service_total_run_time">
+      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="48"/>
+      <source>Total run time</source>
+      <translation></translation>
+    </message>
+    <message id="page_settings_run_time_and_service_generator_total_run_time">
+      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="57"/>
+      <source>Generator total run time (hours)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_minmax_dc_input">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="111"/>
+      <source>DC input</source>
+      <translation>DC入力</translation>
+    </message>
+    <message id="ess_recommended">
+      <location filename="../../components/dialogs/ESSMinimumSOCDialog.qml" line="73"/>
+      <source>For Lithium batteries, below 10% charge is not recommended. For other battery types, check the datasheet for the minimum level recommended by the manufacturer.</source>
+      <oldsource>For Lithium batteries, below 10% is not recommended. For other battery types, check the datasheet for the manufacturer recommended minimum.</oldsource>
+      <translation></translation>
+    </message>
+    <message id="controlcard_generator_autostart_conditions">
+      <location filename="../../pages/controlcards/GeneratorCard.qml" line="68"/>
+      <source>Start and stop the generator based on the configured autostart conditions.</source>
+      <oldsource>The generator will start and stop based on the configured autostart conditions.</oldsource>
+      <translation></translation>
+    </message>
+    <message id="generator_dialog_disabled">
+      <location filename="../../components/GeneratorManualControlButton.qml" line="103"/>
+      <source>Generator start/stop disabled</source>
+      <translation></translation>
+    </message>
+    <message id="generator_dialog_remote_start_disabled">
+      <location filename="../../components/GeneratorManualControlButton.qml" line="106"/>
+      <source>The remote start functionality is disabled on the genset. The GX will not be able to start or stop the genset now. Enable it on the genset control panel.</source>
+      <translation></translation>
+    </message>
+    <message id="controlcard_inverter">
+      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="23"/>
+      <source>Inverter (%1)</source>
+      <extracomment>%1 = the inverter name</extracomment>
+      <translation></translation>
+    </message>
+    <message id="controlcard_inverter_charger">
+      <location filename="../../pages/controlcards/InverterChargerCard.qml" line="26"/>
+      <source>Inverter / Charger (%1)</source>
+      <extracomment>%1 = the inverter/charger name</extracomment>
+      <oldsource>Inverter / Charger</oldsource>
+      <translation></translation>
+    </message>
+    <message id="settings_page_debug_quit_application">
+      <location filename="../../pages/settings/debug/PageDebug.qml" line="24"/>
+      <source>Quit application</source>
+      <oldsource>Quit Application</oldsource>
+      <translation></translation>
+    </message>
+    <message id="genset_controller_requires_helper_relay">
+      <location filename="../../components/PageGensetModel.qml" line="62"/>
+      <source>This genset controller requires a helper relay to be controlled but the helper relay is not configured. Please configure Relay 1 under Settings → Relay to "Connected genset helper relay".</source>
+      <translation></translation>
+    </message>
+    <message id="settings_page_relay_generator_run_time">
+      <location filename="../../pages/settings/PageGenerator.qml" line="79"/>
+      <source>Current run time</source>
+      <oldsource>Run time</oldsource>
+      <translation></translation>
+    </message>
+    <message id="ac-in-genset_auto_control_status">
+      <location filename="../../components/PageGensetModel.qml" line="134"/>
+      <source>Control status</source>
+      <translation></translation>
+    </message>
+    <message id="ac-in-genset_control_error_code">
+      <location filename="../../components/PageGensetModel.qml" line="154"/>
+      <source>Control error code</source>
+      <translation>コントロールエラーコード</translation>
+    </message>
+    <message id="ac-in-genset_status">
+      <location filename="../../components/PageGensetModel.qml" line="161"/>
+      <source>Genset status</source>
+      <translation>発電機状態</translation>
+    </message>
+    <message id="ac-in-genset_error">
+      <location filename="../../components/PageGensetModel.qml" line="172"/>
+      <source>Genset error codes</source>
+      <translation>発電機エラーコード</translation>
+    </message>
+    <message id="ac-in-genset_remote_start_mode">
+      <location filename="../../components/PageGensetModel.qml" line="244"/>
+      <source>Remote start mode</source>
+      <translation>リモートスタートモード</translation>
+    </message>
+    <message id="ac-in-genset_oil_pressure">
+      <location filename="../../components/PageGensetModel.qml" line="284"/>
+      <source>Oil pressure</source>
+      <oldsource>Oil Pressure</oldsource>
+      <translation>油圧</translation>
+    </message>
+    <message id="ac-in-genset_oil_temperature">
+      <location filename="../../components/PageGensetModel.qml" line="292"/>
+      <source>Oil temperature</source>
+      <translation>油温</translation>
+    </message>
+    <message id="genset_heatsink_temperature">
+      <location filename="../../components/PageGensetModel.qml" line="322"/>
+      <source>Heatsink temperature</source>
+      <translation>ヒートシンク温度</translation>
+    </message>
+    <message id="page_genset_model_dc_genset_settings">
+      <location filename="../../components/PageGensetModel.qml" line="362"/>
+      <source>DC genset settings</source>
+      <translation>DC発電機設定</translation>
+    </message>
+    <message id="genset_charge_voltage_controlled_by_bms">
+      <location filename="../../components/PageGensetModel.qml" line="400"/>
+      <source>The charge voltage is currently controlled by the BMS.</source>
+      <translation>充電電圧は現在BMSによって制御されています。</translation>
+    </message>
+    <message id="genset_charge_current_limit">
+      <location filename="../../components/PageGensetModel.qml" line="406"/>
+      <source>Charge current limit</source>
+      <translation>充電電流限度</translation>
+    </message>
+    <message id="common_words_bms_control_info">
+      <location filename="../../components/CommonWords.qml" line="107"/>
+      <source>BMS control is enabled automatically when a BMS is present. Reset it if the system configuration changed or if there is no BMS present.</source>
+      <translation>BMSが存在する場合、BMS制御は自動的に有効になります。システム設定が変更された場合やBMSが存在しない場合は、リセットしてください。</translation>
+    </message>
+    <message id="battery_bank_error">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="90"/>
+      <source>Battery bank error</source>
+      <translation>バッテリーバンクエラー</translation>
+    </message>
+    <message id="battery_bank_error_voltage_not_supported">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="99"/>
+      <source>Battery voltage not supported</source>
+      <translation>バッテリー電圧はサポートされていません</translation>
+    </message>
+    <message id="battery_bank_error_incorrect_number_of_batteries">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="102"/>
+      <source>Incorrect number of batteries</source>
+      <translation>バッテリー数が正しくありません</translation>
+    </message>
+    <message id="battery_bank_error_invalid_configuration">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="105"/>
+      <source>Invalid battery configuration</source>
+      <translation>無効なバッテリー設定</translation>
+    </message>
+    <message id="devicelist_battery_total_capacity">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="143"/>
+      <source>Total Capacity</source>
+      <translation>総容量</translation>
+    </message>
+    <message id="devicelist_battery_system_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="155"/>
+      <source>System voltage</source>
+      <translation>システム電圧</translation>
+    </message>
+    <message id="devicelist_battery_number_of_bmses">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="169"/>
+      <source>Number of BMSes</source>
+      <translation>BMS数</translation>
+    </message>
+    <message id="batteryalarms_high_cell_voltage">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="31"/>
+      <source>High cell voltage</source>
+      <translation>セル高電圧</translation>
+    </message>
+    <message id="batteryalarms_high_current">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="45"/>
+      <source>High current</source>
+      <translation>高電流</translation>
+    </message>
+    <message id="batteryalarms_bms_cable">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="169"/>
+      <source>BMS cable fault</source>
+      <translation>BMSケーブル故障</translation>
+    </message>
+    <message id="batteryalarms_contactor">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryAlarms.qml" line="176"/>
+      <source>Bad contactor</source>
+      <translation>コンタクタ不良</translation>
+    </message>
+    <message id="batterydetails_connection_information">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryDetails.qml" line="99"/>
+      <source>Connection information</source>
+      <translation>接続情報</translation>
+    </message>
+    <message id="batteryhistory_high_starter_bat_voltage_alarms">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryHistory.qml" line="130"/>
+      <source>High starter battery voltage alarms</source>
+      <oldsource>High starter batttery voltage alarms</oldsource>
+      <translation>始動用バッテリー高電圧アラーム</translation>
+    </message>
+    <message id="batterysettingsbattery_time_to_go_discharge_note">
+      <location filename="../../pages/settings/devicelist/battery/PageBatterySettingsBattery.qml" line="118"/>
+      <source>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu.</source>
+      <oldsource>Note that changing the Time-to-go discharge floor setting also changes the Low state-of-charge setting in the relay menu</oldsource>
+      <translation>残存時間放電下限設定を変更すると、リレーメニューの低充電状態設定も変更されることに注意してください。</translation>
+    </message>
+    <message id="lynxionsystem_cells_per_battery">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="42"/>
+      <source>Cells per battery</source>
+      <translation>バッテリーあたりのセル数</translation>
+    </message>
+    <message id="lynxionsystem_balancer_status">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxIonSystem.qml" line="100"/>
+      <source>Balancer status</source>
+      <translation>バランサーの状態</translation>
+    </message>
+    <message id="battery_status_balanced">
+      <location filename="../../src/enums.cpp" line="70"/>
+      <source>Balanced</source>
+      <translation>バランス型</translation>
+    </message>
+    <message id="battery_status_imbalance">
+      <location filename="../../src/enums.cpp" line="74"/>
+      <source>Imbalance</source>
+      <translation>アンバランス</translation>
+    </message>
+    <message id="alternator_temperature">
+      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="33"/>
+      <source>Alternator Temperature</source>
+      <translation>オルタネーター温度</translation>
+    </message>
+    <message id="alternator_wakespeed_utilization">
+      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="76"/>
+      <source>Utilization</source>
+      <translation>利用率</translation>
+    </message>
+    <message id="engine_temperature">
+      <location filename="../../pages/settings/devicelist/dc-in/PageAlternatorModel.qml" line="99"/>
+      <source>Engine Temperature</source>
+      <translation>エンジン温度</translation>
+    </message>
+    <message id="alternator_wakespeed_operation_time">
+      <location filename="../../pages/settings/devicelist/dc-in/DcHistorySettingsColumn.qml" line="36"/>
+      <source>Operation time</source>
+      <translation>動作時間</translation>
+    </message>
+    <message id="alternator_wakespeed_charged_ah">
+      <location filename="../../pages/settings/devicelist/dc-in/DcHistorySettingsColumn.qml" line="44"/>
+      <source>Charged Ah</source>
+      <translation>充電時 Ah</translation>
+    </message>
+    <message id="alternator_wakespeed_cycles_started">
+      <location filename="../../pages/settings/devicelist/dc-in/DcHistorySettingsColumn.qml" line="53"/>
+      <source>Cycles started</source>
+      <translation>サイクル開始しました</translation>
+    </message>
+    <message id="alternator_wakespeed_cycles_completed">
+      <location filename="../../pages/settings/devicelist/dc-in/DcHistorySettingsColumn.qml" line="60"/>
+      <source>Cycles completed</source>
+      <translation>サイクル完了</translation>
+    </message>
+    <message id="alternator_wakespeed_nr_of_power_ups">
+      <location filename="../../pages/settings/devicelist/dc-in/DcHistorySettingsColumn.qml" line="67"/>
+      <source>Number of power-ups</source>
+      <translation>電源投入回数</translation>
+    </message>
+    <message id="alternator_wakespeed_nr_of_deep_discharges">
+      <location filename="../../pages/settings/devicelist/dc-in/DcHistorySettingsColumn.qml" line="74"/>
+      <source>Number of deep discharges</source>
+      <translation>重放電回数</translation>
+    </message>
+    <message id="alternator_wakespeed_charge_cycle_history">
+      <location filename="../../pages/settings/devicelist/dc-in/DcHistorySettingsColumn.qml" line="95"/>
+      <source>Charge cycle history</source>
+      <translation>充電サイクル履歴</translation>
+    </message>
+    <message id="devicelist_solarcharger_error">
+      <location filename="../../pages/settings/devicelist/delegates/DeviceListDelegate_solarcharger.qml" line="34"/>
+      <source>Error: #%1</source>
+      <extracomment>%1 = error number</extracomment>
+      <oldsource>Error: %1</oldsource>
+      <translation>エラー: #%1</translation>
+    </message>
+    <message id="devicelistpage_genset">
+      <location filename="../../pages/settings/devicelist/DeviceListPage.qml" line="104"/>
+      <source>Genset</source>
+      <translation>発電機</translation>
+    </message>
+    <message id="page_meteo_wind_direction">
+      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="90"/>
+      <source>Wind direction</source>
+      <translation>風向</translation>
+    </message>
+    <message id="page_meteo_daily_yield">
+      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="107"/>
+      <source>Today's yield</source>
+      <translation>本日の発電量</translation>
+    </message>
+    <message id="devicelist_tanksetup_sensor_value_when_full">
+      <location filename="../../pages/settings/devicelist/tank/PageTankSetup.qml" line="69"/>
+      <source>Sensor value when full</source>
+      <translation>満タン時のセンサー値</translation>
+    </message>
+    <message id="generator_condition_prevent_start_value">
+      <location filename="../../pages/settings/GeneratorCondition.qml" line="27"/>
+      <source>Prevent start until %1 is higher than</source>
+      <extracomment>%1 is the name of the tank level sensor</extracomment>
+      <translation>%1 が以下の値を超えるまで起動を防止</translation>
+    </message>
+    <message id="page_generator_conditions_tank_service">
+      <location filename="../../pages/settings/GeneratorCondition.qml" line="77"/>
+      <source>Tank service</source>
+      <translation>タンクサービス</translation>
+    </message>
+    <message id="page_generator_conditions_unavailable_tank_service_set_another">
+      <location filename="../../pages/settings/GeneratorCondition.qml" line="79"/>
+      <source>Unavailable tank service, set another</source>
+      <translation>タンクサービスは利用できません。別のサービスを設定してください。</translation>
+    </message>
+    <message id="settings_generator_condition_skip_warmup">
+      <location filename="../../pages/settings/GeneratorCondition.qml" line="193"/>
+      <source>Skip generator warm-up</source>
+      <translation>発電機のウォームアップをスキップ</translation>
+    </message>
+    <message id="settings_generator_condition_tank_level_enable_warning">
+      <location filename="../../pages/settings/GeneratorCondition.qml" line="200"/>
+      <source>Trigger warning when the generator is stopped</source>
+      <translation>発電機停止時に警告をトリガー</translation>
+    </message>
+    <message id="settings_page_relay_generator_auto_start_enabled">
+      <location filename="../../pages/settings/PageGenerator.qml" line="54"/>
+      <source>Autostart functionality</source>
+      <oldsource>Auto start functionality</oldsource>
+      <translation>自動起動機能</translation>
+    </message>
+    <message id="page_generator_conditions_make_sure_generator_is_not_connected">
+      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="97"/>
+      <source>Make sure that the generator is not connected to AC input %1 when using this option</source>
+      <oldsource>Make sure that the generator is not connected to AC input %1 when using this option.</oldsource>
+      <translation>このオプションを使用する場合、発電機がAC入力 %1 に接続されていないことを確認してください。</translation>
+    </message>
+    <message id="page_generator_conditions_tank_level">
+      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="159"/>
+      <source>Tank level</source>
+      <translation>タンク残量</translation>
+    </message>
+    <message id="page_generator_conditions_stop_on_tank_level">
+      <location filename="../../pages/settings/PageGeneratorConditions.qml" line="162"/>
+      <source>Stop on tank level</source>
+      <translation>タンク残量で停止</translation>
+    </message>
+    <message id="settings_page_run_time_and_service_time_to_service">
+      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="150"/>
+      <source>Runtime until service</source>
+      <translation>サービスまでの稼働時間</translation>
+    </message>
+    <message id="page_settings_run_time_and_service_service_time_disabled">
+      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="172"/>
+      <source>Service timer disabled.</source>
+      <translation>サービスタイマーは無効です。</translation>
+    </message>
+    <message id="page_settings_run_time_and_service_service_timer_has_been_reset">
+      <location filename="../../pages/settings/PageGeneratorRuntimeService.qml" line="185"/>
+      <source>The service timer has been reset</source>
+      <translation>サービスタイマーがリセットされました</translation>
+    </message>
+    <message id="settings_generator_function_not_enabled">
+      <location filename="../../pages/settings/PageRelayGenerator.qml" line="24"/>
+      <source>Generator start/stop function is not enabled, go to relay settings and set function to "Genset start/stop"</source>
+      <oldsource>Generator start/stop function is not enabled, go to relay settings and set function to "Generator start/stop"</oldsource>
+      <translation>発電機の起動/停止機能は有効になっていません。リレー設定で機能を「発電機の起動/停止」に設定してください。</translation>
+    </message>
+    <message id="settings_batteries_intro">
+      <location filename="../../pages/settings/PageSettingsBatteryMeasurements.qml" line="45"/>
+      <source>Use this menu to define the battery data shown when clicking the Battery icon on the Overview page. The same selection is also visible on the VRM Portal.</source>
+      <oldsource>Use this menu to define which battery measurements to see on the VRM Portal and the MFD HTML5 App.</oldsource>
+      <translation>このメニューでは、概要ページのバッテリーアイコンをクリックしたときに表示されるバッテリーデータを定義します。同じ選択内容はVRMポータルでも表示されます。</translation>
+    </message>
+    <message id="settings_continuous_scan_may_interfere">
+      <location filename="../../pages/settings/PageSettingsBleSensors.qml" line="53"/>
+      <source>Continuous scanning may interfere with Wi-Fi operation.</source>
+      <oldsource>Continuous scanning may interfere with Wi-Fi operation</oldsource>
+      <translation>連続スキャンはWi-Fiの動作に干渉する可能性があります。</translation>
+    </message>
+    <message id="settings_canbus_bms">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="54"/>
+      <source>CAN-bus BMS LV (500 kbit/s)</source>
+      <oldsource>CAN-bus BMS (500 kbit/s)</oldsource>
+      <translation>CANバスBMS LV (500 kbit/s)</translation>
+    </message>
+    <message id="settings_canbus_high_voltage">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="60"/>
+      <source>CAN-bus BMS HV (500 kbit/s)</source>
+      <translation>CANバスBMS HV (500 kbit/s)</translation>
+    </message>
+    <message id="settings_up_but_no_services_500">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="84"/>
+      <source>Up, but no services (500 kbit/s)</source>
+      <translation>稼働中、ただしサービスなし (500 kbit/s)</translation>
+    </message>
+    <message id="pagesettingsgeneral_data_units">
+      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="141"/>
+      <source>Data units</source>
+      <translation>データ単位</translation>
+    </message>
+    <message id="settings_brief_page">
+      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="127"/>
+      <source>Brief page</source>
+      <translation>概要ページ</translation>
+    </message>
+    <message id="settings_display_minmax">
+      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="147"/>
+      <source>Minimum and maximum gauge ranges</source>
+      <translation>ゲージの最小および最大範囲</translation>
+    </message>
+    <message id="settings_startpage_name">
+      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="37"/>
+      <source>Start page</source>
+      <translation>スタートページ</translation>
+    </message>
+    <message id="settings_display_onscreen_ui">
+      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="169"/>
+      <source>User interface</source>
+      <translation>ユーザーインターフェース</translation>
+    </message>
+    <message id="settings_display_remote_console_ui">
+      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="171"/>
+      <source>User interface (Remote Console)</source>
+      <translation>ユーザーインターフェース (リモートコンソール)</translation>
+    </message>
+    <message id="settings_display_classic_ui">
+      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="178"/>
+      <source>Classic UI</source>
+      <translation>従来のUI</translation>
+    </message>
+    <message id="settings_display_new_ui">
+      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="183"/>
+      <source>New UI</source>
+      <translation>New UI</translation>
+    </message>
+    <message id="settings_restarting_app">
+      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="214"/>
+      <source>Restarting application...</source>
+      <translation>アプリケーションを再起動しています...</translation>
+    </message>
+    <message id="settings_app_restarted">
+      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="217"/>
+      <source>%1 updated</source>
+      <extracomment>%1 = The name of the setting being updated</extracomment>
+      <translation>%1 が更新されました</translation>
+    </message>
+    <message id="settings_switch_ui">
+      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="221"/>
+      <source>User interface will switch to %1.</source>
+      <extracomment>%1 = the UI version that the system is switching to</extracomment>
+      <translation>ユーザーインターフェースが %1 に切り替わります。</translation>
+    </message>
+    <message id="settings_has_switched_ui">
+      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="225"/>
+      <source>%1 is set to %2</source>
+      <extracomment>%1 = The name of the setting being updated %2 = the UI version that the system has switched to.</extracomment>
+      <translation>%1 は %2 に設定されています</translation>
+    </message>
+    <message id="pagesettingsgeneral_access_and_security">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="125"/>
+      <source>Access &amp; Security</source>
+      <translation>アクセスとセキュリティ</translation>
+    </message>
+    <message id="pagesettingsgeneral_preferences">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="131"/>
+      <source>Preferences</source>
+      <translation>設定</translation>
+    </message>
+    <message id="pagesettingsgeneral_display_and_appearance">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="136"/>
+      <source>Display &amp; Appearance</source>
+      <translation>表示と外観</translation>
+    </message>
+    <message id="pagesettingsgeneral_alarms_and_feedback">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="142"/>
+      <source>Alarms &amp; Feedback</source>
+      <translation>アラームとフィードバック</translation>
+    </message>
+    <message id="settings_language_change_failed">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="205"/>
+      <source>Failed to change language!</source>
+      <translation>言語の変更に失敗しました！</translation>
+    </message>
+    <message id="settings_language_change_succeeded">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="208"/>
+      <source>Successfully changed language!</source>
+      <translation>言語の変更に成功しました！</translation>
+    </message>
+    <message id="settings_language_please_wait">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="210"/>
+      <source>Please wait while the language is changed.</source>
+      <oldsource>Please wait while the language is changed</oldsource>
+      <translation>言語変更中です。しばらくお待ちください。</translation>
+    </message>
+    <message id="settings_briefview_totals">
+      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="29"/>
+      <source>Tank totals</source>
+      <translation>タンク合計</translation>
+    </message>
+    <message id="settings_briefview_battery_not_connected">
+      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="50"/>
+      <source>Battery is not connected.</source>
+      <translation>バッテリーは接続されていません。</translation>
+    </message>
+    <message id="settings_briefview_tank_not_connected">
+      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="71"/>
+      <source>Tank is not connected.</source>
+      <translation>タンクは接続されていません。</translation>
+    </message>
+    <message id="settings_briefview_individual_batteries">
+      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="86"/>
+      <source>Individual batteries</source>
+      <translation>個別のバッテリー</translation>
+    </message>
+    <message id="settings_briefview_individual_tanks">
+      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="96"/>
+      <source>Individual tanks</source>
+      <translation>個別のタンク</translation>
+    </message>
+    <message id="settings_briefview_unconnected_battery">
+      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="183"/>
+      <source>Battery not connected</source>
+      <translation>バッテリー未接続</translation>
+    </message>
+    <message id="settings_briefview_unconnected_tank">
+      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="192"/>
+      <source>Tank not connected</source>
+      <translation>タンク未接続</translation>
+    </message>
+    <message id="settings_briefview_not_configured">
+      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="196"/>
+      <source>Not configured</source>
+      <extracomment>No option has been selected</extracomment>
+      <translation>未設定</translation>
+    </message>
+    <message id="settings_briefview_tank_details">
+      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="221"/>
+      <source>Tank details</source>
+      <translation>タンクの詳細</translation>
+    </message>
+    <message id="settings_briefview_unit_none">
+      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="224"/>
+      <source>No labels</source>
+      <translation>ラベルなし</translation>
+    </message>
+    <message id="settings_briefview_unit_absolute">
+      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="226"/>
+      <source>Show tank volumes</source>
+      <translation>タンク容量を表示</translation>
+    </message>
+    <message id="settings_briefview_unit_percentages">
+      <location filename="../../pages/settings/PageSettingsDisplayBrief.qml" line="228"/>
+      <source>Show percentages</source>
+      <translation></translation>
+    </message>
+    <message id="settings_dvcc_charge_current_limits">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="30"/>
+      <source>Charge current limits</source>
+      <oldsource>Charge Current limits</oldsource>
+      <translation></translation>
+    </message>
+    <message id="settings_firmware_official_release">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="39"/>
+      <source>Official release</source>
+      <translation></translation>
+    </message>
+    <message id="settings_firmware_beta_release">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="41"/>
+      <source>Beta release</source>
+      <translation>ベータリリース</translation>
+    </message>
+    <message id="settings_firmware_testing_internal">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="44"/>
+      <source>Testing (Victron internal)</source>
+      <extracomment>Select the 'Testing' update feed</extracomment>
+      <translation></translation>
+    </message>
+    <message id="settings_firmware_develop_internal">
+      <location filename="../../pages/settings/PageSettingsFirmwareOnline.qml" line="47"/>
+      <source>Develop (Victron internal)</source>
+      <extracomment>Select the 'Develop' update feed</extracomment>
+      <translation></translation>
+    </message>
+    <message id="page_settings_fronius_inverter_dynamic_power_limiting">
+      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="65"/>
+      <source>Dynamic power limiting</source>
+      <translation></translation>
+    </message>
+    <message id="page_settings_fronius_inverter_power_limiting_label">
+      <location filename="../../pages/settings/PageSettingsFroniusInverter.qml" line="73"/>
+      <source>This PV inverter has support for power limiting. Disable this setting if it interferes with normal operation.</source>
+      <translation></translation>
+    </message>
+    <message id="page_setting_fronius_inverters_add_a_pv_inverter">
+      <location filename="../../pages/settings/PageSettingsFroniusInverters.qml" line="26"/>
+      <source>Add a PV inverter by using the “Find PV Inverter” function or by entering an IP address manually on the previous page.</source>
+      <translation></translation>
+    </message>
+    <message id="settings_local_network_security_profile">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="124"/>
+      <source>Local network security profile</source>
+      <translation></translation>
+    </message>
+    <message id="settings_security_profile_indeterminate">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="129"/>
+      <source>Please select...</source>
+      <translation></translation>
+    </message>
+    <message id="settings_security_profile_secured">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="133"/>
+      <source>Secured</source>
+      <translation></translation>
+    </message>
+    <message id="settings_security_profile_secured_caption">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="136"/>
+      <source>Password protected and the network communication is encrypted</source>
+      <translation></translation>
+    </message>
+    <message id="settings_security_profile_weak">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="141"/>
+      <source>Weak</source>
+      <translation>Weak</translation>
+    </message>
+    <message id="settings_security_profile_weak_caption">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="144"/>
+      <source>Password protected, but the network communication is not encrypted</source>
+      <translation></translation>
+    </message>
+    <message id="settings_security_profile_unsecured">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="149"/>
+      <source>Unsecured</source>
+      <translation></translation>
+    </message>
+    <message id="settings_security_profile_unsecured_caption">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="152"/>
+      <source>No password and the network communication is not encrypted</source>
+      <translation></translation>
+    </message>
+    <message id="settings_security_profile_password_incorrect_length">
+      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="28"/>
+      <source>Password needs to be at least 8 characters long</source>
+      <translation></translation>
+    </message>
+    <message id="settings_security_profile_secured_title">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="224"/>
+      <source>Select 'Secured' profile?</source>
+      <translation></translation>
+    </message>
+    <message id="settings_security_profile_weak_title">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="227"/>
+      <source>Select 'Weak' profile?</source>
+      <translation></translation>
+    </message>
+    <message id="settings_security_profile_unsecured_title">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="230"/>
+      <source>Select 'Unsecured' profile?</source>
+      <translation></translation>
+    </message>
+    <message id="settings_security_profile_secured_description">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="241"/>
+      <source>• Local network services are password protected
+• The network communication is encrypted
+• A secure connection with VRM is enabled
+• Insecure settings cannot be enabled</source>
+      <translation></translation>
+    </message>
+    <message id="settings_security_profile_weak_description">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="244"/>
+      <source>• Local network services are password protected
+• Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_security_profile_unsecured_description">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="247"/>
+      <source>• Local network services do not need a password
+• Unencrypted access to local websites is enabled as well (HTTP/HTTPS)</source>
+      <translation></translation>
+    </message>
+    <message id="access_and_security_page_will_reload">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="118"/>
+      <source>Page will automatically reload in 5 seconds</source>
+      <translation></translation>
+    </message>
+    <message id="settings_root_password">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="269"/>
+      <source>Root password</source>
+      <translation></translation>
+    </message>
+    <message id="settings_root_password_changed_to">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="283"/>
+      <source>Root password changed to %1</source>
+      <translation></translation>
+    </message>
+    <message id="settings_enable_ssh_on_lan">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="290"/>
+      <source>Enable SSH on LAN</source>
+      <translation></translation>
+    </message>
+    <message id="settings_logout">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="321"/>
+      <source>Logout</source>
+      <translation></translation>
+    </message>
+    <message id="settings_logout_now">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="323"/>
+      <source>Log out now</source>
+      <translation></translation>
+    </message>
+    <message id="settings_logout_dialog_title">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="335"/>
+      <source>Log out?</source>
+      <translation></translation>
+    </message>
+    <message id="settings_logout_dialog_description">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="337"/>
+      <source>This will disconnect all local network connections.</source>
+      <translation></translation>
+    </message>
+    <message id="settings_logout_dialog_accept_text">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="339"/>
+      <source>Log out</source>
+      <translation></translation>
+    </message>
+    <message id="settings_enable_status_leds">
+      <location filename="../../pages/settings/PageSettingsAlarmsAndFeedback.qml" line="30"/>
+      <source>Enable status LEDs</source>
+      <translation></translation>
+    </message>
+    <message id="settings_page_debug_application_version">
+      <location filename="../../pages/settings/debug/PageDebug.qml" line="16"/>
+      <source>Application version</source>
+      <translation></translation>
+    </message>
+    <message id="settings_page_debug_quit">
+      <location filename="../../pages/settings/debug/PageDebug.qml" line="27"/>
+      <source>Quit</source>
+      <translation></translation>
+    </message>
+    <message id="settings_page_debug_display_cpu_usage">
+      <location filename="../../pages/settings/debug/PageDebug.qml" line="56"/>
+      <source>Display CPU usage</source>
+      <translation></translation>
+    </message>
+    <message id="settings_page_generator_warm_up_cool_down">
+      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="48"/>
+      <source>Warm-up &amp; cool-down</source>
+      <translation></translation>
+    </message>
+    <message id="page_settings_generator_stop_time">
+      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="88"/>
+      <source>Generator stop time</source>
+      <translation></translation>
+    </message>
+    <message id="page_settings_generator_detect_generator_at_dc">
+      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="138"/>
+      <source>Alarm if DC generator is not providing power</source>
+      <translation></translation>
+    </message>
+    <message id="page_settings_generator_detect_at_dc_in_generator_set">
+      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="144"/>
+      <source>An alarm will be triggered when the DC genset does not reach at least 5A within the first 5 minutes after starting</source>
+      <translation></translation>
+    </message>
+    <message id="page_settings_generator_alarm_when_not_in_auto_start">
+      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="152"/>
+      <source>Alarm when generator is not in autostart mode</source>
+      <oldsource>Alarm when generator is not in auto start mode</oldsource>
+      <translation></translation>
+    </message>
+    <message id="page_settings_generator_alarm_info">
+      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="158"/>
+      <source>An alarm will be triggered when autostart function is left disabled for more than 10 minutes</source>
+      <oldsource>An alarm will be triggered when auto start function is left disabled for more than 10 minutes.</oldsource>
+      <translation></translation>
+    </message>
+    <message id="settings_units_amps_exceptions">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="50"/>
+      <source>Note: If current cannot be displayed (for example, when showing a total for combined AC and DC sources) then power will be shown instead.</source>
+      <translation></translation>
+    </message>
+    <message id="settings_ess_rs_information">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="31"/>
+      <source>For Multi-RS and HS19 devices, ESS settings are available on the RS System product page.</source>
+      <translation></translation>
+    </message>
+    <message id="settings_ess_use_this_option_for_peak_shaving">
+      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="63"/>
+      <source>Use this option for peak shaving.</source>
+      <oldsource>Use this option for peak shaving.
+
+The peak shaving threshold is set using the AC input current limit setting.
+
+See documentation for further information.</oldsource>
+      <translation></translation>
+    </message>
+    <message id="settings_ess_use_this_option_for_peak_shaving_no_grid_meter">
+      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="73"/>
+      <source>The peak shaving threshold is set using the AC input current limit setting. See documentation for further information.</source>
+      <translation></translation>
+    </message>
+    <message id="settings_ess_use_this_option_for_peak_shaving_with_grid_meter">
+      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="76"/>
+      <source>The peak shaving thresholds for import and export can be changed on this screen. See documentation for further information.</source>
+      <translation></translation>
+    </message>
+    <message id="settings_ess_limit_system_ac_import_current">
+      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="86"/>
+      <source>Limit system AC import current</source>
+      <translation></translation>
+    </message>
+    <message id="settings_ess_limit_ac_import_restrictions">
+      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="100"/>
+      <source>To use this feature, Grid metering must be set to External meter, and an up to date ESS assistant must be installed.</source>
+      <translation></translation>
+    </message>
+    <message id="settings_ess_max_system_import_current">
+      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="105"/>
+      <source>Maximum system import current (per phase)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_ess_limit_system_ac_export_current">
+      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="119"/>
+      <source>Limit system AC export current</source>
+      <translation></translation>
+    </message>
+    <message id="settings_ess_limit_ac_export_restrictions">
+      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="133"/>
+      <source>Grid metering must be set to External meter to use this feature.</source>
+      <translation></translation>
+    </message>
+    <message id="settings_ess_max_system_export_current">
+      <location filename="../../pages/settings/PageSettingsHub4Peakshaving.qml" line="138"/>
+      <source>Maximum system export current (per phase)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_ess_self_consumption_battery">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="93"/>
+      <source>Self-consumption from battery</source>
+      <translation>バッテリーからの自家消費</translation>
+    </message>
+    <message id="settings_ess_all_system_loads">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="98"/>
+      <source>All system loads</source>
+      <translation></translation>
+    </message>
+    <message id="settings_ess_only_critical_loads">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="100"/>
+      <source>Only critical loads</source>
+      <translation></translation>
+    </message>
+    <message id="settings_rs_scheduled_charge_levels">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="65"/>
+      <source>Scheduled charge levels</source>
+      <translation></translation>
+    </message>
+    <message id="scheduled_charge_active">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemEss.qml" line="68"/>
+      <source>Active (%1)</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingsintegrations_pv_inverters">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="38"/>
+      <source>PV Inverters</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingsintegrations_energy_meters">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="44"/>
+      <source>Energy meters via RS485</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingsintegrations_modbus_devices">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="50"/>
+      <source>Modbus Devices</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingsintegrations_bluetooth_sensors">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="74"/>
+      <source>Bluetooth Sensors</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingsintegrations_physical_io">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="86"/>
+      <source>Physical I/O</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingsintegrations_tank_and_temperature_sensors">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="96"/>
+      <source>Tank and Temperature Sensors</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingsintegrations_relays">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="130"/>
+      <source>Relays</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingsintegrations_digital_io">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="144"/>
+      <source>Digital I/O</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingsintegrations_server_applications">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="206"/>
+      <source>Server Applications</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingssupportstate_modbus_tcp_server">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="444"/>
+      <source>Modbus TCP Server</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingsintegrations_venus_os_large_features">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="229"/>
+      <source>Venus OS Large Features</source>
+      <translation></translation>
+    </message>
+    <message id="page_settings_nodered_factory_reset">
+      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="31"/>
+      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="45"/>
+      <source>Node-RED factory reset</source>
+      <translation></translation>
+    </message>
+    <message id="page_settings_nodered_factory_reset_confirmation">
+      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="47"/>
+      <source>Are you sure that you want to reset Node-RED to factory defaults? This will delete all of your flows.</source>
+      <translation></translation>
+    </message>
+    <message id="settings_vrm_portal_readonly">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="53"/>
+      <source>Read-only</source>
+      <translation></translation>
+    </message>
+    <message id="settings_vrm_portal_full">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="55"/>
+      <source>Full</source>
+      <translation></translation>
+    </message>
+    <message id="vebus_device_restart_vebus_system_restart_confirmation_title">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="238"/>
+      <source>Are you sure?</source>
+      <translation></translation>
+    </message>
+    <message id="settings_vrm_portal_mode_confirm_description">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="77"/>
+      <source>Changing this setting to Read-only or Off will lock you out.</source>
+      <translation></translation>
+    </message>
+    <message id="settings_connection_status">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="199"/>
+      <source>Connection status</source>
+      <translation></translation>
+    </message>
+    <message id="settings_connection_error_https_channel">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="240"/>
+      <source>Connection status (HTTPS channel)</source>
+      <translation></translation>
+    </message>
+    <message id="settings_connection_error_http_channel">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="242"/>
+      <source>Connection status (HTTP channel)</source>
+      <translation>接続ステータス（HTTPチャネル）</translation>
+    </message>
+    <message id="settings_connection_error_realtime_channel">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="260"/>
+      <source>Connection status (MQTT Real-time channel)</source>
+      <translation>接続ステータス（MQTTリアルタイムチャネル）</translation>
+    </message>
+    <message id="settings_connection_error_rpc_channel">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="267"/>
+      <source>Connection status (MQTT RPC channel)</source>
+      <translation>接続ステータス（MQTT RPCチャネル）</translation>
+    </message>
+    <message id="settings_relay_genset_start_stop">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="58"/>
+      <source>Genset start/stop</source>
+      <translation>発電機の始動/停止</translation>
+    </message>
+    <message id="settings_relay_genset_helper_relay">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="60"/>
+      <source>Connected genset helper relay</source>
+      <translation>接続された発電機ヘルパーリレー</translation>
+    </message>
+    <message id="settings_relay_genset_can_now_be_found">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="16"/>
+      <source>The Genset can now be found in the devices list</source>
+      <translation>発電機がデバイスリストに表示されるようになりました。</translation>
+    </message>
+    <message id="settings_relay_tank_pump_can_now_be_found">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="20"/>
+      <source>The Tank Pump can now be found in the devices list</source>
+      <translation>タンクポンプがデバイスリストに表示されるようになりました。</translation>
+    </message>
+    <message id="settings_relay_no_temperature_sensors">
+      <location filename="../../pages/settings/PageSettingsRelayTempSensors.qml" line="39"/>
+      <source>No temperature sensors have been added yet.</source>
+      <translation>まだ温度センサーが追加されていません。</translation>
+    </message>
+    <message id="settings_firmware_switching_not_possible_indeterminate_profile">
+      <location filename="../../pages/settings/PageSettingsRootfsSelect.qml" line="70"/>
+      <source>Switching firmware version is not possible without "Network Security Profile" in "Settings / General" being selected.</source>
+      <translation>「設定 / 一般」で「ネットワークセキュリティプロファイル」が選択されていないと、ファームウェアバージョンを切り替えることはできません。</translation>
+    </message>
+    <message id="pagesettingsconnectivity_mobile_network">
+      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="71"/>
+      <source>Mobile Network</source>
+      <translation>モバイルネットワーク</translation>
+    </message>
+    <message id="pagesettingssystem_ac_system">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="79"/>
+      <source>AC System</source>
+      <translation>ACシステム</translation>
+    </message>
+    <message id="pagesettingssystem_inputs_and_monitoring">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="81"/>
+      <source>Inputs and Monitoring</source>
+      <translation>入力と監視</translation>
+    </message>
+    <message id="pagesettingssystem_energy_storage_System">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="88"/>
+      <source>Energy Storage System</source>
+      <translation>エネルギー貯蔵システム</translation>
+    </message>
+    <message id="pagesettingssystem_batteries_and_bms">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="100"/>
+      <source>Batteries and Battery Management Systems (BMS)</source>
+      <translation>バッテリーとバッテリー管理システム (BMS)</translation>
+    </message>
+    <message id="settings_system_charge_control">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="106"/>
+      <source>Charge Control</source>
+      <translation>充電制御</translation>
+    </message>
+    <message id="pagesettingssystem_distributed_voltage_and_current_control">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="108"/>
+      <source>Distributed Voltage and Current Control (DVCC)</source>
+      <translation>分散型電圧および電流制御 (DVCC)</translation>
+    </message>
+    <message id="settings_system_ac_position">
+      <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="58"/>
+      <source>Position of AC loads</source>
+      <translation>AC負荷の位置</translation>
+    </message>
+    <message id="settings_system_ac_input_only">
+      <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="64"/>
+      <source>AC input only</source>
+      <translation>AC入力のみ</translation>
+    </message>
+    <message id="settings_system_ac_input_only_description">
+      <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="66"/>
+      <source>The AC output of the Inverter/Charger is not used.</source>
+      <translation>インバーター/チャージャーのAC出力は使用されていません。</translation>
+    </message>
+    <message id="settings_system_ac_output_only">
+      <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="71"/>
+      <source>AC output only</source>
+      <translation>AC出力のみ</translation>
+    </message>
+    <message id="settings_system_ac_output_only_description">
+      <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="73"/>
+      <source>All AC loads are on the output of the Inverter/Charger.</source>
+      <translation>すべてのAC負荷はインバーター/チャージャーの出力にあります。</translation>
+    </message>
+    <message id="settings_system_ac_input_and_output">
+      <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="77"/>
+      <source>AC input &amp; output</source>
+      <translation>AC入出力</translation>
+    </message>
+    <message id="settings_system_ac_input_and_output_description">
+      <location filename="../../pages/settings/PageSettingsAcSystem.qml" line="79"/>
+      <source>The system will automatically display loads on the input of the Inverter/Charger if a grid meter is present. Loads on the output are always displayed.</source>
+      <translation>グリッドメーターがある場合、システムはインバーター/チャージャーの入力側の負荷を自動的に表示します。出力側の負荷は常に表示されます。</translation>
+    </message>
+    <message id="settings_system_has_dc_system">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="115"/>
+      <source>Display DC Loads</source>
+      <oldsource>Has DC system</oldsource>
+      <translation>DC負荷の表示</translation>
+    </message>
+    <message id="settings_system_battery_measurements">
+      <location filename="../../pages/settings/PageSettingsBatteries.qml" line="65"/>
+      <source>Battery measurements</source>
+      <oldsource>Battery Measurements</oldsource>
+      <translation>バッテリー測定</translation>
+    </message>
+    <message id="settings_system_system_status">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="120"/>
+      <source>System status</source>
+      <oldsource>System Status</oldsource>
+      <translation>システムステータス</translation>
+    </message>
+    <message id="settings_tcpip_wired">
+      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="19"/>
+      <source>Wired</source>
+      <translation>有線</translation>
+    </message>
+    <message id="settings_vecan_device_instance">
+      <location filename="../../pages/settings/PageSettingsVecanDevice.qml" line="41"/>
+      <source>VE.Can Device Instance</source>
+      <oldsource>Device Instance</oldsource>
+      <translation>VE.Canデバイスインスタンス</translation>
+    </message>
+    <message id="settings_vecan_device_number">
+      <location filename="../../pages/settings/PageSettingsVecanDevices.qml" line="43"/>
+      <source>VE.Can Instance# %1</source>
+      <oldsource>Device# %1</oldsource>
+      <translation>VE.Canインスタンス# %1</translation>
+    </message>
+    <message id="settings_tz_antarctica">
+      <location filename="../../pages/settings/PageTzInfo.qml" line="247"/>
+      <source>Antarctica</source>
+      <translation>南極</translation>
+    </message>
+    <message id="settings_tz_arctic">
+      <location filename="../../pages/settings/PageTzInfo.qml" line="253"/>
+      <source>Arctic</source>
+      <translation>北極</translation>
+    </message>
+    <message id="settings_all_connected_devices">
+      <location filename="../../pages/SettingsPage.qml" line="39"/>
+      <source>All connected devices</source>
+      <translation>全ての接続済みデバイス</translation>
+    </message>
+    <message id="settings_connectivity">
+      <location filename="../../pages/SettingsPage.qml" line="59"/>
+      <source>Connectivity</source>
+      <translation>接続</translation>
+    </message>
+    <message id="settings_ethernet_wifi_bluetooth_vecan">
+      <location filename="../../pages/SettingsPage.qml" line="61"/>
+      <source>Ethernet, Wi-Fi, Bluetooth, VE.Can</source>
+      <translation>イーサネット、Wi-Fi、Bluetooth、VE.Can</translation>
+    </message>
+    <message id="settings_vrm">
+      <location filename="../../pages/SettingsPage.qml" line="68"/>
+      <source>VRM</source>
+      <extracomment>Forced by %2 to dark</extracomment>
+      <translation>VRM</translation>
+    </message>
+    <message id="settings_remote_monitoring_portal">
+      <location filename="../../pages/SettingsPage.qml" line="70"/>
+      <source>Remote monitoring portal</source>
+      <translation>リモート監視ポータル</translation>
+    </message>
+    <message id="pagesettingssupportstate_integrations">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="438"/>
+      <source>Integrations</source>
+      <translation>統合</translation>
+    </message>
+    <message id="settings_acdcsystem_ess_dvcc_battery">
+      <location filename="../../pages/SettingsPage.qml" line="93"/>
+      <source>AC/DC system, ESS, DVCC, Battery...</source>
+      <translation>AC/DCシステム、ESS、DVCC、バッテリー...</translation>
+    </message>
+    <message id="settings_debug_and_develop">
+      <location filename="../../pages/SettingsPage.qml" line="100"/>
+      <source>Debug &amp; Develop</source>
+      <translation>デバッグと開発</translation>
+    </message>
+    <message id="settings_profilingtools_debugstatistics_appversion">
+      <location filename="../../pages/SettingsPage.qml" line="102"/>
+      <source>Profiling tools, debug statistics, app version...</source>
+      <translation>プロファイリングツール、デバッグ統計、アプリバージョン...</translation>
+    </message>
+    <message id="settings_system_setup">
+      <location filename="../../pages/SettingsPage.qml" line="91"/>
+      <source>System Setup</source>
+      <oldsource>System setup</oldsource>
+      <translation>システム設定</translation>
+    </message>
+    <message id="settings_vrm_device_instances">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="106"/>
+      <source>VRM device instances</source>
+      <oldsource>VRM Device Instances</oldsource>
+      <translation>VRMデバイスインスタンス</translation>
+    </message>
+    <message id="solarcharger_not_supported">
+      <location filename="../../pages/solar/PageSolarCharger.qml" line="67"/>
+      <source>Unfortunately the connected MPPT Solar Charger is not compatible.</source>
+      <translation>申し訳ありませんが、接続されているMPPTソーラーチャージャーは互換性がありません。</translation>
+    </message>
+    <message id="solarcharger_not_supported_reason_70_15">
+      <location filename="../../pages/solar/PageSolarCharger.qml" line="71"/>
+      <source>The 70/15 needs to be from year/week 1308 or later. MPPT 70/15's currently shipped from our warehouse are compatible.</source>
+      <translation>70/15は、1308年/週以降のものである必要があります。現在倉庫から出荷されているMPPT 70/15は互換性があります。</translation>
+    </message>
+    <message id="solarcharger_not_supported_reason_version">
+      <location filename="../../pages/solar/PageSolarCharger.qml" line="74"/>
+      <source>The firmware version in the MPPT Solar Charger must be v1.09 or later. Contact Victron Service for update instructions and files.</source>
+      <translation>MPPTソーラーチャージャーのファームウェアバージョンはv1.09以降である必要があります。アップデートの手順とファイルについては、Victronサービスにお問い合わせください。</translation>
+    </message>
+    <message id="solarcharger_total_power">
+      <location filename="../../pages/solar/PageSolarCharger.qml" line="127"/>
+      <source>Total PV power</source>
+      <translation>合計PV電力</translation>
+    </message>
+    <message id="settings_multirs_total_yield">
+      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="64"/>
+      <source>Total yield</source>
+      <translation>総発電量</translation>
+    </message>
+    <message id="settings_multirs_system_yield">
+      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="72"/>
+      <source>System yield</source>
+      <translation>システム発電量</translation>
+    </message>
+    <message id="charger_alarms_high_temperature_alarm">
+      <location filename="../../pages/solar/PageSolarCharger.qml" line="309"/>
+      <source>High temperature alarm</source>
+      <translation>高温アラーム</translation>
+    </message>
+    <message id="charger_history_last_x_days">
+      <location filename="../../pages/solar/SolarHistoryPage.qml" line="71"/>
+      <source>Last %1 days</source>
+      <extracomment>%1 = number of days of solar history that will be shown</extracomment>
+      <translation>過去%1日間</translation>
+    </message>
+    <message id="common_words_bms_controlled">
+      <location filename="../../components/CommonWords.qml" line="110"/>
+      <source>BMS controlled</source>
+      <translation>BMS制御式</translation>
+    </message>
+    <message id="page_vebus_charge_battery">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="108"/>
+      <source>Charge battery</source>
+      <translation>バッテリーを充電</translation>
+    </message>
+    <message id="vebus_device_update_firmware">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="138"/>
+      <source>This feature requires firmware version 400 or higher. Contact your installer to update your Multi/Quattro.</source>
+      <oldsource>This feature requires firmware version 400 or higher, contact your installer to update your Multi/Quattro.</oldsource>
+      <translation>この機能にはファームウェアバージョン400以上が必要です。Multi/Quattroをアップデートするには、設置業者に連絡してください。</translation>
+    </message>
+    <message id="vebus_device_charger_not_ready">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="144"/>
+      <source>Charger not ready, equalization cannot be started</source>
+      <oldsource>Charger not ready, equalization cannot be started.</oldsource>
+      <translation>充電器が準備できていないため、均等化を開始できません。</translation>
+    </message>
+    <message id="vebus_device_no_equalisation_during_bulk">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="148"/>
+      <source>Equalization cannot be triggered during bulk charge state</source>
+      <oldsource>Equalization cannot be triggered during bulk charge state.</oldsource>
+      <translation>バルク充電中は均等化を開始できません。</translation>
+    </message>
+    <message id="vebus_device_restart_vebus_system_restart_confirmation_description">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="240"/>
+      <source>Restarting the VE.Bus system will reset any inverter on the bus, and result in a loss of power to their outputs.</source>
+      <translation>VE.Busシステムを再起動すると、バス上のすべてのインバーターがリセットされ、それらの出力への電力供給が失われます。</translation>
+    </message>
+    <message id="common_words_dynamic_power_limit">
+      <location filename="../../components/CommonWords.qml" line="616"/>
+      <source>Dynamic power limit</source>
+      <translation>動的電力制限</translation>
+    </message>
+    <message id="common_words_add_device">
+      <location filename="../../components/CommonWords.qml" line="20"/>
+      <source>Add device</source>
+      <translation>デバイスを追加</translation>
+    </message>
+    <message id="controlcard_generator_autostarted">
+      <location filename="../../components/CommonWords.qml" line="89"/>
+      <source>Auto-started • %1</source>
+      <translation>自動起動 • %1</translation>
+    </message>
+    <message id="common_words_daily_history">
+      <location filename="../../components/CommonWords.qml" line="158"/>
+      <source>Daily history</source>
+      <translation>日次履歴</translation>
+    </message>
+    <message id="common_words_error_not_a_number">
+      <location filename="../../components/CommonWords.qml" line="209"/>
+      <source>'%1' is not a number.</source>
+      <translation>「%1」は数値ではありません。</translation>
+    </message>
+    <message id="common_words_input_current_limit">
+      <location filename="../../components/CommonWords.qml" line="274"/>
+      <source>Input current limit</source>
+      <translation>入力電流限度</translation>
+    </message>
+    <message id="common_words_inverter_mode_eco">
+      <location filename="../../components/CommonWords.qml" line="281"/>
+      <source>Eco</source>
+      <extracomment>Inverter 'Eco' mode</extracomment>
+      <translation>エコ</translation>
+    </message>
+    <message id="common_words_manual_stop">
+      <location filename="../../components/CommonWords.qml" line="321"/>
+      <source>Manual stop</source>
+      <translation>手動停止</translation>
+    </message>
+    <message id="common_words_maximum_current">
+      <location filename="../../components/CommonWords.qml" line="331"/>
+      <source>Maximum current</source>
+      <translation>最大電流</translation>
+    </message>
+    <message id="common_words_maximum_power">
+      <location filename="../../components/CommonWords.qml" line="334"/>
+      <source>Maximum power</source>
+      <translation>最大電力</translation>
+    </message>
+    <message id="common_words_minimum_current">
+      <location filename="../../components/CommonWords.qml" line="347"/>
+      <source>Minimum current</source>
+      <translation>最小電流</translation>
+    </message>
+    <message id="common_words_open_circuit">
+      <location filename="../../components/CommonWords.qml" line="407"/>
+      <source>Open circuit</source>
+      <translation>開回路</translation>
+    </message>
+    <message id="common_words_overall_history">
+      <location filename="../../components/CommonWords.qml" line="410"/>
+      <source>Overall history</source>
+      <translation>全体履歴</translation>
+    </message>
+    <message id="common_words_soc">
+      <location filename="../../components/CommonWords.qml" line="494"/>
+      <source>SOC %1</source>
+      <extracomment>State of charge (as a percentage). %1 = the SOC value</extracomment>
+      <translation>SOC %1</translation>
+    </message>
+    <message id="common_words_yield_today">
+      <location filename="../../components/CommonWords.qml" line="613"/>
+      <source>Yield Today</source>
+      <extracomment>Solar charger yield for today, in kWh (kilowatt hours)</extracomment>
+      <oldsource>Yield today</oldsource>
+      <translation>今日の歩留まり</translation>
+    </message>
+    <message id="common_words_format_error">
+      <location filename="../../components/CommonWords.qml" line="657"/>
+      <source>#%1 %2</source>
+      <extracomment>%1 = error number, %2 = text description of this error</extracomment>
+      <translation>#%1 %2</translation>
+    </message>
+    <message id="generator_start_dialog_will_stop_in_x">
+      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="91"/>
+      <source>Generator will stop in %1 unless autostart conditions are enabled that keep it running.</source>
+      <translation>稼働を維持する自動起動条件が有効になっていない限り、発電機は%1で停止します。</translation>
+    </message>
+    <message id="generator_start_dialog_will_run_until_manually_stopped">
+      <location filename="../../components/dialogs/GeneratorStartDialog.qml" line="93"/>
+      <source>Generator will run until manually stopped, unless autostart conditions are enabled that keep it running.</source>
+      <translation>稼働を維持する自動起動条件が有効になっていない限り、発電機は手動で停止されるまで稼働します。</translation>
+    </message>
+    <message id="controlcard_inverter_mode">
+      <location filename="../../components/dialogs/InverterChargerModeDialog.qml" line="30"/>
+      <source>Inverter mode</source>
+      <translation>インバーターモード</translation>
+    </message>
+    <message id="settings_firmware_installed_rebooting">
+      <location filename="../../components/FirmwareUpdate.qml" line="128"/>
+      <source>Firmware installed, device rebooting</source>
+      <oldsource>Firmware installed, rebooting.</oldsource>
+      <translation>ファームウェアがインストールされました。デバイスを再起動しています。</translation>
+    </message>
+    <message id="modaldialog_confirm">
+      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="55"/>
+      <source>Confirm</source>
+      <extracomment>Confirm password, and verify it if possible</extracomment>
+      <translation>確認</translation>
+    </message>
+    <message id="nav_brief_close_side_panel_high_cpu">
+      <location filename="../../pages/BriefPage.qml" line="396"/>
+      <source>System load high, closing the side panel to reduce CPU load</source>
+      <translation>システム負荷が高いため、CPU負荷を軽減するためにサイドパネルを閉じています。</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_monthly">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="23"/>
+      <source>Monthly</source>
+      <translation>月次</translation>
+    </message>
+    <message id="cgwacs_battery_schedule_duration">
+      <location filename="../../components/listitems/ListChargeSchedule.qml" line="144"/>
+      <source>Duration</source>
+      <oldsource>Duration (hh:mm)</oldsource>
+      <translation>期間</translation>
+    </message>
+    <message id="settings_relay_deactivation_value">
+      <location filename="../../components/TemperatureRelaySettings.qml" line="86"/>
+      <source>Deactivation value</source>
+      <oldsource>Deativation value</oldsource>
+      <translation>非アクティブ化値</translation>
+    </message>
+    <message id="splash_view_device_disconnected">
+      <location filename="../../components/SplashView.qml" line="295"/>
+      <source>Connection to the device has been lost, awaiting reconnection</source>
+      <translation>デバイスへの接続が失われました。再接続を待っています。</translation>
+    </message>
+    <message id="splash_view_awaiting_heartbeat">
+      <location filename="../../components/SplashView.qml" line="297"/>
+      <source>Connected to VRM, awaiting device</source>
+      <translation>VRMに接続済み。デバイスを待っています。</translation>
+    </message>
+    <message id="splash_view_heartbeat_missing">
+      <location filename="../../components/SplashView.qml" line="347"/>
+      <source>Device may have lost connectivity to VRM</source>
+      <translation>デバイスがVRMへの接続を失った可能性があります</translation>
+    </message>
+    <message id="splash_view_heartbeat_inactive">
+      <location filename="../../components/SplashView.qml" line="349"/>
+      <source>Device is not connected to VRM</source>
+      <translation>デバイスがVRMに接続されていません</translation>
+    </message>
+    <message id="acInputs_evcharger">
+      <location filename="../../data/AcInputs.qml" line="48"/>
+      <source>EV Charger</source>
+      <translation>EV充電器</translation>
+    </message>
+    <message id="acInputs_heat_pump">
+      <location filename="../../data/AcInputs.qml" line="50"/>
+      <source>Heat pump</source>
+      <translation>ヒートポンプ</translation>
+    </message>
+    <message id="digitalinputs_touch_input_control">
+      <location filename="../../src/enums.cpp" line="322"/>
+      <source>Touch input control</source>
+      <translation>タッチ入力制御</translation>
+    </message>
+    <message id="switchable_output_overtemperature">
+      <location filename="../../src/enums.cpp" line="636"/>
+      <source>Over temperature</source>
+      <translation>過熱</translation>
+    </message>
+    <message id="switch_state_temperature_warning">
+      <location filename="../../src/enums.cpp" line="469"/>
+      <source>Temperature warning</source>
+      <translation>温度警告</translation>
+    </message>
+    <message id="switch_state_channel_fault">
+      <location filename="../../src/enums.cpp" line="472"/>
+      <source>Channel Fault</source>
+      <translation>チャンネル障害</translation>
+    </message>
+    <message id="switch_state_channel_tripped">
+      <location filename="../../src/enums.cpp" line="475"/>
+      <source>Channel Tripped</source>
+      <translation>チャンネル遮断</translation>
+    </message>
+    <message id="switch_state_under_voltage">
+      <location filename="../../src/enums.cpp" line="478"/>
+      <source>Under voltage</source>
+      <translation>低電圧</translation>
+    </message>
+    <message id="switchable_output_momentary">
+      <location filename="../../src/enums.cpp" line="526"/>
+      <source>Momentary</source>
+      <translation>モメンタリ</translation>
+    </message>
+    <message id="switchable_output_dimmable">
+      <location filename="../../src/enums.cpp" line="532"/>
+      <source>Dimmable</source>
+      <translation>調光可能</translation>
+    </message>
+    <message id="switchable_output_slave_of">
+      <location filename="../../src/enums.cpp" line="542"/>
+      <source>Slave of %1</source>
+      <translation>%1のスレーブ</translation>
+    </message>
+    <message id="switchable_output_powered">
+      <location filename="../../src/enums.cpp" line="630"/>
+      <source>Powered</source>
+      <translation>電源オン</translation>
+    </message>
+    <message id="switchable_output_tripped">
+      <location filename="../../src/enums.cpp" line="633"/>
+      <source>Tripped</source>
+      <translation>遮断済み</translation>
+    </message>
+    <message id="switchable_output_short">
+      <location filename="../../src/enums.cpp" line="651"/>
+      <source>Short</source>
+      <translation>短絡</translation>
+    </message>
+    <message id="ess_state_optimized_without_batterylife_button">
+      <location filename="../../data/Ess.qml" line="36"/>
+      <source>Optimized</source>
+      <translation>最適化済み</translation>
+    </message>
+    <message id="ess_state_keep_batteries_charged_button">
+      <location filename="../../data/Ess.qml" line="22"/>
+      <source>Keep charged</source>
+      <translation>充電維持</translation>
+    </message>
+    <message id="evchargers_status_welded_contacts_error">
+      <location filename="../../data/EvChargers.qml" line="76"/>
+      <source>Welded contacts test error (shorted)</source>
+      <oldsource>Welded contacts error</oldsource>
+      <translation>接点溶着テストエラー（短絡）</translation>
+    </message>
+    <message id="evchargers_status_switching_to_three_phase">
+      <location filename="../../data/EvChargers.qml" line="100"/>
+      <source>Switching to 3 phase</source>
+      <oldsource>Switching to 3-phase</oldsource>
+      <translation>3相に切り替え中</translation>
+    </message>
+    <message id="evchargers_status_switching_to_single_phase">
+      <location filename="../../data/EvChargers.qml" line="103"/>
+      <source>Switching to 1 phase</source>
+      <oldsource>Switching to single phase</oldsource>
+      <translation>1相に切り替え中</translation>
+    </message>
+    <message id="evchargers_status_stop_charging">
+      <location filename="../../data/EvChargers.qml" line="106"/>
+      <source>Stop charging</source>
+      <translation>充電停止</translation>
+    </message>
+    <message id="evchargers_status_reserved">
+      <location filename="../../data/EvChargers.qml" line="110"/>
+      <source>Reserved</source>
+      <translation>予約済み</translation>
+    </message>
+    <message id="page_generator_stopped_by_tank_level">
+      <location filename="../../data/Generators.qml" line="49"/>
+      <source>Stopped by tank level</source>
+      <translation>タンクレベルにより停止</translation>
+    </message>
+    <message id="generator_not_running">
+      <location filename="../../data/Generators.qml" line="59"/>
+      <source>Not running</source>
+      <translation>実行中ではありません</translation>
+    </message>
+    <message id="settings_loss_of_communication">
+      <location filename="../../data/Generators.qml" line="68"/>
+      <source>Loss of communication</source>
+      <translation>通信喪失</translation>
+    </message>
+    <message id="settings_soc_condition">
+      <location filename="../../data/Generators.qml" line="71"/>
+      <source>SOC condition</source>
+      <translation>SOC条件</translation>
+    </message>
+    <message id="settings_ac_load_condition">
+      <location filename="../../data/Generators.qml" line="74"/>
+      <source>AC load condition</source>
+      <translation>AC負荷条件</translation>
+    </message>
+    <message id="settings_battery_current_condition">
+      <location filename="../../data/Generators.qml" line="77"/>
+      <source>Battery current condition</source>
+      <translation>バッテリー電流条件</translation>
+    </message>
+    <message id="settings_battery_voltage_condition">
+      <location filename="../../data/Generators.qml" line="80"/>
+      <source>Battery voltage condition</source>
+      <translation>バッテリー電圧条件</translation>
+    </message>
+    <message id="settings_inverter_overload_condition">
+      <location filename="../../data/Generators.qml" line="86"/>
+      <source>Inverter overload condition</source>
+      <translation>インバーター過負荷条件</translation>
+    </message>
+    <message id="application_content_touch_input_on">
+      <location filename="../../ApplicationContent.qml" line="57"/>
+      <source>Touch input on</source>
+      <translation>タッチ入力オン</translation>
+    </message>
+    <message id="application_content_touch_input_off">
+      <location filename="../../ApplicationContent.qml" line="59"/>
+      <source>Touch input off</source>
+      <translation>タッチ入力オフ</translation>
+    </message>
+    <message id="application_content_touch_input_disabled">
+      <location filename="../../ApplicationContent.qml" line="73"/>
+      <source>Touch input disabled</source>
+      <translation>タッチ入力無効</translation>
+    </message>
+    <message id="inverter_ac-out_num">
+      <location filename="../../components/InverterAcOutSettings.qml" line="44"/>
+      <source>AC Out L%1</source>
+      <extracomment>%1 = phase number (1-3)</extracomment>
+      <translation>AC出力 L%1</translation>
+    </message>
+    <message id="notification_description_and_value">
+      <location filename="../../components/NotificationDelegate.qml" line="76"/>
+      <source>%1 %2</source>
+      <extracomment>%1 = notification description (e.g. 'High temperature'), %2 = the value that triggered the notification (e.g. '25 C')</extracomment>
+      <translation>%1 %2</translation>
+    </message>
+    <message id="ess_flags">
+      <location filename="../../components/SystemReason.qml" line="15"/>
+      <source>ESS %1</source>
+      <translation>ESS %1</translation>
+    </message>
+    <message id="systemreason_charge_discharge_disabled">
+      <location filename="../../components/SystemReason.qml" line="47"/>
+      <source>ESS %1 Charge/Discharge Disabled</source>
+      <translation>ESS %1 充電/放電無効</translation>
+    </message>
+    <message id="systemreason_charge_disabled">
+      <location filename="../../components/SystemReason.qml" line="50"/>
+      <source>ESS %1 Charge Disabled</source>
+      <translation>ESS %1 充電無効</translation>
+    </message>
+    <message id="systemreason_discharge_disabled">
+      <location filename="../../components/SystemReason.qml" line="53"/>
+      <source>ESS %1 Discharge Disabled</source>
+      <translation>ESS %1 放電無効</translation>
+    </message>
+    <message id="wifimodel_disconnected_ap_off">
+      <location filename="../../components/WifiModel.qml" line="25"/>
+      <source>Disconnected | AP Off</source>
+      <translation>未接続 | APオフ</translation>
+    </message>
+    <message id="ac-in-genset_disableautostartdialog_title">
+      <location filename="../../components/dialogs/GeneratorDisableAutoStartDialog.qml" line="13"/>
+      <source>Disable autostart?</source>
+      <translation>自動起動を無効にしますか？</translation>
+    </message>
+    <message id="ac-in-genset_disableautostartdialog_description">
+      <location filename="../../components/dialogs/GeneratorDisableAutoStartDialog.qml" line="16"/>
+      <source>Autostart will be disabled and the generator won't automatically start based on the configured conditions.
+If the generator is currently running due to a autostart condition, disabling autostart will also stop it immediately.</source>
+      <translation>自動起動が無効になり、発電機は設定された条件に基づいて自動的に起動しなくなります。
+自動起動条件により発電機が現在稼働中の場合、自動起動を無効にすると直ちに停止します。</translation>
+    </message>
+    <message id="controlcard_inverter_charger_ess_mode">
+      <location filename="../../components/dialogs/InverterChargerEssModeDialog.qml" line="18"/>
+      <source>ESS mode</source>
+      <translation>ESSモード</translation>
+    </message>
+    <message id="settings_briefview_center_details">
+      <location filename="../../components/listitems/ListBriefCenterDetails.qml" line="20"/>
+      <source>Center details</source>
+      <translation>詳細を中央表示</translation>
+    </message>
+    <message id="settings_briefview_center_temperature_services">
+      <location filename="../../components/listitems/ListBriefCenterDetails.qml" line="35"/>
+      <source>Temperature services</source>
+      <translation>温度サービス</translation>
+    </message>
+    <message id="rs_current_limit_not_adjustable">
+      <location filename="../../components/listitems/ListCurrentLimitButton.qml" line="27"/>
+      <source>This current limit is fixed in the system configuration. It cannot be adjusted.</source>
+      <translation>この電流制限はシステム構成で固定されています。調整できません。</translation>
+    </message>
+    <message id="settings_switch_channel_input">
+      <location filename="../../pages/settings/devicelist/PageSwitch.qml" line="79"/>
+      <source>Input</source>
+      <extracomment>DC input measurement values</extracomment>
+      <translation>入力</translation>
+    </message>
+    <message id="inverter_mode_not_adjustable">
+      <location filename="../../components/listitems/ListInverterChargerModeButton.qml" line="43"/>
+      <source>The mode is fixed in the system configuration. It cannot be adjusted.</source>
+      <translation>このモードはシステム構成で固定されています。調整できません。</translation>
+    </message>
+    <message id="listlink_open_link">
+      <location filename="../../components/listitems/ListLink.qml" line="93"/>
+      <source>Open link</source>
+      <translation>リンクを開く</translation>
+    </message>
+    <message id="settings_services_mqtt_access">
+      <location filename="../../components/listitems/ListMqttAccessSwitch.qml" line="11"/>
+      <source>MQTT Access</source>
+      <translation>MQTTアクセス</translation>
+    </message>
+    <message id="settings_security_warning_profile_configuration_order">
+      <location filename="../../components/listitems/ListMqttAccessSwitch.qml" line="19"/>
+      <source>A Security Profile must be configured before the network services can be enabled, see Settings - General</source>
+      <translation>ネットワークサービスを有効にする前にセキュリティプロファイルを構成する必要があります。「設定 - 一般」を参照してください。</translation>
+    </message>
+    <message id="reboot_button_press_ok_to_reboot">
+      <location filename="../../components/listitems/ListRebootButton.qml" line="24"/>
+      <source>Press 'OK' to reboot</source>
+      <translation>「OK」を押して再起動</translation>
+    </message>
+    <message id="reboot_button_dialoglayer_rebooting">
+      <location filename="../../components/dialogs/ModalRebootingDialog.qml" line="14"/>
+      <source>Rebooting...</source>
+      <translation>再起動中...</translation>
+    </message>
+    <message id="number_field_input_too_long">
+      <location filename="../../components/listitems/core/ListIntField.qml" line="21"/>
+      <source>Use a number with %1 digits or less.</source>
+      <translation>%1桁以下の数値を入力してください。</translation>
+    </message>
+    <message id="ip_address_input_not_valid">
+      <location filename="../../components/listitems/core/ListIpAddressField.qml" line="34"/>
+      <source>'%1' is not a valid IP address.</source>
+      <translation>「%1」は有効なIPアドレスではありません。</translation>
+    </message>
+    <message id="port_field_title">
+      <location filename="../../components/listitems/core/ListPortField.qml" line="13"/>
+      <source>Port</source>
+      <translation>ポート</translation>
+    </message>
+    <message id="port_input_not_valid">
+      <location filename="../../components/listitems/core/ListPortField.qml" line="26"/>
+      <source>'%1' is not a valid port number. Use a number between 0-65535.</source>
+      <translation>「%1」は有効なポート番号ではありません。0～65535の数値を入力してください。</translation>
+    </message>
+    <message id="overview_widget_essential_loads_title">
+      <location filename="../../components/widgets/EssentialLoadsWidget.qml" line="13"/>
+      <source>Essential Loads</source>
+      <translation>必須負荷</translation>
+    </message>
+    <message id="rs_alarm_low_ac_out_voltage">
+      <location filename="../../data/InverterChargers.qml" line="30"/>
+      <source>Low AC OUT voltage</source>
+      <translation>低AC出力電圧</translation>
+    </message>
+    <message id="rs_alarm_high_ac_out_voltage">
+      <location filename="../../data/InverterChargers.qml" line="32"/>
+      <source>High AC OUT voltage</source>
+      <translation>高AC出力電圧</translation>
+    </message>
+    <message id="rs_alarm_short_circuit">
+      <location filename="../../data/InverterChargers.qml" line="36"/>
+      <source>Short circuit</source>
+      <translation>短絡</translation>
+    </message>
+    <message id="inverterCharger_mode_passthrough">
+      <location filename="../../data/InverterChargers.qml" line="53"/>
+      <source>Passthrough</source>
+      <translation>パススルー</translation>
+    </message>
+    <message id="startpage_option_brief_with_panel">
+      <location filename="../../data/StartPageConfiguration.qml" line="31"/>
+      <source>Brief (side panel open)</source>
+      <extracomment>The 'Brief' page, with the side panel opened</extracomment>
+      <translation>概要（サイドパネル表示）</translation>
+    </message>
+    <message id="startpage_option_levels_tanks">
+      <location filename="../../data/StartPageConfiguration.qml" line="43"/>
+      <source>Levels (Tanks)</source>
+      <extracomment>The 'Levels' page, with the "Tanks" section opened</extracomment>
+      <translation>レベル（タンク）</translation>
+    </message>
+    <message id="startpage_option_levels_environment">
+      <location filename="../../data/StartPageConfiguration.qml" line="49"/>
+      <source>Levels (Environment)</source>
+      <extracomment>The 'Levels' page, with the "Environment" section opened</extracomment>
+      <translation>レベル（環境）</translation>
+    </message>
+    <message id="startpage_option_battery_list">
+      <location filename="../../data/StartPageConfiguration.qml" line="58"/>
+      <source>Battery list</source>
+      <translation>バッテリーリスト</translation>
+    </message>
+    <message id="firmware_installed_build_gx_device_updated">
+      <location filename="../../pages/DialogLayer.qml" line="60"/>
+      <source>GX device has been updated</source>
+      <translation>GXデバイスが更新されました</translation>
+    </message>
+    <message id="firmware_installed_build_page_will_reload">
+      <location filename="../../pages/DialogLayer.qml" line="62"/>
+      <source>Page will automatically reload in ten seconds to load the latest version.</source>
+      <translation>最新バージョンを読み込むため、ページは10秒後に自動的に再読み込みされます。</translation>
+    </message>
+    <message id="controlcard_evcs_title">
+      <location filename="../../pages/controlcards/EVCSCard.qml" line="21"/>
+      <source>EVCS (%1)</source>
+      <extracomment>%1 = the EVCS name</extracomment>
+      <translation>EVCS (%1)</translation>
+    </message>
+    <message id="inverter_chargers_title">
+      <location filename="../../pages/invertercharger/InverterChargerListPage.qml" line="13"/>
+      <source>Inverter/Chargers</source>
+      <translation>インバーター/充電器</translation>
+    </message>
+    <message id="settings_cgwacs_no_energy_meters">
+      <location filename="../../pages/settings/PageSettingsCGwacsOverview.qml" line="39"/>
+      <source>No energy meters found
+
+Note that this menu only shows Carlo Gavazzi meters connected over RS485. For any other meter, including Carlo Gavazzi meters connected over ethernet, see the Modbus TCP/UDP devices menu instead.</source>
+      <translation>エネルギーメーターが見つかりません
+
+このメニューには、RS485経由で接続されたCarlo Gavazziメーターのみが表示されます。イーサネット経由で接続されたCarlo Gavazziメーターを含むその他のメーターについては、Modbus TCP/UDPデバイスメニューを参照してください。</translation>
+    </message>
+    <message id="settings_minmax_autorange">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="17"/>
+      <source>Auto-ranging</source>
+      <extracomment>Whether to adjust the min/max values in the range dynamically, based on the lowest and highest values observed on the system.</extracomment>
+      <translation>オートレンジ</translation>
+    </message>
+    <message id="settings_minmax_autorange_desc">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="21"/>
+      <source>When enabled, the minima and maxima of gauges and graphs are automatically adjusted based on past values.</source>
+      <translation>有効にすると、ゲージやグラフの最小値と最大値が過去の値に基づいて自動的に調整されます。</translation>
+    </message>
+    <message id="settings_minmax_reset">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="26"/>
+      <source>Reset all range values to zero</source>
+      <translation>全てのレンジ値をゼロにリセット</translation>
+    </message>
+    <message id="settings_minmax_reset_range_values">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="37"/>
+      <source>Reset Range Values</source>
+      <translation>レンジ値のリセット</translation>
+    </message>
+    <message id="settings_minmax_reset_are_you_sure">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="39"/>
+      <source>Are you sure that you want to reset all the values to zero?</source>
+      <translation>全ての値をゼロにリセットしてもよろしいですか？</translation>
+    </message>
+    <message id="settings_minmax_ac_in_not_available">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="81"/>
+      <source>%1 (not available)</source>
+      <extracomment>%1 = 'AC input 1' or 'AC input 2'</extracomment>
+      <translation>%1 (利用不可)</translation>
+    </message>
+    <message id="settings_minmax_ac_in_header_with_source">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="85"/>
+      <source>%1 (%2)</source>
+      <extracomment>%1 = 'AC input 1' or 'AC input 2', %2 = name of connected input (e.g. Grid, Shore)</extracomment>
+      <translation>%1 (%2)</translation>
+    </message>
+    <message id="settings_minmax_acout_max_acin1">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="130"/>
+      <source>Maximum current: AC in 1 connected</source>
+      <translation>最大電流：AC入力1接続時</translation>
+    </message>
+    <message id="settings_minmax_acout_max_acin2">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="139"/>
+      <source>Maximum current: AC in 2 connected</source>
+      <translation>最大電流：AC入力2接続時</translation>
+    </message>
+    <message id="settings_minmax_acout_max">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="148"/>
+      <source>Maximum current: no AC inputs</source>
+      <translation>最大電流：AC入力なし</translation>
+    </message>
+    <message id="settings_minmax_dc_out">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="156"/>
+      <source>DC output</source>
+      <translation>DC出力</translation>
+    </message>
+    <message id="settings_minmax_solar">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="169"/>
+      <source>Solar</source>
+      <translation>ソーラー</translation>
+    </message>
+    <message id="settings_startpage_timeout_minutes" numerus="yes">
+      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="20"/>
+      <source>After %n minute(s)</source>
+      <translation>
+        <numerusform>%n分後</numerusform>
+      </translation>
+    </message>
+    <message id="settings_startpage_description">
+      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="58"/>
+      <source>Go to this page when the application starts.</source>
+      <translation>アプリケーション起動時にこのページに移動する。</translation>
+    </message>
+    <message id="settings_startpage_timeout">
+      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="68"/>
+      <source>Timeout</source>
+      <translation>タイムアウトしました</translation>
+    </message>
+    <message id="settings_startpage_timeout_description">
+      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="73"/>
+      <source>Revert to the start page when the application is inactive.</source>
+      <translation>アプリケーションが非アクティブな場合、開始ページに戻る。</translation>
+    </message>
+    <message id="settings_startpage_auto_description">
+      <location filename="../../pages/settings/PageSettingsDisplayStartPage.qml" line="97"/>
+      <source>After one minute of inactivity, select the current page as the start page, if it is in this list.</source>
+      <translation>1分間操作がない場合、現在のページがリストにあれば、開始ページとして選択する。</translation>
+    </message>
+    <message id="settings_ess_buying">
+      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="40"/>
+      <source>Buying</source>
+      <translation>買電</translation>
+    </message>
+    <message id="settings_ess_selling">
+      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="42"/>
+      <source>Selling</source>
+      <translation>売電</translation>
+    </message>
+    <message id="settings_ess_target_soc">
+      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="50"/>
+      <source>Target SOC</source>
+      <translation>目標SOC</translation>
+    </message>
+    <message id="page_settings_modbus_scan_for_devices">
+      <location filename="../../pages/settings/PageSettingsModbus.qml" line="37"/>
+      <source>Scan for devices</source>
+      <translation>デバイスをスキャン</translation>
+    </message>
+    <message id="page_settings_modbus_saved_devices">
+      <location filename="../../pages/settings/PageSettingsModbus.qml" line="45"/>
+      <source>Saved devices</source>
+      <translation>保存済みのデバイス</translation>
+    </message>
+    <message id="common_words_discovered_devices">
+      <location filename="../../components/CommonWords.qml" line="184"/>
+      <source>Discovered devices</source>
+      <translation>検出されたデバイス</translation>
+    </message>
+    <message id="add_modbus_tcp_udp_device">
+      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="15"/>
+      <source>Add Modbus TCP/UDP device</source>
+      <translation>Modbus TCP/UDPデバイスを追加</translation>
+    </message>
+    <message id="modbus_add_device_tcp">
+      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="29"/>
+      <source>TCP</source>
+      <translation>TCP</translation>
+    </message>
+    <message id="modbus_add_device_udp">
+      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="31"/>
+      <source>UDP</source>
+      <translation>UDP</translation>
+    </message>
+    <message id="modbus_add_device_protocol">
+      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="34"/>
+      <source>Protocol</source>
+      <translation>プロトコル</translation>
+    </message>
+    <message id="modbus_add_device_unit">
+      <location filename="../../pages/settings/PageSettingsModbusAddDevice.qml" line="55"/>
+      <source>Unit</source>
+      <translation>ユニット</translation>
+    </message>
+    <message id="page_settings_fronius_unitid_invalid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="35"/>
+      <source>%1 is not a valid unit number. Use a number between 1-247.</source>
+      <translation>%1 は有効なユニット番号ではありません。1から247の間の番号を使用してください。</translation>
+    </message>
+    <message id="page_settings_modbus_device_number">
+      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="64"/>
+      <source>Device %1</source>
+      <translation>デバイス %1</translation>
+    </message>
+    <message id="page_settings_modbus_device_remove_device">
+      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="97"/>
+      <source>Remove Modbus device?</source>
+      <translation>Modbusデバイスを削除しますか？</translation>
+    </message>
+    <message id="settings_modbus_no_devices_discovered">
+      <location filename="../../pages/settings/PageSettingsModbusDiscovered.qml" line="32"/>
+      <source>No Modbus devices discovered</source>
+      <translation>Modbusデバイスは検出されませんでした。</translation>
+    </message>
+    <message id="pagesettingssupportstate_support_state_unsupported_gx_device">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="33"/>
+      <source>Unsupported GX device</source>
+      <translation>サポートされていないGXデバイス</translation>
+    </message>
+    <message id="pagesettingssupportstate_custom_startup_unknown">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="135"/>
+      <source>Unknown: %1</source>
+      <translation>不明: %1</translation>
+    </message>
+    <message id="pagesettingssupportstate_firmware_no_available">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="152"/>
+      <source>No, %1 is available</source>
+      <extracomment>%1 = firmware version</extracomment>
+      <translation>いいえ、%1 が利用可能です。</translation>
+    </message>
+    <message id="pagesettingssupportstate_device_model">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="224"/>
+      <source>Device model</source>
+      <translation>デバイスモデル</translation>
+    </message>
+    <message id="pagesettingssupportstate_hq_serial_number">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="232"/>
+      <source>HQ serial number</source>
+      <translation>HQシリアル番号</translation>
+    </message>
+    <message id="pagesettingssupportstate_data_free_space">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="240"/>
+      <source>Data partition free space</source>
+      <translation>データパーティション空き容量</translation>
+    </message>
+    <message id="pagesettingssupportstate_installed_firmware_version">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="347"/>
+      <source>Installed firmware version</source>
+      <translation>インストール済みファームウェアバージョン</translation>
+    </message>
+    <message id="pagesettingssupportstate_installed_image_type">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="353"/>
+      <source>Installed image type</source>
+      <translation>インストール済みイメージタイプ</translation>
+    </message>
+    <message id="pagesettingssupportstate_user_ssh_key_present">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="247"/>
+      <source>User SSH key present</source>
+      <translation>ユーザーSSHキーが存在します</translation>
+    </message>
+    <message id="pagesettingssupportstate_modifications">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="253"/>
+      <source>Modifications</source>
+      <translation>変更</translation>
+    </message>
+    <message id="settings_support_links_product_support_manuals">
+      <location filename="../../pages/settings/PageSettingsDocumentation.qml" line="21"/>
+      <source>Product support &amp; manuals</source>
+      <translation>製品サポートとマニュアル</translation>
+    </message>
+    <message id="settings_support_links_community">
+      <location filename="../../pages/settings/PageSettingsDocumentation.qml" line="36"/>
+      <source>Victron Community</source>
+      <translation>Victronコミュニティ</translation>
+    </message>
+    <message id="settings_support_links_distributor">
+      <location filename="../../pages/settings/PageSettingsDocumentation.qml" line="42"/>
+      <source>Find a local distributor</source>
+      <translation>最寄りの販売店を探す</translation>
+    </message>
+    <message id="settings_accharger_battery">
+      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="65"/>
+      <source>Battery %1</source>
+      <extracomment>%1 = battery number</extracomment>
+      <translation>バッテリー %1</translation>
+    </message>
+    <message id="settings_accharger_current">
+      <location filename="../../pages/settings/devicelist/PageAcCharger.qml" line="92"/>
+      <source>AC current</source>
+      <translation>AC電流</translation>
+    </message>
+    <message id="devicelist_motordrive_motorrpm">
+      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="49"/>
+      <source>Motor RPM</source>
+      <translation>モーターRPM</translation>
+    </message>
+    <message id="cycle_history_active">
+      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="18"/>
+      <source>Active cycle</source>
+      <translation>作動サイクル</translation>
+    </message>
+    <message id="cycle_history_num">
+      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="21"/>
+      <source>Cycle %1</source>
+      <extracomment>%1 = cycle number</extracomment>
+      <translation>サイクル %1</translation>
+    </message>
+    <message id="cycle_history_dc_disconnect">
+      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="33"/>
+      <source>DC Disconnect</source>
+      <translation>DC切断</translation>
+    </message>
+    <message id="cycle_history_powered_off">
+      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="35"/>
+      <source>Powered off</source>
+      <translation>電源オフ</translation>
+    </message>
+    <message id="cycle_history_function_change">
+      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="37"/>
+      <source>Function change</source>
+      <translation>機能変更</translation>
+    </message>
+    <message id="cycle_history_firmware_update">
+      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="39"/>
+      <source>Firmware update</source>
+      <translation>ファームウェア更新</translation>
+    </message>
+    <message id="cycle_history_software_reset">
+      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="43"/>
+      <source>Software reset</source>
+      <translation>ソフトウェアのリセット</translation>
+    </message>
+    <message id="cycle_history_incomplete">
+      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="46"/>
+      <source>Incomplete</source>
+      <translation>未完了</translation>
+    </message>
+    <message id="cycle_history_elapsed_time">
+      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="53"/>
+      <source>Elapsed time</source>
+      <translation>経過時間</translation>
+    </message>
+    <message id="cycle_history_charge_maintain_ah">
+      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="70"/>
+      <source>Charge / maintain (Ah)</source>
+      <translation>充電 / 維持 (Ah)</translation>
+    </message>
+    <message id="cycle_history_battery_voltage">
+      <location filename="../../pages/settings/devicelist/dc-in/ListCycleHistoryItem.qml" line="85"/>
+      <source>Battery (V&lt;sub&gt;start&lt;/sub&gt;/V&lt;sub&gt;end&lt;/sub&gt;)</source>
+      <translation>バッテリー (V&lt;sub&gt;開始&lt;/sub&gt;/V&lt;sub&gt;終了&lt;/sub&gt;)</translation>
+    </message>
+    <message id="inverter_maximum_pv_voltage">
+      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="18"/>
+      <source>Maximum PV voltage</source>
+      <translation>最大PV電圧</translation>
+    </message>
+    <message id="inverter_maximum_battery_voltage">
+      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="26"/>
+      <source>Maximum battery voltage</source>
+      <translation>最大バッテリー電圧</translation>
+    </message>
+    <message id="inverter_minimum_battery_voltage">
+      <location filename="../../pages/settings/devicelist/inverter/PageSolarStats.qml" line="34"/>
+      <source>Minimum battery voltage</source>
+      <translation>最小バッテリー電圧</translation>
+    </message>
+    <message id="settings_multirs_ac_out_phase">
+      <location filename="../../pages/settings/devicelist/rs/PageMultiRs.qml" line="158"/>
+      <source>AC out %1</source>
+      <extracomment>%1 = phase name (e.g. L1, L2, L3)</extracomment>
+      <translation>AC出力 %1</translation>
+    </message>
+    <message id="rs_alarm_no_alarms_to_be_configured">
+      <location filename="../../pages/settings/devicelist/rs/PageRsAlarmSettings.qml" line="32"/>
+      <source>No alarms to be configured</source>
+      <translation>設定するアラームはありません。</translation>
+    </message>
+    <message id="rssystem_system_alarms">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="74"/>
+      <source>System alarms</source>
+      <translation>システムアラーム</translation>
+    </message>
+    <message id="settings_rs_devices">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystem.qml" line="99"/>
+      <source>RS devices</source>
+      <translation>RSデバイス</translation>
+    </message>
+    <message id="rs_no_system_alarms">
+      <location filename="../../pages/settings/devicelist/rs/PageRsSystemAlarms.qml" line="60"/>
+      <source>No system alarms</source>
+      <translation>システムアラームはありません。</translation>
+    </message>
+    <message id="welcome_page_back">
+      <location filename="../../pages/welcome/WelcomePage.qml" line="94"/>
+      <source>Back</source>
+      <translation>戻る</translation>
+    </message>
+    <message id="welcome_whatsnew">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="34"/>
+      <source>What's New</source>
+      <translation>新機能</translation>
+    </message>
+    <message id="welcome_skip">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="44"/>
+      <source>Skip</source>
+      <translation>スキップ</translation>
+    </message>
+    <message id="welcome_landing_title">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="63"/>
+      <source>Welcome!</source>
+      <translation>ようこそ！</translation>
+    </message>
+    <message id="welcome_landing_text">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="69"/>
+      <source>We’re excited to introduce a completely redesigned interface that enhances both the usability and aesthetics of your GX.
+
+With streamlined navigation and a fresh look, everything you love is now even easier to access and more visually appealing.</source>
+      <translation>お客様のGXの使いやすさとデザイン性を高める、完全に刷新されたインターフェースをご紹介します。
+
+合理化されたナビゲーションと新しいデザインにより、お気に入りの機能がよりアクセスしやすく、視覚的にも魅力的になりました。</translation>
+    </message>
+    <message id="welcome_colors_title">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="73"/>
+      <source>Dark - light mode</source>
+      <translation>ダークモードとライトモード</translation>
+    </message>
+    <message id="welcome_colors_text">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="77"/>
+      <source>Different environments call for different display settings. Dark and Light Modes ensure the best viewing experience no matter where you are.</source>
+      <translation>さまざまな環境に合わせて表示設定を変更できます。ダークモードとライトモードは、場所に関わらず最高の表示体験を提供します。</translation>
+    </message>
+    <message id="welcome_brief_text">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="86"/>
+      <source>All the key information you need, presented in a clean and simple layout. The centerpiece is a customizable widget featuring rings, giving you quick access to your system insights at a glance.</source>
+      <translation>必要なすべての主要情報が、クリーンでシンプルなレイアウトで表示されます。中心となるのは、リングを特徴とするカスタマイズ可能なウィジェットで、システムの状態を一目で素早く把握できます。</translation>
+    </message>
+    <message id="welcome_overview_text">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="94"/>
+      <source>Gain greater control with our updated Overview panel, featuring real-time system data — all in one place for easy monitoring.</source>
+      <translation>リアルタイムのシステムデータを一箇所で簡単に監視できる、更新された概要パネルでより詳細な制御が可能になります。</translation>
+    </message>
+    <message id="controlcards_empty_title">
+      <location filename="../../pages/ControlCardsPage.qml" line="155"/>
+      <source>Controls</source>
+      <translation>コントロール</translation>
+    </message>
+    <message id="welcome_controls_text">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="101"/>
+      <source>All the day to day controls are now combined together in the new Controls pane. Accessible from anywhere by tapping the dedicated button on top left of the display.</source>
+      <translation>日常的なすべてのコントロールは、新しい「コントロール」パネルにまとめられました。ディスプレイ左上の専用ボタンをタップすれば、どこからでもアクセスできます。</translation>
+    </message>
+    <message id="welcome_units_title">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="105"/>
+      <source>Watts &amp; Amps</source>
+      <translation>ワットとアンペア</translation>
+    </message>
+    <message id="welcome_units_text">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="109"/>
+      <source>You can now switch between Watts and Amps. Choose the unit that best fits your preference.</source>
+      <translation>ワットとアンペアを切り替えられるようになりました。お好みに合わせて単位を選択してください。</translation>
+    </message>
+    <message id="welcome_more_title">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="113"/>
+      <source>Learn more</source>
+      <translation>さらに詳しく</translation>
+    </message>
+    <message id="welcome_more_text_wasm">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="118"/>
+      <source>Access the link below to find out more about the Renewed UI.&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</source>
+      <extracomment>%1 = link to URL with more information</extracomment>
+      <translation>刷新されたUIの詳細については、以下のリンクをご覧ください。&lt;br /&gt;&lt;br /&gt;&lt;a href="%1"&gt;%1&lt;/a&gt;</translation>
+    </message>
+    <message id="welcome_more_text">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="120"/>
+      <source>Scan the QR code to find out more about the Renewed UI.</source>
+      <translation>刷新されたUIの詳細については、QRコードをスキャンしてください。</translation>
+    </message>
+    <message id="welcome_done">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="136"/>
+      <source>Done</source>
+      <translation>完了</translation>
+    </message>
+    <message id="welcome_next">
+      <location filename="../../pages/welcome/WelcomeView.qml" line="138"/>
+      <source>Next</source>
+      <translation>次へ</translation>
+    </message>
+    <message id="direction_north">
+      <location filename="../../src/units.cpp" line="449"/>
+      <source>N</source>
+      <translation>北</translation>
+    </message>
+    <message id="direction_northeast">
+      <location filename="../../src/units.cpp" line="451"/>
+      <source>NE</source>
+      <translation>いいえ</translation>
+    </message>
+    <message id="direction_east">
+      <location filename="../../src/units.cpp" line="453"/>
+      <source>E</source>
+      <translation>東</translation>
+    </message>
+    <message id="direction_southeast">
+      <location filename="../../src/units.cpp" line="455"/>
+      <source>SE</source>
+      <translation>南東</translation>
+    </message>
+    <message id="direction_south">
+      <location filename="../../src/units.cpp" line="457"/>
+      <source>S</source>
+      <translation>南</translation>
+    </message>
+    <message id="direction_southwest">
+      <location filename="../../src/units.cpp" line="459"/>
+      <source>SW</source>
+      <translation>南西</translation>
+    </message>
+    <message id="direction_west">
+      <location filename="../../src/units.cpp" line="461"/>
+      <source>W</source>
+      <translation>西</translation>
+    </message>
+    <message id="direction_northwest">
+      <location filename="../../src/units.cpp" line="463"/>
+      <source>NW</source>
+      <translation>北西</translation>
+    </message>
+    <message id="genset_controller_multiple_genset_controllers">
+      <location filename="../../components/PageGensetModel.qml" line="69"/>
+      <source>Multiple genset controllers detected.
+The GX device can only control one connected genset and takes the one with the lowest VRM instance number. To avoid unexpected behavior, make sure that only one unit is available to the GX device.</source>
+      <translation>複数の発電機コントローラーが検出されました。
+GXデバイスは接続された発電機を1台のみ制御できます。最も低いVRMインスタンス番号を持つものが選択されます。予期せぬ動作を避けるため、GXデバイスには1台のユニットのみが利用可能であることを確認してください。</translation>
+    </message>
+    <message id="settings_tz_etc">
+      <location filename="../../pages/settings/PageTzInfo.qml" line="295"/>
+      <source>Other</source>
+      <oldsource>Etc</oldsource>
+      <translation>その他</translation>
+    </message>
+    <message id="ac-in-modeldefault_energy_reverse_x">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInModel.qml" line="141"/>
+      <source>Reversed Energy L%1</source>
+      <extracomment>%1 = phase number (1-3)</extracomment>
+      <translation>逆方向エネルギー L%1</translation>
+    </message>
+    <message id="settings_minmax_boat_page">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="182"/>
+      <source>Boat page</source>
+      <translation>ボートページ</translation>
+    </message>
+    <message id="switchable_output_unsupported">
+      <location filename="../../src/enums.cpp" line="575"/>
+      <location filename="../../src/enums.cpp" line="608"/>
+      <source>Unsupported type: %1</source>
+      <translation>サポートされていないタイプ: %1</translation>
+    </message>
+    <message id="common_words_press">
+      <location filename="../../components/CommonWords.qml" line="430"/>
+      <source>Press</source>
+      <translation>押す</translation>
+    </message>
+    <message id="output_aux_battery_service_changed_dcdc">
+      <location filename="../../components/listitems/ListOutputBatteryRadioButtonGroup.qml" line="27"/>
+      <source>%1 changed to DC-DC service</source>
+      <translation>%1がDC-DCサービスに変更されました</translation>
+    </message>
+    <message id="output_aux_battery_service_changed_alternator">
+      <location filename="../../components/listitems/ListOutputBatteryRadioButtonGroup.qml" line="29"/>
+      <source>%1 changed to alternator service</source>
+      <translation>%1がオルタネーターサービスに変更されました</translation>
+    </message>
+    <message id="settings_minmax_gauge_display">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="187"/>
+      <source>Gauge Display</source>
+      <translation>ゲージ表示</translation>
+    </message>
+    <message id="settings_minmax_max_speed">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="209"/>
+      <source>Max Speed</source>
+      <translation>最高速度</translation>
+    </message>
+    <message id="settings_minmax_max_rpm">
+      <location filename="../../pages/settings/PageSettingsDisplayMinMax.qml" line="221"/>
+      <source>Max RPM</source>
+      <translation>最大RPM</translation>
+    </message>
+    <message id="settings_module_state">
+      <location filename="../../pages/settings/devicelist/PageSwitch.qml" line="28"/>
+      <source>Module state</source>
+      <translation>モジュール状態</translation>
+    </message>
+    <message id="settings_module_voltage">
+      <location filename="../../pages/settings/devicelist/PageSwitch.qml" line="35"/>
+      <source>Module Voltage</source>
+      <translation>モジュール電圧</translation>
+    </message>
+    <message id="page_generic_input_group">
+      <location filename="../../components/listitems/ListIOChannelGroupField.qml" line="11"/>
+      <source>Group</source>
+      <translation>グループ</translation>
+    </message>
+    <message id="page_switchable_output_fuse_rating">
+      <location filename="../../pages/settings/devicelist/iochannel/PageSwitchableOutput.qml" line="76"/>
+      <source>Fuse rating</source>
+      <translation>ヒューズ定格</translation>
+    </message>
+    <message id="boat_page_rpm">
+      <location filename="../../pages/boat/LargeCenterGauge.qml" line="162"/>
+      <location filename="../../pages/boat/LargeCenterGauge.qml" line="302"/>
+      <source>RPM</source>
+      <translation>RPM</translation>
+    </message>
+    <message id="boat_page_motor_drive">
+      <location filename="../../pages/boat/MotorDriveGauges.qml" line="39"/>
+      <source>Motordrive</source>
+      <translation></translation>
+    </message>
+    <message id="common_words_time_to_go">
+      <location filename="../../components/CommonWords.qml" line="548"/>
+      <source>Time To Go</source>
+      <translation></translation>
+    </message>
+    <message id="backup_and_restore">
+      <location filename="../../pages/vebusdevice/PageVeBusAdvanced.qml" line="307"/>
+      <source>Backup &amp; Restore</source>
+      <translation></translation>
+    </message>
+    <message id="wifimodel_disconnected_ap_on">
+      <location filename="../../components/WifiModel.qml" line="23"/>
+      <source>Disconnected | AP On</source>
+      <translation></translation>
+    </message>
+    <message id="ess_check_multiphase_regulation_setting">
+      <location filename="../../data/Ess.qml" line="76"/>
+      <source>Make sure to check the Multiphase regulation setting</source>
+      <translation></translation>
+    </message>
+    <message id="mk2vsc_state_init">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="16"/>
+      <source>Init</source>
+      <translation></translation>
+    </message>
+    <message id="mk2vsc_state_query_products">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="18"/>
+      <source>Query products</source>
+      <translation></translation>
+    </message>
+    <message id="mk2vsc_state_read_setting_data">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="22"/>
+      <source>Read setting data</source>
+      <translation></translation>
+    </message>
+    <message id="mk2vsc_state_read_assistants">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="24"/>
+      <source>Read assistants</source>
+      <translation></translation>
+    </message>
+    <message id="mk2vsc_state_read_vebus_configuration">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="26"/>
+      <source>Read VE.Bus configuration</source>
+      <translation></translation>
+    </message>
+    <message id="mk2vsc_state_read_grid_info">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="28"/>
+      <source>Read grid info</source>
+      <translation></translation>
+    </message>
+    <message id="mk2vsc_state_write_settings_info">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="30"/>
+      <source>Write settings info</source>
+      <translation></translation>
+    </message>
+    <message id="mk2vsc_state_write_settings_data">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="32"/>
+      <source>Write Settings Data</source>
+      <translation></translation>
+    </message>
+    <message id="mk2vsc_state_write_assistants">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="34"/>
+      <source>Write assistants</source>
+      <translation></translation>
+    </message>
+    <message id="mk2vsc_state_write_vebus_configuration">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="36"/>
+      <source>Write VE.Bus configuration</source>
+      <translation></translation>
+    </message>
+    <message id="mk2vsc_state_resetting_vebus_products">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="38"/>
+      <source>Resetting VE.Bus products</source>
+      <translation></translation>
+    </message>
+    <message id="mk2vsc_error_mk2_mk3_comm">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="49"/>
+      <source>MK2/MK3 communication error</source>
+      <translation>MK2/MK3通信エラー</translation>
+    </message>
+    <message id="mk2vsc_error_prod_addr_unreach">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="51"/>
+      <source>Product address not reachable</source>
+      <translation>製品アドレスに到達できません</translation>
+    </message>
+    <message id="mk2vsc_error_incomp_mk2_fw">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="53"/>
+      <source>Incompatible MK2 firmware version</source>
+      <translation>MK2ファームウェアのバージョンに互換性がありません</translation>
+    </message>
+    <message id="mk2vsc_error_no_vebus_prod">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="55"/>
+      <source>No VE.Bus product was found</source>
+      <translation>VE.Bus製品が見つかりませんでした</translation>
+    </message>
+    <message id="mk2vsc_error_too_many_devices">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="57"/>
+      <source>Too many devices on the VE.Bus</source>
+      <translation>VE.Bus上のデバイスが多すぎます</translation>
+    </message>
+    <message id="mk2vsc_error_timed_out">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="59"/>
+      <source>Timed out</source>
+      <translation>タイムアウトしました</translation>
+    </message>
+    <message id="mk2vsc_error_wrong_pass">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="61"/>
+      <source>Wrong password. (Use VeConfigure to set gridcode to None)</source>
+      <translation></translation>
+    </message>
+    <message id="mk2vsc_error_malloc">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="63"/>
+      <source>Malloc error</source>
+      <translation>Mallocエラー</translation>
+    </message>
+    <message id="mk2vsc_error_file_no_settings">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="65"/>
+      <source>Uploaded file does not contain settings data for the connected unit</source>
+      <translation>アップロードされたファイルには、接続されたユニットの設定データが含まれていません</translation>
+    </message>
+    <message id="mk2vsc_error_file_mismatch">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="67"/>
+      <source>Uploaded file does not match model and/or installed firmware version</source>
+      <translation>アップロードされたファイルは、モデルやインストールされているファームウェアのバージョンと一致しません。</translation>
+    </message>
+    <message id="mk2vsc_error_mult_unknown_units">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="69"/>
+      <source>More than one unknown unit detected</source>
+      <translation>複数の不明なユニットが検出されました。</translation>
+    </message>
+    <message id="mk2vsc_error_update_single_unit">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="71"/>
+      <source>Updating a single unit with another unit's settings is not possible, even if they are of the same type</source>
+      <translation>たとえ同じタイプであっても、あるユニットの設定を別のユニットに更新することはできません。</translation>
+    </message>
+    <message id="mk2vsc_error_unit_count_mismatch">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="73"/>
+      <source>The number of units in file does not match the number of units discovered</source>
+      <translation>ファイル内のユニット数と検出されたユニット数が一致しません。</translation>
+    </message>
+    <message id="mk2vsc_error_file_open">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="75"/>
+      <source>File open error</source>
+      <translation>ファイルオープンエラー</translation>
+    </message>
+    <message id="mk2vsc_error_file_write">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="77"/>
+      <source>File write error</source>
+      <translation>ファイル書き込みエラー</translation>
+    </message>
+    <message id="mk2vsc_error_file_read">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="79"/>
+      <source>File read error</source>
+      <translation>ファイル読み込みエラー</translation>
+    </message>
+    <message id="mk2vsc_error_file_checksum">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="81"/>
+      <source>File checksum error</source>
+      <translation>ファイルチェックサムエラー</translation>
+    </message>
+    <message id="mk2vsc_error_file_ver_incompat">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="83"/>
+      <source>File incompatible version number</source>
+      <translation>ファイルのバージョン番号が互換性がありません。</translation>
+    </message>
+    <message id="mk2vsc_error_file_section_not_found">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="85"/>
+      <source>File section not found</source>
+      <translation>ファイルセクションが見つかりません。</translation>
+    </message>
+    <message id="mk2vsc_error_file_format">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="87"/>
+      <source>File format error</source>
+      <translation>ファイル形式エラー</translation>
+    </message>
+    <message id="mk2vsc_error_prod_num_mismatch">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="89"/>
+      <source>Product number does not match file</source>
+      <translation>製品番号がファイルと一致しません。</translation>
+    </message>
+    <message id="mk2vsc_error_file_expired">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="91"/>
+      <source>File expired</source>
+      <translation>ファイルの有効期限が切れました。</translation>
+    </message>
+    <message id="mk2vsc_error_wrong_file_format">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="93"/>
+      <source>Wrong file format. First open the file with VE.Bus System Configurator, then save it to a new file by closing VE.Configure</source>
+      <translation>ファイル形式が間違っています。まずVE.Bus System Configuratorでファイルを開き、VE.Configureを閉じて新しいファイルに保存してください。</translation>
+    </message>
+    <message id="mk2vsc_error_vebus_write_fail">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="95"/>
+      <source>VE.Bus write of assistant enable/disable setting failed</source>
+      <translation>アシスタントの有効/無効設定のVE.Bus書き込みに失敗しました。</translation>
+    </message>
+    <message id="mk2vsc_error_vebus_config_fail">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="97"/>
+      <source>Incompatible VE.Bus system configuration. Writing system configuration failed</source>
+      <translation>互換性のないVE.Busシステム構成です。システム構成の書き込みに失敗しました。</translation>
+    </message>
+    <message id="mk2vsc_error_read_settings_fail">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="99"/>
+      <source>Cannot read settings. VE.Bus system not configured</source>
+      <translation>設定を読み取れません。VE.Busシステムが構成されていません。</translation>
+    </message>
+    <message id="mk2vsc_error_assist_write_fail">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="101"/>
+      <source>Assistants write failed</source>
+      <translation>アシスタントの書き込みに失敗しました</translation>
+    </message>
+    <message id="mk2vsc_error_assist_read_fail">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="103"/>
+      <source>Assistants read failed</source>
+      <translation>アシスタントの読み込みに失敗しました</translation>
+    </message>
+    <message id="mk2vsc_error_grid_info_read_fail">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="105"/>
+      <source>Grid info read failed</source>
+      <translation>グリッド情報の読み込みに失敗しました</translation>
+    </message>
+    <message id="mk2vsc_error_os_unknown_app">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="107"/>
+      <source>OSerror, unknown application</source>
+      <translation>OSエラー、不明なアプリケーション</translation>
+    </message>
+    <message id="mk2vsc_error_com_port_no_resp">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="109"/>
+      <source>Failed to open com port(no response)</source>
+      <translation></translation>
+    </message>
+    <message id="vebus_backup_result_backup_successful">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="118"/>
+      <source>Backup successful</source>
+      <translation></translation>
+    </message>
+    <message id="vebus_backup_result_restore_successful">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="120"/>
+      <source>Restore successful</source>
+      <translation></translation>
+    </message>
+    <message id="vebus_backup_result_file delete_successful">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="122"/>
+      <source>File delete successful</source>
+      <translation></translation>
+    </message>
+    <message id="vebus_backup_result_backup_process_unexpedly_closed">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="124"/>
+      <source>Backup process unexpectedly closed</source>
+      <translation></translation>
+    </message>
+    <message id="vebus_backup_result_restore_process_unexpedly_closed">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="126"/>
+      <source>Restore process unexpectedly closed</source>
+      <translation></translation>
+    </message>
+    <message id="vebus_backup_result_file_delete_failed">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="128"/>
+      <source>File delete failed</source>
+      <translation></translation>
+    </message>
+    <message id="incompatible">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="230"/>
+      <source>Incompatible</source>
+      <translation></translation>
+    </message>
+    <message id="backup_name">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="323"/>
+      <source>Backup name</source>
+      <translation></translation>
+    </message>
+    <message id="vebus_backup_backup_name">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="328"/>
+      <source>Enter backup name</source>
+      <translation></translation>
+    </message>
+    <message id="backup_name_empty">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="332"/>
+      <source>File name cannot be empty</source>
+      <translation></translation>
+    </message>
+    <message id="backup_name_invalid">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="337"/>
+      <source>Invalid file name. Avoid using special characters</source>
+      <translation></translation>
+    </message>
+    <message id="vebus_backup_backup">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="351"/>
+      <source>Backup</source>
+      <translation></translation>
+    </message>
+    <message id="vebus_backup_press_to_backup">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="354"/>
+      <source>Press to backup</source>
+      <translation></translation>
+    </message>
+    <message id="vebus_backup_backing_up">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="356"/>
+      <source>Backing up...</source>
+      <translation></translation>
+    </message>
+    <message id="vebus_backup_restore">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="369"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="388"/>
+      <source>Restore</source>
+      <translation>復元</translation>
+    </message>
+    <message id="vebus_backup_select_backup_file_to_restore">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="372"/>
+      <source>Select backup file to restore</source>
+      <translation></translation>
+    </message>
+    <message id="vebus_backup_restoring">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="393"/>
+      <source>Restoring...</source>
+      <translation></translation>
+    </message>
+    <message id="vebus_backup_delete">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="406"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="425"/>
+      <source>Delete</source>
+      <translation>削除</translation>
+    </message>
+    <message id="vebus_backup_select_backup_file_to_delete">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="409"/>
+      <source>Select backup file to delete</source>
+      <translation></translation>
+    </message>
+    <message id="vebus_backup_press_to_delete">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="428"/>
+      <source>Press to delete</source>
+      <translation></translation>
+    </message>
+    <message id="vebus_backup_deleting">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="430"/>
+      <source>Deleting...</source>
+      <translation></translation>
+    </message>
+    <message id="vebus_backup_press_to_cancel">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="444"/>
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="467"/>
+      <source>Press to cancel</source>
+      <translation></translation>
+    </message>
+    <message id="vebus_backup_firmware_version_specific_message">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="477"/>
+      <source>Note: Backup files are VE.Bus firmware version specific and can only be used to restore settings on products with matching firmware versions</source>
+      <translation></translation>
+    </message>
+    <message id="batteryparameters_charge_request">
+      <location filename="../../pages/settings/devicelist/battery/PageBatteryParameters.qml" line="49"/>
+      <source>Requests Charging</source>
+      <extracomment>Shows if the battery requests charging: yes or no</extracomment>
+      <translation></translation>
+    </message>
+    <message id="settings_security_profile_change_password">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="186"/>
+      <source>Change password</source>
+      <translation>パスワードの変更</translation>
+    </message>
+    <message id="settings_security_profile_update">
+      <location filename="../../pages/settings/PageSettingsAccessAndSecurity.qml" line="188"/>
+      <source>Update</source>
+      <translation>更新</translation>
+    </message>
+    <message id="pagecontrollableloads_documentation">
+      <location filename="../../pages/settings/PageControllableLoads.qml" line="142"/>
+      <source>Documentation</source>
+      <translation></translation>
+    </message>
+    <message id="common_words_ac_input_number">
+      <location filename="../../components/CommonWords.qml" line="625"/>
+      <source>AC input %1</source>
+      <extracomment>%1 = number of the AC input</extracomment>
+      <translation></translation>
+    </message>
+    <message id="settings_security_profile_change_password_description">
+      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="83"/>
+      <source>Please enter a new GX password:</source>
+      <translation></translation>
+    </message>
+    <message id="settings_security_profile_enter_new_password">
+      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="98"/>
+      <source>Enter new password</source>
+      <translation></translation>
+    </message>
+    <message id="settings_modbus_unit_name_and_id">
+      <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="52"/>
+      <source>%1 | Unit ID: %2</source>
+      <extracomment>Modbus TCP service details. %1 = service name or uid, %2 = unit id</extracomment>
+      <translation></translation>
+    </message>
+    <message id="settings_dvcc_control_mk3_usb_inverter_charger_system">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="233"/>
+      <source>Control MK3-USB connected inverter/charger system</source>
+      <translation></translation>
+    </message>
+    <message id="settings_dvcc_control_mk3_usb_inverter_charger_system_caption">
+      <location filename="../../pages/settings/PageSettingsDvcc.qml" line="238"/>
+      <source>Enable this setting when having a secondary MultiPlus or Quattro system powered by the same battery bank as the main inverter/charger system. When this setting is enabled, this secondary system will use the CVL and DCL parameters of the selected BMS.</source>
+      <translation></translation>
+    </message>
+    <message id="settings_access_control_display_firmware">
+      <location filename="../../pages/SettingsPage.qml" line="50"/>
+      <source>Access control, Display, Firmware, Support</source>
+      <translation></translation>
+    </message>
+    <message id="output_battery">
+      <location filename="../../components/listitems/ListOutputBatteryRadioButtonGroup.qml" line="14"/>
+      <source>Output battery</source>
+      <translation></translation>
+    </message>
+    <message id="alternator_charge_battery">
+      <location filename="../../components/listitems/ListOutputBatteryRadioButtonGroup.qml" line="19"/>
+      <source>Alternator charging the main battery</source>
+      <translation></translation>
+    </message>
+    <message id="charge_another_battery">
+      <location filename="../../components/listitems/ListOutputBatteryRadioButtonGroup.qml" line="21"/>
+      <source>Charging another battery from the main battery</source>
+      <translation></translation>
+    </message>
+    <message id="iochannel_showui_controls">
+      <location filename="../../components/listitems/ListIOChannelShowRadioButtonGroup.qml" line="12"/>
+      <source>Show controls</source>
+      <extracomment>Whether UI controls should be shown for this output</extracomment>
+      <translation></translation>
+    </message>
+    <message id="page_settings_connect_cellular_modem">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="41"/>
+      <source>Connect a Victron Energy GX GSM or GX LTE 4G modem to enable mobile network connectivity.</source>
+      <translation></translation>
+    </message>
+    <message id="page_settings_no_cellular_modem_connected">
+      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="73"/>
+      <source>No cellular modem connected</source>
+      <translation></translation>
+    </message>
+    <message id="ess_active_soc_limit">
+      <location filename="../../pages/controlcards/ESSCard.qml" line="87"/>
+      <source>Active SOC Limit: %1%</source>
+      <translation></translation>
+    </message>
+    <message id="settings_modbus_access_rights">
+      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="36"/>
+      <source>Access permissions</source>
+      <translation></translation>
+    </message>
+    <message id="settings_modbus_access_readwrite">
+      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="41"/>
+      <source>Write allowed</source>
+      <translation></translation>
+    </message>
+    <message id="settings_modbus_access_readonly">
+      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="43"/>
+      <source>Read only</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingsgeneral_modificationchecks_modified">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="24"/>
+      <source>Modifications installed</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingsgeneral_modificationchecks_running_integrations">
+      <location filename="../../pages/settings/PageSettingsGeneral.qml" line="44"/>
+      <source>%1 running integrations</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingssupportstate_modifiedstate_clean">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="75"/>
+      <source>Clean</source>
+      <translation></translation>
+    </message>
+    <message id="reboot_button_dialoglayer_reboot_initiated">
+      <location filename="../../components/dialogs/ModalRebootingDialog.qml" line="16"/>
+      <source>Reboot initiated</source>
+      <translation></translation>
+    </message>
+    <message id="reboot_button_dialoglayer_rebooting_description">
+      <location filename="../../components/dialogs/ModalRebootingDialog.qml" line="19"/>
+      <source>Please wait until the device rebooted.</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingssupportstate_modifiedstate_not_available_on_this_device">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="81"/>
+      <source>Not available on this device</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingssupportstate_custom_startup_not_installed">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="101"/>
+      <source>Not installed</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingssupportstate_custom_startup_installed_but_disabled_rc_local_rcS_local">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="106"/>
+      <source>Installed but disabled (rc.local and rcS.local)</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingssupportstate_custom_startup_installed_but_disabled_rc_local">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="109"/>
+      <source>Installed but disabled (rc.local)</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingssupportstate_custom_startup_installed_but_disabled_rcS_local">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="112"/>
+      <source>Installed but disabled (rcS.local)</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingssupportstate_custom_startup_installed_but_disabled_but_enable_next_boot">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="116"/>
+      <source>Installed but disabled, enables at next boot</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingssupportstate_custom_startup_installed_and_enabled_rc_local_rcS_local">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="122"/>
+      <source>Installed and enabled (rc.local and rcS.local)</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingssupportstate_custom_startup_installed_and_enabled_rc_local">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="125"/>
+      <source>Installed and enabled (rc.local)</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingssupportstate_custom_startup_installed_and_enabled_rcS_local">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="128"/>
+      <source>Installed and enabled (rcS.local)</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingssupportstate_custom_startup_installed_and_enabled_but_disable_next_boot">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="131"/>
+      <source>Installed and enabled, disables at next boot</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingssupportstate_support_status">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="217"/>
+      <source>Support status</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingssupportstate_custom_startup_scripts">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="258"/>
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="416"/>
+      <source>Custom startup scripts</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingssupportstate_disable_custom_startup_scripts">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="265"/>
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="276"/>
+      <source>Disable custom startup scripts</source>
+      <translation>カスタム起動スクリプトを無効にする</translation>
+    </message>
+    <message id="pagesettingssupportstate_disable_custom_startup_scripts_description">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="278"/>
+      <source>Press 'OK' to disable custom startup scripts and reboot</source>
+      <translation>カスタム起動スクリプトを無効にして再起動するには、「OK」を押してください</translation>
+    </message>
+    <message id="pagesettingssupportstate_reenable_and_reboot_now">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="312"/>
+      <source>Re-enable custom startup scripts</source>
+      <translation>カスタム起動スクリプトを再度有効にする</translation>
+    </message>
+    <message id="pagesettingssupportstate_press_ok_to_reenable_and_reboot">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="314"/>
+      <source>Press 'OK' to re-enable custom startup scripts and reboot</source>
+      <translation>カスタム起動スクリプトを再度有効にして再起動するには、「OK」を押してください</translation>
+    </message>
+    <message id="pagesettingssupportstate_latest_official_firmware_installed">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="358"/>
+      <source>Latest official firmware version installed?</source>
+      <translation>最新の公式ファームウェアバージョンがインストールされていますか？</translation>
+    </message>
+    <message id="pagesettingssupportstate_disable_also_custom_startup_scripts">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="418"/>
+      <source>Disable also custom startup scripts?</source>
+      <translation>カスタム起動スクリプトも無効にしますか？</translation>
+    </message>
+    <message id="settings_bluetooth_unavailable_message">
+      <location filename="../../pages/settings/PageSettingsBluetooth.qml" line="26"/>
+      <source>Connect a compatible Bluetooth USB dongle to enable Bluetooth connectivity.</source>
+      <translation>Bluetooth接続を有効にするには、対応するBluetooth USBドングルを接続してください。</translation>
+    </message>
+    <message id="settings_ess_batteryLife_state">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="162"/>
+      <source>BatteryLife state</source>
+      <translation>BatteryLife状態</translation>
+    </message>
+    <message id="pagesettingsintegrations_device_integrations">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="33"/>
+      <source>Device Integrations</source>
+      <translation>デバイス統合</translation>
+    </message>
+    <message id="settings_venusos_large_documentation">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="279"/>
+      <source>Venus OS Large Documentation</source>
+      <translation>Venus OS Large ドキュメント</translation>
+    </message>
+    <message id="settings_modbus_enable_modbus_tcp">
+      <location filename="../../pages/settings/PageSettingsModbusTcp.qml" line="30"/>
+      <source>Enable Modbus TCP Server</source>
+      <oldsource>Enable Modbus/TCP</oldsource>
+      <translation>Modbus TCPサーバーを有効にする</translation>
+    </message>
+    <message id="pagesettingsconnectivity_bluetooth_for_victronconnect_app">
+      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="54"/>
+      <source>Bluetooth (for VictronConnect App)</source>
+      <translation>Bluetooth (VictronConnectアプリ用)</translation>
+    </message>
+    <message id="pagesettingsconnectivity_bluetooth_not_available">
+      <location filename="../../pages/settings/PageSettingsConnectivity.qml" line="58"/>
+      <source>No Bluetooth available</source>
+      <translation>Bluetooth利用不可</translation>
+    </message>
+    <message id="switchable_output_toggle">
+      <location filename="../../src/enums.cpp" line="529"/>
+      <source>Toggle</source>
+      <translation>切り替え</translation>
+    </message>
+    <message id="ess_state_optimized_with_batterylife">
+      <location filename="../../data/Ess.qml" line="27"/>
+      <source>Optimized with BatteryLife</source>
+      <translation>BatteryLifeにより最適化</translation>
+    </message>
+    <message id="ess_state_optimized_with_batterylife_button">
+      <location filename="../../data/Ess.qml" line="29"/>
+      <source>Optimized + BatteryLife</source>
+      <translation>最適化 + BatteryLife</translation>
+    </message>
+    <message id="ess_state_optimized_without_batterylife">
+      <location filename="../../data/Ess.qml" line="34"/>
+      <source>Optimized without BatteryLife</source>
+      <translation>BatteryLifeなしで最適化</translation>
+    </message>
+    <message id="pagesettingssupportstate_modifiedstate_modified">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="78"/>
+      <source>Modified</source>
+      <translation>変更済み</translation>
+    </message>
+    <message id="pagesettingssupportstate_disable_and_reboot_now">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="267"/>
+      <source>Disable and reboot now</source>
+      <translation>無効にして今すぐ再起動</translation>
+    </message>
+    <message id="pagesettingssupportstate_re_enable_and_reboot_now">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="301"/>
+      <source>Re-enable and reboot now</source>
+      <translation>再度有効にして今すぐ再起動</translation>
+    </message>
+    <message id="pagesettingssupportstate_update_firmware_to_fix_modified_state">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="365"/>
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="392"/>
+      <source>Update the firmware to fix the modified state</source>
+      <translation>変更された状態を修正するためにファームウェアを更新してください</translation>
+    </message>
+    <message id="pagesettingssupportstate_updating_progress">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="371"/>
+      <source>Updating %1 %2%</source>
+      <extracomment>Firmware update firmwareProgressItem. %1 = firmware version, %2 = current update progress</extracomment>
+      <translation>%1を更新中 %2%</translation>
+    </message>
+    <message id="pagesettingssupportstate_updating">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="375"/>
+      <source>Updating %1...</source>
+      <extracomment>%1 = firmware version</extracomment>
+      <translation>%1を更新中...</translation>
+    </message>
+    <message id="pagesettingssupportstate_press_to_update">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="379"/>
+      <source>Press to update to</source>
+      <translation>押して更新</translation>
+    </message>
+    <message id="pagesettingssupportstate_update_firmware_to_fix_modified_state_description">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="394"/>
+      <source>This will download and update rootfs with the latest official firmware.&lt;br&gt;Internet connectivity is required.&lt;br&gt;Press 'OK' to continue.</source>
+      <translation>これにより、最新の公式ファームウェアでrootfsがダウンロードおよび更新されます。&lt;br&gt;インターネット接続が必要です。&lt;br&gt;続行するには「OK」を押してください。</translation>
+    </message>
+    <message id="settings_gps_format_kmh">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="95"/>
+      <source>Kilometres per hour</source>
+      <oldsource>Kilometers per hour</oldsource>
+      <translation>時速キロメートル</translation>
+    </message>
+    <message id="settings_gps_format_ms">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="97"/>
+      <source>Metres per second</source>
+      <oldsource>Meters per second</oldsource>
+      <translation>メートル毎秒</translation>
+    </message>
+    <message id="components_volumeunit_cubic_metres">
+      <location filename="../../components/listitems/ListVolumeUnitRadioButtonGroup.qml" line="15"/>
+      <source>Cubic metres</source>
+      <translation>立方メートル</translation>
+    </message>
+    <message id="components_volumeunit_litres">
+      <location filename="../../components/listitems/ListVolumeUnitRadioButtonGroup.qml" line="17"/>
+      <source>Litres</source>
+      <translation>リットル</translation>
+    </message>
+    <message id="settings_ui_animations">
+      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="156"/>
+      <source>UI Animations</source>
+      <translation>UIアニメーション</translation>
+    </message>
+    <message id="settings_ui_animations_description">
+      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="158"/>
+      <source>Disable to reduce CPU usage</source>
+      <translation>CPU使用率を削減するために無効にする</translation>
+    </message>
+    <message id="settings_relay_manual_can_now_be_found">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="24"/>
+      <source>The Relay can now be found in the devices list</source>
+      <translation>リレーがデバイスリストで見つかるようになりました</translation>
+    </message>
+    <message id="gx_device_relays">
+      <location filename="../../src/iochannelgroupmodel.cpp" line="105"/>
+      <source>GX device relays</source>
+      <translation>GXデバイスリレー</translation>
+    </message>
+    <message id="ess_active_soc_limit_info">
+      <location filename="../../pages/controlcards/ESSCard.qml" line="94"/>
+      <source>BatteryLife dynamically adjusts the minimum battery state of charge to prevent deep discharges and ensure regular full charges, helping to prolong battery life and maintain system reliability.</source>
+      <translation>BatteryLifeは、バッテリーの過放電を防ぎ、定期的な満充電を確実にするために、バッテリーの最低充電状態を動的に調整し、バッテリー寿命の延長とシステム信頼性の維持に役立ちます。</translation>
+    </message>
+    <message id="settings_canbus_rvc_reverse_current_polarity">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="85"/>
+      <source>Reverse current polarity</source>
+      <translation>電流極性を反転</translation>
+    </message>
+    <message id="settings_canbus_rvc_reverse_current_polarity_description">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="89"/>
+      <source>When enabled, the current polarity in the CHARGER_AC_STATUS_1, CHARGER_STATUS_2, INVERTER_AC_STATUS_1, and SOLAR_CONTROLLER_BATTERY_STATUS DGNs is reversed.</source>
+      <translation>有効にすると、CHARGER_AC_STATUS_1、CHARGER_STATUS_2、INVERTER_AC_STATUS_1、およびSOLAR_CONTROLLER_BATTERY_STATUS DGNsの電流極性が反転します。</translation>
+    </message>
+    <message id="settings_gx_display_appearance">
+      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="59"/>
+      <source>GX display appearance</source>
+      <translation>GXディスプレイの外観</translation>
+    </message>
+    <message id="settings_remote_console_appearance">
+      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="74"/>
+      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="105"/>
+      <source>Remote Console appearance</source>
+      <translation>リモートコンソールの外観</translation>
+    </message>
+    <message id="settings_remote_console_forced">
+      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="78"/>
+      <source>Forced by %2 to %1</source>
+      <extracomment>%1 = "dark", "light" or "auto" %2 = "VRM" or "app"</extracomment>
+      <translation>%2により%1に強制</translation>
+    </message>
+    <message id="settings_remote_console_forced_appearance_dark">
+      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="82"/>
+      <source>dark</source>
+      <extracomment>Forced by app to %1</extracomment>
+      <translation>ダーク</translation>
+    </message>
+    <message id="settings_remote_console_forced_appearance_light">
+      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="86"/>
+      <source>light</source>
+      <extracomment>Forced by app to %1</extracomment>
+      <translation>ライト</translation>
+    </message>
+    <message id="settings_remote_console_forced_appearance_auto">
+      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="89"/>
+      <source>auto</source>
+      <extracomment>Forced by app to %1</extracomment>
+      <translation>自動</translation>
+    </message>
+    <message id="settings_remote_console_forced_by_app">
+      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="97"/>
+      <source>app</source>
+      <extracomment>Forced by %2 to dark</extracomment>
+      <translation>アプリ</translation>
+    </message>
+    <message id="settings_remote_console_appearance_same_as_gx_display">
+      <location filename="../../pages/settings/PageSettingsDisplayAndAppearance.qml" line="110"/>
+      <source>Same as GX display</source>
+      <translation>GXディスプレイと同じ</translation>
+    </message>
+    <message id="page_settings_gsm_registration_status">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="143"/>
+      <source>Registration status</source>
+      <translation>登録ステータス</translation>
+    </message>
+    <message id="page_settings_gsm_not_registered_not_searching">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="148"/>
+      <source>Not registered, not searching for operator</source>
+      <translation>未登録、オペレーターを検索していません</translation>
+    </message>
+    <message id="page_settings_gsm_registered_home_network">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="151"/>
+      <source>Registered, home network</source>
+      <translation>登録済み、ホームネットワーク</translation>
+    </message>
+    <message id="page_settings_gsm_not_registered_searching">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="154"/>
+      <source>Not registered, searching for operator</source>
+      <translation>未登録、オペレーターを検索中</translation>
+    </message>
+    <message id="page_settings_gsm_registration_denied">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="157"/>
+      <source>Registration denied</source>
+      <translation>登録拒否</translation>
+    </message>
+    <message id="page_settings_gsm_registered_roaming">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="163"/>
+      <source>Registered, roaming</source>
+      <translation>登録済み、ローミング中</translation>
+    </message>
+    <message id="page_settings_gsm_data_link_status">
+      <location filename="../../pages/settings/PageSettingsGsm.qml" line="175"/>
+      <source>Data link (PPP) status</source>
+      <translation>データリンク (PPP) ステータス</translation>
+    </message>
+    <message id="settings_large_access_signal_k">
+      <location filename="../../pages/settings/PageSettingsSignalK.qml" line="24"/>
+      <source>Access Signal K</source>
+      <oldsource>Access Signal K (local network)</oldsource>
+      <translation>Signal Kにアクセス</translation>
+    </message>
+    <message id="pagesettingsintegrations_shelly_devices">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="62"/>
+      <source>Shelly Devices</source>
+      <translation>Shellyデバイス</translation>
+    </message>
+    <message id="settings_large_access_node_red">
+      <location filename="../../pages/settings/PageSettingsNodeRed.qml" line="56"/>
+      <source>Access Node-RED</source>
+      <oldsource>Access Node-RED (local network)</oldsource>
+      <translation>Node-REDにアクセス</translation>
+    </message>
+    <message id="settings_wifi_access_point_password">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="73"/>
+      <source>Access Point password</source>
+      <translation>アクセスポイントパスワード</translation>
+    </message>
+    <message id="dcMeter_dccharger">
+      <location filename="../../src/enums.cpp" line="218"/>
+      <source>DC/DC charger</source>
+      <translation>DC/DC チャージャー</translation>
+    </message>
+    <message id="dcMeter_electric_drive">
+      <location filename="../../src/enums.cpp" line="224"/>
+      <source>Electric drive</source>
+      <translation>電気ドライブ</translation>
+    </message>
+    <message id="dcMeter_fridge">
+      <location filename="../../src/enums.cpp" line="227"/>
+      <source>Fridge</source>
+      <translation>冷蔵庫</translation>
+    </message>
+    <message id="dcMeter_generic_load">
+      <location filename="../../src/enums.cpp" line="233"/>
+      <source>Generic load</source>
+      <translation>一般負荷</translation>
+    </message>
+    <message id="dcMeter_generic_meter">
+      <location filename="../../src/enums.cpp" line="236"/>
+      <source>Generic meter</source>
+      <translation>汎用メーター</translation>
+    </message>
+    <message id="dcMeter_generic_source">
+      <location filename="../../src/enums.cpp" line="239"/>
+      <source>Generic source</source>
+      <translation>一般ソース</translation>
+    </message>
+    <message id="dcMeter_dc_genset">
+      <location filename="../../src/enums.cpp" line="242"/>
+      <source>DC genset</source>
+      <translation>DC発電機</translation>
+    </message>
+    <message id="dcMeter_inverter">
+      <location filename="../../src/enums.cpp" line="245"/>
+      <source>Inverter</source>
+      <translation>インバーター</translation>
+    </message>
+    <message id="dcMeter_solar_charger">
+      <location filename="../../src/enums.cpp" line="251"/>
+      <source>Solar charger</source>
+      <translation>ソーラー チャージャー</translation>
+    </message>
+    <message id="dcMeter_water_heater">
+      <location filename="../../src/enums.cpp" line="257"/>
+      <source>Water heater</source>
+      <translation>ウォーターヒーター</translation>
+    </message>
+    <message id="dcMeter_water_pump">
+      <location filename="../../src/enums.cpp" line="260"/>
+      <source>Water pump</source>
+      <translation>ウォーターポンプ</translation>
+    </message>
+    <message id="dcMeter_wind_charger">
+      <location filename="../../src/enums.cpp" line="263"/>
+      <source>Wind charger</source>
+      <translation>ウィンドチャージャー</translation>
+    </message>
+    <message id="switchable_output_temperature_setpoint">
+      <location filename="../../src/enums.cpp" line="535"/>
+      <source>Temperature setpoint</source>
+      <translation>温度設定値</translation>
+    </message>
+    <message id="switchable_output_Stepped_Switch">
+      <location filename="../../src/enums.cpp" line="538"/>
+      <source>Stepped switch</source>
+      <translation>段階式スイッチ</translation>
+    </message>
+    <message id="switchable_output_dropdown">
+      <location filename="../../src/enums.cpp" line="549"/>
+      <source>Dropdown</source>
+      <translation>ドロップダウン</translation>
+    </message>
+    <message id="switchable_output_basic_slider">
+      <location filename="../../src/enums.cpp" line="552"/>
+      <source>Basic slider</source>
+      <translation>基本スライダー</translation>
+    </message>
+    <message id="switchable_output_three_state_switch">
+      <location filename="../../src/enums.cpp" line="558"/>
+      <source>Three-state switch</source>
+      <translation>3状態スイッチ</translation>
+    </message>
+    <message id="settings_modbus_tcp_unit_id_note">
+      <location filename="../../pages/settings/PageSettingsModbusTcpServices.qml" line="41"/>
+      <source>See the Settings → VRM → VRM device instances menu to change the Modbus-TCP unit IDs.</source>
+      <translation>Modbus-TCPユニットIDを変更するには、設定 → VRM → VRMデバイスインスタンスメニューを参照してください。</translation>
+    </message>
+    <message id="settings_shelly_refresh_devices">
+      <location filename="../../pages/settings/PageSettingsShelly.qml" line="97"/>
+      <source>Refresh devices</source>
+      <translation>デバイスを更新</translation>
+    </message>
+    <message id="settings_shelly_press_to_refresh">
+      <location filename="../../pages/settings/PageSettingsShelly.qml" line="99"/>
+      <source>Press to refresh</source>
+      <translation>押して更新</translation>
+    </message>
+    <message id="common_words_total_power">
+      <location filename="../../components/CommonWords.qml" line="557"/>
+      <source>Total power</source>
+      <translation>総合力</translation>
+    </message>
+    <message id="venus_os_gui">
+      <location filename="../../Main.qml" line="17"/>
+      <source>Venus OS GUI</source>
+      <extracomment>Application title</extracomment>
+      <extra-Context>only shown on desktop systems</extra-Context>
+      <translation>Venus OS GUI</translation>
+    </message>
+    <message id="load_delegate_status">
+      <location filename="../../pages/loads/LoadListDelegate.qml" line="70"/>
+      <source>Status: %1</source>
+      <translation>ステータス: %1</translation>
+    </message>
+    <message id="settings_relay_polarity_relay1">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="76"/>
+      <source>Polarity (Relay 1)</source>
+      <translation>極性 (リレー1)</translation>
+    </message>
+    <message id="page_switchable_output_polarity">
+      <location filename="../../pages/settings/devicelist/iochannel/PageSwitchableOutput.qml" line="200"/>
+      <source>Polarity</source>
+      <translation>極性</translation>
+    </message>
+    <message id="settings_relay_polarity_relay2">
+      <location filename="../../pages/settings/PageSettingsRelay.qml" line="111"/>
+      <source>Polarity (Relay 2)</source>
+      <translation>極性 (リレー2)</translation>
+    </message>
+    <message id="page_settings_wifi_invalid_password">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="85"/>
+      <source>Password length must be either 0 or between 10 and 63 characters long</source>
+      <translation>パスワードの長さは0文字、または10文字から63文字の間である必要があります</translation>
+    </message>
+    <message id="page_settings_wifi_password_updated">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="88"/>
+      <source>Password updated</source>
+      <translation>パスワードを更新しました</translation>
+    </message>
+    <message id="common_words_max">
+      <location filename="../../components/CommonWords.qml" line="328"/>
+      <source>Max</source>
+      <extracomment>Short for Maximum</extracomment>
+      <translation>最大</translation>
+    </message>
+    <message id="common_words_min">
+      <location filename="../../components/CommonWords.qml" line="344"/>
+      <source>Min</source>
+      <extracomment>Short for Minimum</extracomment>
+      <translation>最小</translation>
+    </message>
+    <message id="settings_ess_deprecated">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="341"/>
+      <source>Deprecated settings</source>
+      <translation>非推奨の設定</translation>
+    </message>
+    <message id="settings_ess_max_charge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="348"/>
+      <source>Battery charge limit (% of CCL)</source>
+      <translation>バッテリー充電上限 (CCLの%)</translation>
+    </message>
+    <message id="settings_ess_max_discharge_percentage">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="359"/>
+      <source>Battery discharge limit (% of DCL)</source>
+      <translation>バッテリー放電上限 (DCLの%)</translation>
+    </message>
+    <message id="vebus_device_bms_message">
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="234"/>
+      <source>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the GX device is therefore not possible.</source>
+      <oldsource>A VE.Bus BMS automatically turns the system off when needed to protect the battery. Controlling the system from the Color Control is therefore not possible.</oldsource>
+      <translation>VE.Bus BMSはバッテリー保護のため、必要に応じてシステムを自動的に停止します。そのため、GXデバイスからシステムを制御することはできません。</translation>
+    </message>
+    <message id="switchable_output_numeric_input">
+      <location filename="../../src/enums.cpp" line="555"/>
+      <source>Numeric input</source>
+      <translation>数値入力</translation>
+    </message>
+    <message id="autotoggleswitch_disable_auto_mode_info">
+      <location filename="../../components/controls/AutoToggleButton.qml" line="23"/>
+      <source>Disable Auto mode first</source>
+      <translation>最初に自動モードを無効にしてください</translation>
+    </message>
+    <message id="pagesettingsintegrations_venus_os_enable_large_features">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="231"/>
+      <source>Enable the Venus OS Large firmware to use Node-RED or Signal-K</source>
+      <translation>Node-REDまたはSignal-Kを使用するには、Venus OS Largeファームウェアを有効にしてください</translation>
+    </message>
+    <message id="settings_relays_sensors_tanks">
+      <location filename="../../pages/SettingsPage.qml" line="84"/>
+      <source>Relays, Sensors, PV Inverters, Modbus, Node-RED</source>
+      <oldsource>Relays, Sensors, Tanks, PV Inverters, Modbus, MQTT…</oldsource>
+      <translation>リレー、センサー、PVインバーター、Modbus、Node-RED</translation>
+    </message>
+    <message id="vebus_device_page_microgrid_parameters">
+      <location filename="../../pages/invertercharger/OverviewInverterChargerPage.qml" line="146"/>
+      <location filename="../../pages/vebusdevice/PageVeBus.qml" line="194"/>
+      <source>Microgrid parameters</source>
+      <translation>マイクログリッドパラメーター</translation>
+    </message>
+    <message id="microgrid_mode_hybrid_droop">
+      <location filename="../../src/enums.cpp" line="763"/>
+      <source>Hybrid droop</source>
+      <translation>ハイブリッドドループ</translation>
+    </message>
+    <message id="microgrid">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="15"/>
+      <source>Microgrid</source>
+      <translation>マイクログリッド</translation>
+    </message>
+    <message id="page_microgrid_active_mode">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="29"/>
+      <source>Active mode</source>
+      <translation>アクティブモード</translation>
+    </message>
+    <message id="page_microgrid_hybrid_droop_parameters">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="138"/>
+      <source>Hybrid droop parameters</source>
+      <translation>ハイブリッドドループパラメーター</translation>
+    </message>
+    <message id="page_microgrid_reference_active_power_p0">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="145"/>
+      <source>Reference active power (P&lt;sub&gt;0&lt;/sub&gt;)</source>
+      <translation>基準有効電力 (P&lt;sub&gt;0&lt;/sub&gt;)</translation>
+    </message>
+    <message id="page_microgrid_reference_frequency_f0">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="159"/>
+      <source>Reference frequency (f&lt;sub&gt;0&lt;/sub&gt;)</source>
+      <translation>基準周波数 (f&lt;sub&gt;0&lt;/sub&gt;)</translation>
+    </message>
+    <message id="page_microgrid_frequency_droop_slope">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="174"/>
+      <source>Frequency droop slope (droop&lt;sub&gt;fP&lt;/sub&gt;)</source>
+      <translation>周波数ドループ傾斜 (droop&lt;sub&gt;fP&lt;/sub&gt;)</translation>
+    </message>
+    <message id="page_microgrid_reference_reactive_power">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="189"/>
+      <source>Reference reactive power (Q&lt;sub&gt;0&lt;/sub&gt;)</source>
+      <translation>基準無効電力 (Q&lt;sub&gt;0&lt;/sub&gt;)</translation>
+    </message>
+    <message id="page_microgrid_reference_voltage">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="203"/>
+      <source>Reference Voltage (U&lt;sub&gt;0&lt;/sub&gt;)</source>
+      <translation>基準電圧 (U&lt;sub&gt;0&lt;/sub&gt;)</translation>
+    </message>
+    <message id="page_microgrid_voltage_droop_slope">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="218"/>
+      <source>Voltage droop slope (droop&lt;sub&gt;UQ&lt;/sub&gt;)</source>
+      <translation>電圧ドループ傾斜 (droop&lt;sub&gt;UQ&lt;/sub&gt;)</translation>
+    </message>
+    <message id="page_microgrid_minimum_and_maximum_parameters">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="231"/>
+      <source>Minimum and maximum parameters</source>
+      <translation>最小および最大パラメーター</translation>
+    </message>
+    <message id="page_microgrid_allowed_active_power_range">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="237"/>
+      <source>Allowed active power range</source>
+      <translation>許容有効電力範囲</translation>
+    </message>
+    <message id="page_microgrid_allowed_reactive_power_range">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="259"/>
+      <source>Allowed reactive power range</source>
+      <translation>許容無効電力範囲</translation>
+    </message>
+    <message id="page_microgrid_p_q_direct_drive_settings">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="313"/>
+      <source>P-Q direct drive settings</source>
+      <translation>P-Q直接制御設定</translation>
+    </message>
+    <message id="page_microgrid_active_power_setpoint_p">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="318"/>
+      <source>Active power setpoint (P)</source>
+      <translation>有効電力設定値 (P)</translation>
+    </message>
+    <message id="page_microgrid_reactive_power_setpoint_q">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="325"/>
+      <source>Reactive power setpoint (Q)</source>
+      <translation>無効電力設定値 (Q)</translation>
+    </message>
+    <message id="page_microgrid_allowed_frequency_range">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="332"/>
+      <source>Allowed frequency range</source>
+      <translation>許容周波数範囲</translation>
+    </message>
+    <message id="page_microgrid_allowed_voltage_range">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="340"/>
+      <source>Allowed voltage range</source>
+      <translation>許容電圧範囲</translation>
+    </message>
+    <message id="page_microgrid_v_f_direct_drive_settings">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="357"/>
+      <source>V-f direct drive settings</source>
+      <translation>V-f直接制御設定</translation>
+    </message>
+    <message id="page_microgrid_voltage_setpoint">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="362"/>
+      <source>Voltage setpoint (U)</source>
+      <translation>電圧設定値 (U)</translation>
+    </message>
+    <message id="page_microgrid_frequency_setpoint">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="369"/>
+      <source>Frequency setpoint (f)</source>
+      <translation>周波数設定値 (f)</translation>
+    </message>
+    <message id="pagesettingsintegrations_canopenmotordrive">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="176"/>
+      <source>CANopen motor drives</source>
+      <translation>CANopenモータドライブ</translation>
+    </message>
+    <message id="pagesettingsintegrations_ui_plugins">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="295"/>
+      <source>UI Plugins</source>
+      <translation>UIプラグイン</translation>
+    </message>
+    <message id="page_settings_canopenmotordrive_scan_for_motor_drives">
+      <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="31"/>
+      <source>Scan for motor drives</source>
+      <translation>モータドライブをスキャン</translation>
+    </message>
+    <message id="page_settings_canopenmotordrive_discovered_motor_drive_ids">
+      <location filename="../../pages/settings/PageSettingsCanOpenMotordrive.qml" line="39"/>
+      <source>Discovered motor drive IDs</source>
+      <translation>検出されたモータドライブID</translation>
+    </message>
+    <message id="temperature_pm25">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="70"/>
+      <source>PM2.5</source>
+      <translation>PM2.5</translation>
+    </message>
+    <message id="temperature_co2">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="78"/>
+      <source>CO₂</source>
+      <translation>CO₂</translation>
+    </message>
+    <message id="temperature_voc">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="86"/>
+      <source>VOC index</source>
+      <translation>VOC指数</translation>
+    </message>
+    <message id="temperature_nox">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="94"/>
+      <source>NOx index</source>
+      <translation>NOx指数</translation>
+    </message>
+    <message id="temperature_luminosity">
+      <location filename="../../pages/settings/devicelist/temperature/PageTemperatureSensor.qml" line="102"/>
+      <source>Luminosity</source>
+      <translation>輝度</translation>
+    </message>
+    <message id="switchable_output_bypassed">
+      <location filename="../../src/enums.cpp" line="666"/>
+      <source>Bypassed</source>
+      <translation>バイパス済み</translation>
+    </message>
+    <message id="switchableoutput_list_delegate_auto_status">
+      <location filename="../../pages/settings/devicelist/iochannel/SwitchableOutputListDelegate.qml" line="93"/>
+      <source>Auto (%1)</source>
+      <extracomment>%1 = 'On' or 'Off'</extracomment>
+      <translation>自動 ({1})</translation>
+    </message>
+    <message id="switchableoutput_list_delegate_state_forced">
+      <location filename="../../pages/settings/devicelist/iochannel/SwitchableOutputListDelegate.qml" line="109"/>
+      <source>Forced</source>
+      <translation>強制</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_settings">
+      <location filename="../../pages/settings/PageSettingsFronius.qml" line="68"/>
+      <source>Modbus port and unit ID settings</source>
+      <translation>ModbusポートおよびユニットID設定</translation>
+    </message>
+    <message id="pagesettingsintegrations_uiplugin_integrates_with_devicelist">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="334"/>
+      <source>Integrates with the device list</source>
+      <translation>デバイスリストと統合</translation>
+    </message>
+    <message id="common_words_color">
+      <location filename="../../components/CommonWords.qml" line="139"/>
+      <source>Color</source>
+      <translation>カラー</translation>
+    </message>
+    <message id="common_words_value_must_be_greater_than_start_value">
+      <location filename="../../components/CommonWords.qml" line="574"/>
+      <source>Value must be greater than start value</source>
+      <translation>値は開始値よりも大きい必要があります</translation>
+    </message>
+    <message id="common_words_value_must_be_lower_than_stop_value">
+      <location filename="../../components/CommonWords.qml" line="583"/>
+      <source>Value must be lower than stop value</source>
+      <translation>値は停止値よりも小さい必要があります</translation>
+    </message>
+    <message id="notifications_page_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="42"/>
+      <source>Active Notifications</source>
+      <extracomment>List section header, for the section which contains current/active notifications</extracomment>
+      <translation>アクティブな通知</translation>
+    </message>
+    <message id="notifications_page_inactive_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="46"/>
+      <source>Inactive Notifications</source>
+      <extracomment>List section header, for the section which contains inactive (but unseen) notifications</extracomment>
+      <translation>非アクティブな通知</translation>
+    </message>
+    <message id="notifications_no_active_notifications">
+      <location filename="../../pages/NotificationsPage.qml" line="105"/>
+      <source>No active notifications</source>
+      <translation>アクティブな通知はありません</translation>
+    </message>
+    <message id="switchable_output_rgb_color_wheel">
+      <location filename="../../src/enums.cpp" line="564"/>
+      <source>RGB color wheel</source>
+      <translation>RGBカラーホイール</translation>
+    </message>
+    <message id="switchable_output_cct_color_wheel">
+      <location filename="../../src/enums.cpp" line="568"/>
+      <source>CCT color wheel</source>
+      <extracomment>Correlated Color Temperature color wheel</extracomment>
+      <translation>CCTカラーホイール</translation>
+    </message>
+    <message id="switchable_output_rgbw_color_wheel">
+      <location filename="../../src/enums.cpp" line="572"/>
+      <source>RGB + W color wheel</source>
+      <extracomment>RGB + white color wheel</extracomment>
+      <translation>RGB + Wカラーホイール</translation>
+    </message>
+    <message id="listlink_show_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="118"/>
+      <source>Show QR code</source>
+      <translation>QRコードを表示</translation>
+    </message>
+    <message id="listlink_scan_qr_code">
+      <location filename="../../components/listitems/ListLink.qml" line="142"/>
+      <source>Open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
+      <extracomment>%1 = url text</extracomment>
+      <oldsource>Scan the QR code with your portable device.&lt;br /&gt;Or insert the link: %1</oldsource>
+      <translation>ポータブルデバイスでスキャンするためにQRコードを開いてください。&lt;br /&gt;または、リンクを挿入してください: %1</translation>
+    </message>
+    <message id="color_preset">
+      <location filename="../../components/ColorPresetGrid.qml" line="33"/>
+      <source>Preset</source>
+      <translation>プリセット</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="15"/>
+      <source>Add Modbus port and unit ID</source>
+      <translation>ModbusポートとユニットIDを追加</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_unitid">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="29"/>
+      <source>Unit ID</source>
+      <translation>ユニットID</translation>
+    </message>
+    <message id="page_settings_fronius_add_modbus_location_button">
+      <location filename="../../pages/settings/PageSettingsFroniusAddLocation.qml" line="43"/>
+      <source>Add</source>
+      <translation>追加</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_location_number">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="62"/>
+      <source>Port/Unit ID %1</source>
+      <translation>ポート/ユニットID %1</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location_description">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="17"/>
+      <source>Port: %1 (Unit %2)</source>
+      <translation>ポート: %1 (ユニット %2)</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_remove_location">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="93"/>
+      <source>Remove Modbus port and unit ID?</source>
+      <translation>ModbusポートとユニットIDを削除しますか？</translation>
+    </message>
+    <message id="devicelist_tankshape_edit_point">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="202"/>
+      <source>Edit point %1</source>
+      <extracomment>%1 = which point is being edited, a number like "1" or "2"</extracomment>
+      <translation>ポイント %1を編集</translation>
+    </message>
+    <message id="settings_canbus_vecan">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="36"/>
+      <source>VE.Can (250 kbit/s)</source>
+      <translation>VE.Can (250 kbit/s)</translation>
+    </message>
+    <message id="settings_canopen_motordrive_250">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="48"/>
+      <source>VE.Can &amp; CANopen E-drive (250 kbit/s)</source>
+      <translation>VE.Can &amp; CANopen E-ドライブ (250 kbit/s)</translation>
+    </message>
+    <message id="settings_canopen_motordrive_500">
+      <location filename="../../pages/settings/CanbusProfile.qml" line="90"/>
+      <source>CANopen E-drive (500 kbit/s)</source>
+      <translation>CANopen E-ドライブ (500 kbit/s)</translation>
+    </message>
+    <message id="page_microgrid_from_p1_to_p2">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="66"/>
+      <source>%1%2 to %3%4</source>
+      <extracomment>Describes a range from one quantity to another, e.g. "30W to 60W". The first argument is the first quantity, the second argument is the units of the first quantity, the third argument is the second quantity, the fourth argument is the units of the second quantity.</extracomment>
+      <translation>%1%2 から %3%4</translation>
+    </message>
+    <message id="settings_ac-in-setup_changed_role">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="85"/>
+      <source>%1 changed role, the devices list has been updated</source>
+      <translation>%1の役割が変更されました。デバイスリストが更新されました。</translation>
+    </message>
+    <message id="page_meteo_estimated_power">
+      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="98"/>
+      <source>Estimated power</source>
+      <translation>推計電力</translation>
+    </message>
+    <message id="startpage_option_device_list">
+      <location filename="../../data/StartPageConfiguration.qml" line="63"/>
+      <source>Device list</source>
+      <translation>デバイスリスト</translation>
+    </message>
+    <message id="page_switchable_output_switch_mode">
+      <location filename="../../pages/settings/devicelist/iochannel/PageSwitchableOutput.qml" line="30"/>
+      <source>Switch mode</source>
+      <translation>スイッチモード</translation>
+    </message>
+    <message id="page_switchable_output_switch_mode_linear">
+      <location filename="../../pages/settings/devicelist/iochannel/PageSwitchableOutput.qml" line="38"/>
+      <source>Permanent on</source>
+      <translation>常時オン</translation>
+    </message>
+    <message id="page_switchable_output_switch_mode_optical">
+      <location filename="../../pages/settings/devicelist/iochannel/PageSwitchableOutput.qml" line="40"/>
+      <source>Switching</source>
+      <translation>切り替え</translation>
+    </message>
+    <message id="page_switchable_output_dim_mode">
+      <location filename="../../pages/settings/devicelist/iochannel/PageSwitchableOutput.qml" line="46"/>
+      <source>Dim mode</source>
+      <translation>調光モード</translation>
+    </message>
+    <message id="page_switchable_output_dim_mode_disabled">
+      <location filename="../../pages/settings/devicelist/iochannel/PageSwitchableOutput.qml" line="52"/>
+      <source>Dimming disabled</source>
+      <translation>調光無効</translation>
+    </message>
+    <message id="page_switchable_output_dim_mode_linear">
+      <location filename="../../pages/settings/devicelist/iochannel/PageSwitchableOutput.qml" line="54"/>
+      <source>Linear</source>
+      <translation>リニア</translation>
+    </message>
+    <message id="page_switchable_output_dim_mode_optical">
+      <location filename="../../pages/settings/devicelist/iochannel/PageSwitchableOutput.qml" line="56"/>
+      <source>Optical curve</source>
+      <translation></translation>
+    </message>
+    <message id="page_switchable_output_fuse_detection_mode">
+      <location filename="../../pages/settings/devicelist/iochannel/PageSwitchableOutput.qml" line="62"/>
+      <source>Fuse detection mode</source>
+      <translation></translation>
+    </message>
+    <message id="page_switchable_output_fuse_detection_mode_only_when_off">
+      <location filename="../../pages/settings/devicelist/iochannel/PageSwitchableOutput.qml" line="70"/>
+      <source>Only when the output is off</source>
+      <translation></translation>
+    </message>
+    <message id="page_switchable_output_startup_state">
+      <location filename="../../pages/settings/devicelist/iochannel/PageSwitchableOutput.qml" line="128"/>
+      <source>Startup switch state</source>
+      <translation></translation>
+    </message>
+    <message id="page_switchable_output_startup_state_restore_from_memory">
+      <location filename="../../pages/settings/devicelist/iochannel/PageSwitchableOutput.qml" line="136"/>
+      <location filename="../../pages/settings/devicelist/iochannel/PageSwitchableOutput.qml" line="143"/>
+      <source>Restore from memory</source>
+      <translation></translation>
+    </message>
+    <message id="settings_dvcc_startup_dim_level">
+      <location filename="../../pages/settings/devicelist/iochannel/PageSwitchableOutput.qml" line="185"/>
+      <source>Startup dim level</source>
+      <translation></translation>
+    </message>
+    <message id="page_switchable_output_restore_dim_level">
+      <location filename="../../pages/settings/devicelist/iochannel/PageSwitchableOutput.qml" line="163"/>
+      <source>Restore dim level from memory</source>
+      <translation></translation>
+    </message>
+    <message id="page_switchable_output_polarity_active_high">
+      <location filename="../../pages/settings/devicelist/iochannel/PageSwitchableOutput.qml" line="206"/>
+      <source>Active high / Normally open</source>
+      <translation></translation>
+    </message>
+    <message id="page_switchable_output_polarity_active_low">
+      <location filename="../../pages/settings/devicelist/iochannel/PageSwitchableOutput.qml" line="208"/>
+      <source>Active low / Normally closed</source>
+      <translation></translation>
+    </message>
+    <message id="settings_dvcc_output_limit_min">
+      <location filename="../../pages/settings/devicelist/iochannel/PageSwitchableOutput.qml" line="214"/>
+      <source>Output limit min</source>
+      <translation></translation>
+    </message>
+    <message id="settings_dvcc_output_limit_max">
+      <location filename="../../pages/settings/devicelist/iochannel/PageSwitchableOutput.qml" line="226"/>
+      <source>Output limit max</source>
+      <translation></translation>
+    </message>
+    <message id="ac-in-setup-default_phase_setting">
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="159"/>
+      <source>Phase Setting</source>
+      <translation></translation>
+    </message>
+    <message id="iochannel_showui_local">
+      <location filename="../../components/listitems/ListIOChannelShowRadioButtonGroup.qml" line="20"/>
+      <source>Only local</source>
+      <translation></translation>
+    </message>
+    <message id="iochannel_showui_vrm">
+      <location filename="../../components/listitems/ListIOChannelShowRadioButtonGroup.qml" line="22"/>
+      <source>Only on VRM</source>
+      <translation></translation>
+    </message>
+    <message id="controlcards_empty_desc1">
+      <location filename="../../pages/ControlCardsPage.qml" line="157"/>
+      <source>No compatible devices found</source>
+      <translation></translation>
+    </message>
+    <message id="controlcards_empty_desc2">
+      <location filename="../../pages/ControlCardsPage.qml" line="159"/>
+      <source>Connect devices that support this function</source>
+      <translation></translation>
+    </message>
+    <message id="settings_vrm_device_registration">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="95"/>
+      <source>VRM device registration</source>
+      <oldsource>VRM Device Registration</oldsource>
+      <translation></translation>
+    </message>
+    <message id="common_words_go_to_redetect_system">
+      <location filename="../../components/CommonWords.qml" line="230"/>
+      <source>If it was recently disconnected, go to Settings → Devices → %1 → Advanced, and select 'Redetect VE.Bus system'.</source>
+      <extracomment>%1 = name of the device</extracomment>
+      <translation></translation>
+    </message>
+    <message id="settings_canbus_nmea2000out_alerts">
+      <location filename="../../pages/settings/PageSettingsCanbus.qml" line="76"/>
+      <source>NMEA2000 outbound alerts</source>
+      <translation></translation>
+    </message>
+    <message id="settings_logging_vrm_portal">
+      <location filename="../../pages/settings/PageSettingsLogger.qml" line="45"/>
+      <source>VRM Portal access level</source>
+      <oldsource>VRM Portal</oldsource>
+      <translation></translation>
+    </message>
+    <message id="settings_firmware_check_timed_out">
+      <location filename="../../components/FirmwareUpdate.qml" line="252"/>
+      <source>Firmware check timed out</source>
+      <translation></translation>
+    </message>
+    <message id="settings_units_mixed">
+      <location filename="../../pages/settings/PageSettingsDisplayUnits.qml" line="53"/>
+      <source>Mixed (AC in Watts, DC in Amps)</source>
+      <translation></translation>
+    </message>
+    <message id="switchable_output_overtemperature_tripped">
+      <location filename="../../src/enums.cpp" line="639"/>
+      <source>Over temp, tripped</source>
+      <translation></translation>
+    </message>
+    <message id="switchable_output_disabled_tripped">
+      <location filename="../../src/enums.cpp" line="657"/>
+      <source>Disabled, tripped</source>
+      <translation></translation>
+    </message>
+    <message id="switchable_output_disabled_overtemperature">
+      <location filename="../../src/enums.cpp" line="660"/>
+      <source>Disabled, over temp</source>
+      <translation></translation>
+    </message>
+    <message id="switchable_output_disabled_on">
+      <location filename="../../src/enums.cpp" line="663"/>
+      <source>Disabled but on</source>
+      <translation></translation>
+    </message>
+    <message id="switchable_output_bypassed_tripped">
+      <location filename="../../src/enums.cpp" line="669"/>
+      <source>Bypassed, tripped</source>
+      <translation></translation>
+    </message>
+    <message id="switchable_output_bypassed_overtemperature">
+      <location filename="../../src/enums.cpp" line="672"/>
+      <source>Bypassed, over temp</source>
+      <translation></translation>
+    </message>
+    <message id="switchable_output_externalcontrol_tripped">
+      <location filename="../../src/enums.cpp" line="678"/>
+      <source>External control, tripped</source>
+      <translation></translation>
+    </message>
+    <message id="switchable_output_externalcontrol_overtemperature">
+      <location filename="../../src/enums.cpp" line="681"/>
+      <source>External control, over temp</source>
+      <translation></translation>
+    </message>
+    <message id="page_meteo_configuration_required">
+      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="23"/>
+      <source>Configuration required</source>
+      <translation></translation>
+    </message>
+    <message id="page_meteo_config_caption">
+      <location filename="../../pages/settings/devicelist/PageMeteo.qml" line="31"/>
+      <source>Setup is needed for power estimation. For instructions, open the QR code to scan it with your portable device.&lt;br /&gt;Or insert the link: %1</source>
+      <extracomment>%1 = url text</extracomment>
+      <translation></translation>
+    </message>
+    <message id="ev_target_soc">
+      <location filename="../../pages/ev/EvPage.qml" line="40"/>
+      <source>Target state of charge</source>
+      <translation></translation>
+    </message>
+    <message id="ev_range">
+      <location filename="../../pages/ev/EvPage.qml" line="47"/>
+      <source>Range</source>
+      <translation></translation>
+    </message>
+    <message id="ev_battery_capacity">
+      <location filename="../../pages/ev/EvPage.qml" line="57"/>
+      <source>Battery capacity</source>
+      <translation>バッテリー容量</translation>
+    </message>
+    <message id="ev_charging_state">
+      <location filename="../../pages/ev/EvPage.qml" line="73"/>
+      <source>Charging state</source>
+      <translation>充電状態</translation>
+    </message>
+    <message id="ev_charging_state_not_charging">
+      <location filename="../../pages/ev/EvPage.qml" line="79"/>
+      <source>Not charging</source>
+      <translation></translation>
+    </message>
+    <message id="ev_charging_state_low_power">
+      <location filename="../../pages/ev/EvPage.qml" line="82"/>
+      <source>Low power mode</source>
+      <translation>低電力モード</translation>
+    </message>
+    <message id="ev_charging_state_scheduled_charging">
+      <location filename="../../pages/ev/EvPage.qml" line="97"/>
+      <source>Scheduled charging</source>
+      <translation></translation>
+    </message>
+    <message id="ev_at_site">
+      <location filename="../../pages/ev/EvPage.qml" line="108"/>
+      <source>At site</source>
+      <translation></translation>
+    </message>
+    <message id="ev_vin">
+      <location filename="../../pages/ev/EvPage.qml" line="123"/>
+      <source>VIN</source>
+      <translation></translation>
+    </message>
+    <message id="ev_odometer">
+      <location filename="../../pages/ev/EvPage.qml" line="130"/>
+      <source>Odometer</source>
+      <translation></translation>
+    </message>
+    <message id="ev_nr_phases">
+      <location filename="../../pages/ev/EvPage.qml" line="158"/>
+      <source>Number of phases</source>
+      <translation></translation>
+    </message>
+    <message id="battery_individual_info">
+      <location filename="../../pages/settings/devicelist/battery/PageBattery.qml" line="276"/>
+      <source>Individual Battery Info</source>
+      <translation>個別バッテリー情報</translation>
+    </message>
+    <message id="lynxionbatteryinfo_battery_number_with_serial">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxIonBatteryInfo.qml" line="38"/>
+      <source>Battery #%1 [%2]</source>
+      <extracomment>%1 = battery number, %2 = battery name</extracomment>
+      <translation></translation>
+    </message>
+    <message id="lynxionbatteryinfo_battery_number">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxIonBatteryInfo.qml" line="41"/>
+      <source>Battery #%1</source>
+      <extracomment>%1 = battery number</extracomment>
+      <translation></translation>
+    </message>
+    <message id="lynxionbatteryinfo_battery_info_section_header">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxIonBatteryInfo.qml" line="72"/>
+      <source>Battery Info</source>
+      <translation></translation>
+    </message>
+    <message id="lynxionbatteryinfo_battery_measurements_section_header">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxIonBatteryInfo.qml" line="106"/>
+      <source>Battery Measurements</source>
+      <translation></translation>
+    </message>
+    <message id="lynxionbatteryinfo_cell_measurements_section_header">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxIonBatteryInfo.qml" line="131"/>
+      <source>Cell Measurements</source>
+      <translation></translation>
+    </message>
+    <message id="lynxionbatteryinfo_cell_number">
+      <location filename="../../pages/settings/devicelist/battery/PageLynxIonBatteryInfo.qml" line="155"/>
+      <source>Cell #%1</source>
+      <translation></translation>
+    </message>
+    <message id="settings_ess_grid_meter_required">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="71"/>
+      <source>Grid meter required</source>
+      <translation></translation>
+    </message>
+    <message id="settings_ess_grid_meter_required_caption">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="80"/>
+      <source>A grid meter must be present for ESS operation. If not available, the system will switch to pass-through.</source>
+      <translation></translation>
+    </message>
+    <message id="settings_ess_grid_meter_optional_caption">
+      <location filename="../../pages/settings/PageSettingsHub4.qml" line="86"/>
+      <source>The system will use a grid meter when present, but fall back to internal measurements if the connection to the grid meter is lost.</source>
+      <translation></translation>
+    </message>
+    <message id="settings_tcpip_ethernet_gateway_enabled">
+      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="130"/>
+      <source>Allow using ethernet for internet access</source>
+      <translation></translation>
+    </message>
+    <message id="settings_wifi_access_point">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="30"/>
+      <source>Access point</source>
+      <translation>アクセスポイント</translation>
+    </message>
+    <message id="settings_tcpip_wifi_gateway_enabled">
+      <location filename="../../pages/settings/PageSettingsWifi.qml" line="111"/>
+      <source>Allow using WiFi for internet access</source>
+      <translation></translation>
+    </message>
+    <message id="battery_status_overvoltage">
+      <location filename="../../src/enums.cpp" line="82"/>
+      <source>Overvoltage</source>
+      <translation>過電圧</translation>
+    </message>
+    <message id="battery_status_undervoltage">
+      <location filename="../../src/enums.cpp" line="86"/>
+      <source>Undervoltage</source>
+      <translation>過小電圧</translation>
+    </message>
+    <message id="battery_status_low_temperature_atc">
+      <location filename="../../src/enums.cpp" line="90"/>
+      <source>Low Temperature (ATC)</source>
+      <translation></translation>
+    </message>
+    <message id="battery_status_high_temperature_atc">
+      <location filename="../../src/enums.cpp" line="94"/>
+      <source>High Temperature (ATC)</source>
+      <translation></translation>
+    </message>
+    <message id="battery_status_cell_error">
+      <location filename="../../src/enums.cpp" line="98"/>
+      <source>Cell Error</source>
+      <translation></translation>
+    </message>
+    <message id="battery_status_high_temperature_atd">
+      <location filename="../../src/enums.cpp" line="102"/>
+      <source>High Temperature (ATD)</source>
+      <translation></translation>
+    </message>
+    <message id="battery_status_high_cell_voltage">
+      <location filename="../../src/enums.cpp" line="106"/>
+      <source>High Cell Voltage</source>
+      <translation>セル高電圧</translation>
+    </message>
+    <message id="battery_status_update_failure">
+      <location filename="../../src/enums.cpp" line="110"/>
+      <source>Update Failure</source>
+      <translation>アップデート失敗</translation>
+    </message>
+    <message id="battery_status_charge_overcurrent_warning">
+      <location filename="../../src/enums.cpp" line="114"/>
+      <source>Charge Overcurrent Warning</source>
+      <translation></translation>
+    </message>
+    <message id="battery_status_charge_overcurrent_alarm">
+      <location filename="../../src/enums.cpp" line="118"/>
+      <source>Charge Overcurrent Alarm</source>
+      <translation></translation>
+    </message>
+    <message id="battery_status_discharge_overcurrent_warning">
+      <location filename="../../src/enums.cpp" line="122"/>
+      <source>Discharge Overcurrent Warning</source>
+      <translation></translation>
+    </message>
+    <message id="battery_status_discharge_overcurrent_alarm">
+      <location filename="../../src/enums.cpp" line="126"/>
+      <source>Discharge Overcurrent Alarm</source>
+      <translation></translation>
+    </message>
+    <message id="battery_status_low_cell_voltage">
+      <location filename="../../src/enums.cpp" line="130"/>
+      <source>Low Cell Voltage</source>
+      <translation>低セル電圧</translation>
+    </message>
+    <message id="battery_status_low_temperature_atd">
+      <location filename="../../src/enums.cpp" line="134"/>
+      <source>Low Temperature (ATD)</source>
+      <translation></translation>
+    </message>
+    <message id="devicelist_motordrive_motordirection">
+      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="57"/>
+      <source>Motor direction</source>
+      <translation></translation>
+    </message>
+    <message id="devicelist_motordrive_motortorque">
+      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="64"/>
+      <source>Motor torque</source>
+      <translation></translation>
+    </message>
+    <message id="devicelist_motordrive_motortemperature">
+      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="72"/>
+      <source>Motor temperature</source>
+      <oldsource>Motor Temperature</oldsource>
+      <translation></translation>
+    </message>
+    <message id="devicelist_motordrive_controllertemperature">
+      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="86"/>
+      <source>Controller temperature</source>
+      <oldsource>Controller Temperature</oldsource>
+      <translation></translation>
+    </message>
+    <message id="devicelist_motordrive_motordirectioninverted">
+      <location filename="../../pages/settings/devicelist/PageMotorDrive.qml" line="93"/>
+      <source>Motor direction inverted</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingsboatpage_edrive_with_vrm_instance">
+      <location filename="../../pages/settings/PageSettingsBoatPage.qml" line="48"/>
+      <source>E-drive with VRM instance #%1</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingsboatpage_dual_drive_configuration">
+      <location filename="../../pages/settings/PageSettingsBoatPage.qml" line="79"/>
+      <source>Dual-Drive Configuration</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingsboatpage_multi_drive_left">
+      <location filename="../../pages/settings/PageSettingsBoatPage.qml" line="85"/>
+      <source>Left E-drive</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingsboatpage_multi_drive_right">
+      <location filename="../../pages/settings/PageSettingsBoatPage.qml" line="93"/>
+      <source>Right E-drive</source>
+      <translation></translation>
+    </message>
+    <message id="settings_tcpip_ethernet_linklocal_enabled">
+      <location filename="../../pages/settings/NetworkSettingsPageModel.qml" line="175"/>
+      <source>Enable Link-local</source>
+      <translation></translation>
+    </message>
+    <message id="switchable_output_running_over_temperature">
+      <location filename="../../src/enums.cpp" line="690"/>
+      <source>Running, over temperature</source>
+      <translation></translation>
+    </message>
+    <message id="switchable_output_running_disabled">
+      <location filename="../../src/enums.cpp" line="693"/>
+      <source>Running, disabled</source>
+      <translation></translation>
+    </message>
+    <message id="switchable_output_not_running_disabled">
+      <location filename="../../src/enums.cpp" line="701"/>
+      <source>Not running, disabled</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingssystem_opportunity_loads">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="62"/>
+      <source>Opportunity Loads</source>
+      <translation></translation>
+    </message>
+    <message id="pagesettingssystem_automate_controllable_devices">
+      <location filename="../../pages/settings/PageSettingsSystem.qml" line="64"/>
+      <source>Automate controllable devices to maximize PV self-use</source>
+      <translation>制御可能なデバイスを自動化し、PV自家消費を最大化する</translation>
+    </message>
+    <message id="microgrid_mode_ems_hybrid_droop">
+      <location filename="../../src/enums.cpp" line="766"/>
+      <source>EMS Control: Hybrid droop</source>
+      <translation>EMS制御：ハイブリッドドループ</translation>
+    </message>
+    <message id="microgrid_mode_ems_grid_following">
+      <location filename="../../src/enums.cpp" line="770"/>
+      <source>EMS Control: Grid-following</source>
+      <translation>EMS制御：グリッド追従</translation>
+    </message>
+    <message id="microgrid_mode_ems_grid_forming">
+      <location filename="../../src/enums.cpp" line="773"/>
+      <source>EMS Control: Grid-forming</source>
+      <translation>EMS制御：グリッド形成</translation>
+    </message>
+    <message id="microgrid_error_hybrid_droop_values_out_of_sync">
+      <location filename="../../src/enums.cpp" line="787"/>
+      <source>Different fallback hybrid droop values in phase masters</source>
+      <translation>位相マスターにおける異なるフォールバックハイブリッドドループ値</translation>
+    </message>
+    <message id="microgrid_error_write_failed">
+      <location filename="../../src/enums.cpp" line="790"/>
+      <source>Hybrid droop parameter write failed</source>
+      <translation>ハイブリッドドループパラメータの書き込みに失敗しました</translation>
+    </message>
+    <message id="microgrid_error_param_fmin_greater_than_fmax">
+      <location filename="../../src/enums.cpp" line="793"/>
+      <source>Parameter error Fmin &gt; Fmax</source>
+      <translation>パラメータエラー Fmin &gt; Fmax</translation>
+    </message>
+    <message id="microgrid_error_param_pmin_greater_than_pmaxv">
+      <location filename="../../src/enums.cpp" line="796"/>
+      <source>Parameter error Pmin &gt; Pmax</source>
+      <translation>パラメータエラー Pmin &gt; Pmax</translation>
+    </message>
+    <message id="microgrid_error_param_umin_greater_than_umax">
+      <location filename="../../src/enums.cpp" line="799"/>
+      <source>Parameter error Umin &gt; Umax</source>
+      <translation>パラメータエラー Umin &gt; Umax</translation>
+    </message>
+    <message id="microgrid_error_param_qmin_greater_than_qmax">
+      <location filename="../../src/enums.cpp" line="802"/>
+      <source>Parameter error Qmin &gt; Qmax</source>
+      <translation>パラメータエラー Qmin &gt; Qmax</translation>
+    </message>
+    <message id="microgrid_error_param_q0_out_of_range">
+      <location filename="../../src/enums.cpp" line="805"/>
+      <source>Parameter error Q0 out of range</source>
+      <translation>パラメータエラー Q0が範囲外です</translation>
+    </message>
+    <message id="microgrid_error_param_qmin_out_of_range">
+      <location filename="../../src/enums.cpp" line="808"/>
+      <source>Parameter error Qmin out of range</source>
+      <translation>パラメータエラー Qminが範囲外です</translation>
+    </message>
+    <message id="microgrid_error_param_qmax_out_of_range">
+      <location filename="../../src/enums.cpp" line="811"/>
+      <source>Parameter error Qmax out of range</source>
+      <translation>パラメータエラー Qmaxが範囲外です</translation>
+    </message>
+    <message id="microgrid_error_param_u0_out_of_range">
+      <location filename="../../src/enums.cpp" line="814"/>
+      <source>Parameter error U0 out of range</source>
+      <translation>パラメータエラー U0が範囲外です</translation>
+    </message>
+    <message id="microgrid_error_param_u_droop_out_of_range">
+      <location filename="../../src/enums.cpp" line="817"/>
+      <source>Parameter error U droop out of range</source>
+      <translation>パラメータエラー Uドループが範囲外です</translation>
+    </message>
+    <message id="microgrid_error_param_p0_out_of_range">
+      <location filename="../../src/enums.cpp" line="820"/>
+      <source>Parameter error P0 out of range</source>
+      <translation>パラメータエラー P0が範囲外です</translation>
+    </message>
+    <message id="microgrid_error_param_pmin_out_of_range">
+      <location filename="../../src/enums.cpp" line="823"/>
+      <source>Parameter error Pmin out of range</source>
+      <translation>パラメータエラー Pminが範囲外です</translation>
+    </message>
+    <message id="microgrid_error_param_pmax_out_of_range">
+      <location filename="../../src/enums.cpp" line="826"/>
+      <source>Parameter error Pmax out of range</source>
+      <translation>パラメータエラー Pmaxが範囲外です</translation>
+    </message>
+    <message id="microgrid_error_param_f0_out_of_range">
+      <location filename="../../src/enums.cpp" line="829"/>
+      <source>Parameter error F0 out of range</source>
+      <translation>パラメータエラー F0が範囲外です</translation>
+    </message>
+    <message id="microgrid_error_param_freq_droop_out_of_range">
+      <location filename="../../src/enums.cpp" line="832"/>
+      <source>Parameter error freq droop out of range</source>
+      <translation>パラメータエラー 周波数ドループが範囲外です</translation>
+    </message>
+    <message id="microgrid_error_pf_fp_mismatch">
+      <location filename="../../src/enums.cpp" line="835"/>
+      <source>Ve.Bus internal error PF vs FP data mismatch</source>
+      <translation>Ve.Bus内部エラー PFとFPのデータ不一致</translation>
+    </message>
+    <message id="microgrid_error_qu_uq_mismatch">
+      <location filename="../../src/enums.cpp" line="838"/>
+      <source>Ve.Bus internal error QU vs UQ data mismatch</source>
+      <translation>Ve.Bus内部エラー QUとUQのデータ不一致</translation>
+    </message>
+    <message id="generic_input_discrete">
+      <location filename="../../src/enums.cpp" line="489"/>
+      <source>Discrete value indicator</source>
+      <translation>離散値インジケーター</translation>
+    </message>
+    <message id="generic_input_value_unranged">
+      <location filename="../../src/enums.cpp" line="492"/>
+      <source>Value indicator (unranged)</source>
+      <translation>値インジケーター (範囲なし)</translation>
+    </message>
+    <message id="generic_input_value_ranged">
+      <location filename="../../src/enums.cpp" line="495"/>
+      <source>Value indicator (ranged)</source>
+      <translation>値インジケーター (範囲指定あり)</translation>
+    </message>
+    <message id="generic_input_temperature">
+      <location filename="../../src/enums.cpp" line="498"/>
+      <source>Temperature indicator</source>
+      <translation>温度インジケーター</translation>
+    </message>
+    <message id="switchable_output_function_generator_startstop">
+      <location filename="../../src/enums.cpp" line="590"/>
+      <source>Generator start/stop</source>
+      <translation>発電機 起動/停止</translation>
+    </message>
+    <message id="switchable_output_function_genset_helper">
+      <location filename="../../src/enums.cpp" line="602"/>
+      <source>Genset Helper</source>
+      <translation>発電機アシスタント</translation>
+    </message>
+    <message id="switchable_output_function_opportunity_load">
+      <location filename="../../src/enums.cpp" line="605"/>
+      <source>Opportunity load</source>
+      <translation>オポチュニティロード</translation>
+    </message>
+    <message id="mk2vsc_state_waiting_for_vebus_setting_access_password">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="40"/>
+      <source>Waiting for VE.Bus setting access password</source>
+      <translation>VE.Bus設定アクセスパスワードを待機中</translation>
+    </message>
+    <message id="vebus_settings_password_required">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="290"/>
+      <source>VE.Bus settings password required</source>
+      <translation>VE.Bus設定パスワードが必要です</translation>
+    </message>
+    <message id="vebus_settings_access_password">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="454"/>
+      <source>VE.Bus settings access password</source>
+      <translation>VE.Bus設定アクセスパスワード</translation>
+    </message>
+    <message id="vebus_settings_enter_password">
+      <location filename="../../pages/vebusdevice/PageVeBusBackupRestore.qml" line="457"/>
+      <source>Enter VE.Bus password for access level %1</source>
+      <translation>アクセスレベル %1 のVE.Busパスワードを入力してください</translation>
+    </message>
+    <message id="device_page_inputs">
+      <location filename="../../components/DevicePage.qml" line="73"/>
+      <source>Inputs</source>
+      <translation>入力</translation>
+    </message>
+    <message id="list-spin-box-range_minimum_value_with_arguments">
+      <location filename="../../components/listitems/ListSpinBoxRange.qml" line="105"/>
+      <source>Minimum value (%1)</source>
+      <translation>最小値 (%1)</translation>
+    </message>
+    <message id="list-spin-box-range_minimum_maximum_delimiter">
+      <location filename="../../components/listitems/ListSpinBoxRange.qml" line="121"/>
+      <source>to</source>
+      <extracomment>Used as a delimiter between two values that specify a range (e.g. '-70% to 80%')</extracomment>
+      <translation>木</translation>
+    </message>
+    <message id="list-spin-box-range_maximum_value_with_arguments">
+      <location filename="../../components/listitems/ListSpinBoxRange.qml" line="149"/>
+      <source>Maximum value (%1)</source>
+      <translation>最大値 (%1)</translation>
+    </message>
+    <message id="generic_input_value">
+      <location filename="../../components/switches/delegates/GenericInputCardDelegate_1.qml" line="54"/>
+      <source>Value</source>
+      <extracomment>Refers to the current value of the input.</extracomment>
+      <translation>値</translation>
+    </message>
+    <message id="pagecontrollableloads_devices_and_priorities">
+      <location filename="../../pages/settings/PageControllableLoads.qml" line="57"/>
+      <source>Devices and Priorities</source>
+      <translation>デバイスと優先度</translation>
+    </message>
+    <message id="pagecontrollableloads_arrange">
+      <location filename="../../pages/settings/PageControllableLoads.qml" line="131"/>
+      <source>Arrange the controllable devices according to their priority; the control algorithm will control them based on the currently available PV excess.</source>
+      <translation>制御可能なデバイスを優先度に従って配置してください。制御アルゴリズムは、現在利用可能なPV余剰に基づいてそれらを制御します。</translation>
+    </message>
+    <message id="pagecontrollableloads_expected_power_consumption">
+      <location filename="../../pages/settings/PageControllableLoadsAcLoad.qml" line="19"/>
+      <source>Expected power consumption</source>
+      <translation>予想消費電力</translation>
+    </message>
+    <message id="pagecontrollableloads_minimum_run_duration">
+      <location filename="../../pages/settings/PageControllableLoadsAcLoad.qml" line="25"/>
+      <source>Minimum run duration when turned on</source>
+      <translation>オン時の最小稼働時間</translation>
+    </message>
+    <message id="pagecontrollableloads_minimum_rest_duration">
+      <location filename="../../pages/settings/PageControllableLoadsAcLoad.qml" line="31"/>
+      <source>Minimum rest duration when turned off</source>
+      <translation>オフ時の最小停止時間</translation>
+    </message>
+    <message id="pagecontrollableloads_battery_reserved_power_0">
+      <location filename="../../pages/settings/PageControllableLoadsBattery.qml" line="19"/>
+      <source>Reserved power for battery charging at 0% SOC</source>
+      <translation>SOC 0%時のバッテリー充電用予約電力</translation>
+    </message>
+    <message id="pagecontrollableloads_battery_reduce_power">
+      <location filename="../../pages/settings/PageControllableLoadsBattery.qml" line="26"/>
+      <source>Reduce power per percentage point of SOC by</source>
+      <translation>SOCの1パーセントポイントあたりの電力削減量</translation>
+    </message>
+    <message id="pagecontrollableloads_battery_batterylife_compatibility">
+      <location filename="../../pages/settings/PageControllableLoadsBattery.qml" line="32"/>
+      <source>BatteryLife compatibility</source>
+      <translation>BatteryLife互換性</translation>
+    </message>
+    <message id="page_controllableloads_battery_pause_opportunity_loads">
+      <location filename="../../pages/settings/PageControllableLoadsBattery.qml" line="37"/>
+      <source>Pause Opportunity Loads when Active SOC limit exceeds 85%</source>
+      <translation>アクティブSOC制限が85%を超えた場合、オポチュニティロードを一時停止</translation>
+    </message>
+    <message id="pagecontrollableloads_battery_this_supports_the_batterylife_algorithm">
+      <location filename="../../pages/settings/PageControllableLoadsBattery.qml" line="40"/>
+      <source>This helps the BatteryLife algorithm recharge the battery to 100%.</source>
+      <translation>これはBatteryLifeアルゴリズムがバッテリーを100%まで再充電するのに役立ちます。</translation>
+    </message>
+    <message id="pagecontrollableloads_evcs_maximum_charging_power_limit">
+      <location filename="../../pages/settings/PageControllableLoadsEVCS.qml" line="19"/>
+      <source>Maximum charging power limit</source>
+      <translation>最大充電電力制限</translation>
+    </message>
+    <message id="pagecontrollableloads_limiting_the_maximum">
+      <location filename="../../pages/settings/PageControllableLoadsEVCS.qml" line="22"/>
+      <source>Limiting the maximum charging power can improve simultaneity with other controllable devices.</source>
+      <translation>最大充電電力を制限することで、他の制御可能なデバイスとの同時実行性を向上させることができます。</translation>
+    </message>
+    <message id="page_generic_input_invert">
+      <location filename="../../pages/settings/devicelist/iochannel/PageGenericInput.qml" line="34"/>
+      <source>Invert</source>
+      <translation>反転</translation>
+    </message>
+    <message id="iochannel_digital_input_mode">
+      <location filename="../../pages/settings/devicelist/iochannel/PageGenericInput.qml" line="48"/>
+      <source>Digital input mode</source>
+      <translation>デジタル入力モード</translation>
+    </message>
+    <message id="iochannel_digital_input_mode_input">
+      <location filename="../../pages/settings/devicelist/iochannel/PageGenericInput.qml" line="55"/>
+      <source>Digital input</source>
+      <translation>デジタル入力</translation>
+    </message>
+    <message id="iochannel_digital_input_mode_toggle">
+      <location filename="../../pages/settings/devicelist/iochannel/PageGenericInput.qml" line="57"/>
+      <source>Toggle switch</source>
+      <translation>トグルスイッチ</translation>
+    </message>
+    <message id="iochannel_digital_input_mode_press">
+      <location filename="../../pages/settings/devicelist/iochannel/PageGenericInput.qml" line="59"/>
+      <source>Press button</source>
+      <translation>ボタンを押す</translation>
+    </message>
+    <message id="iochannel_digital_input_mode_press_and_hold">
+      <location filename="../../pages/settings/devicelist/iochannel/PageGenericInput.qml" line="61"/>
+      <source>Press and hold button</source>
+      <translation>ボタンを長押し</translation>
+    </message>
+    <message id="page_microgrid_apply_all_parameters">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="285"/>
+      <source>Apply all parameters</source>
+      <translation>全パラメータを適用</translation>
+    </message>
+    <message id="page_microgrid_apply">
+      <location filename="../../pages/vebusdevice/PageMicrogrid.qml" line="287"/>
+      <source>Apply</source>
+      <translation>適用</translation>
+    </message>
+    <message id="page_settings_generator_warm_up_cool_down_unavailable_message">
+      <location filename="../../pages/settings/PageSettingsGenerator.qml" line="60"/>
+      <source>Warm-up &amp; cool-down is unavailable with the current inverter/charger firmware. 
+Please update to the latest firmware to be able to adjust these settings.</source>
+      <translation>現在のインバーター/充電器ファームウェアでは、ウォームアップ＆クールダウンは利用できません。これらの設定を調整できるように、最新のファームウェアに更新してください。</translation>
+    </message>
+    <message id="generic_input_unknown_status">
+      <location filename="../../src/enums.cpp" line="518"/>
+      <source>Unknown status</source>
+      <translation>不明なステータス</translation>
+    </message>
+    <message id="page_switchable_output_set_dim_level_manually">
+      <location filename="../../pages/settings/devicelist/iochannel/PageSwitchableOutput.qml" line="174"/>
+      <source>Set startup dim level manually</source>
+      <translation>起動時の輝度レベルを手動で設定</translation>
+    </message>
+    <message id="main_system_service_settings_offline_warning">
+      <location filename="../../Main.qml" line="207"/>
+      <source>Warning: detected localsettings service offline; reloading UI when it becomes available again...</source>
+      <translation>警告：localsettingsサービスがオフラインを検出しました。サービスが再度利用可能になったらUIを再読み込みします...</translation>
+    </message>
+    <message id="main_system_service_platform_offline_warning">
+      <location filename="../../Main.qml" line="228"/>
+      <source>Warning: detected venus-platform service offline; reloading UI when it becomes available again...</source>
+      <translation>警告：venus-platformサービスがオフラインを検出しました。サービスが再度利用可能になったらUIを再読み込みします...</translation>
+    </message>
+    <message id="pagesettingssupportstate_support_state_check_items">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="30"/>
+      <source>Check items below</source>
+      <translation>以下の項目を確認してください</translation>
+    </message>
+    <message id="pagesettingssupportstate_operating_system_partition_status">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="335"/>
+      <source>Operating system partition status</source>
+      <translation>オペレーティングシステムパーティションの状態</translation>
+    </message>
+    <message id="pagesettingssupportstate_items_with_warning_icon_description">
+      <location filename="../../pages/settings/PageSettingsSupportStatus.qml" line="488"/>
+      <source>Items with a warning icon are supported and provided by Victron Energy, but using them incorrectly can affect system stability. In case of troubleshooting, disable those first.</source>
+      <translation>警告アイコンが付いている項目はVictron Energyによってサポート・提供されていますが、誤って使用するとシステム安定性に影響を及ぼす可能性があります。トラブルシューティングの際は、まずそれらを無効にしてください。</translation>
+    </message>
+    <message id="pagecontrollableloads_starting">
+      <location filename="../../pages/settings/PageControllableLoads.qml" line="59"/>
+      <source>Starting, this may take a few seconds...</source>
+      <translation>起動中、数秒かかる場合があります...</translation>
+    </message>
+    <message id="settings_security_profile_change_password_title">
+      <location filename="../../components/dialogs/SecurityProfilePasswordDialog.qml" line="52"/>
+      <source>Change the GX Password</source>
+      <oldsource>Changing the GX Password</oldsource>
+      <translation>GXパスワードの変更</translation>
+    </message>
+    <message id="settings_modbus_remove_description">
+      <location filename="../../pages/settings/PageSettingsModbusDevices.qml" line="55"/>
+      <source>%1 %2:%3 (Unit %4)</source>
+      <extracomment>%1=protocol, %2=IP address, %3=port number, %4=unit number</extracomment>
+      <translation>%1 %2:%3 (ユニット %4)</translation>
+    </message>
+    <message id="settings_switch_channel_configuration">
+      <location filename="../../pages/settings/devicelist/PageSwitch.qml" line="44"/>
+      <source>Channel configuration</source>
+      <translation>チャンネル設定</translation>
+    </message>
+    <message id="device_page_outputs">
+      <location filename="../../components/DevicePage.qml" line="46"/>
+      <source>Outputs</source>
+      <extracomment>Settings page for switchable outputs</extracomment>
+      <translation>出力</translation>
+    </message>
+    <message id="radiobutton_list_password_validation_not_supported">
+      <location filename="../../components/RadioButtonListPage.qml" line="126"/>
+      <source>Password validation not supported!</source>
+      <translation>パスワード検証はサポートされていません！</translation>
+    </message>
+    <message id="devicelist_tankshape_add_shape_point">
+      <location filename="../../pages/settings/devicelist/tank/PageTankShape.qml" line="65"/>
+      <source>Add shape point</source>
+      <translation>シェイプポイントを追加</translation>
+    </message>
+    <message id="settings_add_ip_addresses">
+      <location filename="../../pages/settings/IpAddressListView.qml" line="40"/>
+      <source>Add IP address</source>
+      <translation>IPアドレスを追加</translation>
+    </message>
+    <message id="pagesettingsintegrations_mqtt_devices">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="56"/>
+      <source>MQTT Devices</source>
+      <translation>MQTTデバイス</translation>
+    </message>
+    <message id="pagesettingsintegrations_eebus_devices">
+      <location filename="../../pages/settings/PageSettingsIntegrations.qml" line="68"/>
+      <source>EEBus Devices</source>
+      <translation>EEBusデバイス</translation>
+    </message>
+    <message id="settings_ess_disable_ol_first">
+      <location filename="../../pages/settings/PageSettingsDynamicEss.qml" line="20"/>
+      <source>Dynamic ESS cannot be enabled while Opportunity Loads is enabled. Disable Dynamic ESS first.</source>
+      <translation>オポチュニティロードが有効な間は、Dynamic ESSを有効にできません。まずDynamic ESSを無効にしてください。</translation>
+    </message>
+    <message id="pagecontrollableloads_disable_dess_first">
+      <location filename="../../pages/settings/PageControllableLoads.qml" line="46"/>
+      <source>Opportunity loads cannot be enabled while Dynamic ESS is running. Disable Dynamic ESS first.</source>
+      <translation>Dynamic ESSが実行中の間は、オポチュニティロードを有効にできません。まずDynamic ESSを無効にしてください。</translation>
+    </message>
+    <message id="eebus_local_ski">
+      <location filename="../../pages/settings/PageSettingsEebus.qml" line="66"/>
+      <source>Local SKI</source>
+      <translation>ローカルSKI</translation>
+    </message>
+    <message id="eebus_pairing_qr_code">
+      <location filename="../../pages/settings/PageSettingsEebus.qml" line="73"/>
+      <source>QR Code for pairing</source>
+      <translation>ペアリング用QRコード</translation>
+    </message>
+    <message id="eebus_device_trusted">
+      <location filename="../../pages/settings/PageSettingsEebusDevice.qml" line="18"/>
+      <source>Trusted</source>
+      <translation>信頼済み</translation>
+    </message>
+    <message id="eebus_untrusted">
+      <location filename="../../pages/settings/PageSettingsEebus.qml" line="102"/>
+      <source>Untrusted</source>
+      <translation>未信頼</translation>
+    </message>
+    <message id="eebus_device_host">
+      <location filename="../../pages/settings/PageSettingsEebusDevice.qml" line="35"/>
+      <source>Host</source>
+      <translation>ホスト</translation>
+    </message>
+    <message id="eebus_device_ski">
+      <location filename="../../pages/settings/PageSettingsEebusDevice.qml" line="41"/>
+      <source>SKI</source>
+      <translation>SKI</translation>
+    </message>
+    <message id="eebus_device_auto_accept">
+      <location filename="../../pages/settings/PageSettingsEebusDevice.qml" line="52"/>
+      <source>Auto Accept</source>
+      <translation>自動承認</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_add_title">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="36"/>
+      <source>Add port and unit ID</source>
+      <translation>ポートとユニットIDを追加</translation>
+    </message>
+    <message id="page_settings_fronius_modbus_locations_note">
+      <location filename="../../pages/settings/PageSettingsFroniusModbus.qml" line="45"/>
+      <source>The default modbus port is 502 and the default unit ID is 126.</source>
+      <translation>デフォルトのModbusポートは502、ユニットIDは126です。</translation>
+    </message>
+    <message id="settings_fronius_rescan_for_ip_addresses">
+      <location filename="../../pages/settings/PageSettingsFroniusShowIpAddresses.qml" line="21"/>
+      <source>Rescan for IP addresses</source>
+      <translation>IPアドレスを再スキャン</translation>
+    </message>
+    <message id="mqtt_devices_ev_charging_station">
+      <location filename="../../pages/settings/PageSettingsMqttDevices.qml" line="16"/>
+      <source>EV Charging Station</source>
+      <translation>EV 充電ステーション</translation>
+    </message>
+    <message id="mqtt_devices_pairing_mode">
+      <location filename="../../pages/settings/PageSettingsMqttDevices.qml" line="52"/>
+      <source>Pairing mode</source>
+      <translation>ペアリングモード</translation>
+    </message>
+    <message id="mqtt_devices_pairing_active">
+      <location filename="../../pages/settings/PageSettingsMqttDevices.qml" line="56"/>
+      <source>Active • %1s remaining</source>
+      <extracomment>%1 = number of seconds remaining</extracomment>
+      <translation>有効 • 残り%1秒</translation>
+    </message>
+    <message id="mqtt_devices_pairing_activate">
+      <location filename="../../pages/settings/PageSettingsMqttDevices.qml" line="58"/>
+      <source>Activate</source>
+      <translation>有効にする</translation>
+    </message>
+    <message id="mqtt_devices_pairing_enabled">
+      <location filename="../../pages/settings/PageSettingsMqttDevices.qml" line="82"/>
+      <source>Pairing mode enabled for %1 seconds</source>
+      <translation>ペアリングモードが%1秒間有効になりました</translation>
+    </message>
+    <message id="mqtt_devices_pairing_description">
+      <location filename="../../pages/settings/PageSettingsMqttDevices.qml" line="94"/>
+      <source>Activate Pairing mode to allow a device to connect. Paired devices appear here, and will show in the Devices list when connected.</source>
+      <translation>デバイスを接続するには、ペアリングモードを有効にしてください。ペアリング済みのデバイスはここに表示され、接続するとデバイスリストにも表示されます。</translation>
+    </message>
+    <message id="mqtt_devices_pairing_access_tokens">
+      <location filename="../../pages/settings/PageSettingsMqttDevices.qml" line="101"/>
+      <source>Access tokens for paired devices</source>
+      <translation>ペアリング済みデバイスのアクセストークン</translation>
+    </message>
+    <message id="mqtt_devices_pairing_unpair">
+      <location filename="../../pages/settings/PageSettingsMqttDevices.qml" line="113"/>
+      <source>Unpair</source>
+      <translation>ペアリング解除</translation>
+    </message>
+    <message id="mqtt_devices_unpairing_confirm_title">
+      <location filename="../../pages/settings/PageSettingsMqttDevices.qml" line="130"/>
+      <source>Unpairing %1</source>
+      <translation>%1のペアリングを解除</translation>
+    </message>
+    <message id="mqtt_devices_unpairing_confirm_description">
+      <location filename="../../pages/settings/PageSettingsMqttDevices.qml" line="133"/>
+      <source>This will disconnect the device and it will need to be paired again to reconnect.</source>
+      <translation>これによりデバイスとの接続が解除され、再接続には再度ペアリングが必要です。</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAfricaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="10"/>
+      <source>Morocco Standard Time</source>
+      <translation>モロッコ標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="11"/>
+      <source>W. Central Africa Standard Time</source>
+      <translation>西中央アフリカ標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="12"/>
+      <source>South Africa Standard Time</source>
+      <translation>南アフリカ標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="13"/>
+      <source>Namibia Standard Time</source>
+      <translation>ナミビア標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="14"/>
+      <source>Egypt Standard Time</source>
+      <translation>エジプト標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAfricaData.qml" line="15"/>
+      <source>E. Africa Standard Time</source>
+      <translation>東アフリカ標準時</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAmericaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="10"/>
+      <source>Argentina Standard Time</source>
+      <translation>アルゼンチン標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="11"/>
+      <source>E. South America Standard Time</source>
+      <translation>東南米標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="12"/>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="13"/>
+      <source>Greenland Standard Time</source>
+      <translation>グリーンランド標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="14"/>
+      <source>Montevideo Standard Time</source>
+      <translation>モンテビデオ標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="15"/>
+      <source>Newfoundland Standard Time</source>
+      <translation>ニューファンドランド標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="16"/>
+      <source>SA Eastern Standard Time</source>
+      <translation>南米東部標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="18"/>
+      <source>Atlantic Standard Time</source>
+      <translation>大西洋標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="19"/>
+      <source>Central Brazilian Standard Time</source>
+      <translation>ブラジル中央標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="20"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>南米太平洋標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="21"/>
+      <source>Paraguay Standard Time</source>
+      <translation>パラグアイ標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="22"/>
+      <source>SA Western Standard Time</source>
+      <translation>南米西部標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="23"/>
+      <source>Venezuela Standard Time</source>
+      <translation>ベネズエラ標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="24"/>
+      <source>Eastern Standard Time</source>
+      <translation>東部標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="25"/>
+      <source>SA Pacific Standard Time</source>
+      <translation>南米太平洋標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="26"/>
+      <source>US Eastern Standard Time</source>
+      <translation>米国東部標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="27"/>
+      <source>Canada Central Standard Time</source>
+      <translation>カナダ中央標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="28"/>
+      <source>Central America Standard Time</source>
+      <translation>中央アメリカ標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="29"/>
+      <source>Central Standard Time (Mexico)</source>
+      <translation>中央標準時（メキシコ）</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="30"/>
+      <source>Central Standard Time</source>
+      <translation>中央標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="31"/>
+      <source>Mountain Standard Time (Mexico)</source>
+      <translation>山岳部標準時（メキシコ）</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="32"/>
+      <source>Mountain Standard Time</source>
+      <translation>山岳部標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="33"/>
+      <source>US Mountain Standard Time</source>
+      <translation>米国山岳部標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="34"/>
+      <source>Pacific Standard Time (Mexico)</source>
+      <translation>太平洋標準時（メキシコ）</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="35"/>
+      <source>Pacific Standard Time</source>
+      <translation>太平洋標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="36"/>
+      <source>Alaskan Standard Time</source>
+      <translation>アラスカ標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="37"/>
+      <source>Hawaii-Aleutian</source>
+      <translation>ハワイ・アリューシャン</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAmericaData.qml" line="17"/>
+      <source>Atlantic Daylight Time</source>
+      <translation>大西洋夏時間</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAntarcticaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="10"/>
+      <source>New Zealand Standard Time</source>
+      <translation>ニュージーランド標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="11"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>中央太平洋標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="12"/>
+      <source>West Pacific Standard Time</source>
+      <translation>西太平洋標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="13"/>
+      <source>W. Australia Standard Time</source>
+      <translation>西オーストラリア標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="14"/>
+      <source>SE Asia Standard Time</source>
+      <translation>東南アジア標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="15"/>
+      <source>Central Asia Standard Time</source>
+      <translation>中央アジア標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="16"/>
+      <source>West Asia Standard Time</source>
+      <translation>西アジア標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="17"/>
+      <source>E. Africa Standard Time</source>
+      <translation>東アフリカ標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="18"/>
+      <source>Pacific SA Standard Time</source>
+      <translation>南米太平洋標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAntarcticaData.qml" line="19"/>
+      <source>SA Western Standard Time</source>
+      <translation>南米西部標準時</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzArcticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzArcticData.qml" line="10"/>
+      <source>W. Europe Standard Time</source>
+      <translation>西ヨーロッパ標準時</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAsiaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="10"/>
+      <source>Kamchatka Standard Time</source>
+      <translation>カムチャツカ標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="11"/>
+      <source>Magadan Standard Time</source>
+      <translation>マガダン標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="12"/>
+      <source>Vladivostok Standard Time</source>
+      <translation>ウラジオストク標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="13"/>
+      <source>Yakutsk Standard Time</source>
+      <translation>ヤクーツク標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="14"/>
+      <source>Tokyo Standard Time</source>
+      <translation>東京標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="15"/>
+      <source>Korea Standard Time</source>
+      <translation>韓国標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="16"/>
+      <source>Singapore Standard Time</source>
+      <translation>シンガポール標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="17"/>
+      <source>Ulaanbaatar Standard Time</source>
+      <translation>ウランバートル標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="18"/>
+      <source>Taipei Standard Time</source>
+      <translation>台北標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="19"/>
+      <source>North Asia East Standard Time</source>
+      <translation>北アジア東部標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="20"/>
+      <source>China Standard Time</source>
+      <translation>中国標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="21"/>
+      <source>SE Asia Standard Time</source>
+      <translation>東南アジア標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="22"/>
+      <source>North Asia Standard Time</source>
+      <translation>北アジア標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="23"/>
+      <source>Myanmar Standard Time</source>
+      <translation>ミャンマー標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="24"/>
+      <source>N. Central Asia Standard Time</source>
+      <translation>北中央アジア標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="25"/>
+      <source>Central Asia Standard Time</source>
+      <translation>中央アジア標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="26"/>
+      <source>Bangladesh Standard Time</source>
+      <translation>バングラデシュ標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="27"/>
+      <source>Nepal Standard Time</source>
+      <translation>ネパール標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="28"/>
+      <source>Sri Lanka Standard Time</source>
+      <translation>スリランカ標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="29"/>
+      <source>India Standard Time</source>
+      <translation>インド標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="30"/>
+      <source>West Asia Standard Time</source>
+      <translation>西アジア標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="31"/>
+      <source>Pakistan Standard Time</source>
+      <translation>パキスタン標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="32"/>
+      <source>Ekaterinburg Standard Time</source>
+      <translation>エカテリンブルク標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="33"/>
+      <source>Georgian Standard Time</source>
+      <translation>ジョージア標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="34"/>
+      <source>Caucasus Standard Time</source>
+      <translation>コーカサス標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="35"/>
+      <source>Azerbaijan Standard Time</source>
+      <translation>アゼルバイジャン標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="36"/>
+      <source>Arabian Standard Time</source>
+      <translation>アラビア標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="37"/>
+      <source>Afghanistan Standard Time</source>
+      <translation>アフガニスタン標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="38"/>
+      <source>Iran Standard Time</source>
+      <translation>イラン標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="39"/>
+      <source>Arabic Standard Time</source>
+      <translation>アラビア標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="40"/>
+      <source>Arab Standard Time</source>
+      <translation>アラブ標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="41"/>
+      <source>Syria Standard Time</source>
+      <translation>シリア標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="42"/>
+      <source>Middle East Standard Time</source>
+      <translation>中東標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="43"/>
+      <source>Jordan Standard Time</source>
+      <translation>ヨルダン標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAsiaData.qml" line="44"/>
+      <source>Israel Standard Time</source>
+      <translation>イスラエル標準時</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAtlanticData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="10"/>
+      <source>Greenwich Standard Time</source>
+      <translation>グリニッジ標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="11"/>
+      <source>Azores Standard Time</source>
+      <translation>アゾレス標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="12"/>
+      <source>Cape Verde Standard Time</source>
+      <translation>カーボベルデ標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAtlanticData.qml" line="13"/>
+      <source>Mid-Atlantic Standard Time</source>
+      <translation>大西洋中部標準時</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzAustraliaData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="10"/>
+      <source>Tasmania Standard Time</source>
+      <translation>タスマニア標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="11"/>
+      <source>E. Australia Standard Time</source>
+      <translation>東オーストラリア標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="12"/>
+      <source>AUS Eastern Standard Time</source>
+      <translation>オーストラリア東部標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="13"/>
+      <source>Cen. Australia Standard Time</source>
+      <translation>中央オーストラリア標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="14"/>
+      <source>AUS Central Standard Time</source>
+      <translation>オーストラリア中部標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzAustraliaData.qml" line="15"/>
+      <source>W. Australia Standard Time</source>
+      <translation>西オーストラリア標準時</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEtcData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="35"/>
+      <source>GMT +12</source>
+      <translation>GMT +12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="21"/>
+      <source>GMT -02</source>
+      <translation>GMT -02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="12"/>
+      <source>GMT -11</source>
+      <translation>GMT -11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="10"/>
+      <source>GMT -13</source>
+      <translation>グリニッジ標準時 -13</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="11"/>
+      <source>GMT -12</source>
+      <translation>グリニッジ標準時 -12</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="13"/>
+      <source>GMT -10</source>
+      <translation>グリニッジ標準時 -10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="14"/>
+      <source>GMT -09</source>
+      <translation>グリニッジ標準時 -09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="15"/>
+      <source>GMT -08</source>
+      <translation>グリニッジ標準時 -08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="16"/>
+      <source>GMT -07</source>
+      <translation>グリニッジ標準時 -07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="17"/>
+      <source>GMT -06</source>
+      <translation>グリニッジ標準時 -06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="18"/>
+      <source>GMT -05</source>
+      <translation>グリニッジ標準時 -05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="19"/>
+      <source>GMT -04</source>
+      <translation>グリニッジ標準時 -04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="20"/>
+      <source>GMT -03</source>
+      <translation>グリニッジ標準時 -03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="22"/>
+      <source>GMT -01</source>
+      <translation>グリニッジ標準時 -01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="23"/>
+      <source>GMT</source>
+      <translation>グリニッジ標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="24"/>
+      <source>GMT +01</source>
+      <translation>グリニッジ標準時 +01</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="25"/>
+      <source>GMT +02</source>
+      <translation>グリニッジ標準時 +02</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="26"/>
+      <source>GMT +03</source>
+      <translation>グリニッジ標準時 +03</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="27"/>
+      <source>GMT +04</source>
+      <translation>グリニッジ標準時 +04</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="28"/>
+      <source>GMT +05</source>
+      <translation>グリニッジ標準時 +05</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="29"/>
+      <source>GMT +06</source>
+      <translation>グリニッジ標準時 +06</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="30"/>
+      <source>GMT +07</source>
+      <translation>グリニッジ標準時 +07</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="31"/>
+      <source>GMT +08</source>
+      <translation>グリニッジ標準時 +08</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="32"/>
+      <source>GMT +09</source>
+      <translation>グリニッジ標準時 +09</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="33"/>
+      <source>GMT +10</source>
+      <translation>グリニッジ標準時 +10</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="34"/>
+      <source>GMT +11</source>
+      <translation>グリニッジ標準時 +11</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEtcData.qml" line="36"/>
+      <source>UTC</source>
+      <translation>協定世界時</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzEuropeData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="10"/>
+      <source>GMT Standard Time</source>
+      <translation>GMT標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="11"/>
+      <source>Central Europe Standard Time</source>
+      <translation>中央ヨーロッパ標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="12"/>
+      <source>Central European Standard Time</source>
+      <translation>中央ヨーロッパ標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="13"/>
+      <source>Romance Standard Time</source>
+      <translation>ロマンス標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="14"/>
+      <source>W. Europe Standard Time</source>
+      <translation>西ヨーロッパ標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="15"/>
+      <source>E. Europe Standard Time</source>
+      <translation>東ヨーロッパ標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="16"/>
+      <source>FLE Standard Time</source>
+      <translation>FLE標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="17"/>
+      <source>GTB Standard Time</source>
+      <translation>GTB標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="18"/>
+      <source>Belarus Standard Time</source>
+      <translation>ベラルーシ標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="19"/>
+      <source>Russian Standard Time</source>
+      <translation>ロシア標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzEuropeData.qml" line="20"/>
+      <source>Turkey Standard Time</source>
+      <translation>トルコ標準時</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzIndianData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="10"/>
+      <source>Mauritius Standard Time</source>
+      <translation>モーリシャス標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzIndianData.qml" line="11"/>
+      <source>Christmas Island Standard Time</source>
+      <translation>クリスマス島標準時</translation>
+    </message>
+  </context>
+  <context>
+    <name>TzPacificData</name>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="10"/>
+      <source>Tonga Standard Time</source>
+      <translation>トンガ標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="11"/>
+      <source>Fiji Standard Time</source>
+      <translation>フィジー標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="12"/>
+      <source>New Zealand Standard Time</source>
+      <translation>ニュージーランド標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="13"/>
+      <source>Central Pacific Standard Time</source>
+      <translation>中部太平洋標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="14"/>
+      <source>West Pacific Standard Time</source>
+      <translation>西太平洋標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="15"/>
+      <source>Samoa Standard Time</source>
+      <translation>サモア標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="16"/>
+      <source>Hawaiian Standard Time</source>
+      <translation>ハワイ標準時</translation>
+    </message>
+    <message>
+      <location filename="../../pages/settings/tz/TzPacificData.qml" line="17"/>
+      <source>Easter Island Standard Time</source>
+      <translation>イースター島標準時</translation>
+    </message>
+  </context>
+  <context>
+    <name>AlternatorError</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="22"/>
+      <source>No error</source>
+      <translation>エラーなし</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="25"/>
+      <source>Unknown error: %1</source>
+      <translation>不明なエラー: %1</translation>
+    </message>
+  </context>
+  <context>
+    <name>BmsError</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="10"/>
+      <source>No error</source>
+      <translation>エラーなし</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="13"/>
+      <source>Battery initialization error</source>
+      <translation>バッテリー初期化エラー</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="16"/>
+      <source>No batteries connected</source>
+      <translation>バッテリーが接続されていません</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="19"/>
+      <source>Unknown battery</source>
+      <translation>不明なバッテリー</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="22"/>
+      <source>Different battery types</source>
+      <translation>異なるバッテリータイプ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="25"/>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="40"/>
+      <source>No. of batteries incorrect</source>
+      <translation>バッテリー数が正しくありません</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="28"/>
+      <source>Lynx Shunt not found</source>
+      <translation>Lynx Shuntが見つかりません</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="31"/>
+      <source>Battery measure error</source>
+      <translation>バッテリー測定エラー</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="34"/>
+      <source>Internal calculation error</source>
+      <translation>内部計算エラー</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="37"/>
+      <source>No. of batteries in series incorrect</source>
+      <translation>直列バッテリー数が正しくありません</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="44"/>
+      <source>Hardware error</source>
+      <translation>ハードウエア エラー</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="47"/>
+      <source>Watchdog error</source>
+      <translation>ウォッチドッグエラー</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="50"/>
+      <source>Over voltage</source>
+      <translation>過電圧</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="53"/>
+      <source>Under voltage</source>
+      <translation>低電圧</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="56"/>
+      <source>Over temperature</source>
+      <translation>過熱</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="59"/>
+      <source>Under temperature</source>
+      <translation>低温</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="62"/>
+      <source>Under-charge standby</source>
+      <translation>充電不足スタンバイ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="65"/>
+      <source>ADC error</source>
+      <translation>ADCエラー</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="68"/>
+      <source>Battery comm. error</source>
+      <translation>バッテリー通信エラー</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="71"/>
+      <source>Pre-Charge error</source>
+      <translation>プレチャージエラー</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="75"/>
+      <source>Safety contactor error</source>
+      <translation>安全コンタクタエラー</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="79"/>
+      <source>Battery update error</source>
+      <translation>バッテリー更新エラー</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="82"/>
+      <source>BMS cable error</source>
+      <translation>BMSケーブルエラー</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="85"/>
+      <source>Reference voltage failure</source>
+      <translation>基準電圧障害</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="88"/>
+      <source>Wrong system voltage</source>
+      <translation>不正なシステム電圧</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="91"/>
+      <source>Pre charge timeout</source>
+      <translation>プレチャージタイムアウト</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="94"/>
+      <source>ATC/ATD failure</source>
+      <translation>ATC/ATD故障</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="98"/>
+      <source>Calibration data lost</source>
+      <translation>校正データ損失</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="102"/>
+      <source>Settings invalid</source>
+      <translation>設定が無効</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="105"/>
+      <source>Interlock</source>
+      <translation>インターロック</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="108"/>
+      <source>Emergency stop</source>
+      <translation>緊急停止</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="111"/>
+      <source>Communication timeout</source>
+      <translation>通信タイムアウト</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="114"/>
+      <source>Safety lock</source>
+      <translation>安全ロック</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/bms_error.cpp" line="117"/>
+      <source>Terminal over temperature</source>
+      <translation>端子過熱</translation>
+    </message>
+  </context>
+  <context>
+    <name>CRE</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="855"/>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="860"/>
+      <source>Unknown error: </source>
+      <translation>不明なエラー:</translation>
+    </message>
+  </context>
+  <context>
+    <name>ChargerError</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="7"/>
+      <source>No error</source>
+      <translation>エラーなし</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="9"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="103"/>
+      <source>Battery high temperature</source>
+      <translation>バッテリー高温</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="10"/>
+      <source>Battery high voltage</source>
+      <translation>バッテリー高電圧</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="11"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="12"/>
+      <source>Battery Tsense miswired</source>
+      <translation>バッテリーTセンスの配線ミス</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="13"/>
+      <source>Battery Tsense missing</source>
+      <translation>バッテリーTセンスが欠落しています</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="14"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="15"/>
+      <source>Battery Vsense miswired</source>
+      <translation>バッテリーVセンスの配線ミス</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="16"/>
+      <source>Battery Vsense missing</source>
+      <translation>バッテリーVセンスが欠落しています</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="17"/>
+      <source>Battery high wire losses</source>
+      <translation>バッテリー配線のロスが大きいです</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="18"/>
+      <source>Battery low voltage</source>
+      <translation>バッテリー低電圧</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="19"/>
+      <source>Battery high ripple voltage</source>
+      <translation>バッテリーの高リプル電圧</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="20"/>
+      <source>Battery low state of charge</source>
+      <translation>バッテリー充電状態が低い</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="21"/>
+      <source>Battery mid-point voltage issue</source>
+      <translation>バッテリー中点電圧に問題あり</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="22"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="104"/>
+      <source>Battery temperature too low</source>
+      <translation>バッテリー温度が低すぎる</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="24"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="106"/>
+      <source>Charger high temperature</source>
+      <translation>チャージャーの高温</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="25"/>
+      <source>Charger excessive current</source>
+      <translation>チャージャーの過度電流</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="26"/>
+      <source>Charger negative current</source>
+      <translation>チャージャーの負電流</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="27"/>
+      <source>Charger bulk time expired</source>
+      <translation>チャージャーのバルク時間経過</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="28"/>
+      <source>Charger current sensor issue</source>
+      <translation>チャージャー電流センサーの問題</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="29"/>
+      <source>Internal Tsensor miswired</source>
+      <translation>内部Tセンサーの配線ミス</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="30"/>
+      <source>Internal Tsensor missing</source>
+      <translation>内部Tセンサーが欠落しています</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="31"/>
+      <source>Charger fan not detected</source>
+      <translation>チャージャーファンが検出されません</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="32"/>
+      <source>Charger fan over-current</source>
+      <translation>チャージャーファンの過電流</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="33"/>
+      <source>Charger terminal overheat</source>
+      <translation>チャージャーターミナルのオーバーヒート</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="34"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="107"/>
+      <source>Charger short circuit</source>
+      <translation>チャージャーの短絡</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="35"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="108"/>
+      <source>Charger power stage issue</source>
+      <translation>チャージャーパワーステージの問題</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="36"/>
+      <source>Over-charge protection</source>
+      <translation>過充電防止</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="38"/>
+      <source>Input high voltage</source>
+      <translation>入力高電圧</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="39"/>
+      <source>Input excessive current</source>
+      <translation>入力過剰電流</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="40"/>
+      <source>Input excessive power</source>
+      <translation>入力過剰電力</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="41"/>
+      <source>Input polarity issue</source>
+      <translation>入力極性の問題</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="42"/>
+      <source>Input voltage absent</source>
+      <translation>入力電圧不在</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="43"/>
+      <source>Input shutdown (no retries)</source>
+      <translation>入力シャットダウン（再トライ無し）</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="44"/>
+      <source>Input shutdown (retry)</source>
+      <translation>入力シャットダウン（再トライ）</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="45"/>
+      <source>Input internal failure</source>
+      <translation>入力内部不良</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="47"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="48"/>
+      <source>PV isolation failure</source>
+      <translation>PV絶縁不良</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="49"/>
+      <source>Ground fault detected</source>
+      <translation>接地入力検出</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="51"/>
+      <source>Inverter overload</source>
+      <translation>コンディショナー過負荷状態</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="52"/>
+      <source>Inverter temp too high</source>
+      <translation>コンディショナーの温度が異常に高い</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="53"/>
+      <source>Inverter peak current</source>
+      <translation>コンディショナーのピーク電流</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="54"/>
+      <source>Inverter internal DC level</source>
+      <translation>コンディショナー内部DCレベル</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="55"/>
+      <source>Inverter wrong ACout level</source>
+      <translation>コンディショナーACoutレベルが不正</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="56"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="57"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="59"/>
+      <source>Inverter powerstage fault</source>
+      <translation>コンディショナーパワーステージ入力</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="58"/>
+      <source>Inverter connected to AC</source>
+      <translation>コンディショナーはACと接続済み</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="60"/>
+      <source>ACIN1 relay test fault</source>
+      <translation>ACIN1 リレーテスト障害</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="61"/>
+      <source>ACIN2 relay test fault</source>
+      <translation>ACIN2 リレーテスト障害</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="63"/>
+      <source>Device disappeared</source>
+      <translation>デバイスが消滅した</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="64"/>
+      <source>Incompatible device</source>
+      <translation>非互換なデバイスです</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="65"/>
+      <source>BMS connection lost</source>
+      <translation>BMS接続が切れました</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="66"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="67"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="68"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="69"/>
+      <source>Network misconfigured</source>
+      <translation>ネットワーク設定不良</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="70"/>
+      <source>Phase rotation</source>
+      <translation>フェーズローテーション</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="71"/>
+      <source>Multiple AC inputs</source>
+      <translation>複数のAC入力</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="72"/>
+      <source>Phase overload</source>
+      <translation>フェーズ過負荷</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="74"/>
+      <source>Memory write error</source>
+      <translation>メモリー上書きエラー</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="75"/>
+      <source>CPU temperature too high</source>
+      <translation>CPU温度が異常に高い</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="76"/>
+      <source>Communication lost</source>
+      <translation>通信遮断</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="77"/>
+      <source>Calibration data lost</source>
+      <translation>校正データ損失</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="78"/>
+      <source>Incompatible firmware</source>
+      <translation>非互換のファームウェア</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="79"/>
+      <source>Incompatible hardware</source>
+      <translation>非互換のハードウェア</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="80"/>
+      <source>Settings invalid</source>
+      <translation>設定が無効</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="81"/>
+      <source>Reference voltage failed</source>
+      <translation>参照電圧が落ちました</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="82"/>
+      <source>Tester fail</source>
+      <translation>テスターの故障</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="83"/>
+      <source>History invalid</source>
+      <translation>無効な履歴です</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="84"/>
+      <source>kWh counters invalid</source>
+      <translation>kWhカウンターが無効です</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="86"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="87"/>
+      <source>DC voltage error</source>
+      <translation>DC電圧エラー</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="88"/>
+      <source>GFCI sensor error</source>
+      <translation>GFCIセンサーエラー</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="89"/>
+      <source>3V3 supply error</source>
+      <translation>3V3供給エラー</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="90"/>
+      <source>5V supply error</source>
+      <translation>5V供給エラー</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="91"/>
+      <source>12V supply error</source>
+      <translation>12V供給エラー</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="92"/>
+      <source>15V supply error</source>
+      <translation>15V供給エラー</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="94"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="95"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="96"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="97"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="98"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="99"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="100"/>
+      <location filename="../../src/veutil/src/qt/charger_error.cpp" line="101"/>
+      <source>PV Input shutdown</source>
+      <translation>PV入力シャットダウン</translation>
+    </message>
+  </context>
+  <context>
+    <name>DEIF</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="874"/>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="879"/>
+      <source>Unknown error: </source>
+      <translation>不明なエラー:</translation>
+    </message>
+  </context>
+  <context>
+    <name>DSE</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="259"/>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="264"/>
+      <source>Unknown error: </source>
+      <translation>不明なエラー:</translation>
+    </message>
+  </context>
+  <context>
+    <name>EnvironmentInputs</name>
+    <message>
+      <location filename="../../data/EnvironmentInputs.qml" line="18"/>
+      <source>Battery</source>
+      <translation>バッテリー</translation>
+    </message>
+    <message>
+      <location filename="../../data/EnvironmentInputs.qml" line="24"/>
+      <source>Fridge</source>
+      <translation>冷蔵庫</translation>
+    </message>
+    <message>
+      <location filename="../../data/EnvironmentInputs.qml" line="30"/>
+      <source>Generic</source>
+      <translation>汎用</translation>
+    </message>
+    <message>
+      <location filename="../../data/EnvironmentInputs.qml" line="36"/>
+      <source>Room</source>
+      <translation>部屋</translation>
+    </message>
+    <message>
+      <location filename="../../data/EnvironmentInputs.qml" line="42"/>
+      <source>Outdoor</source>
+      <translation>屋外</translation>
+    </message>
+    <message>
+      <location filename="../../data/EnvironmentInputs.qml" line="48"/>
+      <source>Water Heater</source>
+      <translation>ウォーターヒーター</translation>
+    </message>
+    <message>
+      <location filename="../../data/EnvironmentInputs.qml" line="54"/>
+      <source>Freezer</source>
+      <translation>冷凍庫</translation>
+    </message>
+  </context>
+  <context>
+    <name>FischerPanda</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="104"/>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="109"/>
+      <source>Unknown error: </source>
+      <translation>不明なエラー: </translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="115"/>
+      <source>No error</source>
+      <translation>エラーなし</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="118"/>
+      <source>AC voltage L1 too low</source>
+      <translation>AC電圧 L1 低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="118"/>
+      <source>AC voltage too low</source>
+      <translation>AC電圧 低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="119"/>
+      <source>AC voltage L1 too high</source>
+      <translation>AC電圧 L1 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="119"/>
+      <source>AC voltage too high</source>
+      <translation>AC電圧 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="120"/>
+      <source>AC frequency L1 too low</source>
+      <translation>AC周波数 L1 低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="120"/>
+      <source>AC frequency too low</source>
+      <translation>AC周波数 低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="121"/>
+      <source>AC frequency L1 too high</source>
+      <translation>AC周波数 L1 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="121"/>
+      <source>AC frequency too high</source>
+      <translation>AC周波数 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="122"/>
+      <source>AC current L1 too high</source>
+      <translation>AC電流 L1 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="122"/>
+      <source>AC current too high</source>
+      <translation>AC電流 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="123"/>
+      <source>AC power L1 too high</source>
+      <translation>AC電力 L1 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="123"/>
+      <source>AC power too high</source>
+      <translation>AC電力 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="124"/>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="248"/>
+      <source>Emergency stop</source>
+      <translation>緊急停止</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="125"/>
+      <source>Servo current too high</source>
+      <translation>サーボ電流 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="126"/>
+      <source>Oil pressure too low</source>
+      <translation>油圧 低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="127"/>
+      <source>Oil pressure too high</source>
+      <translation>油圧 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="128"/>
+      <source>Engine temperature too low</source>
+      <translation>エンジン温度 低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="129"/>
+      <source>Engine temperature too high</source>
+      <translation>エンジン温度 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="130"/>
+      <source>Winding temperature too low</source>
+      <translation>巻線温度 低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="131"/>
+      <source>Winding temperature too high</source>
+      <translation>巻線温度 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="132"/>
+      <source>Exhaust temperature too low</source>
+      <translation>排気温度 低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="133"/>
+      <source>Exhaust temperature too high</source>
+      <translation>排気温度 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="134"/>
+      <source>Electronic temperature low</source>
+      <translation>電子部品温度 低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="135"/>
+      <source>Electronic temperature high</source>
+      <translation>電子部品温度 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="136"/>
+      <source>Starter voltage too low</source>
+      <translation>スターター電圧 低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="137"/>
+      <source>Starter current too high</source>
+      <translation>スターター電流 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="138"/>
+      <source>Glow voltage too low</source>
+      <translation>グロー電圧 低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="139"/>
+      <source>Glow current too high</source>
+      <translation>グロー電流 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="140"/>
+      <source>Cold-Start-Aid voltage too high</source>
+      <translation>コールドスタート補助電圧 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="141"/>
+      <source>Cold-Start-Aid current too high</source>
+      <translation>コールドスタート補助電流 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="142"/>
+      <source>Fuel holding magnet voltage too low</source>
+      <translation>燃料保持マグネット電圧 低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="143"/>
+      <source>Fuel holding magnet current too high</source>
+      <translation>燃料保持マグネット電流 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="144"/>
+      <source>Stop solenoid hold coil voltage too low</source>
+      <translation>ストップソレノイド保持コイル電圧 低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="145"/>
+      <source>Stop solenoid hold coil current too high</source>
+      <translation>ストップソレノイド保持コイル電流 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="146"/>
+      <source>Stop solenoid pull coil voltage too low </source>
+      <translation>ストップソレノイドプルコイル電圧 低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="147"/>
+      <source>Stop solenoid pull coil current too high</source>
+      <translation>ストップソレノイドプルコイル電流 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="148"/>
+      <source>Fan/water pump voltage too low</source>
+      <translation>ファン/水ポンプ電圧 低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="149"/>
+      <source>Fan/water pump current too high</source>
+      <translation>ファン/水ポンプ電流 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="150"/>
+      <source>Current sensor voltage low</source>
+      <translation>電流センサー電圧 低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="151"/>
+      <source>Current sensor current high</source>
+      <translation>電流センサー電流 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="152"/>
+      <source>Boost output voltage too low</source>
+      <translation>ブースト出力電圧 低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="153"/>
+      <source>Boost output current too high</source>
+      <translation>ブースト出力電流 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="154"/>
+      <source>Bus supply voltage too low</source>
+      <translation>バス供給電圧 低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="155"/>
+      <source>Bus supply current too high</source>
+      <translation>バス供給電流 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="156"/>
+      <source>Starter battery voltage too low</source>
+      <translation>スターターバッテリー電圧 低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="157"/>
+      <source>Starter battery voltage too high</source>
+      <translation>スターターバッテリー電圧 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="158"/>
+      <source>Rotation too low</source>
+      <translation>回転数 低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="159"/>
+      <source>Rotation too high</source>
+      <translation>回転数 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="160"/>
+      <source>Unexpected stop/problem with fuel supply</source>
+      <translation>予期せぬ停止/燃料供給の問題</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="161"/>
+      <source>Power contactor voltage too low</source>
+      <translation>電力コンタクタ電圧 低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="162"/>
+      <source>Power contactor current too high</source>
+      <translation>電力コンタクタ電流 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="163"/>
+      <source>AC voltage L2 too low</source>
+      <translation>AC電圧 L2 低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="164"/>
+      <source>AC voltage L2 too high</source>
+      <translation>AC電圧 L2 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="165"/>
+      <source>AC frequency L2 too low</source>
+      <translation>AC周波数 L2 低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="166"/>
+      <source>AC frequency L2 too high</source>
+      <translation>AC周波数 L2 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="167"/>
+      <source>AC current L2 too high</source>
+      <translation>AC電流 L2 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="168"/>
+      <source>AC power L2 too high</source>
+      <translation>AC電力 L2 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="169"/>
+      <source>AC voltage L3 too low</source>
+      <translation>AC電圧 L3 低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="170"/>
+      <source>AC voltage L3 too high</source>
+      <translation>AC電圧 L3 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="171"/>
+      <source>AC frequency L3 too low</source>
+      <translation>AC周波数 L3 低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="172"/>
+      <source>AC frequency L3 too high</source>
+      <translation>AC周波数 L3 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="173"/>
+      <source>AC current L3 too high</source>
+      <translation>AC電流 L3 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="174"/>
+      <source>AC power L3 too high</source>
+      <translation>AC電力 L3 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="175"/>
+      <source>Output Inverter voltage too low</source>
+      <translation>出力インバーター電圧 低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="176"/>
+      <source>Output Inverter current too  high</source>
+      <translation>出力インバーター電流 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="177"/>
+      <source>Universal output (1A) voltage too low</source>
+      <translation>ユニバーサル出力 (1A) 電圧 低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="178"/>
+      <source>Universal output (1A) current too high</source>
+      <translation>ユニバーサル出力 (1A) 電流 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="179"/>
+      <source>Universal output (5A) voltage too low</source>
+      <translation>ユニバーサル出力 (5A) 電圧 低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="180"/>
+      <source>Universal output (5A) current too high</source>
+      <translation>ユニバーサル出力 (5A) 電流 高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="181"/>
+      <source>AGT DC voltage 1 low</source>
+      <translation>AGT DC電圧 1 低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="182"/>
+      <source>AGT DC voltage 1 high</source>
+      <translation>AGT DC電圧1高</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="183"/>
+      <source>AGT DC current 1 low</source>
+      <translation>AGT DC電流1低</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="184"/>
+      <source>AGT DC current 1 high</source>
+      <translation>AGT DC電流1高</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="185"/>
+      <source>AGT DC voltage 2 low</source>
+      <translation>AGT DC電圧2低</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="186"/>
+      <source>AGT DC voltage 2 high</source>
+      <translation>AGT DC電圧2高</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="187"/>
+      <source>AGT DC current 2 low</source>
+      <translation>AGT DC電流2低</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="188"/>
+      <source>AGT DC current 2 high</source>
+      <translation>AGT DC電流2高</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="189"/>
+      <source>AGT B6 cooler low</source>
+      <translation>AGT B6クーラー低</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="190"/>
+      <source>AGT B6 cooler high</source>
+      <translation>AGT B6クーラー高</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="191"/>
+      <source>AGT B6 rail (-) low</source>
+      <translation>AGT B6レール(-)低</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="192"/>
+      <source>AGT B6 rail (-) high</source>
+      <translation>AGT B6レール(-)高</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="193"/>
+      <source>AGT B6 rail (+) low</source>
+      <translation>AGT B6レール(+)低</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="194"/>
+      <source>AGT B6 rail (+) high</source>
+      <translation>AGT B6レール(+)高</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="195"/>
+      <source>Fuel temperature too low</source>
+      <translation>燃料温度低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="196"/>
+      <source>Fuel temperature too high</source>
+      <translation>燃料温度高すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="197"/>
+      <source>Fuel level too low</source>
+      <translation>燃料レベル低すぎ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="200"/>
+      <source>Lost control unit</source>
+      <translation>制御ユニット喪失</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="201"/>
+      <source>Lost panel</source>
+      <translation>パネル喪失</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="202"/>
+      <source>Service needed</source>
+      <translation>サービスが必要</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="203"/>
+      <source>Lost 3-phase module</source>
+      <translation>三相モジュール喪失</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="204"/>
+      <source>Lost AGT module</source>
+      <translation>AGTモジュール喪失</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="205"/>
+      <source>Synchronization failure</source>
+      <translation>同期失敗</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="206"/>
+      <source>Lost external ECU</source>
+      <translation>外部ECU喪失</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="207"/>
+      <source>Intake airfilter</source>
+      <translation>吸気エアフィルター</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="208"/>
+      <source>Diagnostic message (ECU)</source>
+      <translation>診断メッセージ (ECU)</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="209"/>
+      <source>Lost sync. module</source>
+      <translation>同期モジュール喪失</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="210"/>
+      <source>Load-balance failed</source>
+      <translation>負荷バランス失敗</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="211"/>
+      <source>Sync-mode deactivated</source>
+      <translation>同期モード解除</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="212"/>
+      <source>Red Stop Lamp (RSL)</source>
+      <translation>赤色停止ランプ (RSL)</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="213"/>
+      <source>Amber Warning Lamp (AWL)</source>
+      <translation>黄色警告ランプ (AWL)</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="214"/>
+      <source>Malfunction Indicator Lamp (MIL)</source>
+      <translation>故障表示ランプ (MIL)</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="215"/>
+      <source>Protect Lamp (PL)</source>
+      <translation>保護ランプ (PL)</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="216"/>
+      <source>Rotating field wrong</source>
+      <translation>回転磁界異常</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="217"/>
+      <source>Fuel level sensor lost</source>
+      <translation>燃料レベルセンサー喪失</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="218"/>
+      <source>Starting without inverter</source>
+      <translation>インバーターなしで起動</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="219"/>
+      <source>Bus #1 dead</source>
+      <translation>バス#1停止</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="220"/>
+      <source>Start request denied</source>
+      <translation>起動要求拒否</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="221"/>
+      <source>Remote start denied</source>
+      <translation>リモート起動拒否</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="222"/>
+      <source>Forced switch off load relay</source>
+      <translation>負荷リレー強制オフ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="223"/>
+      <source>Synchronization Module is offline</source>
+      <translation>同期モジュールオフライン</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="224"/>
+      <source>Lost BMS</source>
+      <translation>BMS喪失</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="225"/>
+      <source>Converter DC Link Voltage Low/Reverse</source>
+      <translation>コンバーターDCリンク電圧低/逆極性</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="226"/>
+      <source>Converter DC Link Current Low</source>
+      <translation>コンバーターDCリンク電流低</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="227"/>
+      <source>Converter DC Precharge Voltage Low</source>
+      <translation>コンバーターDCプレチャージ電圧低</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="228"/>
+      <source>Converter DC Precharge Voltage High</source>
+      <translation>コンバーターDCプレチャージ電圧高</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="229"/>
+      <source>Converter IGBT/MOSFET Driver Error</source>
+      <translation>コンバーターIGBT/MOSFETドライバーエラー</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="230"/>
+      <source>Converter Error Power Control Loop</source>
+      <translation>コンバーター電力制御ループエラー</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="231"/>
+      <source>Converter AC Frequency Detection</source>
+      <translation>コンバーターAC周波数検出</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="232"/>
+      <source>Converter Control Value Fail</source>
+      <translation>コンバーター制御値異常</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="233"/>
+      <source>Factory setting changed</source>
+      <translation>工場出荷時設定変更</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="234"/>
+      <source>Parameter changed in admin mode</source>
+      <translation>管理者モードでパラメーター変更</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="235"/>
+      <source>Manual Intervention (ext. System)</source>
+      <translation>手動介入 (外部システム)</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="238"/>
+      <source>Init failed</source>
+      <translation>初期化失敗</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="239"/>
+      <source>Watchdog</source>
+      <translation>ウォッチドッグ</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="240"/>
+      <source>Inverter temperature high L1</source>
+      <translation>インバーター温度高 L1</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="241"/>
+      <source>Inverter temperature high L2</source>
+      <translation>インバーター温度高 L2</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="242"/>
+      <source>Inverter temperature high L3</source>
+      <translation>インバーター温度高 L3</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="243"/>
+      <source>Inverter temperature high DC link</source>
+      <translation>インバーター温度高 DCリンク</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="244"/>
+      <source>Inverter overload</source>
+      <translation>コンディショナー過負荷状態</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="245"/>
+      <source>Inverter communication lost</source>
+      <translation>インバーター通信喪失</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="246"/>
+      <source>DC overload</source>
+      <translation>DC過負荷</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="247"/>
+      <source>DC overvoltage</source>
+      <translation>DC過電圧</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="249"/>
+      <source>No connection</source>
+      <translation>接続なし</translation>
+    </message>
+  </context>
+  <context>
+    <name>GensetError</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="83"/>
+      <source>No error</source>
+      <translation>エラーなし</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="96"/>
+      <source>Unknown error: %1</source>
+      <translation>不明なエラー: %1</translation>
+    </message>
+  </context>
+  <context>
+    <name>Hatz</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="795"/>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="801"/>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="807"/>
+      <source>Unknown error: </source>
+      <translation>不明なエラー:</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="814"/>
+      <source>Oil pressure</source>
+      <translation>油圧</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="815"/>
+      <source>Cylinder head overtemperature</source>
+      <translation>シリンダーヘッド過熱</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="816"/>
+      <source>Charge control</source>
+      <translation>充電制御</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="817"/>
+      <source>Speed higher than expected</source>
+      <translation>予想外の速度超過</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="818"/>
+      <source>Overspeed</source>
+      <translation>過速度</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="820"/>
+      <source>Oiltemperature higher than expected</source>
+      <translation>予想外の油温高</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="821"/>
+      <source>Oiltemperature open circuit / short to power</source>
+      <translation>油温センサー断線/電源短絡</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="822"/>
+      <source>Oiltemperature short to ground</source>
+      <translation>油温センサー地絡短絡</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="823"/>
+      <source>Analog setpoint high / short to power</source>
+      <translation>アナログ設定値高/電源短絡</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="824"/>
+      <source>Analog setpoint low / short to ground</source>
+      <translation>アナログ設定値低/地絡短絡</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="825"/>
+      <source>TSC1 message receive timeout</source>
+      <translation>TSC1メッセージ受信タイムアウト</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="826"/>
+      <source>CM1 message receive timeout</source>
+      <translation>CM1メッセージ受信タイムアウト</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="827"/>
+      <source>Battery voltage high</source>
+      <translation>バッテリー高電圧</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="828"/>
+      <source>Battery voltage low</source>
+      <translation>バッテリー低電圧</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="829"/>
+      <source>Speed signal distorted</source>
+      <translation>スピード信号異常</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="830"/>
+      <source>Internal 5V sensor supply high</source>
+      <translation>内部5Vセンサー電源電圧高</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="831"/>
+      <source>Internal 5V sensor supply low</source>
+      <translation>内部5Vセンサー電源電圧低</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="832"/>
+      <source>Barometric pressure high</source>
+      <translation>気圧高</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="833"/>
+      <source>Barometric pressure low</source>
+      <translation>気圧低</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="834"/>
+      <source>Output fuelpump short to power</source>
+      <translation>出力燃料ポンプ電源短絡</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="835"/>
+      <source>Output fuelpump short to ground</source>
+      <translation>出力燃料ポンプGND短絡</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="836"/>
+      <source>Output glow plug short to power</source>
+      <translation>出力グロープラグ電源短絡</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="837"/>
+      <source>Output glow plug short to ground</source>
+      <translation>出力グロープラグGND短絡</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="838"/>
+      <source>Injector open circuit/low side short to ground</source>
+      <translation>インジェクター断線/ローサイドGND短絡</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="839"/>
+      <source>Injector coil internal short circuit</source>
+      <translation>インジェクターコイル内部短絡</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="840"/>
+      <source>Injector low side short to power</source>
+      <translation>インジェクターローサイド電源短絡</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="841"/>
+      <source>Service hours expired</source>
+      <translation>サービス時間が期限切れです</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="845"/>
+      <source>Processor failure</source>
+      <translation>プロセッサー故障</translation>
+    </message>
+  </context>
+  <context>
+    <name>PageAcInSetup</name>
+    <message>
+      <location filename="../../pages/settings/devicelist/ac-in/PageAcInSetup.qml" line="136"/>
+      <source>Set the switch in an unlocked position to modify the settings.</source>
+      <translation>設定を変更するには、スイッチをロック解除位置に設定してください。</translation>
+    </message>
+  </context>
+  <context>
+    <name>QGuiApplication</name>
+    <message>
+      <location filename="../../src/main.cpp" line="120"/>
+      <source>Use D-Bus data source: connect to the specified D-Bus address.</source>
+      <translation>D-Busデータソースを使用：指定されたD-Busアドレスに接続します。</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="121"/>
+      <source>address</source>
+      <comment>D-Bus address</comment>
+      <translation>アドレス</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="126"/>
+      <source>Use D-Bus data source: connect to the default D-Bus address</source>
+      <translation>D-Busデータソースを使用：デフォルトのD-Busアドレスに接続します</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="132"/>
+      <source>Use MQTT data source: connect to the specified MQTT broker address.</source>
+      <translation>MQTTデータソースを使用：指定されたMQTTブローカーアドレスに接続します。</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="133"/>
+      <source>address</source>
+      <comment>MQTT broker address</comment>
+      <translation>アドレス</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="139"/>
+      <source>MQTT data source device portal id.</source>
+      <translation>MQTTデータソースデバイスポータルID。</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="140"/>
+      <source>portalId</source>
+      <translation>portalId</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="145"/>
+      <source>MQTT VRM webhost shard</source>
+      <translation>MQTT VRMウェブホストシャード</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="146"/>
+      <source>shard</source>
+      <comment>MQTT VRM webhost shard</comment>
+      <translation>shard</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="151"/>
+      <source>MQTT data source username</source>
+      <translation>MQTTデータソースユーザー名</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="152"/>
+      <source>user</source>
+      <comment>MQTT broker username.</comment>
+      <translation>ユーザー</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="157"/>
+      <source>MQTT data source password</source>
+      <translation>MQTTデータソースパスワード</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="158"/>
+      <source>pass</source>
+      <comment>MQTT broker password.</comment>
+      <translation>パス</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="163"/>
+      <source>MQTT data source token</source>
+      <translation>MQTTデータソーストークン</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="164"/>
+      <source>token</source>
+      <comment>MQTT broker auth token.</comment>
+      <translation>token</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="169"/>
+      <source>Enable FPS counter</source>
+      <translation>FPSカウンターを有効にする</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="174"/>
+      <source>Skip splash screen</source>
+      <translation>スプラッシュスクリーンをスキップ</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="179"/>
+      <source>Use mock data source for testing.</source>
+      <translation>テスト用にモックデータソースを使用。</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="184"/>
+      <source>Name of mock configuration</source>
+      <translation>模擬設定名</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="185"/>
+      <source>mockConfig</source>
+      <comment>Configuration name</comment>
+      <translation>mockConfig</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="191"/>
+      <source>Set to disable mock timers on startup</source>
+      <translation>起動時に模擬タイマーを無効にするように設定</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="196"/>
+      <source>Node-RED URL</source>
+      <translation>Node-RED URL</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="197"/>
+      <source>url</source>
+      <comment>Node-RED URL</comment>
+      <translation>URL</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="202"/>
+      <source>Signal K URL</source>
+      <translation>Signal K URL</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="203"/>
+      <source>url</source>
+      <comment>Signal K URL</comment>
+      <translation>URL</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="208"/>
+      <source>Color scheme (dark, light, auto, default)</source>
+      <translation>配色 (ダーク、ライト、自動、デフォルト)</translation>
+    </message>
+    <message>
+      <location filename="../../src/main.cpp" line="209"/>
+      <source>scheme</source>
+      <comment>Color scheme value</comment>
+      <translation>スキーム</translation>
+    </message>
+  </context>
+  <context>
+    <name>Wakespeed</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="138"/>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="143"/>
+      <source>Unknown error: </source>
+      <translation>不明なエラー：</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="151"/>
+      <source>Internal error</source>
+      <translation>内部エラー</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="156"/>
+      <source>No error</source>
+      <translation>エラーなし</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="159"/>
+      <source>Battery high temperature</source>
+      <translation>バッテリー高温</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="162"/>
+      <source>Battery high voltage</source>
+      <translation>バッテリー高電圧</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="165"/>
+      <source>Battery low voltage</source>
+      <translation>バッテリー低電圧</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="168"/>
+      <source>Battery voltage exceeded configured max</source>
+      <translation>バッテリー電圧が設定された最大値を超過しました</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="171"/>
+      <source>Battery temperature sensor defective</source>
+      <translation>バッテリー温度センサー不良</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="175"/>
+      <source>Alternator high temperature</source>
+      <translation>オルタネーター高温</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="178"/>
+      <source>Alternator high RPM</source>
+      <translation>オルタネーター高回転数</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="181"/>
+      <source>Field drive FET high temperature</source>
+      <translation>フィールドドライブFET高温</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="184"/>
+      <source>Required sensor missing</source>
+      <translation>必要なセンサーがありません</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="187"/>
+      <source>Alternator low voltage</source>
+      <translation>オルタネーター低電圧</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="190"/>
+      <source>Alternator high voltage offset</source>
+      <translation>オルタネーター高電圧オフセット</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="193"/>
+      <source>Alternator Voltage exceeded configured max</source>
+      <translation>オルタネーター電圧が設定された最大値を超過しました</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="196"/>
+      <source>Alternator high voltage</source>
+      <translation>オルタネーター高電圧</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="199"/>
+      <source>Battery disconnected</source>
+      <translation>バッテリーが切断されました</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="202"/>
+      <source>Battery high voltage disconnect</source>
+      <translation>バッテリー高電圧による切断</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="205"/>
+      <source>Battery instance ouf of range</source>
+      <translation>バッテリーインスタンスが範囲外です</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="208"/>
+      <source>Too many BMS's</source>
+      <translation>BMSが多すぎます</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="211"/>
+      <source>Battery about to disconnect</source>
+      <translation>バッテリーがまもなく切断されます</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="214"/>
+      <source>Too many devices to track</source>
+      <translation>追跡するデバイスが多すぎます</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="217"/>
+      <source>Battery low voltage disconnect</source>
+      <translation>バッテリー低電圧による切断</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="220"/>
+      <source>Battery high current disconnect</source>
+      <translation>バッテリー高電流による切断</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="223"/>
+      <source>Battery high temperature disconnect</source>
+      <translation>バッテリー高温による切断</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="226"/>
+      <source>Battery low temperature disconnect</source>
+      <translation>バッテリー低温による切断</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="229"/>
+      <source>BMS connection lost</source>
+      <translation>BMS接続が切れました</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="232"/>
+      <source>ATC Disabled</source>
+      <translation>ATC無効</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="235"/>
+      <source>DC/DC converter not ready</source>
+      <translation>DC/DCコンバーターが準備できていません</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="238"/>
+      <source>DC/DC high primary voltage</source>
+      <translation>DC/DC一次側高電圧</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="241"/>
+      <source>DC/DC low primary voltage</source>
+      <translation>DC/DC一次側低電圧</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="244"/>
+      <source>DC/DC high secondary voltage</source>
+      <translation>DC/DC二次側高電圧</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="247"/>
+      <source>DC/DC low secondary voltage</source>
+      <translation>DC/DC二次側低電圧</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="250"/>
+      <source>DC/DC high temperature</source>
+      <translation>DC/DC高温</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/alternator_error.cpp" line="253"/>
+      <source>DC/DC misconfiguration</source>
+      <translation>DC/DC設定ミス</translation>
+    </message>
+  </context>
+  <context>
+    <name>VebusError</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="10"/>
+      <source>Device switched off</source>
+      <translation>デバイスがオフです</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="13"/>
+      <source>Mixed old/new MK2</source>
+      <translation>新旧MK2が混ざっています</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="16"/>
+      <source>Expected devices error</source>
+      <translation>予期されたデバイスエラー</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="19"/>
+      <source>No other device detected</source>
+      <translation>他に検知されたデバイスはありません</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="22"/>
+      <source>Overvoltage on AC-out</source>
+      <translation>ACoutでの過電圧</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="25"/>
+      <source>DDC program error</source>
+      <translation>DDCのプログラムエラー</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="28"/>
+      <source>VE.Bus BMS without assistant</source>
+      <translation>アシスタントなしのVE.Bus BMS</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="31"/>
+      <source>Ground relay test failed</source>
+      <translation>接地リレーテストは失敗しました</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="34"/>
+      <source>System time sync error</source>
+      <translation>システム時刻の同期エラー</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="37"/>
+      <source>Grid relay test fault</source>
+      <translation>グリッドリレーテスト障害</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="40"/>
+      <source>Config mismatch with 2nd mcu</source>
+      <translation>第2のmcuと設定が不一致しています</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="43"/>
+      <source>Device transmit error</source>
+      <translation>デバイス転送エラー</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="46"/>
+      <source>Awaiting configuration or dongle missing</source>
+      <translation>設定待ちまたはドングルがありません</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="49"/>
+      <source>Phase master missing</source>
+      <translation>フェーズマスターがありません</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="52"/>
+      <source>Overvoltage has occurred</source>
+      <translation>過電圧が生じています</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="55"/>
+      <source>Slave does not have AC input!</source>
+      <translation>スレーブにAC入力が欠落しています！</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="58"/>
+      <source>Device can't be slave</source>
+      <translation>デバイスがスレーブであることはできません</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="61"/>
+      <source>System protection initiated</source>
+      <translation>システム保護が開始されました</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="64"/>
+      <source>Firmware incompatibiltiy</source>
+      <translation>ファームウェアが非互換です</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="67"/>
+      <source>Internal error</source>
+      <translation>内部エラー</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="70"/>
+      <source>Failing relay test prevents connection</source>
+      <translation>リレーテスト失敗で接続できなくなっています</translation>
+    </message>
+    <message>
+      <location filename="../../src/veutil/src/qt/vebus_error.cpp" line="73"/>
+      <source>VE.Bus error</source>
+      <translation>VE.Busエラー</translation>
+    </message>
+  </context>
+  <context>
+    <name>CUMMINS</name>
+    <message>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="1034"/>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="1040"/>
+      <location filename="../../src/veutil/src/qt/genset_error.cpp" line="1046"/>
+      <source>Unknown error: </source>
+      <translation></translation>
+    </message>
+  </context>
+</TS>

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -22,6 +22,7 @@ QUrl fontUrlForLanguage(QLocale::Language language, const QString &urlPrefix = Q
 	static const QHash<QLocale::Language, QString> fontFileNames = {
 		{ QLocale::Arabic, QStringLiteral("DejaVuSans.ttf") },
 		{ QLocale::Chinese, QStringLiteral("DroidSansFallback.ttf") },
+		{ QLocale::Japanese, QStringLiteral("DroidSansFallback.ttf") },
 		{ QLocale::Thai, QStringLiteral("NotoSansThai.ttf") },
 	};
 
@@ -79,6 +80,7 @@ LanguageModel::LanguageModel(QObject *parent)
 	addLanguage("Español", "es", QLocale::Spanish);
 	addLanguage("Français", "fr", QLocale::French);
 	addLanguage("Italiano", "it", QLocale::Italian);
+	addLanguage("日本語", "ja", QLocale::Japanese);
 	addLanguage("Nederlands", "nl", QLocale::Dutch);
 	addLanguage("Polski", "pl", QLocale::Polish);
 	addLanguage("Português", "pt", QLocale::Portuguese);


### PR DESCRIPTION
Adds Japanese (日本語) to the language selection, using DroidSansFallback.ttf for CJK rendering (same as Chinese). Includes full translations from POEditor.

Note that this requires [the venus-platform branch](https://github.com/victronenergy/venus-platform/tree/faberd/add-language-japanese) to be merged first (which is already on the todo). They should both get in the same Venus release.