### PR TITLE
Settings: ac-in consumption and production limit

### DIFF
--- a/cmake/ModuleVenus_Sources.cmake
+++ b/cmake/ModuleVenus_Sources.cmake
@@ -577,6 +577,8 @@ set (VictronVenusOS_QML_MODULE_SOURCES
     pages/settings/devicelist/tank/PageTankSensor.qml
     pages/settings/devicelist/tank/PageTankSetup.qml
     pages/settings/devicelist/tank/PageTankShape.qml
+    pages/settings/devicelist/ac-in/AcLimitsConsumptionSettings.qml
+    pages/settings/devicelist/ac-in/AcLimitsProductionSettings.qml
     pages/settings/devicelist/ac-in/PageAcIn.qml
     pages/settings/devicelist/ac-in/PageAcInSetup.qml
     pages/settings/devicelist/ac-in/PageAcInModel.qml

--- a/pages/settings/devicelist/ac-in/AcLimitsConsumptionSettings.qml
+++ b/pages/settings/devicelist/ac-in/AcLimitsConsumptionSettings.qml
@@ -1,0 +1,49 @@
+/*
+** Copyright (C) 2026 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+SettingsColumn {
+	id: root
+
+	required property string bindPrefix
+
+	preferredVisible: consumptionLimitSwitch.preferredVisible || consumptionPowerLimitSpinBox.preferredVisible
+			|| consumptionCurrentLimitSpinBox.preferredVisible
+	width: parent ? parent.width : 0
+
+	ListSwitch {
+		id: consumptionLimitSwitch
+
+		//% "Consumption limit"
+		text: qsTrId("ac-limits-consumptionsettings_consumption_limit")
+		dataItem.uid: root.bindPrefix + "/Ac/Limits/Consumption/Active"
+		writeAccessLevel: VenusOS.User_AccessType_SuperUser
+		preferredVisible: dataItem.valid
+	}
+
+	ListSpinBox {
+		id: consumptionPowerLimitSpinBox
+
+		//% "Consumption power limit"
+		text: qsTrId("ac-limits-consumptionsettings_consumption_power_limit")
+		dataItem.uid: root.bindPrefix + "/Ac/Limits/Consumption/Power"
+		suffix: Units.defaultUnitString(VenusOS.Units_Watt)
+		writeAccessLevel: VenusOS.User_AccessType_SuperUser
+		preferredVisible: dataItem.valid
+	}
+
+	ListSpinBox {
+		id: consumptionCurrentLimitSpinBox
+
+		//% "Consumption current limit"
+		text: qsTrId("ac-limits-consumptionsettings_consumption_current_limit")
+		dataItem.uid: root.bindPrefix + "/Ac/Limits/Consumption/Current"
+		suffix: Units.defaultUnitString(VenusOS.Units_Amp)
+		writeAccessLevel: VenusOS.User_AccessType_SuperUser
+		preferredVisible: dataItem.valid
+	}
+}

--- a/pages/settings/devicelist/ac-in/AcLimitsProductionSettings.qml
+++ b/pages/settings/devicelist/ac-in/AcLimitsProductionSettings.qml
@@ -1,0 +1,49 @@
+/*
+** Copyright (C) 2026 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+SettingsColumn {
+	id: root
+
+	required property string bindPrefix
+
+	preferredVisible: productionLimitSwitch.preferredVisible || productionPowerLimitSpinBox.preferredVisible
+			|| productionCurrentLimitSpinBox.preferredVisible
+	width: parent ? parent.width : 0
+
+	ListSwitch {
+		id: productionLimitSwitch
+
+		//% "Production limit"
+		text: qsTrId("ac-limits-productionsettings_production_limit")
+		dataItem.uid: root.bindPrefix + "/Ac/Limits/Production/Active"
+		writeAccessLevel: VenusOS.User_AccessType_SuperUser
+		preferredVisible: dataItem.valid
+	}
+
+	ListSpinBox {
+		id: productionPowerLimitSpinBox
+
+		//% "Production power limit"
+		text: qsTrId("ac-limits-productionsettings_production_power_limit")
+		dataItem.uid: root.bindPrefix + "/Ac/Limits/Production/Power"
+		suffix: Units.defaultUnitString(VenusOS.Units_Watt)
+		writeAccessLevel: VenusOS.User_AccessType_SuperUser
+		preferredVisible: dataItem.valid
+	}
+
+	ListSpinBox {
+		id: productionCurrentLimitSpinBox
+
+		//% "Production current limit"
+		text: qsTrId("ac-limits-productionsettings_production_current_limit")
+		dataItem.uid: root.bindPrefix + "/Ac/Limits/Production/Current"
+		suffix: Units.defaultUnitString(VenusOS.Units_Amp)
+		writeAccessLevel: VenusOS.User_AccessType_SuperUser
+		preferredVisible: dataItem.valid
+	}
+}

--- a/pages/settings/devicelist/ac-in/PageAcInModel.qml
+++ b/pages/settings/devicelist/ac-in/PageAcInModel.qml
@@ -187,4 +187,12 @@ VisibleItemModel {
 			uid: root.bindPrefix + "/Role"
 		}
 	}
+
+	AcLimitsConsumptionSettings {
+		bindPrefix: root.bindPrefix
+	}
+
+	AcLimitsProductionSettings {
+		bindPrefix: root.bindPrefix
+	}
 }


### PR DESCRIPTION
We have a new generic dbus api in development to set consumption and production limits on relevant devices.
This will in the future allow a service to manage all of the devices in accordance with the DSO.
An example would be the grid requesting a temporary export/production limit.
More details on the API [here](https://docs.google.com/document/d/156xmYsZPO2W1CYcIF9Jx2s2M6B0-VGrfFK9D4LdDfO8/edit?usp=sharing).

This change is simply to expose those properties so that superusers can change those limits and remain read-only for other access levels.
This is purely for test and diagnostics purposes while the feature matures.

Superusers:  
<img width="799" height="478" alt="Screenshot 2026-06-04 at 11 49 28" src="https://github.com/user-attachments/assets/7e58e68a-30c3-4d0a-ae11-4b3ee549b3e4" />  
<img width="799" height="478" alt="Screenshot 2026-06-04 at 11 49 48" src="https://github.com/user-attachments/assets/d2742236-7bdc-4546-85ef-7b5080e8fff9" />

Other access levels:  
<img width="799" height="478" alt="Screenshot 2026-06-04 at 11 47 39" src="https://github.com/user-attachments/assets/e1744800-ca20-44b3-8634-54712fa5d9ff" />  
<img width="799" height="478" alt="Screenshot 2026-06-04 at 11 47 48" src="https://github.com/user-attachments/assets/e2835d4f-314f-4959-b265-232d853e5416" />
