### PR TITLE
Switches: fix misalignment between controls in the Switch Pane grid

### DIFF
--- a/components/switches/IOChannelCardDelegateHeader.qml
+++ b/components/switches/IOChannelCardDelegateHeader.qml
@@ -24,6 +24,8 @@ RowLayout {
 	spacing: Theme.geometry_iochannel_label_margin
 
 	Label {
+		id: nameLabel
+
 		Layout.fillWidth: true
 		Layout.bottomMargin: Theme.geometry_iochannel_label_margin
 		text: root.ioChannel.formattedName
@@ -33,6 +35,7 @@ RowLayout {
 
 	IOChannelQuantityLabel {
 		Layout.bottomMargin: Theme.geometry_iochannel_label_margin
+		Layout.preferredHeight: nameLabel.height
 		ioChannel: root.ioChannel
 		value: root.quantityValue
 		valueColor: root.quantityColor
@@ -46,11 +49,11 @@ RowLayout {
 	Rectangle {
 		id: statusRect
 
-		Layout.bottomMargin: Theme.geometry_iochannel_statusBackground_bottomPadding
+		Layout.bottomMargin: Theme.geometry_iochannel_label_margin
 		Layout.maximumWidth: parent.width / 2
 		Layout.minimumWidth: statusLabel.implicitWidth
-		Layout.alignment: Qt.AlignRight
-		height: statusLabel.height
+		Layout.alignment: Qt.AlignRight | Qt.AlignTop
+		Layout.preferredHeight: statusLabel.height
 		color: statusLabel.color === Theme.color_green ? Theme.color_darkGreen
 				: statusLabel.color === Theme.color_orange ? Theme.color_darkOrange
 				: statusLabel.color === Theme.color_red ? Theme.color_darkRed


### PR DESCRIPTION
In the control header, used a fixed height for the quantity label and status rectangle which is the same as the name label height. Otherwise, the header height differs slightly depending on whether a label or status is shown, which affects the position of the control button that is below the header, and in turn causes a vertical misalignment across different control buttons in the Switch Pane depending on whether the quantity/status is shown.

Also change the status to use the same bottom margin as that of the name label. Align the status to the top to improve the visual alignment with the name label.

Fixes #3027