### PR TITLE
AC Inputs: improve current limit presets

### DIFF
--- a/components/SegmentedButtonRow.qml
+++ b/components/SegmentedButtonRow.qml
@@ -13,6 +13,7 @@ FocusScope {
 	property int fontPixelSize: Theme.font_buttonRow_size
 	property alias model: buttonRepeater.model
 	property int currentIndex
+	property bool showBorderWhenDisabled: false
 
 	signal buttonClicked(buttonIndex: int)
 
@@ -72,7 +73,7 @@ FocusScope {
 							  ? modelData.selectedBackgroundColor ?? Theme.color_ok
 							  : Theme.color_darkOk)
 					border.width: Theme.geometry_button_border_width
-					border.color: (mouseArea.enabled === false && model.index !== root.currentIndex) ? buttonDelegate.color : Theme.color_ok
+					border.color: (!root.showBorderWhenDisabled && mouseArea.enabled === false && model.index !== root.currentIndex) ? buttonDelegate.color : Theme.color_ok
 					radius: Theme.geometry_button_radius
 					roundedSide: model.index === 0 ? VenusOS.AsymmetricRoundedRectangle_RoundedSide_Left
 							: model.index === (buttonRepeater.count-1) ? VenusOS.AsymmetricRoundedRectangle_RoundedSide_Right

--- a/components/controls/MiniSpinBox.qml
+++ b/components/controls/MiniSpinBox.qml
@@ -40,6 +40,14 @@ CT.SpinBox {
 	onValueChanged: inputArea.setTextFromValue(value)
 	Component.onCompleted: inputArea.setTextFromValue(value)
 
+	property var updateValueTo: function(v, text) {
+		const previousValue = root.value
+		root.value = v
+		if (root.value !== previousValue) {
+			root.valueModified()
+		}
+	}
+
 	contentItem: FocusScope {
 		// needed for QQuickSpinBoxPrivate to read the "text" property of the contentItem
 		// so that it can call the valueFromText() function

--- a/components/controls/SpinBox.qml
+++ b/components/controls/SpinBox.qml
@@ -44,6 +44,10 @@ T.SpinBox {
 	property int _scalingFactor: 1
 	property int _originalStepSize
 
+	property var customIncrease: null
+	property var customDecrease: null
+	property var stepSizeForValue: null
+
 	signal increaseFailed()
 	signal decreaseFailed()
 
@@ -273,7 +277,11 @@ T.SpinBox {
 				root.increaseFailed()
 				return
 			}
-			root.increase()
+			if (root.customIncrease) {
+				root.customIncrease(root)
+			} else {
+				root.increase()
+			}
 			root.valueModified()
 			root.up.pressed = true
 		}
@@ -299,7 +307,11 @@ T.SpinBox {
 				root.decreaseFailed()
 				return
 			}
-			root.decrease()
+			if (root.customDecrease) {
+				root.customDecrease(root)
+			} else {
+				root.decrease()
+			}
 			root.valueModified()
 			root.down.pressed = true
 		}
@@ -329,6 +341,13 @@ T.SpinBox {
 		}
 
 		return value
+	}
+	property var updateValueTo: function(v, text) {
+		const previousValue = root.value
+		root.value = v
+		if (root.value !== previousValue) {
+			root.valueModified()
+		}
 	}
 
 	Timer {
@@ -361,14 +380,22 @@ T.SpinBox {
 			interval = 100
 			if (up.pressed) {
 				if (root.up.indicator.enabled) {
-					root.increase()
+					if (root.customIncrease) {
+						root.customIncrease(root)
+					} else {
+						root.increase()
+					}
 					root.valueModified()
 				} else {
 					root.increaseFailed()
 				}
 			} else {
 				if (root.down.indicator.enabled) {
-					root.decrease()
+					if (root.customDecrease) {
+						root.customDecrease(root)
+					} else {
+						root.decrease()
+					}
 					root.valueModified()
 				} else {
 					root.decreaseFailed()

--- a/components/controls/SpinBoxInputArea.qml
+++ b/components/controls/SpinBoxInputArea.qml
@@ -26,14 +26,18 @@ TextInput {
 	// These change the displayed value (which may not yet be accepted), rather than the actual
 	// spinBox value.
 	function increase() {
-		const nextValue = spinBox.valueFromText(text, spinBox.locale) + spinBox.stepSize
+		const currentValue = spinBox.valueFromText(text, spinBox.locale)
+		const stepSize = spinBox.stepSizeForValue ? spinBox.stepSizeForValue(currentValue, true) : spinBox.stepSize
+		const nextValue = currentValue + stepSize
 		if (nextValue > spinBox.to) {
 			root.increaseFailed()
 		}
 		setTextFromValue(Math.min(spinBox.to, nextValue))
 	}
 	function decrease() {
-		const nextValue = spinBox.valueFromText(text, spinBox.locale) - spinBox.stepSize
+		const currentValue = spinBox.valueFromText(text, spinBox.locale)
+		const stepSize = spinBox.stepSizeForValue ? spinBox.stepSizeForValue(currentValue, false) : spinBox.stepSize
+		const nextValue = currentValue - stepSize
 		if (nextValue < spinBox.from) {
 			root.decreaseFailed()
 		}
@@ -50,25 +54,12 @@ TextInput {
 		switch (event.key) {
 		case Qt.Key_Return:
 		case Qt.Key_Enter:
-			// Save the entered text. The text may at this time represent a value outside of the
-			// to/from range, so clamp it here.
-			let v = root.spinBox.valueFromText(text, root.spinBox.locale)
-			if (v < root.spinBox.from) {
-				root.decreaseFailed()
-				v = root.spinBox.from
-			} else if (v > root.spinBox.to) {
-				root.increaseFailed()
-				v = root.spinBox.to
-			}
-
-			// Force-update the displayed text, to guarantee the text is in sync
-			// with the numeric value, even if the value has not changed due to the
-			// user entering an out-of-range value on consecutive attempts.
-			text = root.spinBox.textFromValue(v, root.spinBox.locale)
-			if (v !== spinBox.value) {
-				root.spinBox.value = v
-				root.spinBox.valueModified()
-			}
+			// Save the entered text.
+			let origText = text
+			root.spinBox.updateValueTo(
+				root.spinBox.valueFromText(origText, root.spinBox.locale),
+				origText)
+			text = root.spinBox.textFromValue(root.spinBox.value, root.spinBox.locale)
 			break
 		case Qt.Key_Escape:
 			// Restore the initial value.
@@ -95,6 +86,8 @@ TextInput {
 			// Don't allow left/right keys to move focus away from the text input.
 			event.accepted = cursorPosition >= length
 			return
+		default:
+			break
 		}
 		event.accepted = false
 	}

--- a/components/dialogs/CurrentLimitDialog.qml
+++ b/components/dialogs/CurrentLimitDialog.qml
@@ -9,30 +9,54 @@ import Victron.VenusOS
 NumberSelectorDialog {
 	id: root
 
-	property int productId
-
-	/* - Mask the Product id with `0xFF00`
-	 * - If the result is `0x1900` or `0x2600` it is an EU model (230VAC)
-	 * - If the result is `0x2000` or `0x2700` it is an US model (120VAC)
-	 */
-	readonly property int _productUpperByte: productId > 0 ? productId / 0x100 : 0
-
-	function _euAmpOptions() {
-		return [ 3.0, 6.0, 10.0, 13.0, 16.0, 25.0, 32.0, 63.0 ].map(function(v) { return { value: v } })
-	}
-
-	function _usAmpOptions() {
-		return [ 10.0, 15.0, 20.0, 30.0, 50.0, 100.0 ].map(function(v) { return { value: v } })
-	}
+	readonly property real transitionValue: 25.0
 
 	title: CommonWords.input_current_limit
 	suffix: Units.defaultUnitString(VenusOS.Units_Amp)
-	stepSize: 0.1
-	to: 1000
-	decimals: 1
+	decimals: value <= root.transitionValue ? 1 : 0
+	stepSize: value <= root.transitionValue ? 0.1 : 1.0
+	to: root.maxCurrentLimit > 0 ? root.maxCurrentLimit : root._presetLimits[root._presetLimits.length - 1]
+	presets: _presetAmpOptions()
 
-	// Show the correct amp presets depending on whether this is an EU or US product.
-	presets: _productUpperByte === 0x19 || _productUpperByte === 0x26
-			 ? _euAmpOptions()
-			 : (_productUpperByte === 0x20 || _productUpperByte === 0x27 ? _usAmpOptions() : [])
+	stepSizeForValue: (v, increasing) => {
+		const epsilon = 0.0001
+		const atTransition = Math.abs(v - root.transitionValue) <= epsilon
+		return (increasing && atTransition) ? 1.0 : (v <= root.transitionValue ? 0.1 : 1.0)
+	}
+
+	customIncrease: (spinbox) => {
+		const epsilon = 0.0001
+		if (Math.abs(root.value - root.transitionValue) <= epsilon) {
+			// we are increasing, but the step size will currently be 0.1 due to the binding.
+			// use the larger step size which is appropriate for increasing beyond the transition value.
+			root.value = Math.min(root.to, root.value + 1.0)
+		} else {
+			spinbox.increase()
+		}
+	}
+
+	property real maxCurrentLimit: -1
+	readonly property var _presetLimits: [3.0, 6.0, 10.0, 13.0, 16.0, 25.0, 32.0, 63.0, 100, 150, 200, 300, 500, 750, 1000, 1500, 2000, 2500, 3000, 3500, 4000]
+	function _presetAmpOptions() {
+		let upperIndex = root._presetLimits.length - 1
+		if (root.maxCurrentLimit > 0) {
+			// select the 8 values which are (equal to or less than) the max current limit.
+			for (let i = 0; i < root._presetLimits.length; ++i) {
+				if (root._presetLimits[i] === root.maxCurrentLimit) {
+					upperIndex = i
+					break
+				} else if (root._presetLimits[i] > root.maxCurrentLimit) {
+					upperIndex = i - 1
+					break
+				}
+			}
+			// also select values which are over the max current limit if necessary, but they will be disabled.
+			upperIndex = Math.max(7, upperIndex)
+		} else {
+			// if we don't know the max current limit, just use the lowest 8 values as presets.
+			upperIndex = 7
+		}
+		const lowerIndex = Math.max(0, upperIndex - 7)
+		return root._presetLimits.slice(lowerIndex, upperIndex+1).map(function(v) { return { value: v, enabled: ((root.maxCurrentLimit < 0) || (v <= root.maxCurrentLimit)) } })
+	}
 }

--- a/components/dialogs/NumberSelectorDialog.qml
+++ b/components/dialogs/NumberSelectorDialog.qml
@@ -18,22 +18,34 @@ ModalDialog {
 	property real from
 	property real to
 	property real stepSize
+	property var stepSizeForValue: null
 	property var presets: []
 
 	// Error text shown when user tries to set a value < from or > to.
 	property string fromErrorText
 	property string toErrorText
 
+	property var customIncrease: null
+
+	function _presetIndexForValue(v) {
+		const epsilon = 0.0001
+		const valueAsNumber = Number(v)
+		for (let i = 0; i < presets.length; ++i) {
+			const presetValue = Number(presets[i].value)
+			if (!isNaN(presetValue) && !isNaN(valueAsNumber)) {
+				if (Math.abs(presetValue - valueAsNumber) <= epsilon * Math.max(1, Math.abs(presetValue), Math.abs(valueAsNumber))) {
+					return i
+				}
+			} else if (presets[i].value === v) {
+				return i
+			}
+		}
+		return -1
+	}
+
 	onAboutToShow: {
 		if (presets.length) {
-			let presetsIndex = -1
-			for (let i = 0; i < presets.length; ++i) {
-				if (presets[i].value === value) {
-					presetsIndex = i
-					break
-				}
-			}
-			presetsRow.currentIndex = presetsIndex
+			presetsRow.currentIndex = root._presetIndexForValue(value)
 		}
 	}
 
@@ -94,12 +106,45 @@ ModalDialog {
 				from: decimalConverter.intFrom
 				to: decimalConverter.intTo
 				stepSize: decimalConverter.intStepSize
+				stepSizeForValue: (v, increasing) => {
+					if (!root.stepSizeForValue) {
+						return spinBox.stepSize
+					}
+					// At this point, the value we receive will be "decimal converter scaled"
+					// whereas the CurrentLimitDialog does pure value comparison in its
+					// stepSizeForValue implementation.  So, we need to convert the
+					// scaled value into a raw value, ask the root implementation what
+					// the step size should be, and then scale that step size up appropriately.
+					const decimalValue = decimalConverter.intToDecimal(v)
+					const decimalStepSize = root.stepSizeForValue(decimalValue, increasing)
+					return decimalConverter.decimalToInt(decimalStepSize)
+				}
 				value: decimalConverter.decimalToInt(root.value)
 				textFromValue: (value, locale) => decimalConverter.textFromValue(value)
 				valueFromText: (text, locale) => {
 					const v = decimalConverter.valueFromText(text)
 					return isNaN(v) ? decimalConverter.decimalToInt(root.value) : v // if invalid, use the previous value
 				}
+				updateValueTo: (v, text) => {
+					// Manually set the root value from the text,
+					// rather than attempting to determine the appropriate next
+					// spinbox value for the given text (as SpinBoxInputArea does),
+					// because the text value might be associated with
+					// a different number of decimals than the current spinbox value.
+					let value = Units.formattedNumberToReal(text)
+					if (isNaN(value)) {
+						// don't change the current value
+						value = root.value
+					} else if (value < root.from) {
+						spinBox.decreaseFailed()
+						value = root.from
+					} else if (value > root.to) {
+						spinBox.increaseFailed()
+						value = root.to
+					}
+					root.value = value
+				}
+				customIncrease: root.customIncrease
 
 				// Use BeforeItem priority to override the default key Spinbox event handling, else
 				// up/down keys will modify the number even when SpinBox is not in "edit" mode.
@@ -112,7 +157,6 @@ ModalDialog {
 
 				onValueModified: {
 					dialogContent.valueModified()
-					presetsRow.currentIndex = -1
 				}
 				onDecreaseFailed: {
 					if (root.fromErrorText) {
@@ -148,12 +192,17 @@ ModalDialog {
 			SegmentedButtonRow {
 				id: presetsRow
 
+				showBorderWhenDisabled: true
 				model: root.presets
 				visible: model.length > 0
 				enabled: visible
 				onButtonClicked: function (buttonIndex) {
-					spinBox.value = decimalConverter.decimalToInt(model[buttonIndex].value)
-					dialogContent.valueModified()
+					root.value = model[buttonIndex].value
+				}
+
+				property real rootValue: root.value
+				onRootValueChanged: {
+					presetsRow.currentIndex = root._presetIndexForValue(rootValue)
 				}
 
 				KeyNavigation.down: root.footer

--- a/components/listitems/ListCurrentLimitButton.qml
+++ b/components/listitems/ListCurrentLimitButton.qml
@@ -64,6 +64,12 @@ ListButton {
 	VeQuickItem {
 		id: currentLimitItem
 		uid: root.serviceUid + "/Ac/In/" + root.inputNumber + "/CurrentLimit"
+		property real maxCurrentLimit: currentLimitItem.valid
+				&& currentLimitItem.max != null
+				&& currentLimitItem.max > 0
+				&& currentLimitItem.max < Global.int32Max
+			? currentLimitItem.max
+			: -1 // -1 = unknown / no max current limit
 	}
 
 	VeQuickItem {
@@ -81,16 +87,11 @@ ListButton {
 		uid: root.serviceUid + "/Devices/Dmc/Version"
 	}
 
-	VeQuickItem {
-		id: productIdItem
-		uid: root.serviceUid + "/ProductId"
-	}
-
 	Component {
 		id: currentLimitDialogComponent
 
 		CurrentLimitDialog {
-			productId: productIdItem.valid ? productIdItem.value : 0
+			maxCurrentLimit: currentLimitItem.maxCurrentLimit
 			title: Global.acInputs.currentLimitTypeToText(root.inputType)
 			secondaryTitle: CommonWords.acInputFromNumber(root.inputNumber)
 			onAccepted: currentLimitItem.setValue(value)


### PR DESCRIPTION
Previously, the current limit dialog displayed presets which were dependent upon whether the productId identified the device as an EU or US device.  However, it did not take into account large systems with many parallel inputs, where the total current limit should be much higher than that allowed by a single device.

This commit changes the current limit presets to be a single pre-defined list, from which we select the eight largest values which are less than the reported max current limit for the input.

It also ensures that we use a step size of 1 amp rather than 0.1 amps, if the current limit value is larger than 25 amps. It also reduces the precision to zero decimals, in that case.

Contributes to issue #2863