### PR TITLE
AcLoads: display status for device if available

### DIFF
--- a/components/CommonWords.qml
+++ b/components/CommonWords.qml
@@ -628,6 +628,12 @@ QtObject {
 		return qsTrId("common_words_ac_input_number").arg(number)
 	}
 
+	function autoStatus(stateText) {
+		//: %1 = status such as 'On' or 'Off'
+		//% "Auto (%1)"
+		return qsTrId("common_words_auto_status").arg(stateText)
+	}
+
 	function onOrOff(value) {
 		if (value === 0 || value === false) {
 			return off

--- a/data/mock/conf/services/em-heatpump-input.json
+++ b/data/mock/conf/services/em-heatpump-input.json
@@ -33,6 +33,12 @@
         "/ProductId": 45058,
         "/ProductName": "Heat pump",
         "/RefreshTime": 600,
-        "/Role": "heatpump"
+        "/Role": "heatpump",
+        "/SwitchableOutput/output_0/Auto": 1,
+        "/SwitchableOutput/output_0/Name": "Heat pump 3-state switch",
+        "/SwitchableOutput/output_0/Settings/Type": 9,
+        "/SwitchableOutput/output_0/Settings/ValidTypes": 16383,
+        "/SwitchableOutput/output_0/State": 0,
+        "/SwitchableOutput/output_0/Status": 9
     }
 }

--- a/pages/loads/AcLoadListPage.qml
+++ b/pages/loads/AcLoadListPage.qml
@@ -126,7 +126,7 @@ Page {
 
 			required property Device device
 
-			name: device.name
+			name: device ? device.name : ""
 			power: powerItem.value ?? NaN
 			current: root.measurements.singlePhaseCurrentValid ? root.measurements.current : NaN
 			columnWidth: ListView.view.headerItem?.contentItem?.columnWidth ?? NaN
@@ -141,9 +141,12 @@ Page {
 
 			// Status depends on the service:
 			// - evcharger: /Status
+			// - acload/heatpump: /State and /Auto
 			// - other service types: no status
-			statusText: !statusItem.valid ? ""
-				: device.serviceType === "evcharger" ? Global.evChargers.chargerStatusToText(statusItem.value)
+			statusText: !device ? ""
+				: device.serviceType === "evcharger" ?
+					statusItem.valid ? Global.evChargers.chargerStatusToText(statusItem.value) : ""
+				: switchableOutputInfoLoader.item ? switchableOutputInfoLoader.item.statusText
 				: ""
 
 			onClicked: {
@@ -159,14 +162,54 @@ Page {
 				}
 			}
 
+			Loader {
+				id: switchableOutputInfoLoader
+				active: loadDelegate.device && (loadDelegate.device.serviceType === "acload" || loadDelegate.device.serviceType === "heatpump")
+				sourceComponent: Item {
+					readonly property string statusText: (_stateText.length > 0
+								&& autoItem.valid && autoItem.value === 1)
+							? CommonWords.autoStatus(_stateText)
+							: _stateText
+
+					readonly property string _stateText: output.hasValidState
+							? CommonWords.onOrOff(output.state)
+							: ""
+
+					VeQItemTableModel {
+						id: switchableOutputModel
+						uids: [ loadDelegate.device.serviceUid + "/SwitchableOutput" ]
+						flags: VeQItemTableModel.AddChildren | VeQItemTableModel.AddNonLeaves | VeQItemTableModel.DontAddItem
+						readonly property string firstUid: {
+							for (let i = 0 ; i < switchableOutputModel.rowCount; ++i) {
+								let temp = switchableOutputModel.data(index(i, 0), VeQItemTableModel.UniqueIdRole) ?? ""
+								if (temp.length > 0) {
+									return temp
+								}
+							}
+							return ""
+						}
+					}
+
+					SwitchableOutput {
+						id: output
+						uid: switchableOutputModel.firstUid
+					}
+
+					VeQuickItem {
+						id: autoItem
+						uid: output.uid.length > 0 ? output.uid + "/Auto" : ""
+					}
+				}
+			}
+
 			VeQuickItem {
 				id: statusItem
-				uid: device.serviceType === "evcharger" ? device.serviceUid + "/Status" : ""
+				uid: device && device.serviceType === "evcharger" ? device.serviceUid + "/Status" : ""
 			}
 
 			VeQuickItem {
 				id: powerItem
-				uid: device.serviceUid + "/Ac/Power"
+				uid: device ? device.serviceUid + "/Ac/Power" : ""
 			}
 		}
 	}

--- a/pages/settings/devicelist/iochannel/SwitchableOutputListDelegate.qml
+++ b/pages/settings/devicelist/iochannel/SwitchableOutputListDelegate.qml
@@ -88,9 +88,7 @@ ListQuantityGroupNavigation {
 				if (output.status === VenusOS.SwitchableOutput_Status_On) {
 					const stateText = CommonWords.onOrOff(output.state)
 					if (autoItem.value === 1) {
-						//: %1 = 'On' or 'Off'
-						//% "Auto (%1)"
-						return qsTrId("switchableoutput_list_delegate_auto_status").arg(stateText)
+						return CommonWords.autoStatus(stateText)
 					} else {
 						return stateText
 					}


### PR DESCRIPTION
When drilling down into AC Loads from the overview, we display the list of AC Load devices which may include devices which support the /SwitchableOutput/x/State and
/SwitchableOutput/x/Auto paths.  This state information can be displayed as secondary status text in the delegate.

Contributes to issue #2914