### PR TITLE
Switches: fix bug in status code display

### DIFF
--- a/components/switches/SwitchableOutputCardDelegateHeader.qml
+++ b/components/switches/SwitchableOutputCardDelegateHeader.qml
@@ -22,12 +22,15 @@ IOChannelCardDelegateHeader {
 			|| switchableOutput.status === VenusOS.SwitchableOutput_Status_On
 			|| switchableOutput.status === VenusOS.SwitchableOutput_Status_Powered)
 	statusColor: {
-		// Mask the 'output on' bit so that if any error bit is set (e.g. over temperature,
+		// Mask the 'output on' bits so that if any error bit is set (e.g. over temperature,
 		// disabled) the background will be red, even if the output is on.
 		// Don't do this for Bilge Pump as they have special status handling.
 		const maskedValue = root.switchableOutput.type === VenusOS.SwitchableOutput_Type_BilgePump
-						  ? root.switchableOutput.status
-						  : root.switchableOutput.status &~ VenusOS.SwitchableOutput_Status_On
+				? root.switchableOutput.status
+			: (((root.switchableOutput.status & VenusOS.SwitchableOutput_Status_On) === VenusOS.SwitchableOutput_Status_On)
+					&& root.switchableOutput.status !== VenusOS.SwitchableOutput_Status_On)
+				? root.switchableOutput.status & ~VenusOS.SwitchableOutput_Status_On
+			: root.switchableOutput.status
 		switch (maskedValue) {
 		case VenusOS.SwitchableOutput_Status_Off:
 			return Theme.color_font_secondary
@@ -40,10 +43,10 @@ IOChannelCardDelegateHeader {
 			return Theme.color_green
 		case VenusOS.SwitchableOutput_Status_ExternalControl:
 			return Theme.color_green
-		case VenusOS.SwitchableOutput_Status_OutputFault:
 		case VenusOS.SwitchableOutput_Status_Bypassed:
 		case VenusOS.SwitchableOutput_Status_Disabled_On:
 			return Theme.color_orange
+		case VenusOS.SwitchableOutput_Status_OutputFault:
 		case VenusOS.SwitchableOutput_Status_Tripped:
 		case VenusOS.SwitchableOutput_Status_OverTemperature:
 		case VenusOS.SwitchableOutput_Status_OverTemperature_Tripped:
@@ -63,7 +66,7 @@ IOChannelCardDelegateHeader {
 		// For Bilge Pumps: a running Bilge Pump is not a normal state, so use a warning
 		// colour, unless it is a known error state, and in that case use red instead.
 		if (root.switchableOutput.type === VenusOS.SwitchableOutput_Type_BilgePump
-				&& (root.switchableOutput.status & VenusOS.SwitchableOutput_Status_On)) {
+				&& ((root.switchableOutput.status & VenusOS.SwitchableOutput_Status_On) === VenusOS.SwitchableOutput_Status_On)) {
 			if ((root.switchableOutput.status & VenusOS.SwitchableOutput_Status_OverTemperature)
 				|| (root.switchableOutput.status & VenusOS.SwitchableOutput_Status_Disabled)) {
 				return Theme.color_red

--- a/src/enums.cpp
+++ b/src/enums.cpp
@@ -611,18 +611,39 @@ QString Enums::switchableOutput_functionToText(SwitchableOutput_Function value) 
 
 QString Enums::switchableOutput_statusToText(SwitchableOutput_Status value, SwitchableOutput_Type type) const
 {
-	// For all types except for Bilge Pump, mask out the 'output on' bit (0x09), because devices
-	// may have set a status even when the output is on. E.g. an output might be both 'on' and
+	// For bilge pumps, always display 'Running' when status includes 0x09.
+	if (type == SwitchableOutput_Type_BilgePump) {
+		if ((value & SwitchableOutput_Status_On) == SwitchableOutput_Status_On) {
+			if (value & SwitchableOutput_Status_OverTemperature) {
+				//% "Running, over temperature"
+				return qtTrId("switchable_output_running_over_temperature");
+			} else if (value & SwitchableOutput_Status_Disabled) {
+				//% "Running, disabled"
+				return qtTrId("switchable_output_running_disabled");
+			} else {
+				//% "Running"
+				return qtTrId("switchable_output_running");
+			}
+		} else if (value == SwitchableOutput_Status_Disabled) {
+			//% "Not running, disabled"
+			return qtTrId("switchable_output_not_running_disabled");
+		} else if (value == SwitchableOutput_Status_Off) {
+			//% "Not running"
+			return qtTrId("switchable_output_not_running");
+		}
+	}
+
+	// For all types except for Bilge Pump, mask out the 'output on' value (0x09) if the device
+	// has set a status even when the output is on. E.g. an output might be both 'on' and
 	// 'over temperature' set, so a combined status of (0x09 | 0x04) = 0x0D = 13. In this case we
 	// want to show 'over temperature' instead of just '13'.
-	// For Bilge Pump, do not mask, as 'Running' must be shown when status is 0x09.
-	const int maskedValue = type == SwitchableOutput_Type_BilgePump ? value : value &~ SwitchableOutput_Status_On;
+	const int maskedValue = type == SwitchableOutput_Type_BilgePump ? value
+			: (((value & SwitchableOutput_Status_On) == SwitchableOutput_Status_On)
+				&& value != SwitchableOutput_Status_On) ? value & ~SwitchableOutput_Status_On
+			: value;
 
 	switch (maskedValue) {
 	case SwitchableOutput_Status_Off:
-		if (type == SwitchableOutput_Type_BilgePump) {
-			break;
-		}
 		//% "Off"
 		return qtTrId("switchable_output_off");
 	case SwitchableOutput_Status_Powered:
@@ -641,9 +662,6 @@ QString Enums::switchableOutput_statusToText(SwitchableOutput_Status value, Swit
 		//% "Fault"
 		return qtTrId("switchable_output_fault");
 	case SwitchableOutput_Status_On:
-		if (type == SwitchableOutput_Type_BilgePump) {
-			break;
-		}
 		//% "On"
 		return qtTrId("switchable_output_on");
 	case SwitchableOutput_Status_ShortFault:
@@ -680,30 +698,10 @@ QString Enums::switchableOutput_statusToText(SwitchableOutput_Status value, Swit
 		//% "External control, over temp"
 		return qtTrId("switchable_output_externalcontrol_overtemperature");
 	default:
-		break;
-	}
-
-	if (type == SwitchableOutput_Type_BilgePump) {
-		if (value & SwitchableOutput_Status_On) {
-			if (value & SwitchableOutput_Status_OverTemperature) {
-				//% "Running, over temperature"
-				return qtTrId("switchable_output_running_over_temperature");
-			} else if (value & SwitchableOutput_Status_Disabled) {
-				//% "Running, disabled"
-				return qtTrId("switchable_output_running_disabled");
-			} else {
-				//% "Running"
-				return qtTrId("switchable_output_running");
-			}
-		} else {
-			if (value & SwitchableOutput_Status_Disabled) {
-				//% "Not running, disabled"
-				return qtTrId("switchable_output_not_running_disabled");
-			} else if (value == SwitchableOutput_Status_Off) {
-				//% "Not running"
-				return qtTrId("switchable_output_not_running");
-			}
+		if (maskedValue > 0) {
+			qWarning() << "Unhandled switchable output status combination: " << value << " for type " << type;
 		}
+		break;
 	}
 
 	//% "Unknown status"

--- a/tests/switchableoutput/tst_switchableoutput.qml
+++ b/tests/switchableoutput/tst_switchableoutput.qml
@@ -625,4 +625,147 @@ TestCase {
 		output.uid = ""
 		MockManager.removeValue(data.uid)
 	}
+
+	function test_status_masking_data() {
+		return [
+			{
+				tag: "toggle, off",
+				uid: "mock/com.victronenergy.test.a/SwitchableOutput/0",
+				outputProperties: {
+					"Settings/Type": VenusOS.SwitchableOutput_Type_Toggle,
+					"Status": VenusOS.SwitchableOutput_Status_Off
+				},
+				expected: qsTrId("switchable_output_off")
+			},
+			{
+				tag: "toggle, on",
+				uid: "mock/com.victronenergy.test.a/SwitchableOutput/0",
+				outputProperties: {
+					"Settings/Type": VenusOS.SwitchableOutput_Type_Toggle,
+					"Status": VenusOS.SwitchableOutput_Status_On
+				},
+				expected: qsTrId("switchable_output_on")
+			},
+			{
+				tag: "toggle, on + overtemp",
+				uid: "mock/com.victronenergy.test.a/SwitchableOutput/0",
+				outputProperties: {
+					"Settings/Type": VenusOS.SwitchableOutput_Type_Toggle,
+					"Status": (VenusOS.SwitchableOutput_Status_On | VenusOS.SwitchableOutput_Status_OverTemperature)
+				},
+				expected: qsTrId("switchable_output_overtemperature")
+			},
+			{
+				tag: "toggle, fault",
+				uid: "mock/com.victronenergy.test.a/SwitchableOutput/0",
+				outputProperties: {
+					"Settings/Type": VenusOS.SwitchableOutput_Type_Toggle,
+					"Status": VenusOS.SwitchableOutput_Status_OutputFault
+				},
+				expected: qsTrId("switchable_output_fault")
+			},
+			{
+				tag: "toggle, bypassed overtemp",
+				uid: "mock/com.victronenergy.test.a/SwitchableOutput/0",
+				outputProperties: {
+					"Settings/Type": VenusOS.SwitchableOutput_Type_Toggle,
+					"Status": VenusOS.SwitchableOutput_Status_Bypassed_OverTemperature
+				},
+				expected: qsTrId("switchable_output_bypassed_overtemperature")
+			},
+			{
+				tag: "toggle, on + bypassed overtemp",
+				uid: "mock/com.victronenergy.test.a/SwitchableOutput/0",
+				outputProperties: {
+					"Settings/Type": VenusOS.SwitchableOutput_Type_Toggle,
+					"Status": (VenusOS.SwitchableOutput_Status_On | VenusOS.SwitchableOutput_Status_Bypassed_OverTemperature)
+				},
+				expected: qsTrId("switchable_output_bypassed_overtemperature")
+			},
+			{
+				tag: "toggle, disabled + overtemp",
+				uid: "mock/com.victronenergy.test.a/SwitchableOutput/0",
+				outputProperties: {
+					"Settings/Type": VenusOS.SwitchableOutput_Type_Toggle,
+					"Status": (VenusOS.SwitchableOutput_Status_Disabled | VenusOS.SwitchableOutput_Status_OverTemperature)
+				},
+				expected: qsTrId("switchable_output_disabled_overtemperature")
+			},
+			{
+				tag: "bilgepump, off",
+				uid: "mock/com.victronenergy.test.a/SwitchableOutput/0",
+				outputProperties: {
+					"Settings/Type": VenusOS.SwitchableOutput_Type_BilgePump,
+					"Status": VenusOS.SwitchableOutput_Status_Off
+				},
+				expected: qsTrId("switchable_output_not_running")
+			},
+			{
+				tag: "bilgepump, on",
+				uid: "mock/com.victronenergy.test.a/SwitchableOutput/0",
+				outputProperties: {
+					"Settings/Type": VenusOS.SwitchableOutput_Type_BilgePump,
+					"Status": VenusOS.SwitchableOutput_Status_On
+				},
+				expected: qsTrId("switchable_output_running")
+			},
+			{
+				tag: "bilgepump, on + overtemp",
+				uid: "mock/com.victronenergy.test.a/SwitchableOutput/0",
+				outputProperties: {
+					"Settings/Type": VenusOS.SwitchableOutput_Type_BilgePump,
+					"Status": (VenusOS.SwitchableOutput_Status_On | VenusOS.SwitchableOutput_Status_OverTemperature)
+				},
+				expected: qsTrId("switchable_output_running_over_temperature")
+			},
+			{
+				tag: "bilgepump, fault",
+				uid: "mock/com.victronenergy.test.a/SwitchableOutput/0",
+				outputProperties: {
+					"Settings/Type": VenusOS.SwitchableOutput_Type_BilgePump,
+					"Status": VenusOS.SwitchableOutput_Status_OutputFault
+				},
+				expected: qsTrId("switchable_output_fault")
+			},
+			{
+				tag: "bilgepump, bypassed overtemp",
+				uid: "mock/com.victronenergy.test.a/SwitchableOutput/0",
+				outputProperties: {
+					"Settings/Type": VenusOS.SwitchableOutput_Type_BilgePump,
+					"Status": VenusOS.SwitchableOutput_Status_Bypassed_OverTemperature
+				},
+				expected: qsTrId("switchable_output_bypassed_overtemperature")
+			},
+			{
+				tag: "bilgepump, on + bypassed overtemp",
+				uid: "mock/com.victronenergy.test.a/SwitchableOutput/0",
+				outputProperties: {
+					"Settings/Type": VenusOS.SwitchableOutput_Type_BilgePump,
+					"Status": (VenusOS.SwitchableOutput_Status_On | VenusOS.SwitchableOutput_Status_Bypassed_OverTemperature)
+				},
+				expected: qsTrId("switchable_output_running_over_temperature") // should this display "Bypassed" also?
+			},
+			{
+				tag: "bilgepump, disabled + overtemp",
+				uid: "mock/com.victronenergy.test.a/SwitchableOutput/0",
+				outputProperties: {
+					"Settings/Type": VenusOS.SwitchableOutput_Type_BilgePump,
+					"Status": (VenusOS.SwitchableOutput_Status_Disabled | VenusOS.SwitchableOutput_Status_OverTemperature)
+				},
+				expected: qsTrId("switchable_output_disabled_overtemperature") // should this display "Not running" also?
+			}
+		]
+	}
+
+	function test_status_masking(data) {
+		// Set test values and verify the output of switchableOutput_statusToText() is correct.
+		setOutputProperties(data.uid, data.outputProperties)
+		output.uid = data.uid
+		compare(output.uid, data.uid, data.tag + " UID")
+		compare(VenusOS.switchableOutput_statusToText(output.status, output.type), data.expected, data.tag)
+
+		// Clean up
+		output.uid = ""
+		MockManager.removeValue(data.uid)
+	}
 }


### PR DESCRIPTION
The status code for a switchable output can be a composite status which includes e.g. "on" plus "over temperature".
Previously, we masked out the bits which specified the "on" value, however it turns out that the "fault" value (0x8) requires one of the same bits which is used by the "on" value (0x9).

This commit ensures that we only perform the masking if both of the bits used by the "on" value are set.

Contributes to issue #2951