### PR TITLE
EVCS: show per-phase current in phase table

### DIFF
--- a/pages/evcs/EvChargerPage.qml
+++ b/pages/evcs/EvChargerPage.qml
@@ -74,14 +74,22 @@ DevicePage {
 
 					required property string name
 					required property real power
+					required property real current
 
 					headerText: name
 					model: QuantityObjectModel {
-						// The current, energy and charging time columns are only relevant to
-						// the summary and not the individual devices, so just add empty values
-						// here to pad out the remaining columns.
+						// Show per-phase power, and per-phase current when the charger
+						// publishes it (.../Ac/Lx/Current). The energy and charging time
+						// columns are only relevant to the summary row, so pad them out.
 						QuantityObject { object: tableRow; key: "power"; unit: VenusOS.Units_Watt }
-						QuantityObject { hidden: true }
+						QuantityObject {
+							object: tableRow
+							key: "current"
+							unit: VenusOS.Units_Amp
+							// Hide cell content (column stays for alignment) when this
+							// charger does not provide per-phase current readings.
+							hidden: isNaN(tableRow.current)
+						}
 						QuantityObject { hidden: true }
 						QuantityObject { hidden: true }
 					}
@@ -111,6 +119,10 @@ DevicePage {
 							uid: phaseObject.uid + "/Power"
 							onValueChanged: phaseModel.setValue(phaseObject.index, PhaseModel.PowerRole, value)
 							onValidChanged: if (valid) phaseModel.phaseCount = Math.max(phaseModel.phaseCount, phaseObject.index + 1)
+						}
+						readonly property VeQuickItem _current: VeQuickItem {
+							uid: phaseObject.uid + "/Current"
+							onValueChanged: phaseModel.setValue(phaseObject.index, PhaseModel.CurrentRole, value)
 						}
 					}
 				}


### PR DESCRIPTION
When an EV charger driver publishes per-phase current values via the standard Victron D-Bus paths .../Ac/L1/Current, .../Ac/L2/Current, .../Ac/L3/Current (already part of the com.victronenergy.evcharger spec), expose them in the per-phase rows of the EvCharger page next to the per-phase power.

Chargers that do not publish per-phase current continue to render an empty cell in that column: the underlying PhaseModel role defaults to NaN, and the QuantityObject is bound to hidden=isNaN(current), so the column layout stays identical to the previous behaviour for those drivers and only chargers that already provide the data show the new information. No new D-Bus paths are introduced; the change is purely on the UI consumer side.

The energy and charging-time columns remain summary-only (padded with hidden QuantityObjects in the phase rows), matching the existing design intent.