### PR TITLE
Solar: order solar trackers by tracker index instead of name

### DIFF
--- a/data/mock/conf/services/mppt2.json
+++ b/data/mock/conf/services/mppt2.json
@@ -929,7 +929,7 @@
         "/Pv/2/V": 151.72999572753906,
         "/Pv/3/Enabled": 1,
         "/Pv/3/MppOperationMode": 0,
-        "/Pv/3/Name": "Tracker 4 with long name",
+        "/Pv/3/Name": "This is tracker 4 with a long name",
         "/Pv/3/P": 4234,
         "/Pv/3/V": 45.970001220703125,
         "/Relay/0/State": 1,

--- a/pages/solar/SolarInputListPage.qml
+++ b/pages/solar/SolarInputListPage.qml
@@ -32,9 +32,7 @@ Page {
 	// since PV inverters do not have multiple trackers.
 	GradientListView {
 		model: SortedSolarInputModel {
-			sourceModel: SolarInputModel {
-				id: solarInputModel
-			}
+			sourceModel: SolarInputModel {}
 		}
 		delegate: ListQuantityGroupNavigation {
 			id: solarInputDelegate

--- a/src/solarinput.cpp
+++ b/src/solarinput.cpp
@@ -164,6 +164,11 @@ TrackerSolarInput::TrackerSolarInput(Device *device, bool isSingleTrackerDevice,
 	}
 }
 
+int TrackerSolarInput::trackerIndex() const
+{
+	return m_trackerIndex;
+}
+
 bool TrackerSolarInput::isEnabledTracker(VeQItem *serviceItem, int trackerIndex)
 {
 	if (!serviceItem) {

--- a/src/solarinput.h
+++ b/src/solarinput.h
@@ -87,6 +87,7 @@ class TrackerSolarInput : public SolarInput
 	Q_OBJECT
 public:
 	explicit TrackerSolarInput(Device *device, bool isSingleTrackerDevice, int trackerIndex, QObject *parent = nullptr);
+	int trackerIndex() const;
 
 	static bool isEnabledTracker(VeQItem *serviceItem, int trackerIndex);
 

--- a/src/solarinputmodel.cpp
+++ b/src/solarinputmodel.cpp
@@ -40,6 +40,18 @@ int SolarInputModel::count() const
 	return m_enabledInputs.count();
 }
 
+int SolarInputModel::trackerIndex(int row) const
+{
+	if (row < 0 || row >= m_enabledInputs.count()) {
+		return -1;
+	}
+	if (TrackerSolarInput *input = qobject_cast<TrackerSolarInput *>(m_enabledInputs.at(row))) {
+		return input->trackerIndex();
+	} else {
+		return -1;
+	}
+}
+
 QVariant SolarInputModel::data(const QModelIndex &index, int role) const
 {
 	const int row = index.row();
@@ -296,17 +308,35 @@ SortedSolarInputModel::SortedSolarInputModel(QObject *parent)
 
 bool SortedSolarInputModel::lessThan(const QModelIndex &sourceLeft, const QModelIndex &sourceRight) const
 {
-	const QString leftGroup = sourceModel()->data(
-			sourceModel()->index(sourceLeft.row(), sourceLeft.column()), SolarInputModel::GroupRole).toString();
-	const QString rightGroup = sourceModel()->data(
-			sourceModel()->index(sourceRight.row(), sourceRight.column()), SolarInputModel::GroupRole).toString();
+	// Sort by:
+	// 1. Group: show "generic" first, then "pvinverters"
+	// 2. Device name
+	// 3. Tracker number (if the input is a tracker)
+
+	const QModelIndex leftIndex = sourceModel()->index(sourceLeft.row(), sourceLeft.column());
+	const QModelIndex rightIndex = sourceModel()->index(sourceRight.row(), sourceRight.column());
+
+	const QString leftGroup = sourceModel()->data(leftIndex, SolarInputModel::GroupRole).toString();
+	const QString rightGroup = sourceModel()->data(rightIndex, SolarInputModel::GroupRole).toString();
 
 	if (leftGroup == rightGroup) {
-		const QString leftName = sourceModel()->data(
-				sourceModel()->index(sourceLeft.row(), sourceLeft.column()), SolarInputModel::NameRole).toString();
-		const QString rightName = sourceModel()->data(
-				sourceModel()->index(sourceRight.row(), sourceRight.column()), SolarInputModel::NameRole).toString();
-		return leftName.localeAwareCompare(rightName) < 0;
+		if (sourceModel()->data(leftIndex, SolarInputModel::ServiceUidRole) == sourceModel()->data(leftIndex, SolarInputModel::ServiceUidRole)) {
+			// If the two inputs belong to the same service, then these must be both trackers from
+			// the same device, so sort them by tracker index.
+
+			if (SolarInputModel *inputModel = qobject_cast<SolarInputModel *>(sourceModel())) {
+				// Note: this check is only used for PV chargers, as PV inverters do not have any
+				// individual trackers, so for them the trackerIndex is always -1.
+				const int leftTrackerIndex = inputModel->trackerIndex(leftIndex.row());
+				const int rightTrackerIndex = inputModel->trackerIndex(rightIndex.row());
+				if (leftTrackerIndex >= 0 && rightTrackerIndex >= 0) {
+					return leftTrackerIndex < rightTrackerIndex;
+				}
+			}
+		}
+		// Sort by name.
+		return sourceModel()->data(leftIndex, SolarInputModel::NameRole).toString()
+				.localeAwareCompare(sourceModel()->data(rightIndex, SolarInputModel::NameRole).toString()) < 0;
 	} else {
 		return leftGroup.localeAwareCompare(rightGroup) < 0;
 	}

--- a/src/solarinputmodel.h
+++ b/src/solarinputmodel.h
@@ -46,6 +46,7 @@ public:
 	explicit SolarInputModel(QObject *parent = nullptr);
 
 	int count() const;
+	int trackerIndex(int row) const;
 
 	int rowCount(const QModelIndex &parent) const override;
 	QVariant data(const QModelIndex& index, int role) const override;


### PR DESCRIPTION
In the solar input list, when there are multiple solar trackers for the same PV charger, then sort those trackers by tracker index instead of by name.

Fixes #2852