### PR TITLE
Tanks: unify tank value decimals and step size

### DIFF
--- a/pages/settings/devicelist/tank/PageTankSetup.qml
+++ b/pages/settings/devicelist/tank/PageTankSetup.qml
@@ -163,12 +163,11 @@ Page {
 		// The possible values here are not well defined. The doco says: "can be V, and probably also mA and R or O."
 		// At least one installation uses "cm".
 		// Resistive tank sensors (European 0-180Ω, US 240-30Ω, Custom) publish "Ω" or
-		// its ASCII equivalent "O". 1 decimal place and 1 Ω step are appropriate for
+		// its ASCII equivalent "O". 1 decimal place and 0.1 Ω step are appropriate for
 		// resistance values in the tens-to-hundreds-of-ohms range.
 		readonly property int displayDecimals: {
 			switch (value) {
 			case "cm":
-				return 1
 			case "Ω":
 			case "O":
 				return 1
@@ -180,10 +179,9 @@ Page {
 		readonly property real stepSize: {
 			switch (value) {
 			case "cm":
-				return 0.1
 			case "Ω":
 			case "O":
-				return 1
+				return 0.1
 			default:
 				return 0.005
 			}


### PR DESCRIPTION
Previously, resistive tank sensors were displayed with one decimal place of precision, but a step size of 1 (step by one whole ohm) because the value was expected within the range of tens to low hundreds of ohms.

This commit changes the step size to match the display precision, to ensure fine control over the tank sensor, at the cost of slightly slower initial setup.

Contributes to issue #2978