### PR TITLE
Switches: Fix restore dim level from memory

### DIFF
--- a/pages/settings/devicelist/iochannel/PageSwitchableOutput.qml
+++ b/pages/settings/devicelist/iochannel/PageSwitchableOutput.qml
@@ -161,21 +161,10 @@ Page {
 									id: restoreDimLevelSwitch
 									//% "Restore dim level from memory"
 									text: qsTrId("page_switchable_output_restore_dim_level")
-									checked: startupDimLevel.valid && startupDimLevel.value === -1
+									checked: startupDimLevel.value === -1
 									interactive: _writeable
 									onClicked: {
-										startupDimLevel.setValue(startupDimLevel.value === -1 ? 0 : -1)
-									}
-								}
-
-								ListSwitch {
-									id: setDimLevelManuallySwitch
-									//% "Set startup dim level manually"
-									text: qsTrId("page_switchable_output_set_dim_level_manually")
-									checked: startupDimLevel.valid && startupDimLevel.value !== -1
-									interactive: _writeable
-									onClicked: {
-										startupDimLevel.setValue(-2)
+										startupDimLevel.setValue(checked ? -2 : -1)
 									}
 								}
 
@@ -183,7 +172,7 @@ Page {
 
 									//% "Startup dim level"
 									text: qsTrId("settings_dvcc_startup_dim_level")
-									preferredVisible: setDimLevelManuallySwitch.visible && !setDimLevelManuallySwitch.checked
+									preferredVisible: startupDimLevel.valid && startupDimLevel.value >= 0
 									from: 0
 									to: 100
 									suffix: "%"

--- a/pages/settings/devicelist/iochannel/PageSwitchableOutput.qml
+++ b/pages/settings/devicelist/iochannel/PageSwitchableOutput.qml
@@ -176,6 +176,7 @@ Page {
 									from: 0
 									to: 100
 									suffix: "%"
+									decimals: 0
 									dataItem.uid: startupDimLevel.uid
 								}
 							}


### PR DESCRIPTION
This is specific for the Aurelia DCDB.
The relevant path is `/SwitchableOutput/x/Settings/StartupDimming` When the "Restore dimlevel from memory" toggle is enabled, write -1 to the path. When the toggle is disabled, write -2 to the path, the aurelia will then read the stored value from mem and overwrite the dbus path. When the value of the path is >=0, show the spinbox to enter the dimlevel.

Fixes https://github.com/victronenergy/gui-v2/issues/2656

Screenshot:
<img width="970" height="198" alt="image" src="https://github.com/user-attachments/assets/f63ca8e6-31e6-4373-93a9-5e7e3efa5e89" />
