### PR TITLE
UI Controls: add ThreeLabelLayout labels aliases and ease requirements

### DIFF
--- a/components/ThreeLabelLayout.qml
+++ b/components/ThreeLabelLayout.qml
@@ -24,15 +24,15 @@ GridLayout {
 	id: root
 
 	required property string primaryText
-	required property string secondaryText
-	required property string captionText
-
-	required property font primaryFont
-	required property int primaryTextFormat
-	property alias secondaryTextColor: secondaryLabel.color
+	property alias secondaryText: secondaryLabel.text
+	property alias captionText: captionLabel.text
 	property bool stretchSecondaryText
 	property real topPadding
 	property real bottomPadding
+
+	property alias primaryLabel: primaryLabel
+	property alias secondaryLabel: secondaryLabel
+	property alias captionLabel: captionLabel
 
 	columns: secondaryText.length === 0 ? 1 : 2
 	columnSpacing: 0
@@ -44,8 +44,6 @@ GridLayout {
 		topPadding: root.topPadding
 		bottomPadding: root.secondaryText.length === 0 && root.captionText.length === 0 ? root.bottomPadding : 0
 		text: root.primaryText
-		textFormat: root.primaryTextFormat
-		font: root.primaryFont
 		wrapMode: Text.Wrap
 
 		Layout.fillWidth: true
@@ -59,7 +57,6 @@ GridLayout {
 		bottomPadding: root.captionText.length === 0 ? root.bottomPadding : 0
 		horizontalAlignment: Text.AlignRight
 		visible: text.length > 0
-		text: root.secondaryText
 		wrapMode: Text.Wrap
 
 		Layout.fillWidth: true
@@ -70,9 +67,10 @@ GridLayout {
 	}
 
 	CaptionLabel {
+		id: captionLabel
+
 		topPadding: Theme.geometry_listItem_content_verticalSpacing
 		bottomPadding: root.bottomPadding
-		text: root.captionText
 		visible: text.length > 0
 
 		Layout.fillWidth: true

--- a/components/listitems/ListTextStatus.qml
+++ b/components/listitems/ListTextStatus.qml
@@ -31,8 +31,8 @@ ListSetting {
 				verticalCenter: parent.verticalCenter
 			}
 			primaryText: root.text
-			primaryFont: root.font
-			primaryTextFormat: root.textFormat
+			primaryLabel.font: root.font
+			primaryLabel.textFormat: root.textFormat
 			secondaryText: root.secondaryText
 			captionText: root.caption
 		}

--- a/components/listitems/core/ListNavigation.qml
+++ b/components/listitems/core/ListNavigation.qml
@@ -41,10 +41,10 @@ ListSetting {
 			anchors.verticalCenter: parent.verticalCenter
 			width: parent.width - (arrowIcon.visible ? arrowIcon.width + Theme.geometry_listItem_arrow_leftMargin : 0)
 			primaryText: root.text
-			primaryFont: root.font
-			primaryTextFormat: root.textFormat
+			primaryLabel.font: root.font
+			primaryLabel.textFormat: root.textFormat
 			secondaryText: root.secondaryText
-			secondaryTextColor: root.secondaryTextColor
+			secondaryLabel.color: root.secondaryTextColor
 			captionText: root.caption
 			stretchSecondaryText: true
 		}

--- a/components/listitems/core/ListRadioButton.qml
+++ b/components/listitems/core/ListRadioButton.qml
@@ -36,8 +36,8 @@ ListSetting {
 				verticalCenter: parent.verticalCenter
 			}
 			primaryText: root.text
-			primaryFont: root.font
-			primaryTextFormat: root.textFormat
+			primaryLabel.font: root.font
+			primaryLabel.textFormat: root.textFormat
 			secondaryText: root.secondaryText
 			captionText: root.caption
 			stretchSecondaryText: true

--- a/components/listitems/core/ListSwitch.qml
+++ b/components/listitems/core/ListSwitch.qml
@@ -83,8 +83,8 @@ ListSetting {
 			anchors.verticalCenter: parent.verticalCenter
 			width: parent.width - switchItem.width - root.spacing
 			primaryText: root.text
-			primaryFont: root.font
-			primaryTextFormat: root.textFormat
+			primaryLabel.font: root.font
+			primaryLabel.textFormat: root.textFormat
 			secondaryText: root.secondaryText
 			captionText: root.caption
 			stretchSecondaryText: true

--- a/components/listitems/core/ListText.qml
+++ b/components/listitems/core/ListText.qml
@@ -29,10 +29,10 @@ ListSetting {
 				verticalCenter: parent.verticalCenter
 			}
 			primaryText: root.text
-			primaryFont: root.font
-			primaryTextFormat: root.textFormat
+			primaryLabel.font: root.font
+			primaryLabel.textFormat: root.textFormat
 			secondaryText: root.secondaryText
-			secondaryTextColor: root.secondaryTextColor
+			secondaryLabel.color: root.secondaryTextColor
 			captionText: root.caption
 		}
 	}


### PR DESCRIPTION
Using 'required' for various properties was useful while porting list items to use a Control base type, but in general use creates an unnecessary burden on using ThreeLabelLayout.

Also add label aliases to allow the labels to be customised more easily.
