### PR TITLE
Battery: do not show empty module-level alarm list if id is empty string

### DIFF
--- a/data/mock/conf/services/pylontech.json
+++ b/data/mock/conf/services/pylontech.json
@@ -40,7 +40,7 @@
         "/Diagnostics/Module0/Alarms/LowChargeTemperature": null,
         "/Diagnostics/Module0/Alarms/LowTemperature": null,
         "/Diagnostics/Module0/Alarms/LowVoltage": null,
-        "/Diagnostics/Module0/Id": null,
+        "/Diagnostics/Module0/Id": "",
         "/Diagnostics/Module1/Alarms/CellImbalance": null,
         "/Diagnostics/Module1/Alarms/HighCellVoltage": null,
         "/Diagnostics/Module1/Alarms/HighChargeCurrent": null,

--- a/pages/settings/devicelist/battery/PageBattery.qml
+++ b/pages/settings/devicelist/battery/PageBattery.qml
@@ -481,7 +481,8 @@ DevicePage {
 		id: moduleAlarmModel
 
 		filterRegExp: "\/Module[0-9]\/Id$"
-		filterFlags: VeQItemSortTableModel.FilterInvalid
+		filterFlags: VeQItemSortTableModel.FilterExcludesValue
+		filterExcludedValue: ""
 		model: VeQItemTableModel {
 			uids: [root.bindPrefix + "/Diagnostics"]
 		}


### PR DESCRIPTION
For a battery, the "/Diagnostics/Module<1-3>/Id" may be an empty string in some cases. If so, treat it in the same way as an invalid id, and do not show it in the list of module-level alarms.

Fixes #2885

---

Requires https://github.com/victronenergy/veutil/pull/29