### PR TITLE
Switches: display voltage on switchable output page

### DIFF
--- a/pages/settings/devicelist/iochannel/PageSwitchableOutput.qml
+++ b/pages/settings/devicelist/iochannel/PageSwitchableOutput.qml
@@ -116,6 +116,14 @@ Page {
 			}
 
 			ListQuantity {
+				text: CommonWords.voltage
+				dataItem.uid: root.switchableOutput.uid + "/Voltage"
+				preferredVisible: dataItem.valid
+				interactive: _writeable
+				unit: VenusOS.Units_Volt_DC
+			}
+
+			ListQuantity {
 				text: CommonWords.current_amps
 				dataItem.uid: root.switchableOutput.uid + "/Current"
 				preferredVisible: dataItem.valid


### PR DESCRIPTION
Contributes to https://github.com/victronenergy/gui-v2/issues/2970

<img width="800" height="478" alt="image" src="https://github.com/user-attachments/assets/53e443dc-f317-4c09-9ff0-eae0e653aca8" />
