### PR TITLE
Overview: show VE.Bus state if system state is not available

### DIFF
--- a/components/widgets/InverterChargerWidget.qml
+++ b/components/widgets/InverterChargerWidget.qml
@@ -53,7 +53,9 @@ OverviewWidget {
 			}
 
 			Label {
-				text: VenusOS.system_stateToText(Global.system.state)
+				text: systemState.valid ? VenusOS.system_stateToText(systemState.value)
+					: systemVeBusState.valid ? VenusOS.system_stateToText(systemVeBusState.value)
+					: ""
 				font.pixelSize: Theme.font_overviewPage_widget_quantityLabel_maximumSize
 				minimumPixelSize: Theme.font_overviewPage_widget_quantityLabel_minimumSize
 				fontSizeMode: Text.Fit
@@ -63,6 +65,16 @@ OverviewWidget {
 
 				Layout.fillWidth: true
 				Layout.fillHeight: true // push reason text to bottom of layout
+
+				VeQuickItem {
+					id: systemState
+					uid: Global.system.serviceUid + "/SystemState/State"
+				}
+
+				VeQuickItem {
+					id: systemVeBusState
+					uid: Global.system.veBus.serviceUid ? Global.system.veBus.serviceUid + "/SystemState/State" : ""
+				}
 			}
 
 			Label {

--- a/data/System.qml
+++ b/data/System.qml
@@ -10,7 +10,6 @@ QtObject {
 	id: root
 
 	readonly property string serviceUid: BackendConnection.serviceUidForType("system")
-	readonly property int state: _systemState.valid ? _systemState.value : VenusOS.System_State_Off
 
 	readonly property bool hasGridMeter: _gridDeviceType.valid
 	readonly property bool hasAcOutSystem: _hasAcOutSystem.valid && _hasAcOutSystem.value === 1
@@ -89,10 +88,6 @@ QtObject {
 
 		readonly property VeQuickItem _serviceName: VeQuickItem { uid: root.serviceUid + "/VebusService" }
 		readonly property VeQuickItem _deviceInstance: VeQuickItem { uid: root.serviceUid + "/VebusInstance" }
-	}
-
-	readonly property VeQuickItem _systemState: VeQuickItem {
-		uid: root.serviceUid + "/SystemState/State"
 	}
 
 	readonly property VeQuickItem _systemType: VeQuickItem {


### PR DESCRIPTION
If the system state is not available, the Inverter/Charger box should show the state of the system VE.Bus service instead.

This aligns with the gui-v1 behaviour.