### PR TITLE
UI Controls: do not use parent/external geometry from implicit geometry

### DIFF
--- a/components/Breadcrumbs.qml
+++ b/components/Breadcrumbs.qml
@@ -36,7 +36,7 @@ BaseListView {
 	enabled: visible // don't receive focus when invisble
 	focus: false // don't give status bar initial focus to the breadcrumbs
 
-	delegate: ListItem {
+	delegate: AbstractListItem {
 		id: breadcrumb
 
 		required property int index
@@ -50,7 +50,8 @@ BaseListView {
 		rightInset: rightEdgeIcon.width
 		leftPadding: Theme.geometry_settings_breadcrumb_horizontalMargin + leftEdgeIcon.width
 		rightPadding: Theme.geometry_settings_breadcrumb_horizontalMargin + rightEdgeIcon.width
-
+		focus: true
+		focusPolicy: Qt.TabFocus
 		contentItem: Label {
 			horizontalAlignment: Text.AlignHCenter
 			verticalAlignment: Text.AlignVCenter
@@ -65,6 +66,8 @@ BaseListView {
 			color: breadcrumb.iconColor
 		}
 
+		KeyNavigationHighlight.active: activeFocus
+		Keys.enabled: Global.keyNavigationEnabled
 		Keys.onSpacePressed: root.activate(breadcrumb.index)
 
 		CP.ColorImage {

--- a/components/EnvironmentGauge.qml
+++ b/components/EnvironmentGauge.qml
@@ -47,8 +47,8 @@ Item {
 
 		x: root.orientation === Qt.Horizontal ? 0
 			: parent.width/2 - valueMarker.width + Theme.geometry_environmentGauge_tick_size/2
-		implicitWidth: root.orientation === Qt.Vertical ? Theme.geometry_barGauge_vertical_width_large : parent.width
-		implicitHeight: root.orientation === Qt.Vertical
+		width: root.orientation === Qt.Vertical ? Theme.geometry_barGauge_vertical_width_large : parent.width
+		height: root.orientation === Qt.Vertical
 				? parent.height - bottomSeparator.height - 2*Theme.geometry_levelsGauge_verticalPadding
 				: Theme.geometry_barGauge_horizontal_height
 		radius: root.orientation === Qt.Vertical ? width / 2 : height / 2

--- a/components/FlatListItemSeparator.qml
+++ b/components/FlatListItemSeparator.qml
@@ -7,7 +7,7 @@ import QtQuick
 import Victron.VenusOS
 
 Item {
-	implicitWidth: parent ? parent.width : 0
+	width: parent?.width ?? 0
 	implicitHeight: bar.height
 
 	SeparatorBar {

--- a/components/MultiStepButton.qml
+++ b/components/MultiStepButton.qml
@@ -24,7 +24,7 @@ BaseListView {
 	signal onClicked()
 	signal offClicked()
 
-	implicitWidth: parent.width
+	implicitWidth: Theme.geometry_control_width
 	implicitHeight: Theme.geometry_iochannel_control_height
 
 	orientation: ListView.Horizontal

--- a/components/QuantityTable.qml
+++ b/components/QuantityTable.qml
@@ -57,8 +57,8 @@ ListView {
 		property real topPadding
 		readonly property alias fixedColumnWidth: groupHeader.fixedColumnWidth
 
-		implicitWidth: table.width
-		implicitHeight: groupHeader.y + groupHeader.height
+		width: table.width
+		height: groupHeader.y + groupHeader.height
 		color: Theme.color_quantityTable_row_background
 
 		QuantityGroupListHeader {
@@ -101,8 +101,8 @@ ListView {
 		readonly property real fixedColumnWidth: table.equalWidthColumns ? (table.availableWidth - (table.columnSpacing * (columnCount-1))) / columnCount : NaN
 		readonly property int columnCount: quantityRow.count + (headerColumnLabel.visible ? 1 : 0)
 
-		implicitWidth: table.width
-		implicitHeight: preferredVisible ? Theme.geometry_quantityTable_row_height : 0
+		width: table.width
+		height: preferredVisible ? Theme.geometry_quantityTable_row_height : 0
 		color: index % 2 === 0
 			   ? Theme.color_quantityTable_row_alternateBackground
 			   : Theme.color_quantityTable_row_background

--- a/components/SegmentedButtonRow.qml
+++ b/components/SegmentedButtonRow.qml
@@ -23,7 +23,7 @@ FocusScope {
 		}
 	}
 
-	implicitWidth: parent.width
+	implicitWidth: Theme.geometry_control_width
 	implicitHeight: Theme.geometry_segmentedButtonRow_height
 
 	// Set a default focus policy that will be used by each delegate in the row.

--- a/components/ToastNotification.qml
+++ b/components/ToastNotification.qml
@@ -58,7 +58,7 @@ Item {
 	signal dismissed()
 	signal closed()
 
-	implicitWidth: parent ? parent.width : 0
+	implicitWidth: Theme.geometry_control_width
 	implicitHeight: contentLayout.y + contentLayout.implicitHeight
 
 	// Block mouse events beneath the toast notification area.

--- a/components/dialogs/SolarDailyHistoryDialog.qml
+++ b/components/dialogs/SolarDailyHistoryDialog.qml
@@ -198,9 +198,8 @@ T.Dialog {
 
 				required property int index
 
-				implicitWidth: historyListView.width
-				implicitHeight: tableView.height
-
+				width: historyListView.width
+				height: tableView.height
 				enabled: errorView.expanded
 				onClicked: errorView.expanded = false
 

--- a/components/listitems/ListDevicePriority.qml
+++ b/components/listitems/ListDevicePriority.qml
@@ -29,8 +29,8 @@ ListSetting {
 		radius: Theme.geometry_opportunityLoad_button_radius
 		flat: false
 		icon.source: "qrc:/images/icon_arrow.svg"
-		implicitWidth: root.height - 2*Theme.geometry_opportunityLoad_margin
-		implicitHeight: root.height - 2*Theme.geometry_opportunityLoad_margin
+		defaultBackgroundWidth: Theme.geometry_listItem_height - 2*Theme.geometry_opportunityLoad_margin
+		defaultBackgroundHeight: Theme.geometry_listItem_height - 2*Theme.geometry_opportunityLoad_margin
 	}
 
 	component PageData : QtObject {

--- a/components/listitems/core/ListItem.qml
+++ b/components/listitems/core/ListItem.qml
@@ -37,10 +37,13 @@ AbstractListItem {
 	topPadding: topInset + Theme.geometry_listItem_content_verticalMargin
 	bottomPadding: bottomInset + Theme.geometry_listItem_content_verticalMargin
 
-	implicitWidth: parent?.width ?? Theme.geometry_listItem_width
+	implicitWidth: effectiveVisible ? Math.max(
+			implicitBackgroundWidth + leftInset + rightInset,
+			implicitContentWidth + leftPadding + rightPadding) : 0
 	implicitHeight: effectiveVisible ? Math.max(
 			implicitBackgroundHeight + topInset + bottomInset,
 			implicitContentHeight + topPadding + bottomPadding) : 0
+	width: parent?.width ?? Theme.geometry_listItem_width
 	spacing: Theme.geometry_listItem_content_spacing
 
 	// By default, the item is visible if preferredVisible=true.
@@ -66,8 +69,6 @@ AbstractListItem {
 	Keys.enabled: Global.keyNavigationEnabled
 
 	background: ListItemBackground {
-		implicitWidth: Theme.geometry_listItem_width
-		implicitHeight: Theme.geometry_listItem_height
 		visible: !root.flat
 	}
 }

--- a/components/listitems/core/ListItemBackground.qml
+++ b/components/listitems/core/ListItemBackground.qml
@@ -7,7 +7,8 @@ import QtQuick
 import Victron.VenusOS
 
 Rectangle {
-	implicitWidth: parent ? parent.width : 0
+	implicitWidth: Theme.geometry_listItem_width
+	implicitHeight: Theme.geometry_listItem_height
 	color: Theme.color_listItem_background
 	radius: Theme.geometry_listItem_radius
 }

--- a/themes/geometry/FiveInch.json
+++ b/themes/geometry/FiveInch.json
@@ -2,6 +2,7 @@
     "geometry_page_content_horizontalMargin": 24,
     "geometry_page_content_verticalMargin": 24,
 
+    "geometry_control_width": 80,
     "geometry_icon_size_medium": 32,
 
     "geometry_splashScreen_logo_width": 224,

--- a/themes/geometry/Portrait.json
+++ b/themes/geometry/Portrait.json
@@ -2,6 +2,7 @@
     "geometry_page_content_horizontalMargin": 16,
     "geometry_page_content_verticalMargin": 24,
 
+    "geometry_control_width": 80,
     "geometry_icon_size_medium": 32,
 
     "geometry_splashScreen_logo_width": 284,

--- a/themes/geometry/SevenInch.json
+++ b/themes/geometry/SevenInch.json
@@ -2,6 +2,7 @@
     "geometry_page_content_horizontalMargin": 40,
     "geometry_page_content_verticalMargin": 40,
 
+    "geometry_control_width": 80,
     "geometry_icon_size_medium": 32,
 
     "geometry_splashScreen_logo_width": 284,


### PR DESCRIPTION
When setting implicitWidth and implicitHeight, do not refer to parent.width or parent.height, or external geometry outside of the item. This can cause binding loops as the implicit geometry is used by parent layouts to determine the width/height to allocate to their children.

As part of this, change Breadcrumbs delegates to use AbstractListItem instead of ListItem as the base type, as they do not require the default implicit geometry from ListItem.

