### PR TITLE
UI Controls: move ListView/Column spacing into ListItem inset

### DIFF
--- a/components/Breadcrumbs.qml
+++ b/components/Breadcrumbs.qml
@@ -48,6 +48,7 @@ BaseListView {
 		implicitHeight: Theme.geometry_settings_breadcrumb_height
 		leftInset: leftEdgeIcon.width
 		rightInset: rightEdgeIcon.width
+		bottomInset: 0
 		leftPadding: Theme.geometry_settings_breadcrumb_horizontalMargin + leftEdgeIcon.width
 		rightPadding: Theme.geometry_settings_breadcrumb_horizontalMargin + rightEdgeIcon.width
 

--- a/components/DevicePage.qml
+++ b/components/DevicePage.qml
@@ -55,7 +55,6 @@ Page {
 
 		footer: SettingsColumn {
 			width: parent?.width ?? 0
-			topPadding: ListView.view.count > 0 ? spacing : 0
 
 			ListNavigation {
 				//: Settings page for switchable outputs

--- a/components/FlatListItemSeparator.qml
+++ b/components/FlatListItemSeparator.qml
@@ -14,6 +14,7 @@ Item {
 		id: bar
 
 		x: Theme.geometry_separatorBar_horizontalMargin
+		y: -(Theme.geometry_gradientList_spacing / 2)
 		width: parent.width - (2 * Theme.geometry_separatorBar_horizontalMargin)
 		height: Theme.geometry_separatorBar_size
 		color: Theme.color_card_separator

--- a/components/GradientListView.qml
+++ b/components/GradientListView.qml
@@ -10,7 +10,6 @@ BaseListView {
 	id: root
 
 	bottomMargin: Theme.geometry_gradientList_bottomMargin
-	spacing: Theme.geometry_gradientList_spacing
 
 	ScrollBar.vertical: ScrollBar {
 		topPadding: Theme.geometry_gradientList_topMargin

--- a/components/NotificationDelegate.qml
+++ b/components/NotificationDelegate.qml
@@ -59,7 +59,7 @@ ListItem {
 				right: parent.right
 				verticalCenter: parent.verticalCenter
 			}
-			columnSpacing: Theme.geometry_gradientList_spacing
+			columnSpacing: Theme.geometry_listItem_content_verticalSpacing
 			rowSpacing: Theme.geometry_listItem_content_verticalSpacing
 			columns: 2
 

--- a/components/RadioButtonListPage.qml
+++ b/components/RadioButtonListPage.qml
@@ -65,10 +65,6 @@ Page {
 				}
 			}
 
-			// TODO this is a hack to cancel out the GradientListView spacing, to avoid
-			// showing extra spacing between items if an item is not visible. See #1907.
-			height: effectiveVisible ? implicitHeight : -Theme.geometry_gradientList_spacing
-
 			text: modelObject.display || ""
 			secondaryText: modelObject.secondaryText || ""
 			caption: modelObject.caption ?? ""

--- a/components/SettingsColumn.qml
+++ b/components/SettingsColumn.qml
@@ -52,6 +52,5 @@ FocusScope {
 		id: contentColumn
 		width: parent.width
 		height: parent.height
-		spacing: Theme.geometry_gradientList_spacing
 	}
 }

--- a/components/dialogs/EvcsChargerModeDialog.qml
+++ b/components/dialogs/EvcsChargerModeDialog.qml
@@ -37,7 +37,7 @@ ModalDialog {
 						onClicked: root.mode = modelData.value
 					}
 
-					SeparatorBar {
+					FlatListItemSeparator {
 						width: parent.width
 						visible: model.index !== repeater.count - 1
 					}

--- a/components/dialogs/InverterChargerEssModeDialog.qml
+++ b/components/dialogs/InverterChargerEssModeDialog.qml
@@ -37,7 +37,7 @@ ModalDialog {
 						onClicked: root.essMode = modelData.value
 					}
 
-					SeparatorBar {
+					FlatListItemSeparator {
 						width: parent.width
 						visible: model.index !== repeater.count - 1
 					}

--- a/components/dialogs/InverterChargerModeDialog.qml
+++ b/components/dialogs/InverterChargerModeDialog.qml
@@ -97,7 +97,7 @@ ModalDialog {
 				onClicked: root.mode = modelData.value
 			}
 
-			SeparatorBar {
+			FlatListItemSeparator {
 				width: parent.width
 				visible: model.index !== repeater.count - 1
 			}

--- a/components/dialogs/NavBarMoreDialog.qml
+++ b/components/dialogs/NavBarMoreDialog.qml
@@ -28,7 +28,7 @@ ModalDialog {
 	exit: null
 
 	contentItem: ColumnLayout {
-		spacing: Theme.geometry_gradientList_spacing
+		spacing: 0
 
 		Repeater {
 			id: moreButtonsRepeater

--- a/components/listitems/ListBriefCenterDetails.qml
+++ b/components/listitems/ListBriefCenterDetails.qml
@@ -68,8 +68,6 @@ ListNavigation {
 			optionView.section.property: "section"
 			optionView.section.delegate: SettingsListHeader {
 				required property string section
-
-				bottomPadding: Theme.geometry_gradientList_spacing
 				text: section
 			}
 

--- a/components/listitems/ListDroopGraph.qml
+++ b/components/listitems/ListDroopGraph.qml
@@ -38,13 +38,13 @@ ListItem {
 		verticalAlignment: Text.AlignVCenter
 	}
 
-	leftPadding: Theme.geometry_page_content_horizontalMargin
-	rightPadding: Theme.geometry_page_content_horizontalMargin
-	topPadding: 0
-	bottomPadding: 0
+	leftPadding: leftInset
+	rightPadding: rightInset
+	topPadding: topInset
+	bottomPadding: bottomInset
 
 	contentItem: Flow {
-		readonly property real graphWidth: (Theme.screenSize === Theme.Portrait ? width : (width/2 - spacing))
+		readonly property real graphWidth: (Theme.screenSize === Theme.Portrait ? width : (width - spacing) / 2)
 
 		spacing: Theme.geometry_droopGraph_container_spacing
 

--- a/components/listitems/core/ListItem.qml
+++ b/components/listitems/core/ListItem.qml
@@ -29,9 +29,13 @@ AbstractListItem {
 	// use the parent Flickable left/rightMargin to do this, but the gap changes when switching
 	// between portrait/landscape, and due to QTBUG-144841, dynamic left/rightMargin changes have no
 	// effect on list item geometries.
-	// Use zero inset when flat=true and the background is hidden (e.g. in control cards).
+	// Use zero left/rightInset when flat=true and the background is hidden (e.g. in control cards).
+	// Set bottomInset to provide the standard spacing between this item and the next one in the
+	// list. This cannot be done via ListView::spacing as that spacing is shown even between non-
+	// visible items.
 	leftInset: flat ? 0 : Theme.geometry_page_content_horizontalMargin
 	rightInset: flat ? 0 : Theme.geometry_page_content_horizontalMargin
+	bottomInset: Theme.geometry_gradientList_spacing
 	leftPadding: leftInset + horizontalContentPadding
 	rightPadding: rightInset + horizontalContentPadding
 	topPadding: topInset + Theme.geometry_listItem_content_verticalMargin

--- a/components/listitems/core/ListSlider.qml
+++ b/components/listitems/core/ListSlider.qml
@@ -36,8 +36,8 @@ ListSetting {
 	// Remove padding around the edges, so that the internal Slider can expand its touch area.
 	leftPadding: 0
 	rightPadding: 0
-	topPadding: 0
-	bottomPadding: 0
+	topPadding: topInset
+	bottomPadding: bottomInset
 
 	interactive: (dataItem.uid === "" || dataItem.valid)
 

--- a/components/listitems/core/ListSwitch.qml
+++ b/components/listitems/core/ListSwitch.qml
@@ -68,8 +68,8 @@ ListSetting {
 
 	// Remove padding around the edges, so that the internal Switch can expand its touch area.
 	rightPadding: rightInset
-	topPadding: 0
-	bottomPadding: 0
+	topPadding: topInset
+	bottomPadding: bottomInset
 
 	interactive: (dataItem.uid === "" || dataItem.valid)
 

--- a/components/listitems/core/ListTextField.qml
+++ b/components/listitems/core/ListTextField.qml
@@ -49,8 +49,8 @@ ListSetting {
 	}
 
 	// Remove vertical padding, so that the text field does not stretch the height of the item.
-	topPadding: 0
-	bottomPadding: 0
+	topPadding: topInset
+	bottomPadding: bottomInset
 
 	interactive: (dataItem.uid === "" || dataItem.valid)
 

--- a/components/listitems/core/SettingsListHeader.qml
+++ b/components/listitems/core/SettingsListHeader.qml
@@ -15,7 +15,7 @@ Label {
 	leftPadding: Theme.geometry_page_content_horizontalMargin
 	rightPadding: Theme.geometry_page_content_horizontalMargin
 	topPadding: Theme.geometry_settingsListHeader_topPadding
-	bottomPadding: Theme.geometry_settingsListHeader_bottomPadding
+	bottomPadding: Theme.geometry_settingsListHeader_bottomPadding + Theme.geometry_gradientList_spacing
 	width: Math.max(implicitWidth, 1)
 	font.pixelSize: Theme.font_listItem_flat_primary_size_flat
 	wrapMode: Text.Wrap

--- a/pages/NotificationsPage.qml
+++ b/pages/NotificationsPage.qml
@@ -38,7 +38,7 @@ SwipeViewPage {
 		section.delegate: SettingsListHeader {
 			id: sectionDelegate
 			required property int section
-			bottomPadding: Theme.geometry_gradientList_spacing
+
 			text: sectionDelegate.section === 0 ?
 					//: List section header, for the section which contains current/active notifications
 					//% "Active Notifications"

--- a/pages/evcs/EvChargerListPage.qml
+++ b/pages/evcs/EvChargerListPage.qml
@@ -14,7 +14,6 @@ Page {
 
 	GradientListView {
 		header: ListItem {
-			bottomInset: Theme.geometry_gradientList_spacing
 			topPadding: 0
 			bottomPadding: bottomInset
 			leftPadding: leftInset

--- a/pages/evcs/EvChargerPage.qml
+++ b/pages/evcs/EvChargerPage.qml
@@ -20,7 +20,6 @@ DevicePage {
 	settingsHeader: ListItem {
 		id: tableListItem
 
-		bottomInset: Theme.geometry_gradientList_spacing
 		topPadding: 0
 		bottomPadding: bottomInset
 		leftPadding: leftInset

--- a/pages/loads/AcLoadListPage.qml
+++ b/pages/loads/AcLoadListPage.qml
@@ -21,7 +21,6 @@ Page {
 		ListItem {
 			id: tableListItem
 
-			bottomInset: Theme.geometry_gradientList_spacing
 			topPadding: 0
 			bottomPadding: bottomInset
 			leftPadding: leftInset

--- a/pages/loads/DcLoadListPage.qml
+++ b/pages/loads/DcLoadListPage.qml
@@ -28,7 +28,6 @@ Page {
 		ListItem {
 			id: tableListItem
 
-			bottomInset: Theme.geometry_gradientList_spacing
 			topPadding: 0
 			bottomPadding: bottomInset
 			leftPadding: leftInset

--- a/pages/settings/PageChargeCurrentLimits.qml
+++ b/pages/settings/PageChargeCurrentLimits.qml
@@ -11,7 +11,6 @@ Page {
 
 	GradientListView {
 		header: DvccCommonSettings {
-			bottomPadding: Theme.geometry_gradientList_spacing
 			width: parent.width
 		}
 

--- a/pages/settings/PageControllableLoads.qml
+++ b/pages/settings/PageControllableLoads.qml
@@ -21,7 +21,6 @@ Page {
 
 		header: SettingsColumn {
 			width: parent?.width ?? 0
-			bottomPadding: spacing
 
 			ListSwitch {
 				dataItem.uid: BackendConnection.serviceUidForType("platform") + "/Services/OpportunityLoads/Mode"

--- a/pages/settings/PageSettingsAccessAndSecurity.qml
+++ b/pages/settings/PageSettingsAccessAndSecurity.qml
@@ -179,7 +179,6 @@ Page {
 					visible: securityProfile.currentIndex === VenusOS.Security_Profile_Secured
 							|| securityProfile.currentIndex === VenusOS.Security_Profile_Weak
 					width: parent.width
-					topPadding: spacing
 
 					ListButton {
 						//% "Change password"

--- a/pages/settings/PageSettingsBatteries.qml
+++ b/pages/settings/PageSettingsBatteries.qml
@@ -14,7 +14,6 @@ Page {
 	GradientListView {
 		header: SettingsColumn {
 			width: parent ? parent.width : 0
-			bottomPadding: spacing
 
 			ListRadioButtonGroup {
 				id: batteryMonitorRadioButtons
@@ -58,7 +57,6 @@ Page {
 
 		footer: SettingsColumn {
 			width: parent ? parent.width : 0
-			topPadding: spacing
 
 			ListNavigation {
 				//% "Battery measurements"

--- a/pages/settings/PageSettingsDisplayBrief.qml
+++ b/pages/settings/PageSettingsDisplayBrief.qml
@@ -213,7 +213,6 @@ Page {
 		}
 
 		footer: SettingsColumn {
-			topPadding: Theme.geometry_gradientList_spacing
 			width: parent.width
 
 			ListRadioButtonGroup {
@@ -251,7 +250,6 @@ Page {
 			optionView.section.delegate: SettingsListHeader {
 				required property string section
 
-				bottomPadding: Theme.geometry_gradientList_spacing
 				text: section
 			}
 

--- a/pages/settings/PageSettingsModbusDevices.qml
+++ b/pages/settings/PageSettingsModbusDevices.qml
@@ -19,7 +19,6 @@ Page {
 	GradientListView {
 		header: SettingsColumn {
 			width: parent?.width ?? 0
-			bottomPadding: addDevice.visible ? spacing : 0
 
 			ListNavigation {
 				id: addDevice

--- a/pages/settings/PageSettingsMqttDevices.qml
+++ b/pages/settings/PageSettingsMqttDevices.qml
@@ -45,7 +45,6 @@ Page {
 
 		header: SettingsColumn {
 			width: parent?.width ?? 0
-			bottomPadding: spacing
 
 			ListButton {
 				//% "Pairing mode"

--- a/pages/settings/PageTzInfo.qml
+++ b/pages/settings/PageTzInfo.qml
@@ -183,7 +183,6 @@ Page {
 
 							header: SettingsColumn {
 								width: parent.width
-								bottomPadding: Theme.geometry_gradientList_spacing
 
 								ListSwitch {
 									text: "UTC"

--- a/pages/settings/debug/PageSettingsDemo.qml
+++ b/pages/settings/debug/PageSettingsDemo.qml
@@ -283,8 +283,8 @@ Page {
 			ListItem {
 				id: toastItem
 
-				topPadding: 0
-				bottomPadding: 0
+				topPadding: topInset
+				bottomPadding: bottomInset
 				contentItem: RowLayout {
 					spacing: toastItem.spacing
 
@@ -431,7 +431,6 @@ Page {
 			GradientListView {
 				header: SettingsColumn {
 					width: parent ? parent.width : 0
-					bottomPadding: spacing
 
 					Repeater {
 						model: 5
@@ -448,7 +447,6 @@ Page {
 
 				footer: SettingsColumn {
 					width: parent ? parent.width : 0
-					topPadding: spacing
 
 					ListItem {
 						contentItem: Rectangle {

--- a/pages/settings/devicelist/DeviceListPage.qml
+++ b/pages/settings/devicelist/DeviceListPage.qml
@@ -63,7 +63,6 @@ Page {
 
 		footer: SettingsColumn {
 			width: parent.width
-			topPadding: spacing
 			preferredVisible: relaysMenu.preferredVisible
 					|| gensetMenu.preferredVisible
 					|| tankPumpMenu.preferredVisible

--- a/pages/settings/devicelist/PageSwitch.qml
+++ b/pages/settings/devicelist/PageSwitch.qml
@@ -27,7 +27,6 @@ DevicePage {
 
 	settingsHeader: SettingsColumn {
 		width: parent?.width ?? 0
-		bottomPadding: spacing
 
 		ListText {
 			//% "Module state"

--- a/pages/settings/devicelist/ac-in/PageAcIn.qml
+++ b/pages/settings/devicelist/ac-in/PageAcIn.qml
@@ -26,7 +26,6 @@ DevicePage {
 	}
 	extraDeviceInfo: SettingsColumn {
 		width: parent?.width ?? 0
-		topPadding: spacing
 		preferredVisible: dataManagerVersion.preferredVisible
 
 		ListText {

--- a/pages/solar/PvInverterPage.qml
+++ b/pages/solar/PvInverterPage.qml
@@ -22,7 +22,6 @@ Page {
 		header: ListItem {
 			id: tableListItem
 
-			bottomInset: Theme.geometry_gradientList_spacing
 			topPadding: 0
 			bottomPadding: bottomInset
 			leftPadding: leftInset
@@ -53,10 +52,7 @@ Page {
 				QuantityTable {
 					id: phaseTable
 
-					anchors {
-						top: phaseSummary.bottom
-						topMargin: Theme.geometry_gradientList_spacing
-					}
+					anchors.top: phaseSummary.bottom
 					width: parent.width
 					visible: pvInverter.phases.count > 1
 					metricsFontSize: phaseSummary.metricsFontSize

--- a/pages/solar/SolarDevicePage.qml
+++ b/pages/solar/SolarDevicePage.qml
@@ -40,7 +40,6 @@ Page {
 		header: ListItem {
 			id: tableListItem
 
-			bottomInset: Theme.geometry_gradientList_spacing
 			topPadding: 0
 			bottomPadding: bottomInset
 			leftPadding: leftInset

--- a/pages/vebusdevice/PageVeBus.qml
+++ b/pages/vebusdevice/PageVeBus.qml
@@ -274,7 +274,6 @@ DevicePage {
 
 	extraDeviceInfo: SettingsColumn {
 		width: parent?.width ?? 0
-		topPadding: spacing
 		preferredVisible: deviceInfoModel.count > 0
 
 		Repeater {

--- a/pages/vebusdevice/PageVeBusAlarmSettings.qml
+++ b/pages/vebusdevice/PageVeBusAlarmSettings.qml
@@ -29,7 +29,6 @@ Page {
 		}
 		footer: SettingsColumn {
 			width: parent.width
-			topPadding: Theme.geometry_gradientList_spacing
 
 			ListRadioButtonGroup {
 				text: CommonWords.vebus_error

--- a/pages/vebusdevice/PageVeBusKwhCounters.qml
+++ b/pages/vebusdevice/PageVeBusKwhCounters.qml
@@ -15,7 +15,6 @@ Page {
 	GradientListView {
 		header: SettingsColumn {
 			width: parent?.width ?? 0
-			bottomPadding: spacing
 
 			ListText {
 				//% "VE.Bus Quirks"


### PR DESCRIPTION
When providing spacing between list items, set the spacing using the ListItem bottomInset  instead of the ListView/Column spacing property.

In principle it would be better to set the ListView/Column spacing to do this, but in practice, list items are often hidden (using visible=false) within a ListView: for example, when an associated VeQuickItem value is not available. This is problematic because when ListView::spacing is set, the spacing is shown between items even if they are not visible, creating unexpectedly wider gaps between their neighbouring list items that are visible. VisibleItemModel mitigates this somewhat by ensuring views do not contain invisible items, but there are many list items that are shown outside of a VisualItemModel.

Changes:
- Add bottomInset to the core ListItem to provide standard spacing for all list items.
- Remove spacing property from GradientListView and Column.
- Adjust FlatListItemSeparator y-position to account for the bottomInset spacing between list items in the Control Cards.
- Remove redundant spacing properties from various pages and dialogs.
- Update ListSlider, ListSwitch, and ListTextField to use bottomInset when setting a custom bottomPadding.

Fixes #2721