### PR TITLE
Switches: do not show inputs/outputs without a /Name

### DIFF
--- a/src/iochannel.cpp
+++ b/src/iochannel.cpp
@@ -47,9 +47,11 @@ void IOChannel::initialize(VeQItem *item)
 			connect(nameItem, &VeQItem::valueChanged, this, [this](QVariant variant) {
 				m_name = variant.toString();
 				updateFormattedName();
+				updateAllowedInGroupModel();
 			});
 			m_name = nameItem->getValue().toString();
 			updateFormattedName();
+			updateAllowedInGroupModel();
 		}
 		if (VeQItem *customNameItem = m_item->itemGetOrCreate(QStringLiteral("Settings/CustomName"))) {
 			connect(customNameItem, &VeQItem::valueChanged, this, [this](QVariant variant) {
@@ -278,7 +280,7 @@ void IOChannel::updateDecimals()
 
 bool IOChannel::getAllowedInGroupModel() const
 {
-	return hasValidType();
+	return hasValidType() && !m_name.isEmpty();
 }
 
 void IOChannel::updateAllowedInGroupModel()

--- a/tests/genericinput/tst_genericinput.qml
+++ b/tests/genericinput/tst_genericinput.qml
@@ -247,16 +247,23 @@ TestCase {
 			{
 				tag: "Invalid type",
 				uid: "mock/com.victronenergy.test.a/GenericInput/1",
-				inputProperties: { "Settings/Type": -1, },
+				inputProperties: { "Settings/Type": -1, "Name": "A" },
 				hasValidType: false,
 				allowedInGroupModel: false,
 			},
 			{
 				tag: "ValidTypes matched",
 				uid: "mock/com.victronenergy.test.a/GenericInput/1",
-				inputProperties: { "Settings/Type": 0, "Settings/ValidTypes": 1 << 0 },
+				inputProperties: { "Settings/Type": 0, "Settings/ValidTypes": 1 << 0, "Name": "A" },
 				hasValidType: true,
 				allowedInGroupModel: true,
+			},
+			{
+				tag: "ValidTypes matched, but no Name",
+				uid: "mock/com.victronenergy.test.a/GenericInput/1",
+				inputProperties: { "Settings/Type": 0, "Settings/ValidTypes": 1 << 0 },
+				hasValidType: true,
+				allowedInGroupModel: false,
 			},
 			{
 				tag: "ValidTypes matched, but Type is out of bounds",
@@ -264,6 +271,7 @@ TestCase {
 				inputProperties: {
 					"Settings/Type": VenusOS.GenericInput_Type_MaxSupportedType + 1,
 					"Settings/ValidTypes": 1 << (VenusOS.GenericInput_Type_MaxSupportedType + 1),
+					"Name": "A",
 				},
 				hasValidType: false,
 				allowedInGroupModel: false,
@@ -271,21 +279,21 @@ TestCase {
 			{
 				tag: "ValidTypes matches 1st type",
 				uid: "mock/com.victronenergy.test.a/GenericInput/1",
-				inputProperties: { "Settings/Type": 1, "Settings/ValidTypes": ((1 << 1) | (1 << 2)) },
+				inputProperties: { "Settings/Type": 1, "Settings/ValidTypes": ((1 << 1) | (1 << 2)), "Name": "A" },
 				hasValidType: true,
 				allowedInGroupModel: true,
 			},
 			{
 				tag: "ValidTypes matches 2nd type",
 				uid: "mock/com.victronenergy.test.a/GenericInput/1",
-				inputProperties: { "Settings/Type": 2, "Settings/ValidTypes": ((1 << 1) | (1 << 2)) },
+				inputProperties: { "Settings/Type": 2, "Settings/ValidTypes": ((1 << 1) | (1 << 2)), "Name": "A" },
 				hasValidType: true,
 				allowedInGroupModel: true,
 			},
 			{
 				tag: "ValidTypes not matched for either type",
 				uid: "mock/com.victronenergy.test.a/GenericInput/1",
-				inputProperties: { "Settings/Type": 0, "Settings/ValidTypes": ((1 << 1) | (1 << 2)) },
+				inputProperties: { "Settings/Type": 0, "Settings/ValidTypes": ((1 << 1) | (1 << 2)), "Name": "A" },
 				hasValidType: false,
 				allowedInGroupModel: false,
 			},
@@ -293,21 +301,21 @@ TestCase {
 			{
 				tag: "ShowUIInput=1, other params valid",
 				uid: "mock/com.victronenergy.test.a/GenericInput/1",
-				inputProperties: { "Settings/ShowUIInput": 1, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0 },
+				inputProperties: { "Settings/ShowUIInput": 1, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0, "Name": "A" },
 				hasValidType: true,
 				allowedInGroupModel: true,
 			},
 			{
 				tag: "ShowUIInput=0, other params valid",
 				uid: "mock/com.victronenergy.test.a/GenericInput/1",
-				inputProperties: { "Settings/ShowUIInput": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0 },
+				inputProperties: { "Settings/ShowUIInput": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0, "Name": "A" },
 				hasValidType: true,
 				allowedInGroupModel: false,
 			},
 			{
 				tag: "ShowUIInput=1, ValidTypes not matched",
 				uid: "mock/com.victronenergy.test.a/GenericInput/1",
-				inputProperties: { "Settings/ShowUIInput": 1, "Settings/Type": 0 },
+				inputProperties: { "Settings/ShowUIInput": 1, "Settings/Type": 0, "Name": "A" },
 				hasValidType: false,
 				allowedInGroupModel: false,
 			},
@@ -335,7 +343,9 @@ TestCase {
 				tag: "ShowUIInput not set",
 				uid: "mock/com.victronenergy.test.a/GenericInput/1",
 				inputProperties: {
-					"Settings/Type": 0, "Settings/ValidTypes": 1 << 0
+					"Name": "A",
+					"Settings/Type": 0,
+					"Settings/ValidTypes": 1 << 0,
 				},
 				allowedInGroupModel: true,
 			},
@@ -343,8 +353,9 @@ TestCase {
 				tag: "ShowUIInput=Off",
 				uid: "mock/com.victronenergy.test.a/GenericInput/1",
 				inputProperties: {
+					"Name": "A",
 					"Settings/ShowUIInput": 0, // Off=0
-					"Settings/Type": 0, "Settings/ValidTypes": 1 << 0
+					"Settings/Type": 0, "Settings/ValidTypes": 1 << 0,
 				},
 				allowedInGroupModel: false,
 			},
@@ -352,6 +363,7 @@ TestCase {
 				tag: "ShowUIInput=Always",
 				uid: "mock/com.victronenergy.test.a/GenericInput/1",
 				inputProperties: {
+					"Name": "A",
 					"Settings/ShowUIInput": 1, // Always=1
 					"Settings/Type": 0, "Settings/ValidTypes": 1 << 0
 				},
@@ -361,6 +373,7 @@ TestCase {
 				tag: "ShowUIInput=Local",
 				uid: "mock/com.victronenergy.test.a/GenericInput/1",
 				inputProperties: {
+					"Name": "A",
 					"Settings/ShowUIInput": 2, // Local=0x2
 					"Settings/Type": 0, "Settings/ValidTypes": 1 << 0
 				},
@@ -371,6 +384,7 @@ TestCase {
 				tag: "ShowUIInput=Remote",
 				uid: "mock/com.victronenergy.test.a/GenericInput/1",
 				inputProperties: {
+					"Name": "A",
 					"Settings/ShowUIInput": 4, // Remote=0x4
 					"Settings/Type": 0, "Settings/ValidTypes": 1 << 0
 				},
@@ -381,6 +395,7 @@ TestCase {
 				tag: "ShowUIInput=Local+Remote, local connection",
 				uid: "mock/com.victronenergy.test.a/GenericInput/1",
 				inputProperties: {
+					"Name": "A",
 					"Settings/ShowUIInput": 6, // Local+Remote = 0x2 | 0x4
 					"Settings/Type": 0, "Settings/ValidTypes": 1 << 0
 				},
@@ -391,6 +406,7 @@ TestCase {
 				tag: "ShowUIInput=Local+Remote, remote connection",
 				uid: "mock/com.victronenergy.test.a/GenericInput/1",
 				inputProperties: {
+					"Name": "A",
 					"Settings/ShowUIInput": 6, // Local+Remote = 0x2 | 0x4
 					"Settings/Type": 0, "Settings/ValidTypes": 1 << 0
 				},
@@ -402,6 +418,7 @@ TestCase {
 				tag: "ShowUIInput=0x5 (invalid)",
 				uid: "mock/com.victronenergy.test.a/GenericInput/1",
 				inputProperties: {
+					"Name": "A",
 					"Settings/ShowUIInput": 5,
 					"Settings/Type": 0, "Settings/ValidTypes": 1 << 0
 				},

--- a/tests/iochannelgroupmodel/tst_iochannelgroupmodel.qml
+++ b/tests/iochannelgroupmodel/tst_iochannelgroupmodel.qml
@@ -42,6 +42,22 @@ TestCase {
 	function test_added_groups_data() {
 		return [
 			{
+				tag: "0 groups, device has no /Name so it is not allowed in group model",
+				devices: [
+					{
+						uid: "mock/com.victronenergy.solarcharger.a",
+						children: {
+							DeviceInstance: 0,
+							ProductName: "solarcharger_product",
+							"SwitchableOutput/0/State": 0,
+							"SwitchableOutput/0/Settings/ValidTypes": (1 << 0),
+							"SwitchableOutput/0/Settings/Type": 0,
+						},
+					}
+				],
+				groups: [],
+			},
+			{
 				tag: "1 device group with 1 channel",
 				devices: [
 					{

--- a/tests/switchableoutput/tst_switchableoutput.qml
+++ b/tests/switchableoutput/tst_switchableoutput.qml
@@ -221,16 +221,23 @@ TestCase {
 			{
 				tag: "State valid, invalid type",
 				uid: "mock/com.victronenergy.test.a/SwitchableOutput/1",
-				outputProperties: { "State": 0, "Settings/Type": -1, },
+				outputProperties: { "State": 0, "Settings/Type": -1, "Name": "A" },
 				hasValidType: false,
 				allowedInGroupModel: false,
 			},
 			{
 				tag: "State valid, ValidTypes matched",
 				uid: "mock/com.victronenergy.test.a/SwitchableOutput/1",
-				outputProperties: { "State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0 },
+				outputProperties: { "State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0, "Name": "A" },
 				hasValidType: true,
 				allowedInGroupModel: true,
+			},
+			{
+				tag: "State valid, ValidTypes matched, but no Name",
+				uid: "mock/com.victronenergy.test.a/SwitchableOutput/1",
+				outputProperties: { "State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0 },
+				hasValidType: true,
+				allowedInGroupModel: false,
 			},
 			{
 				tag: "State valid, ValidTypes matched, but Type is out of bounds",
@@ -239,6 +246,7 @@ TestCase {
 					"State": 0,
 					"Settings/Type": VenusOS.SwitchableOutput_Type_MaxSupportedType + 1,
 					"Settings/ValidTypes": 1 << (VenusOS.SwitchableOutput_Type_MaxSupportedType + 1),
+					"Name": "A",
 				},
 				hasValidType: false,
 				allowedInGroupModel: false,
@@ -246,14 +254,14 @@ TestCase {
 			{
 				tag: "Dimming valid but no State, ValidTypes matched",
 				uid: "mock/com.victronenergy.test.a/SwitchableOutput/1",
-				outputProperties: { "Dimming": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0 },
+				outputProperties: { "Dimming": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0, "Name": "A" },
 				hasValidType: true,
 				allowedInGroupModel: true,
 			},
 			{
 				tag: "Neither State nor Dimming valid, ValidTypes matched",
 				uid: "mock/com.victronenergy.test.a/SwitchableOutput/1",
-				outputProperties: { "Settings/Type": 0, "Settings/ValidTypes": 1 << 0 },
+				outputProperties: { "Settings/Type": 0, "Settings/ValidTypes": 1 << 0, "Name": "A" },
 				hasValidType: true,
 				allowedInGroupModel: false,
 			},
@@ -261,21 +269,21 @@ TestCase {
 			{
 				tag: "ValidTypes matches 1st type",
 				uid: "mock/com.victronenergy.test.a/SwitchableOutput/1",
-				outputProperties: { "State": 0, "Settings/Type": 1, "Settings/ValidTypes": ((1 << 1) | (1 << 2)) },
+				outputProperties: { "State": 0, "Settings/Type": 1, "Settings/ValidTypes": ((1 << 1) | (1 << 2)), "Name": "A" },
 				hasValidType: true,
 				allowedInGroupModel: true,
 			},
 			{
 				tag: "ValidTypes matches 2nd type",
 				uid: "mock/com.victronenergy.test.a/SwitchableOutput/1",
-				outputProperties: { "State": 0, "Settings/Type": 2, "Settings/ValidTypes": ((1 << 1) | (1 << 2)) },
+				outputProperties: { "State": 0, "Settings/Type": 2, "Settings/ValidTypes": ((1 << 1) | (1 << 2)), "Name": "A" },
 				hasValidType: true,
 				allowedInGroupModel: true,
 			},
 			{
 				tag: "ValidTypes not matched for either type",
 				uid: "mock/com.victronenergy.test.a/SwitchableOutput/1",
-				outputProperties: { "State": 0, "Settings/Type": 0, "Settings/ValidTypes": ((1 << 1) | (1 << 2)) },
+				outputProperties: { "State": 0, "Settings/Type": 0, "Settings/ValidTypes": ((1 << 1) | (1 << 2)), "Name": "A" },
 				hasValidType: false,
 				allowedInGroupModel: false,
 			},
@@ -283,21 +291,21 @@ TestCase {
 			{
 				tag: "ShowUIControl=1, other params valid",
 				uid: "mock/com.victronenergy.test.a/SwitchableOutput/1",
-				outputProperties: { "Settings/ShowUIControl": 1, "State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0 },
+				outputProperties: { "Settings/ShowUIControl": 1, "State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0, "Name": "A" },
 				hasValidType: true,
 				allowedInGroupModel: true,
 			},
 			{
 				tag: "ShowUIControl=0, other params valid",
 				uid: "mock/com.victronenergy.test.a/SwitchableOutput/1",
-				outputProperties: { "Settings/ShowUIControl": 0, "State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0 },
+				outputProperties: { "Settings/ShowUIControl": 0, "State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0, "Name": "A" },
 				hasValidType: true,
 				allowedInGroupModel: false,
 			},
 			{
 				tag: "ShowUIControl=1, ValidTypes not matched",
 				uid: "mock/com.victronenergy.test.a/SwitchableOutput/1",
-				outputProperties: { "Settings/ShowUIControl": 1, "State": 0, "Settings/Type": 0 },
+				outputProperties: { "Settings/ShowUIControl": 1, "State": 0, "Settings/Type": 0, "Name": "A" },
 				hasValidType: false,
 				allowedInGroupModel: false,
 			},
@@ -305,14 +313,14 @@ TestCase {
 			{
 				tag: "Relay function = manual, other params valid",
 				uid: "mock/com.victronenergy.system/SwitchableOutput/1",
-				outputProperties: { "Settings/Function": 2, "State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0 },
+				outputProperties: { "Settings/Function": 2, "State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0, "Name": "A" },
 				hasValidType: true,
 				allowedInGroupModel: true,
 			},
 			{
 				tag: "Relay function = start/stop, other params valid",
 				uid: "mock/com.victronenergy.system/SwitchableOutput/1",
-				outputProperties: { "Settings/Function": 1, "State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0},
+				outputProperties: { "Settings/Function": 1, "State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0, "Name": "A" },
 				hasValidType: true,
 				allowedInGroupModel: false,
 			},
@@ -340,7 +348,7 @@ TestCase {
 				tag: "ShowUIControl not set",
 				uid: "mock/com.victronenergy.test.a/SwitchableOutput/1",
 				outputProperties: {
-					"State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0
+					"State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0, "Name": "A"
 				},
 				allowedInGroupModel: true,
 			},
@@ -349,7 +357,7 @@ TestCase {
 				uid: "mock/com.victronenergy.test.a/SwitchableOutput/1",
 				outputProperties: {
 					"Settings/ShowUIControl": 0, // Off=0
-					"State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0
+					"State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0, "Name": "A"
 				},
 				allowedInGroupModel: false,
 			},
@@ -358,7 +366,7 @@ TestCase {
 				uid: "mock/com.victronenergy.test.a/SwitchableOutput/1",
 				outputProperties: {
 					"Settings/ShowUIControl": 1, // Always=1
-					"State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0
+					"State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0, "Name": "A"
 				},
 				allowedInGroupModel: true,
 			},
@@ -367,7 +375,7 @@ TestCase {
 				uid: "mock/com.victronenergy.test.a/SwitchableOutput/1",
 				outputProperties: {
 					"Settings/ShowUIControl": 2, // Local=0x2
-					"State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0
+					"State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0, "Name": "A"
 				},
 				vrm: false,
 				allowedInGroupModel: true,
@@ -377,7 +385,7 @@ TestCase {
 				uid: "mock/com.victronenergy.test.a/SwitchableOutput/1",
 				outputProperties: {
 					"Settings/ShowUIControl": 4, // Remote=0x4
-					"State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0
+					"State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0, "Name": "A"
 				},
 				vrm: true,
 				allowedInGroupModel: true,
@@ -387,7 +395,7 @@ TestCase {
 				uid: "mock/com.victronenergy.test.a/SwitchableOutput/1",
 				outputProperties: {
 					"Settings/ShowUIControl": 6, // Local+Remote = 0x2 | 0x4
-					"State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0
+					"State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0, "Name": "A"
 				},
 				vrm: false,
 				allowedInGroupModel: true,
@@ -397,7 +405,7 @@ TestCase {
 				uid: "mock/com.victronenergy.test.a/SwitchableOutput/1",
 				outputProperties: {
 					"Settings/ShowUIControl": 6, // Local+Remote = 0x2 | 0x4
-					"State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0
+					"State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0, "Name": "A"
 				},
 				vrm: true,
 				allowedInGroupModel: true,
@@ -408,7 +416,7 @@ TestCase {
 				uid: "mock/com.victronenergy.test.a/SwitchableOutput/1",
 				outputProperties: {
 					"Settings/ShowUIControl": 5,
-					"State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0
+					"State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0, "Name": "A"
 				},
 				allowedInGroupModel: true,
 			},


### PR DESCRIPTION
When /SwitchableOutput/x/Name or /GenericInput/x/Name is empty or not set, do not show the input/output in the Switch Pane. In such cases the input/output is already omitted from the settings page for the relevant device, so omit it from the Switch Pane as well for consistency.

Fixes #2945