### PR TITLE
Switches: allow stepped switch mode to be selected when output is off

### DIFF
--- a/components/MultiStepButton.qml
+++ b/components/MultiStepButton.qml
@@ -82,7 +82,6 @@ BaseListView {
 			backgroundColor: !root.enabled ? (checked ? Theme.color_button_off_background_disabled : Theme.color_background_disabled)
 					: checked ? (root.checked ? Theme.color_ok : Theme.color_button_off_background)
 					: Theme.color_darkOk
-			enabled: root.checked
 			checked: index === root.currentIndex
 			focus: true
 


### PR DESCRIPTION
In some cases, it makes sense to select the mode before turning on the output - e.g. a user controlling a fan will want to select a power setting before turning it on.

Fixes #2969