### PR TITLE
Generic Input: PrimaryLabel should override reserved unit label

### DIFF
--- a/src/genericinput.cpp
+++ b/src/genericinput.cpp
@@ -164,22 +164,26 @@ void GenericInput::updatePrimaryLabel()
 {
 	const QString prevLabel = m_primaryLabel;
 
-	switch (unitType()) {
-	case Enums::Units_Speed_MetresPerSecond:
-		//% "Speed"
-		m_primaryLabel = qtTrId("generic_input_primaryLabel_speed");
-		break;
-	case Enums::Units_Temperature_Celsius:
-		//% "Temperature"
-		m_primaryLabel = qtTrId("generic_input_primaryLabel_temperature");
-		break;
-	case Enums::Units_Volume_CubicMetre:
-		//% "Volume"
-		m_primaryLabel = qtTrId("generic_input_primaryLabel_volume");
-		break;
-	default:
+	if (!m_rawPrimaryLabel.isEmpty()) {
 		m_primaryLabel = m_rawPrimaryLabel;
-		break;
+	} else {
+		switch (unitType()) {
+		case Enums::Units_Speed_MetresPerSecond:
+			//% "Speed"
+			m_primaryLabel = qtTrId("generic_input_primaryLabel_speed");
+			break;
+		case Enums::Units_Temperature_Celsius:
+			//% "Temperature"
+			m_primaryLabel = qtTrId("generic_input_primaryLabel_temperature");
+			break;
+		case Enums::Units_Volume_CubicMetre:
+			//% "Volume"
+			m_primaryLabel = qtTrId("generic_input_primaryLabel_volume");
+			break;
+		default:
+			m_primaryLabel.clear();
+			break;
+		}
 	}
 
 	if (prevLabel != m_primaryLabel) {

--- a/tests/genericinput/tst_genericinput.qml
+++ b/tests/genericinput/tst_genericinput.qml
@@ -690,6 +690,12 @@ TestCase {
 				inputProperties: { "Settings/Unit": "/Volume" },
 				primaryLabel: qsTrId("generic_input_primaryLabel_volume"),
 			},
+			{
+				tag: "both custom and reserved unit, custom label wins",
+				uid: "mock/com.victronenergy.test.a/GenericInput/0",
+				inputProperties: { "Settings/PrimaryLabel": "A", "Settings/Unit": "/Volume" },
+				primaryLabel: "A",
+			},
 		]
 	}
 


### PR DESCRIPTION
If a generic input has /PrimaryLabel and also a reserved /Unit, the PrimaryLabel should take precedence over the label for the reserved unit.

Fixes #2955