### PR TITLE
Settings: warn user about disabling internet gateway

### DIFF
--- a/components/listitems/core/ListSwitch.qml
+++ b/components/listitems/core/ListSwitch.qml
@@ -47,24 +47,28 @@ ListSetting {
 			return
 		}
 		if (root.updateDataOnClick) {
-			if (root.dataItem.uid.length > 0) {
-				// Note: this logic only holds so long as checkable is false so we can use
-				// the current unmodified checked state at the point of onClicked.
-				// (dataItem might not be valid until the first write so we can't simply use
-				// the comparison of dataItem.value === valueFalse) and forget invertSourceValue).
-				// Note that an malformed uid will result in it being empty when inspected.
-				if (root.invertSourceValue) {
-					root.dataItem.setValue(checked ? valueTrue : valueFalse)
-				} else {
-					root.dataItem.setValue(checked ? valueFalse : valueTrue)
-				}
-			}
+			root.toggleDataValue()
 		}
 		// If checkable, update 'checked' value so that onCheckedChanged signal is fired.
 		if (checkable && !!_switchItem) {
 			checked = _switchItem.checked
 		}
 		root.clicked()
+	}
+
+	function toggleDataValue() {
+		if (root.dataItem.uid.length > 0) {
+			// Note: this logic only holds so long as checkable is false so we can use
+			// the current unmodified checked state at the point of onClicked.
+			// (dataItem might not be valid until the first write so we can't simply use
+			// the comparison of dataItem.value === valueFalse) and forget invertSourceValue).
+			// Note that a malformed uid will result in it being empty when inspected.
+			if (root.invertSourceValue) {
+				root.dataItem.setValue(checked ? valueTrue : valueFalse)
+			} else {
+				root.dataItem.setValue(checked ? valueFalse : valueTrue)
+			}
+		}
 	}
 
 	// Remove padding around the edges, so that the internal Switch can expand its touch area.

--- a/pages/settings/NetworkSettingsPageModel.qml
+++ b/pages/settings/NetworkSettingsPageModel.qml
@@ -134,6 +134,28 @@ VisibleItemModel {
 		writeAccessLevel: VenusOS.User_AccessType_User
 		valueTrue: true
 		valueFalse: false
+		updateDataOnClick: false
+
+		onClicked: {
+			if (!ethernetGatewayEnabled.checked) {
+				ethernetGatewayEnabled.toggleDataValue()
+			} else {
+				Global.dialogLayer.open(disableEthernetGatewayComponent)
+			}
+		}
+
+		Component {
+			id: disableEthernetGatewayComponent
+
+			ModalWarningDialog {
+				dialogDoneOptions: VenusOS.ModalDialog_DoneOptions_OkAndCancel
+				//% "Disable internet access over ethernet?"
+				title: qsTrId("settings_tcpip_disable_ethernet_gateway")
+				//% "This will disconnect the device from VRM, unless it can connect to VRM over WiFi. Are you sure that you want to disable internet access over ethernet?"
+				description: qsTrId("settings_tcpip_disable_ethernet_gateway_confirm")
+				onAccepted: ethernetGatewayEnabled.toggleDataValue()
+			}
+		}
 	}
 
 	ListIpAddressField {

--- a/pages/settings/PageSettingsWifi.qml
+++ b/pages/settings/PageSettingsWifi.qml
@@ -137,12 +137,35 @@ Page {
 			}
 
 			ListSwitch {
+				id: wifiGatewayEnabled
 				//% "Allow using WiFi for internet access"
 				text: qsTrId("settings_tcpip_wifi_gateway_enabled")
 				dataItem.uid: Global.venusPlatform.serviceUid + "/Network/Wifi/GatewayEnabled"
 				writeAccessLevel: VenusOS.User_AccessType_User
 				valueTrue: true
 				valueFalse: false
+				updateDataOnClick: false
+
+				onClicked: {
+					if (!wifiGatewayEnabled.checked) {
+						wifiGatewayEnabled.toggleDataValue()
+					} else {
+						Global.dialogLayer.open(disableWiFiGatewayComponent)
+					}
+				}
+
+				Component {
+					id: disableWiFiGatewayComponent
+
+					ModalWarningDialog {
+						dialogDoneOptions: VenusOS.ModalDialog_DoneOptions_OkAndCancel
+						//% "Disable internet access over WiFi?"
+						title: qsTrId("settings_tcpip_disable_wifi_gateway")
+						//% "This will disconnect the device from VRM, unless it can connect to VRM over ethernet. Are you sure that you want to disable internet access over WiFi?"
+						description: qsTrId("settings_tcpip_disable_wifi_gateway_confirm")
+						onAccepted: wifiGatewayEnabled.toggleDataValue()
+					}
+				}
 			}
 
 			SettingsListHeader {


### PR DESCRIPTION
Previously, the user could disable either the wifi or ethernet internet gateway setting, and no warning dialog would be displayed. This could result in the device becoming inaccessible via VRM.

This commit ensures that the user has to confirm when disabling the internet gateway, to prevent that from occurring accidentally.

Note that within the settings page for the ethernet connection, it is difficult to know whether or not there is an active wifi connection with the internet gateway enabled, as we only pass through the NetworkServices for the ethernet connection there; thus we don't conditionally show the modal dialog when disabling the gateway setting.  Instead, we always show it.

Contributes to issue #3024