### PR TITLE
Switch: omit Inputs/Outputs submenu when there is only one item

### DIFF
--- a/components/DevicePage.qml
+++ b/components/DevicePage.qml
@@ -26,6 +26,23 @@ Page {
 	// Additional settings to be loaded by PageDeviceInfo.
 	property Component extraDeviceInfo
 
+	property bool showInputs: genericInputModel.count > 0
+	property bool showOutputs: switchableOutputModel.count > 0
+
+	readonly property IOChannelProxyModel switchableOutputModel: IOChannelProxyModel {
+		sourceModel: VeQItemTableModel {
+			uids: [ root.serviceUid + "/SwitchableOutput" ]
+			flags: VeQItemTableModel.AddChildren | VeQItemTableModel.AddNonLeaves | VeQItemTableModel.DontAddItem
+		}
+	}
+
+	readonly property IOChannelProxyModel genericInputModel: IOChannelProxyModel {
+		sourceModel: VeQItemTableModel {
+			uids: [ root.serviceUid + "/GenericInput" ]
+			flags: VeQItemTableModel.AddChildren | VeQItemTableModel.AddNonLeaves | VeQItemTableModel.DontAddItem
+		}
+	}
+
 	title: _device.name
 
 	Device {
@@ -44,17 +61,9 @@ Page {
 				//: Settings page for switchable outputs
 				//% "Outputs"
 				text: qsTrId("device_page_outputs")
-				preferredVisible: switchableOutputModel.count > 0
+				preferredVisible: root.showOutputs
 				onClicked: {
 					Global.pageManager.pushPage(switchableOutputPageComponent, { title: text })
-				}
-
-				IOChannelProxyModel {
-					id: switchableOutputModel
-					sourceModel: VeQItemTableModel {
-						uids: [ root.serviceUid + "/SwitchableOutput" ]
-						flags: VeQItemTableModel.AddChildren | VeQItemTableModel.AddNonLeaves | VeQItemTableModel.DontAddItem
-					}
 				}
 
 				Component {
@@ -71,17 +80,9 @@ Page {
 			ListNavigation {
 				//% "Inputs"
 				text: qsTrId("device_page_inputs")
-				preferredVisible: genericInputModel.count > 0
+				preferredVisible: root.showInputs
 				onClicked: {
 					Global.pageManager.pushPage(genericInputPageComponent, { title: text })
-				}
-
-				IOChannelProxyModel {
-					id: genericInputModel
-					sourceModel: VeQItemTableModel {
-						uids: [ root.serviceUid + "/GenericInput" ]
-						flags: VeQItemTableModel.AddChildren | VeQItemTableModel.AddNonLeaves | VeQItemTableModel.DontAddItem
-					}
 				}
 
 				Component {

--- a/pages/settings/devicelist/PageSwitch.qml
+++ b/pages/settings/devicelist/PageSwitch.qml
@@ -19,6 +19,12 @@ DevicePage {
 		}
 	}
 
+	// If there is more than one input or output, show them under the standard "Inputs" and
+	// "Outputs" menus in the DevicePage. If there is only one, show it directly in this page's
+	// list item view.
+	showInputs: root.genericInputModel.count > 1
+	showOutputs: root.switchableOutputModel.count > 1
+
 	settingsHeader: SettingsColumn {
 		width: parent?.width ?? 0
 		bottomPadding: spacing
@@ -94,6 +100,20 @@ DevicePage {
 						}
 					}
 				}
+			}
+		}
+
+		SettingsColumn {
+			width: parent.width
+
+			Repeater {
+				model: root.switchableOutputModel.count === 1 ? root.switchableOutputModel : null
+				delegate: SwitchableOutputListDelegate {}
+			}
+
+			Repeater {
+				model: root.genericInputModel.count === 1 ? root.genericInputModel : null
+				delegate: GenericInputListDelegate {}
 			}
 		}
 	}


### PR DESCRIPTION
For switch services, omit the Inputs/Outputs submenu on the device settings page if there is only one input or output.

Fixes #2976