### PR TITLE
UI Controls: ensure the switch in a disabled ListItem cannot be toggled

### DIFF
--- a/components/controls/Switch.qml
+++ b/components/controls/Switch.qml
@@ -10,8 +10,6 @@ import Victron.VenusOS
 T.Switch {
 	id: root
 
-	property bool showEnabled: enabled
-
 	checkable: false
 	implicitWidth: Math.max(
 		implicitBackgroundWidth + leftInset + rightInset,
@@ -29,7 +27,7 @@ T.Switch {
 		implicitWidth: Theme.geometry_switch_groove_width
 		implicitHeight: Theme.geometry_switch_groove_height
 		radius: Theme.geometry_switch_groove_radius
-		color: root.showEnabled
+		color: root.enabled
 			   ? (root.checked ? Theme.color_switch_groove_on : Theme.color_switch_groove_off)
 			   : Theme.color_switch_groove_disabled
 		border.color: root.checked ? Theme.color_switch_groove_border_on

--- a/components/listitems/core/ListSwitch.qml
+++ b/components/listitems/core/ListSwitch.qml
@@ -115,7 +115,7 @@ ListSetting {
 			checked: root.checked
 			checkable: root.checkable && root.clickable
 			focusPolicy: Qt.NoFocus
-			showEnabled: root.clickable
+			enabled: root.clickable
 
 			onClicked: root.click()
 			Component.onCompleted: root._switchItem = switchItem


### PR DESCRIPTION
When disabling a switch, set Switch::enabled, instead of trying to disable the behaviour from the onClicked handler. Otherwise, the user is still able to toggle the switch with a swipe/drag action.

Also remove the Switch::showEnabled property as it is no longer used.