### PR TITLE
UI: add demo mode indicator

### DIFF
--- a/cmake/ModuleVenus_Sources.cmake
+++ b/cmake/ModuleVenus_Sources.cmake
@@ -40,6 +40,7 @@ set (VictronVenusOS_QML_MODULE_SOURCES
     components/ControlCard.qml
     components/CpuMonitor.qml
     components/DateSelector.qml
+    components/DemoModeIndicator.qml
     components/DeviceListDelegate.qml
     components/DeviceListPluginPage.qml
     components/DevicePage.qml

--- a/components/DemoModeIndicator.qml
+++ b/components/DemoModeIndicator.qml
@@ -1,0 +1,29 @@
+/*
+** Copyright (C) 2026 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+Rectangle {
+	implicitWidth: modeLabel.implicitWidth
+	implicitHeight: modeLabel.implicitHeight
+	topLeftRadius: Theme.geometry_button_radius
+	topRightRadius: Theme.geometry_button_radius
+	color: Theme.color_demoModeIndicator_background
+
+	Label {
+		id: modeLabel
+
+		leftPadding: Theme.geometry_demoModeIndicator_horizontalPadding
+		rightPadding: Theme.geometry_demoModeIndicator_horizontalPadding
+		topPadding: Theme.geometry_demoModeIndicator_verticalPadding
+		bottomPadding: Theme.geometry_demoModeIndicator_verticalPadding
+		color: Theme.color_demoModeIndicator_foreground
+		font.pixelSize: Theme.font_demoModeIndicator_size
+		font.capitalization: Font.AllUppercase
+		//% "Demo mode"
+		text: qsTrId("demo_mode_indicator_text")
+	}
+}

--- a/components/listitems/core/SettingsListHeader.qml
+++ b/components/listitems/core/SettingsListHeader.qml
@@ -12,8 +12,8 @@ Label {
 	readonly property bool effectiveVisible: preferredVisible
 	property bool preferredVisible: true
 
-	leftPadding: Theme.geometry_page_content_horizontalMargin
-	rightPadding: Theme.geometry_page_content_horizontalMargin
+	leftPadding: Theme.geometry_page_content_horizontalMargin + Theme.geometry_listItem_content_horizontalMargin
+	rightPadding: Theme.geometry_page_content_horizontalMargin + Theme.geometry_listItem_content_horizontalMargin
 	topPadding: Theme.geometry_settingsListHeader_topPadding
 	bottomPadding: Theme.geometry_settingsListHeader_bottomPadding
 	width: Math.max(implicitWidth, 1)

--- a/pages/MainView.qml
+++ b/pages/MainView.qml
@@ -520,6 +520,19 @@ FocusScope {
 	}
 
 	Loader {
+		y: -height + statusBar.height
+		active: demoMode.valid && demoMode.value > 0
+		transformOrigin: Item.BottomLeft
+		rotation: 90
+		sourceComponent: DemoModeIndicator {}
+
+		VeQuickItem {
+			id: demoMode
+			uid: Global.systemSettings.serviceUid + "/Settings/Gui/DemoMode"
+		}
+	}
+
+	Loader {
 		active: Global.displayCpuUsage
 		anchors {
 			bottom: parent.bottom

--- a/themes/color/Dark.json
+++ b/themes/color/Dark.json
@@ -65,6 +65,9 @@
     "color_colorWheelDialog_mode_button_background": "#1D1D1B",
     "color_colorWheelDialog_mode_button_separator": "color_gray2",
 
+    "color_demoModeIndicator_foreground": "color_orange",
+    "color_demoModeIndicator_background": "#593912",
+
     "color_droopGraph_axis_line": "color_gray5",
     "color_droopGraph_gradient_centre": "color_blue",
     "color_droopGraph_gradient_edge": "color_orange",

--- a/themes/color/Light.json
+++ b/themes/color/Light.json
@@ -65,6 +65,9 @@
     "color_colorWheelDialog_mode_button_background": "color_gray8",
     "color_colorWheelDialog_mode_button_separator": "color_gray7",
 
+    "color_demoModeIndicator_foreground": "color_white",
+    "color_demoModeIndicator_background": "color_orange",
+
     "color_droopGraph_axis_line": "color_gray5",
     "color_droopGraph_gradient_centre": "color_blue",
     "color_droopGraph_gradient_edge": "color_orange",

--- a/themes/geometry/FiveInch.json
+++ b/themes/geometry/FiveInch.json
@@ -50,6 +50,9 @@
     "geometry_colorWheel_lowerSlider_padding": 5,
     "geometry_colorWheel_component_overlap": 7,
 
+    "geometry_demoModeIndicator_horizontalPadding": 12,
+    "geometry_demoModeIndicator_verticalPadding": 2,
+
     "geometry_droopGraph_container_width": 374,
     "geometry_droopGraph_container_height": 217,
     "geometry_droopGraph_container_spacing": 4,

--- a/themes/geometry/Portrait.json
+++ b/themes/geometry/Portrait.json
@@ -50,6 +50,9 @@
     "geometry_colorWheel_lowerSlider_padding": 5,
     "geometry_colorWheel_component_overlap": 7,
 
+    "geometry_demoModeIndicator_horizontalPadding": 8,
+    "geometry_demoModeIndicator_verticalPadding": 0,
+
     "geometry_droopGraph_container_width": 374,
     "geometry_droopGraph_container_height": 217,
     "geometry_droopGraph_container_spacing": 4,

--- a/themes/geometry/SevenInch.json
+++ b/themes/geometry/SevenInch.json
@@ -50,6 +50,9 @@
     "geometry_colorWheel_lowerSlider_padding": 5,
     "geometry_colorWheel_component_overlap": 7,
 
+    "geometry_demoModeIndicator_horizontalPadding": 12,
+    "geometry_demoModeIndicator_verticalPadding": 2,
+
     "geometry_droopGraph_container_width": 374,
     "geometry_droopGraph_container_height": 217,
     "geometry_droopGraph_container_spacing": 4,

--- a/themes/typography/FiveInch.json
+++ b/themes/typography/FiveInch.json
@@ -27,6 +27,7 @@
     "font_dialog_header_largeSize": "font_size_body3",
     "font_dialog_secondaryTitle_size": "font_size_body1",
     "font_dialog_title_size": "font_size_h1",
+    "font_demoModeIndicator_size": "font_size_micro",
     "font_droopGraph_figure_label_size": "font_size_body1",
     "font_droopGraph_axis_label_size": "font_size_tiny",
     "font_levelsGauge_title": "font_size_body1",

--- a/themes/typography/Portrait.json
+++ b/themes/typography/Portrait.json
@@ -27,6 +27,7 @@
     "font_dialog_header_largeSize": "font_size_body1",
     "font_dialog_secondaryTitle_size": "font_size_tiny",
     "font_dialog_title_size": "font_size_body2",
+    "font_demoModeIndicator_size": 10,
     "font_droopGraph_figure_label_size": "font_size_tiny",
     "font_droopGraph_axis_label_size": "font_size_micro",
     "font_levelsGauge_title": "font_size_tiny",

--- a/themes/typography/SevenInch.json
+++ b/themes/typography/SevenInch.json
@@ -27,6 +27,7 @@
     "font_dialog_header_largeSize": "font_size_body3",
     "font_dialog_secondaryTitle_size": "font_size_body1",
     "font_dialog_title_size": "font_size_h1",
+    "font_demoModeIndicator_size": "font_size_micro",
     "font_droopGraph_figure_label_size": "font_size_body1",
     "font_droopGraph_axis_label_size": "font_size_tiny",
     "font_levelsGauge_title": "font_size_body1",


### PR DESCRIPTION
When the /Settings/Gui/DemoMode local setting indicates that a demo mode is active, show a "Demo mode" label in the top-left of the app view.

Also adjust the left/right padding of SettingsListHeader so that they align with the text of adjacent list items. Otherwise, the header text is too close to the demo mode indicator.

Fixes #2249