### PR TITLE
DESS: fix the Mode menu item and warning

### DIFF
--- a/pages/settings/PageSettingsDynamicEss.qml
+++ b/pages/settings/PageSettingsDynamicEss.qml
@@ -15,8 +15,8 @@ Page {
 				id: dEssMode
 				text: CommonWords.mode
 				dataItem.uid: Global.systemSettings.serviceUid + "/Settings/DynamicEss/Mode"
-				interactive: opportunityLoads.value === 0
-				//% "Dynamic ESS cannot be enabled while Opportunity Loads is enabled. Disable Dynamic ESS first."
+				interactive: opportunityLoads.value !== 1
+				//% "Dynamic ESS cannot be enabled while Opportunity Loads is enabled. Disable Opportunity Loads first."
 				caption: interactive ? "" : qsTrId("settings_ess_disable_ol_first")
 				optionModel: [
 					{ display: CommonWords.off, value: 0 },


### PR DESCRIPTION
Oportunity loads is an optional feature and is not installed at all at the moment and won't not be available for all devices. If it is not installed the /Settings/DynamicEss/Mode in venus-platform doesn't exists, hence the comparison with zero won't work. Correct this by checking if the service is not enabled.

Also correct the warning text, opportunity loads must be disabled, not DESS.

Fixes cfa0d6f104e8 ("Settings: Disable Opportunity Loads when DESS is running")