### PR TITLE
Overview: rename "Solar yield" to "Solar"

### DIFF
--- a/components/CommonWords.qml
+++ b/components/CommonWords.qml
@@ -496,6 +496,9 @@ QtObject {
 	//% "SOC %1"
 	readonly property string soc_with_prefix: qsTrId("common_words_soc")
 
+	//% "Solar"
+	readonly property string solar: qsTrId("common_words_solar")
+
 	//: A speed measurement value
 	//% "Speed"
 	readonly property string speed: qsTrId("common_words_speed")

--- a/components/widgets/SolarYieldWidget.qml
+++ b/components/widgets/SolarYieldWidget.qml
@@ -27,8 +27,7 @@ OverviewWidget {
 		}
 	}
 
-	//% "Solar yield"
-	title: qsTrId("overview_widget_solaryield_title")
+	title: CommonWords.solar
 	type: VenusOS.OverviewWidget_Type_Solar
 	enabled: true
 	preferredSize: _showPhases || _showGraph

--- a/pages/BriefSidePanel.qml
+++ b/pages/BriefSidePanel.qml
@@ -22,8 +22,7 @@ ColumnLayout {
 	spacing: Theme.geometry_sidePanel_spacing
 
 	BriefSidePanelWidget {
-		//% "Solar yield"
-		title: qsTrId("brief_solar_yield")
+		title: CommonWords.solar
 		icon.source: "qrc:/images/solaryield.svg"
 		loadersActive: Global.solarInputs.devices.count > 0 // only show graph if there are solar inputs with history (i.e. not PV inverters)
 		visible: Global.solarInputs.inputCount > 0 // show if there are any solar inputs (PV chargers, PV inverters, etc.)

--- a/pages/settings/PageSettingsDisplayMinMax.qml
+++ b/pages/settings/PageSettingsDisplayMinMax.qml
@@ -165,8 +165,7 @@ Page {
 			}
 
 			SettingsListHeader {
-				//% "Solar"
-				text: qsTrId("settings_minmax_solar")
+				text: CommonWords.solar
 			}
 
 			ListQuantityField {

--- a/tests/ui/smoke/mock-maximal/tst_overview.qml
+++ b/tests/ui/smoke/mock-maximal/tst_overview.qml
@@ -45,9 +45,9 @@ UiTestCase {
 				baseImageName: "overview_generator",
 			},
 			{
-				tag: "Solar yield",
-				widgetValues: { title: "Solar yield" },
-				baseImageName: "overview_solar_yield",
+				tag: "Solar",
+				widgetValues: { title: "Solar" },
+				baseImageName: "overview_solar",
 			},
 			{
 				tag: "Alternator",
@@ -132,7 +132,7 @@ UiTestCase {
 	function test_solar_history() {
 		// Open the "History" page of a solar tracker with history details.
 		addStep(UiTestStep.Invoke, { callable: ()=> { return mouseClick(findClickableChild(
-				findItem(Global.mainView.currentPage, { title: "Solar yield" }))) } })
+				findItem(Global.mainView.currentPage, { title: "Solar" }))) } })
 		addStep(UiTestStep.WaitUntil, { callable: ()=> { return !Global.mainView.animating } })
 		addStep(UiTestStep.Invoke, { callable: ()=> {
 			// Click list item named "MPPT - multi-tracker-Tracker 1"


### PR DESCRIPTION
"Solar yield" is about the energy it yields, and the tile only shows energy values in some cases (namely when only PV chargers with solar history are present) so just "Solar" is more appropriate.

Fixes #3014