### PR TITLE
DC Gensets: fix navigation for DC input widget

### DIFF
--- a/components/listitems/ListGeneratorControlStatus.qml
+++ b/components/listitems/ListGeneratorControlStatus.qml
@@ -15,7 +15,9 @@ ListText {
 	text: qsTrId("list_generator_control_status")
 	secondaryText: activeCondition.isAutoStarted && generatorState.value === VenusOS.Generators_State_Running
 					   ? CommonWords.autostarted_dot_running_by.arg(Global.generators.runningByText(activeCondition.value))
-					   : Global.generators.stateAndCondition(generatorState.value, activeCondition.value)
+					   : generatorState.valid && activeCondition.valid
+						 ? Global.generators.stateAndCondition(generatorState.value, activeCondition.value)
+						 : ""
 
 	VeQuickItem {
 		id: activeCondition

--- a/components/widgets/DcInputWidget.qml
+++ b/components/widgets/DcInputWidget.qml
@@ -18,7 +18,7 @@ OverviewWidget {
 			: serviceType === "dcsource" ? VenusOS.DcMeter_Type_GenericSource
 			: VenusOS.DcMeter_Type_GenericMeter
 	readonly property string detailUrl: serviceType === "alternator" ? "/pages/settings/devicelist/dc-in/PageAlternator.qml"
-			: _widgetOnlyPresentsDcGensets ? "/pages/settings/PageDcGenset.qml"
+			: _widgetOnlyPresentsDcGensets ? "/pages/settings/devicelist/PageGenset.qml"
 			: "/pages/settings/devicelist/dc-in/PageDcMeter.qml"
 	readonly property bool _widgetOnlyPresentsDcGensets: root.serviceType === "dcgenset" && inputDeviceModel.commonMeterType !== -1
 
@@ -50,7 +50,7 @@ OverviewWidget {
 		if (inputDeviceModel.count === 1) {
 			Global.pageManager.pushPage(
 						root.detailUrl,
-						root._widgetOnlyPresentsDcGensets ? { "device": inputDeviceModel.firstObject } : { "bindPrefix": inputDeviceModel.firstObject.serviceUid })
+						{ "bindPrefix": inputDeviceModel.firstObject.serviceUid })
 		} else {
 			Global.pageManager.pushPage(root._widgetOnlyPresentsDcGensets && Global.generators.multipleDcGensetsSupported
 										? "/pages/settings/PageDcGensets.qml" : listPageComponent)

--- a/data/Generators.qml
+++ b/data/Generators.qml
@@ -113,7 +113,7 @@ QtObject {
 			//% "Inverter overload condition"
 			return qsTrId("settings_inverter_overload_condition")
 		default:
-			console.warn("Invalid RunningByConditionCode")
+			console.warn("Invalid RunningByConditionCode:", runningBy)
 			return "--"
 		}
 	}


### PR DESCRIPTION
For single DC gensets, when clicking on the dc input widget on the overview page, navigate to the same page as when you click on a DC genset on the device list page.

For multiple DC gensets, when clicking on the dc input widget on the overview page, navigate to the same page as when you click on 'DC Gensets' in the device list page.