### PR TITLE
UI: add command line arg to disable animations

### DIFF
--- a/ApplicationContent.qml
+++ b/ApplicationContent.qml
@@ -122,7 +122,7 @@ FocusScope {
 		z: 1
 
 		asynchronous: true
-		active: (Global.isGxDevice || BackendConnection.needsWasmKeyboardHandler) && !GuiPluginLoader.busy
+		active: (Global.isGxDevice || UiConfig.needsWasmKeyboardHandler) && !GuiPluginLoader.busy
 
 		// Note that for gx builds, all references to 'qrc:/.../Thing.qml' are intercepted by
 		// UrlInterceptor and changed to '.../Thing.qml', i.e. they are loaded from the file

--- a/FrameRateVisualizer.qml
+++ b/FrameRateVisualizer.qml
@@ -17,7 +17,7 @@ Loader {
 	// Disable the visualizer and the model while the application isn't visible
 	active: FrameRateModel.enabled
 	property bool frameRateModelWasEnabled: false
-	property bool applicationVisible: BackendConnection.applicationVisible
+	property bool applicationVisible: UiConfig.applicationVisible
 	onApplicationVisibleChanged: {
 		if (!applicationVisible) {
 			frameRateModelWasEnabled = FrameRateModel.enabled

--- a/Global.qml
+++ b/Global.qml
@@ -25,8 +25,8 @@ QtObject {
 	property var dialogLayer
 	property var notificationLayer
 	property bool displayCpuUsage
-	readonly property bool animationEnabled: (systemSettings?.animationEnabled ?? true) && BackendConnection.applicationVisible && !ScreenBlanker.blanked
-	readonly property bool timersEnabled: BackendConnection.applicationVisible && !ScreenBlanker.blanked
+	readonly property bool animationEnabled: (systemSettings?.animationEnabled ?? true) && UiConfig.animationEnabled && UiConfig.applicationVisible && !ScreenBlanker.blanked
+	readonly property bool timersEnabled: UiConfig.applicationVisible && !ScreenBlanker.blanked
 
 	// data sources
 	property var acInputs

--- a/cmake/ModuleVenus_Sources.cmake
+++ b/cmake/ModuleVenus_Sources.cmake
@@ -732,6 +732,8 @@ list(APPEND VictronVenusOS_CPP_SOURCES
     src/qrangemodel_p.h
     src/qrangemodel.h
     src/qrangemodel.cpp
+    src/uiconfig.h
+    src/uiconfig.cpp
     src/uitest.h
     src/uitest.cpp
     src/uitestcase.h

--- a/components/Arc.qml
+++ b/components/Arc.qml
@@ -10,7 +10,7 @@ import Victron.VenusOS
 ShapePath {
 	id: path
 
-	property bool animationEnabled: true
+	required property bool animationEnabled
 	property real radius
 	property real startAngle
 	property real endAngle

--- a/components/ArcGauge.qml
+++ b/components/ArcGauge.qml
@@ -30,7 +30,7 @@ Item {
 		anchors.fill: parent
 
 		// Antialiasing without requiring multisample framebuffers.
-		layer.enabled: !BackendConnection.msaaEnabled
+		layer.enabled: !UiConfig.msaaEnabled
 		layer.smooth: true
 		layer.textureSize: Qt.size(antialiased.width*2, antialiased.height*2)
 

--- a/components/BarGaugeBase.qml
+++ b/components/BarGaugeBase.qml
@@ -17,7 +17,7 @@ Rectangle {
 	property color surfaceColor: Theme.color_levelsPage_gauge_separatorBarColor
 	property real value: 0.0
 	property int orientation: Qt.Vertical
-	property bool animationEnabled
+	required property bool animationEnabled
 
 	width: orientation === Qt.Vertical ? Theme.geometry_barGauge_vertical_width_large : parent.width
 	height: orientation === Qt.Vertical ? parent.height : Theme.geometry_barGauge_horizontal_height

--- a/components/CheapBarGauge.qml
+++ b/components/CheapBarGauge.qml
@@ -30,7 +30,7 @@ Rectangle {
 	property color surfaceColor: Theme.color_levelsPage_gauge_separatorBarColor
 	property real value: 0.0
 	property int orientation: Qt.Vertical
-	property bool animationEnabled
+	required property bool animationEnabled
 
 	color: backgroundColor
 	radius: _isVertical ? width / 2 : height / 2

--- a/components/CircularMultiGauge.qml
+++ b/components/CircularMultiGauge.qml
@@ -13,7 +13,7 @@ Item {
 
 	property alias model: arcRepeater.model
 	readonly property real strokeWidth: Theme.geometry_circularMultiGauge_strokeWidth
-	property bool animationEnabled
+	required property bool animationEnabled
 	property real labelMargin
 	property alias labelOpacity: textCol.opacity
 	property int leftGaugeCount
@@ -28,7 +28,7 @@ Item {
 		anchors.fill: parent
 
 		// Antialiasing without requiring multisample framebuffers.
-		layer.enabled: !BackendConnection.msaaEnabled
+		layer.enabled: !UiConfig.msaaEnabled
 		layer.smooth: true
 		layer.textureSize: Qt.size(antialiased.width*2, antialiased.height*2)
 
@@ -43,7 +43,7 @@ Item {
 				height: width
 				anchors.centerIn: parent
 				sourceComponent: model.tankType === VenusOS.Tank_Type_Battery ? shinyProgressArc : progressArc
-				onStatusChanged: if (status === Loader.Error) console.warn("Unable to load circular multi gauge progress arc:", errorString())
+				onStatusChanged: if (status === Loader.Error) console.warn("Unable to load circular multi gauge progress arc")
 
 				Component {
 					id: shinyProgressArc

--- a/components/CircularSingleGauge.qml
+++ b/components/CircularSingleGauge.qml
@@ -21,7 +21,7 @@ Item {
 		anchors.fill: parent
 
 		// Antialiasing without requiring multisample framebuffers.
-		layer.enabled: !BackendConnection.msaaEnabled
+		layer.enabled: !UiConfig.msaaEnabled
 		layer.smooth: true
 		layer.textureSize: Qt.size(antialiased.width*2, antialiased.height*2)
 

--- a/components/ColorSelector.qml
+++ b/components/ColorSelector.qml
@@ -515,7 +515,7 @@ Item {
 	}
 
 	// Antialiasing without requiring multisample framebuffers.
-	layer.enabled: !BackendConnection.msaaEnabled
+	layer.enabled: !UiConfig.msaaEnabled
 	layer.smooth: true
 	layer.textureSize: Qt.size(root.width*2, root.height*2)
 }

--- a/components/Page.qml
+++ b/components/Page.qml
@@ -15,6 +15,7 @@ FocusScope {
 	readonly property bool isCurrentPage: !!Global.mainView && Global.mainView.currentPage === root
 	readonly property bool defaultAnimationEnabled: !!Global.mainView
 			&& Global.mainView.allowPageAnimations
+			&& UiConfig.animationEnabled
 			&& !ScreenBlanker.blanked
 	property bool animationEnabled: defaultAnimationEnabled && isCurrentPage
 

--- a/components/ProgressArc.qml
+++ b/components/ProgressArc.qml
@@ -13,8 +13,8 @@ Shape {
 	property real value // 0 - 100
 	property real radius
 	property real strokeWidth: Theme.geometry_progressArc_strokeWidth
+	required property bool animationEnabled
 	property alias useLargeArc: progress.useLargeArc
-	property alias animationEnabled: progress.animationEnabled
 	property alias progressColor: progress.strokeColor
 	property alias remainderColor: remainder.strokeColor
 	property alias startAngle: remainder.startAngle
@@ -46,5 +46,6 @@ Shape {
 		strokeWidth: control.strokeWidth
 		strokeColor: Theme.color_ok
 		fillColor: control.fillColor
+		animationEnabled: control.animationEnabled
 	}
 }

--- a/components/ShinyProgressArc.qml
+++ b/components/ShinyProgressArc.qml
@@ -13,8 +13,8 @@ Item {
 
 	property real value
 	property real radius
-	property bool animationEnabled
-	property bool shineAnimationEnabled
+	required property bool animationEnabled
+	required property bool shineAnimationEnabled
 	property real strokeWidth: Theme.geometry_progressArc_strokeWidth
 	property alias progressColor: progress.strokeColor
 	property alias remainderColor: remainder.strokeColor
@@ -37,6 +37,7 @@ Item {
 			strokeWidth: control.strokeWidth
 			strokeColor: Theme.color_darkOk
 			fillColor: control.fillColor
+			animationEnabled: progress.animationEnabled
 		}
 	}
 

--- a/components/SideMultiGauge.qml
+++ b/components/SideMultiGauge.qml
@@ -17,7 +17,7 @@ Item {
 	property int horizontalAlignment
 	property real arcVerticalCenterOffset
 	property real phaseLabelHorizontalMargin
-	property bool animationEnabled
+	required property bool animationEnabled
 	property real minimumValue
 	property real maximumValue
 	property bool inputMode

--- a/components/SolarYieldGauge.qml
+++ b/components/SolarYieldGauge.qml
@@ -14,7 +14,7 @@ Item {
 	property real endAngle
 	property int horizontalAlignment
 	property real arcVerticalCenterOffset
-	property bool animationEnabled
+	required property bool animationEnabled
 
 	width: parent.width
 	height: parent.height

--- a/components/SwipePageModel.qml
+++ b/components/SwipePageModel.qml
@@ -50,7 +50,7 @@ ObjectModel {
 		Image {
 			width: status === Image.Null ? 0 : Theme.geometry_screen_width
 			fillMode: Image.PreserveAspectFit
-			source: BackendConnection.demoImageFileName
+			source: UiConfig.demoImageFileName
 			onStatusChanged: {
 				if (status === Image.Ready) {
 					console.info("Loaded demo image:", source)

--- a/components/ThreePhaseBarGauge.qml
+++ b/components/ThreePhaseBarGauge.qml
@@ -15,7 +15,7 @@ Flow {
 	property real maximumValue
 	property bool inputMode
 	property int orientation: Qt.Vertical
-	property bool animationEnabled
+	required property bool animationEnabled
 	property bool inOverviewWidget
 
 	readonly property real _longEdgeLength: orientation === Qt.Vertical ? height : width

--- a/components/controls/Slider.qml
+++ b/components/controls/Slider.qml
@@ -14,7 +14,7 @@ T.Slider {
 	property color grooveColor: enabled ? Theme.color_darkOk : Theme.color_background_disabled
 	property color highlightColor: enabled ? Theme.color_ok : Theme.color_switch_groove_disabled
 	property bool showHandle: true
-	property bool animationEnabled
+	property bool animationEnabled: Global.animationEnabled
 	property Item maskSource: sourceItem
 
 	implicitWidth: Math.max(implicitBackgroundWidth, implicitHandleWidth) + leftInset + rightInset

--- a/components/dialogs/ModalDialog.qml
+++ b/components/dialogs/ModalDialog.qml
@@ -50,7 +50,7 @@ T.Dialog {
 	readonly property string rejectTextCancel: CommonWords.cancel
 
 	readonly property Item focusedInputItem: root.visible
-		&& (Qt.inputMethod.visible || BackendConnection.needsWasmKeyboardHandler)
+		&& (Qt.inputMethod.visible || UiConfig.needsWasmKeyboardHandler)
 			? (root.contentItem.Window.activeFocusItem as TextField ??
 				root.contentItem.Window.activeFocusItem as TextInput ??
 				// root.contentItem.Window.activeFocusItem as TextArea ?? // not used

--- a/components/widgets/OverviewWidget.qml
+++ b/components/widgets/OverviewWidget.qml
@@ -22,7 +22,7 @@ T.Control {
 	readonly property int expandedHeight: getExpandedHeight(size)
 	property bool expanded
 	property bool animateGeometry
-	property bool animationEnabled
+	required property bool animationEnabled
 
 	// Font size for secondary widget details, e.g. AC-in state, battery temp, ESS numbers.
 	readonly property int secondaryFontSize: size >= VenusOS.OverviewWidget_Size_M

--- a/components/widgets/WidgetConnector.qml
+++ b/components/widgets/WidgetConnector.qml
@@ -23,7 +23,7 @@ Item {
 	property int animationMode: VenusOS.WidgetConnector_AnimationMode_NotAnimated
 	property alias expanded: connectorPath.expanded
 	property bool animateGeometry
-	property bool animationEnabled
+	required property bool animationEnabled
 	readonly property bool defaultVisible: startWidget.visible && endWidget.visible && _initialized
 
 	required property FrameAnimation frameAnimation

--- a/data/DataManager.qml
+++ b/data/DataManager.qml
@@ -62,7 +62,7 @@ Item {
 		onLoaded: { console.info("DataManager: mock setup loaded!"); mockLoaded = true }
 		onStatusChanged: {
 			if (status === Loader.Error) {
-				console.warn("DataManager: Unable to load mock setup:", errorString())
+				console.warn("DataManager: Unable to load mock setup")
 			}
 		}
 	}

--- a/data/SystemSettings.qml
+++ b/data/SystemSettings.qml
@@ -313,7 +313,7 @@ QtObject {
 			interval: 60000
 			repeat: true
 			triggeredOnStart: true
-			running: BackendConnection.applicationVisible // even if !Global.timersEnabled, in case screen blank duration is short
+			running: UiConfig.applicationVisible // even if !Global.timersEnabled, in case screen blank duration is short
 			onTriggered: root.time.getValue(true)   // force value refresh
 		}
 	}

--- a/pages/BriefPage.qml
+++ b/pages/BriefPage.qml
@@ -74,7 +74,7 @@ SwipeViewPage {
 				Image {
 					width: status === Image.Null ? 0 : Theme.geometry_screen_width
 					fillMode: Image.PreserveAspectFit
-					source: BackendConnection.demoImageFileName
+					source: UiConfig.demoImageFileName
 					onStatusChanged: {
 						if (status === Image.Ready) {
 							console.info("Loaded demo image:", source)

--- a/pages/BriefPage_Landscape.qml
+++ b/pages/BriefPage_Landscape.qml
@@ -368,6 +368,7 @@ Item {
 			height: Math.max(root._unexpandedHeight, implicitHeight)
 			animationEnabled: root.animationEnabled
 		}
+		onStatusChanged: if (status === Loader.Error) console.warn("Unable to load side panel")
 
 		// the brief monitor panel has animations which mess with the asynchronous heuristic
 		// and cause the object hierarchy to take multiple seconds to load.

--- a/pages/BriefPage_Portrait.qml
+++ b/pages/BriefPage_Portrait.qml
@@ -46,6 +46,7 @@ Item {
 		x: Theme.geometry_page_content_horizontalMargin
 		y: mainGaugeBackground.y + mainGaugeBackground.height + Theme.geometry_sidePanel_spacing
 		sourceComponent: detailPanelActiveComponent
+		onStatusChanged: if (status === Loader.Error) console.warn("Unable to load detail panel")
 
 		Component {
 			id: detailPanelActiveComponent

--- a/pages/BriefSidePanel.qml
+++ b/pages/BriefSidePanel.qml
@@ -10,7 +10,7 @@ import Victron.VenusOS
 ColumnLayout {
 	id: root
 
-	property bool animationEnabled
+	required property bool animationEnabled
 
 	readonly property AcInput generatorInput: Global.acInputs.input1?.source === VenusOS.AcInputs_InputSource_Generator ? Global.acInputs.input1
 			: Global.acInputs.input2?.source === VenusOS.AcInputs_InputSource_Generator ? Global.acInputs.input2

--- a/pages/LevelsTab.qml
+++ b/pages/LevelsTab.qml
@@ -10,7 +10,7 @@ import Victron.Gauges
 BaseListView {
 	id: root
 
-	property bool animationEnabled: true
+	required property bool animationEnabled
 
 	bottomMargin: Global.pageManager?.expandLayout
 			? Theme.geometry_levelsPage_gaugesView_expanded_bottomMargin

--- a/pages/MainView.qml
+++ b/pages/MainView.qml
@@ -23,7 +23,7 @@ FocusScope {
 
 	property alias navBarAnimatingOut: animateNavBarOut.running
 
-	property bool mainViewVisible: BackendConnection.applicationVisible && !Global.splashScreenVisible
+	property bool mainViewVisible: UiConfig.applicationVisible && !Global.splashScreenVisible
 	onMainViewVisibleChanged: if (mainViewVisible) console.info("MainView: UI loaded and visible")
 
 	// To reduce the animation load, disable page animations when the PageStack is transitioning

--- a/pages/OverviewPage_Portrait.qml
+++ b/pages/OverviewPage_Portrait.qml
@@ -139,7 +139,10 @@ FocusScope {
 					visible: active
 					sourceComponent: SolarYieldWidget {
 						size: leftInputColumn.widgetSize
+						animationEnabled: root.animationEnabled
 					}
+					onStatusChanged: if (status === Loader.Error) console.warn("Unable to load solar widget")
+
 					Layout.fillWidth: true
 					Layout.fillHeight: true
 					Layout.minimumHeight: root._widgetHeightForSize(leftInputColumn.widgetSize)
@@ -170,7 +173,10 @@ FocusScope {
 							serviceType: modelData.serviceTypes[0] || ""
 							inputTypeFilter: modelData.commonMeterType
 							size: leftInputColumn.widgetSize
+							animationEnabled: root.animationEnabled
 						}
+						onStatusChanged: if (status === Loader.Error) console.warn("Unable to load dc input widget for type " + modelData.commonMeterType)
+
 						Layout.fillWidth: true
 						Layout.fillHeight: true
 						Layout.minimumHeight: root._widgetHeightForSize(leftInputColumn.widgetSize)
@@ -191,7 +197,10 @@ FocusScope {
 						serviceType: "dcsource"
 						inputTypeFilter: dcSourceModel.commonMeterType
 						size: leftInputColumn.widgetSize
+						animationEnabled: root.animationEnabled
 					}
+					onStatusChanged: if (status === Loader.Error) console.warn("Unable to load combined dc input widget")
+
 					Layout.fillWidth: true
 					Layout.fillHeight: true
 					Layout.minimumHeight: root._widgetHeightForSize(leftInputColumn.widgetSize)
@@ -211,7 +220,10 @@ FocusScope {
 							serviceType: dcsourceWidgetLoader.device.serviceType
 							inputTypeFilter: dcsourceWidgetLoader.meterType
 							size: leftInputColumn.widgetSize
+							animationEnabled: root.animationEnabled
 						}
+						onStatusChanged: if (status === Loader.Error) console.warn("Unable to load dc source widget for type " + dcsourceWidgetLoader.meterType)
+
 						Layout.fillWidth: true
 						Layout.fillHeight: true
 						Layout.minimumHeight: root._widgetHeightForSize(leftInputColumn.widgetSize)
@@ -258,7 +270,9 @@ FocusScope {
 						type: VenusOS.OverviewWidget_Type_AcInputPriority
 						size: rightInputColumn.displayWidgetSize
 						stretchHorizontally: rightInputColumn.stretchHorizontally
+						animationEnabled: root.animationEnabled
 					}
+					onStatusChanged: if (status === Loader.Error) console.warn("Unable to load ac input widget")
 				}
 
 				Loader {
@@ -276,7 +290,9 @@ FocusScope {
 						type: VenusOS.OverviewWidget_Type_AcInputOther
 						size: rightInputColumn.displayWidgetSize
 						stretchHorizontally: rightInputColumn.stretchHorizontally
+						animationEnabled: root.animationEnabled
 					}
+					onStatusChanged: if (status === Loader.Error) console.warn("Unable to load ac input2 widget")
 				}
 			}
 		}
@@ -339,6 +355,8 @@ FocusScope {
 				id: batteryWidget
 
 				size: VenusOS.OverviewWidget_Size_L
+				animationEnabled: root.animationEnabled
+
 				Layout.fillWidth: true
 				Layout.fillHeight: true
 				Layout.minimumHeight: Theme.geometry_overviewPage_widget_height_l
@@ -348,6 +366,8 @@ FocusScope {
 				id: inverterChargerWidget
 
 				size: VenusOS.OverviewWidget_Size_L
+				animationEnabled: root.animationEnabled
+
 				Layout.fillWidth: true
 				Layout.fillHeight: true
 				Layout.minimumHeight: Theme.geometry_overviewPage_widget_height_l
@@ -410,7 +430,10 @@ FocusScope {
 				visible: active
 				sourceComponent: DcLoadsWidget {
 					size: VenusOS.OverviewWidget_Size_L
+					animationEnabled: root.animationEnabled
 				}
+				onStatusChanged: if (status === Loader.Error) console.warn("Unable to load dc loads widget")
+
 				Layout.fillWidth: true
 				Layout.fillHeight: true
 				Layout.minimumHeight: root._widgetHeightForSize(VenusOS.OverviewWidget_Size_L)
@@ -442,7 +465,10 @@ FocusScope {
 					sourceComponent: AcLoadsWidget {
 						size: rightLoadsColumn.displayWidgetSize
 						stretchHorizontally: rightLoadsColumn.stretchHorizontally
+						animationEnabled: root.animationEnabled
 					}
+					onStatusChanged: if (status === Loader.Error) console.warn("Unable to load ac loads widget")
+
 					Layout.fillWidth: true
 					Layout.fillHeight: true
 					Layout.minimumHeight: rightLoadsColumn.minimumWidgetHeight
@@ -455,7 +481,10 @@ FocusScope {
 					sourceComponent: EssentialLoadsWidget {
 						size: rightLoadsColumn.displayWidgetSize
 						stretchHorizontally: rightLoadsColumn.stretchHorizontally
+						animationEnabled: root.animationEnabled
 					}
+					onStatusChanged: if (status === Loader.Error) console.warn("Unable to load essential loads widget")
+
 					Layout.fillWidth: true
 					Layout.fillHeight: true
 					Layout.minimumHeight: rightLoadsColumn.minimumWidgetHeight
@@ -469,7 +498,10 @@ FocusScope {
 					sourceComponent: EvcsWidget {
 						size: rightLoadsColumn.displayWidgetSize
 						stretchHorizontally: rightLoadsColumn.stretchHorizontally
+						animationEnabled: root.animationEnabled
 					}
+					onStatusChanged: if (status === Loader.Error) console.warn("Unable to load evcs widget")
+
 					Layout.fillWidth: true
 					Layout.fillHeight: true
 					Layout.minimumHeight: rightLoadsColumn.minimumWidgetHeight

--- a/pages/PageManager.qml
+++ b/pages/PageManager.qml
@@ -26,7 +26,7 @@ QtObject {
 		running: !Global.splashScreenVisible
 			&& (currentMainPage?.fullScreenWhenIdle || Global.keyNavigationEnabled)
 			&& root.interactivity === VenusOS.PageManager_InteractionMode_Interactive
-			&& BackendConnection.applicationVisible
+			&& UiConfig.applicationVisible
 		interval: Theme.animation_page_idleResize_timeout
 		onTriggered: {
 			Global.main.keyNavigationTimeout()

--- a/pages/boat/LargeCenterGauge.qml
+++ b/pages/boat/LargeCenterGauge.qml
@@ -13,7 +13,7 @@ Item {
 	required property VeQuickItemsQuotient gps
 	required property MotorDrives motorDrives
 
-	property bool animationEnabled: false
+	required property bool animationEnabled
 
 	readonly property VeQuickItemsQuotient motorDriveDcConsumption: root.motorDrives.dcConsumption.quotient
 	readonly property VeQuickItemsQuotient activeDataSource: root.gps.valid ? root.gps
@@ -43,7 +43,7 @@ Item {
 		objectName: "centerGauge"
 		visible: root.activeDataSource === root.gps || root.activeDataSource === root.motorDriveDcConsumption
 
-		layer.enabled: !BackendConnection.msaaEnabled
+		layer.enabled: !UiConfig.msaaEnabled
 		layer.textureSize: Qt.size(2*width, 2*height)
 		layer.smooth: true
 
@@ -184,7 +184,7 @@ Item {
 		animationEnabled: root.animationEnabled
 		visible: root.motorDrives.singleMotorDrive.rpm.valid
 
-		layer.enabled: !BackendConnection.msaaEnabled
+		layer.enabled: !UiConfig.msaaEnabled
 		layer.textureSize: Qt.size(2*width, 2*height)
 		layer.smooth: true
 	}
@@ -208,7 +208,7 @@ Item {
 		animationEnabled: root.animationEnabled
 		visible: root.motorDrives.leftMotorDrive.rpm.valid
 
-		layer.enabled: !BackendConnection.msaaEnabled
+		layer.enabled: !UiConfig.msaaEnabled
 		layer.textureSize: Qt.size(2*width, 2*height)
 		layer.smooth: true
 	}
@@ -233,7 +233,7 @@ Item {
 		animationEnabled: root.animationEnabled
 		visible: root.motorDrives.rightMotorDrive.rpm.valid
 
-		layer.enabled: !BackendConnection.msaaEnabled
+		layer.enabled: !UiConfig.msaaEnabled
 		layer.textureSize: Qt.size(2*width, 2*height)
 		layer.smooth: true
 	}

--- a/pages/settings/PageTzInfo.qml
+++ b/pages/settings/PageTzInfo.qml
@@ -76,7 +76,7 @@ Page {
 		interval: 10000
 		repeat: true
 		triggeredOnStart: true
-		running: BackendConnection.applicationVisible // even if !Global.timersEnabled
+		running: UiConfig.applicationVisible // even if !Global.timersEnabled
 		onTriggered: Global.systemSettings.time.getValue(true)
 	}
 

--- a/src/backendconnection.cpp
+++ b/src/backendconnection.cpp
@@ -623,52 +623,6 @@ void BackendConnection::setVrm(bool v)
 	}
 }
 
-bool BackendConnection::isApplicationVisible() const
-{
-	return m_applicationVisible;
-}
-
-void BackendConnection::setApplicationVisible(bool v)
-{
-	if (m_applicationVisible != v) {
-		m_applicationVisible = v;
-		emit applicationVisibleChanged();
-	}
-}
-
-bool BackendConnection::needsWasmKeyboardHandler() const
-{
-	return m_needsWasmKeyboardHandler;
-}
-
-void BackendConnection::setNeedsWasmKeyboardHandler(bool needsWasmKeyboardHandler)
-{
-	if (m_needsWasmKeyboardHandler != needsWasmKeyboardHandler) {
-		m_needsWasmKeyboardHandler = needsWasmKeyboardHandler;
-		emit needsWasmKeyboardHandlerChanged();
-	}
-}
-
-bool BackendConnection::msaaEnabled() const
-{
-	return m_msaaEnabled;
-}
-
-void BackendConnection::setMsaaEnabled(bool e)
-{
-	if (m_msaaEnabled != e) {
-		m_msaaEnabled = e;
-		emit msaaEnabledChanged();
-	}
-}
-
-QUrl BackendConnection::demoImageFileName() const
-{
-	static const QUrl filePath = QUrl::fromLocalFile("/data/demo-brief.png");
-	static const bool fileExists = QFile::exists(filePath.toLocalFile());
-	return fileExists ? filePath : QUrl();
-}
-
 VeQItemProducer *BackendConnection::producer() const
 {
 	return m_producer;

--- a/src/backendconnection.h
+++ b/src/backendconnection.h
@@ -36,12 +36,8 @@ class BackendConnection : public QObject
 	Q_PROPERTY(QString token READ token WRITE setToken NOTIFY tokenChanged FINAL)
 	Q_PROPERTY(QString nodeRedUrl READ nodeRedUrl WRITE setNodeRedUrl NOTIFY nodeRedUrlChanged FINAL)
 	Q_PROPERTY(QString signalKUrl READ signalKUrl WRITE setSignalKUrl NOTIFY signalKUrlChanged FINAL)
-	Q_PROPERTY(QUrl demoImageFileName READ demoImageFileName CONSTANT FINAL)
 	Q_PROPERTY(int idUser READ idUser WRITE setIdUser NOTIFY idUserChanged FINAL)
 	Q_PROPERTY(bool vrm READ isVrm WRITE setVrm NOTIFY vrmChanged FINAL)
-	Q_PROPERTY(bool applicationVisible READ isApplicationVisible WRITE setApplicationVisible NOTIFY applicationVisibleChanged FINAL)
-	Q_PROPERTY(bool needsWasmKeyboardHandler READ needsWasmKeyboardHandler WRITE setNeedsWasmKeyboardHandler NOTIFY needsWasmKeyboardHandlerChanged FINAL)
-	Q_PROPERTY(bool msaaEnabled READ msaaEnabled WRITE setMsaaEnabled NOTIFY msaaEnabledChanged FINAL)
 
 	friend class BackendConnectionTester;
 public:
@@ -139,16 +135,6 @@ public:
 	bool isVrm() const;
 	void setVrm(bool v);
 
-	bool isApplicationVisible() const;
-	void setApplicationVisible(bool v);
-
-	bool needsWasmKeyboardHandler() const;
-	void setNeedsWasmKeyboardHandler(bool needsWasmKeyboardHandler);
-
-	bool msaaEnabled() const;
-	void setMsaaEnabled(bool e);
-
-	QUrl demoImageFileName() const;
 	VeQItemProducer *producer() const;
 
 	// Each service type (system, settings, battery, etc.) has a base uid, which has different
@@ -192,9 +178,6 @@ Q_SIGNALS:
 	void tokenChanged();
 	void idUserChanged();
 	void vrmChanged();
-	void applicationVisibleChanged();
-	void needsWasmKeyboardHandlerChanged();
-	void msaaEnabledChanged();
 	void nodeRedUrlChanged();
 	void signalKUrlChanged();
 	void producerChanged();
@@ -232,9 +215,6 @@ private:
 	QString m_signalKUrl;
 
 	bool m_vrm = false;
-	bool m_applicationVisible = true;
-	bool m_needsWasmKeyboardHandler = false;
-	bool m_msaaEnabled = true;
 
 	State m_state = BackendConnection::State::Idle;
 	HeartbeatState m_heartbeatState = BackendConnection::HeartbeatState::HeartbeatActive;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include "src/language.h"
 #include "src/logging.h"
 #include "src/backendconnection.h"
+#include "src/uiconfig.h"
 #include "src/guiplugins.h"
 #include "src/allservicesmodel.h"
 #include "src/mockmanager.h"
@@ -45,8 +46,8 @@ namespace {
 #if defined(VENUS_WEBASSEMBLY_BUILD)
 EM_BOOL visibilitychange_callback(int /* eventType */, const EmscriptenVisibilityChangeEvent *e, void *userData)
 {
-	Victron::VenusOS::BackendConnection *backend = static_cast<Victron::VenusOS::BackendConnection*>(userData);
-	backend->setApplicationVisible(!e->hidden);
+	Victron::VenusOS::UiConfig *uiconfig = static_cast<Victron::VenusOS::UiConfig*>(userData);
+	uiconfig->setApplicationVisible(!e->hidden);
 	return 0;
 }
 #endif // VENUS_WEBASSEMBLY_BUILD
@@ -69,11 +70,12 @@ QString calculateMqttAddressFromPortalId(const QString &portalId)
 
 void initBackend(bool *enableFpsCounter, bool *skipSplashScreen)
 {
-	Victron::VenusOS::BackendConnection *backend = Victron::VenusOS::BackendConnection::create();
+	Victron::VenusOS::UiConfig *uiconfig = Victron::VenusOS::UiConfig::create();
+	bool mockTimersEnabled = true;
 
-	QString queryMqttAddress, queryMqttPortalId, queryMqttShard, queryMqttUser, queryMqttPass, queryMqttToken, queryFpsCounter, queryColorScheme, queryNodeRedUrl, querySignalKUrl;
+	QString queryMqttAddress, queryMqttPortalId, queryMqttShard, queryMqttUser, queryMqttPass, queryMqttToken, queryFpsCounter, queryColorScheme, queryAnimationEnabled, queryNodeRedUrl, querySignalKUrl;
 #if defined(VENUS_WEBASSEMBLY_BUILD)
-	emscripten_set_visibilitychange_callback(static_cast<void*>(backend), 1, visibilitychange_callback);
+	emscripten_set_visibilitychange_callback(static_cast<void*>(uiconfig), 1, visibilitychange_callback);
 	emscripten::val webLocation = emscripten::val::global("location");
 	const QUrl webLocationUrl = QUrl(QString::fromStdString(webLocation["href"].as<std::string>()));
 	const QUrlQuery query(webLocationUrl);
@@ -107,6 +109,9 @@ void initBackend(bool *enableFpsCounter, bool *skipSplashScreen)
 	if (query.hasQueryItem("colorScheme")) {
 		// "dark" forces dark mode, "light" forces light mode, "auto" forces auto mode, "default" uses the user choice
 		queryColorScheme = QString::fromUtf8(QByteArray::fromPercentEncoding(query.queryItemValue("colorScheme").toUtf8())); // e.g.: "dark", "light", "auto", "default"
+	}
+	if (query.hasQueryItem("animationEnabled")) {
+		queryAnimationEnabled = QString::fromUtf8(QByteArray::fromPercentEncoding(query.queryItemValue("animationEnabled").toUtf8())); // e.g.: "true", "false"
 	}
 #endif
 
@@ -217,6 +222,12 @@ void initBackend(bool *enableFpsCounter, bool *skipSplashScreen)
 	parser.addOption(colorScheme);
 	optionList << colorScheme;
 
+	QCommandLineOption animationEnabled("animationEnabled",
+		QGuiApplication::tr("UI animations enabled (true, false)"),
+		QGuiApplication::tr("enabled", "Animation enabled value"));
+	parser.addOption(animationEnabled);
+	optionList << animationEnabled;
+
 
 	// parser.setUnknownOptionMode(QCommandLineParser::IgnoreUnknownOptions); did not work
 	// in Qt 6.8.3, so we manually filter the arguments.
@@ -267,7 +278,7 @@ void initBackend(bool *enableFpsCounter, bool *skipSplashScreen)
 	}
 
 	parser.process(filteredArgs);
-
+	Victron::VenusOS::BackendConnection *backend = Victron::VenusOS::BackendConnection::create();
 	if (parser.isSet(mqttAddress) || parser.isSet(mqttPortalId)) {
 		if (parser.isSet(mqttUser)) {
 			backend->setUsername(parser.value(mqttUser));
@@ -301,7 +312,7 @@ void initBackend(bool *enableFpsCounter, bool *skipSplashScreen)
 	} else if (parser.isSet(mockMode)) {
 		backend->setType(Victron::VenusOS::BackendConnection::MockSource);
 		if (parser.isSet(noMockTimers)) {
-			Victron::VenusOS::MockManager::create()->setTimersActive(false);
+			mockTimersEnabled = false;
 		}
 		// Do not load the mock configuration until ui-test has been parsed, as the UI test config
 		// may specify a mock configuration.
@@ -343,6 +354,7 @@ void initBackend(bool *enableFpsCounter, bool *skipSplashScreen)
 			&& Victron::VenusOS::UiTest::create()->testCaseCount() == 0) {
 		const QString configName = parser.value(mockConfig);
 		Victron::VenusOS::MockManager::create()->loadConfiguration(QString(":/data/mock/conf/%1.json").arg(configName));
+		Victron::VenusOS::MockManager::create()->setTimersActive(mockTimersEnabled);
 	}
 
 	if (parser.isSet(fpsCounter) || queryFpsCounter.contains(QStringLiteral("enable"))) {
@@ -368,6 +380,14 @@ void initBackend(bool *enableFpsCounter, bool *skipSplashScreen)
 	} else if (!queryColorScheme.isEmpty()) {
 		colorSchemeValue = queryColorScheme.toLower();
 	}
+
+	bool animationEnabledValue = true;
+	if (parser.isSet(animationEnabled)) {
+		animationEnabledValue = parser.value(animationEnabled).toLower() != QStringLiteral("false");
+	} else if (!queryAnimationEnabled.isEmpty()) {
+		animationEnabledValue = queryAnimationEnabled.toLower() != QStringLiteral("false");
+	}
+	uiconfig->setAnimationEnabled(animationEnabledValue);
 
 	Victron::VenusOS::Theme::ForcedColorScheme forcedScheme;
 	if (colorSchemeValue == "dark") {
@@ -447,7 +467,7 @@ int main(int argc, char *argv[])
 #if defined(VENUS_GX_BUILD_ARM) || defined(VENUS_WEBASSEMBLY_BUILD)
 	// CerboGX and WASM don't support multisample render buffers; other platforms do.
 	surfaceFormat.setSamples(-1);
-	Victron::VenusOS::BackendConnection::create()->setMsaaEnabled(false);
+	Victron::VenusOS::UiConfig::create()->setMsaaEnabled(false);
 #else
 	surfaceFormat.setSamples(4);
 #endif
@@ -477,7 +497,7 @@ int main(int argc, char *argv[])
 		scaleFactor = qMax(1.0, qMin(width/theme->geometry_screen_width(), height/theme->geometry_screen_height()));
 	}
 
-	Victron::VenusOS::BackendConnection::create()->setNeedsWasmKeyboardHandler(hasNativeVirtualKeyboard());
+	Victron::VenusOS::UiConfig::create()->setNeedsWasmKeyboardHandler(hasNativeVirtualKeyboard());
 #endif
 
 	std::string scaleAsString = std::to_string(scaleFactor);

--- a/src/uiconfig.cpp
+++ b/src/uiconfig.cpp
@@ -1,0 +1,76 @@
+#include "uiconfig.h"
+
+#include <QFile>
+
+using namespace Victron::VenusOS;
+
+UiConfig* UiConfig::create(QQmlEngine *engine, QJSEngine *)
+{
+	static UiConfig* uiconfig = new UiConfig(engine);
+	return uiconfig;
+}
+
+UiConfig::UiConfig(QQmlEngine *engine)
+	: QObject(engine)
+{
+}
+
+bool UiConfig::isApplicationVisible() const
+{
+	return m_applicationVisible;
+}
+
+void UiConfig::setApplicationVisible(bool v)
+{
+	if (m_applicationVisible != v) {
+		m_applicationVisible = v;
+		Q_EMIT applicationVisibleChanged();
+	}
+}
+
+bool UiConfig::animationEnabled() const
+{
+	return m_animationEnabled;
+}
+
+void UiConfig::setAnimationEnabled(bool v)
+{
+	if (m_animationEnabled != v) {
+		m_animationEnabled = v;
+		Q_EMIT animationEnabledChanged();
+	}
+}
+
+QUrl UiConfig::demoImageFileName() const
+{
+	static const QUrl filePath = QUrl::fromLocalFile("/data/demo-brief.png");
+	static const bool fileExists = QFile::exists(filePath.toLocalFile());
+	return fileExists ? filePath : QUrl();
+}
+
+bool UiConfig::msaaEnabled() const
+{
+	return m_msaaEnabled;
+}
+
+void UiConfig::setMsaaEnabled(bool e)
+{
+	if (m_msaaEnabled != e) {
+		m_msaaEnabled = e;
+		Q_EMIT msaaEnabledChanged();
+	}
+}
+
+bool UiConfig::needsWasmKeyboardHandler() const
+{
+	return m_needsWasmKeyboardHandler;
+}
+
+void UiConfig::setNeedsWasmKeyboardHandler(bool needsWasmKeyboardHandler)
+{
+	if (m_needsWasmKeyboardHandler != needsWasmKeyboardHandler) {
+		m_needsWasmKeyboardHandler = needsWasmKeyboardHandler;
+		Q_EMIT needsWasmKeyboardHandlerChanged();
+	}
+}
+

--- a/src/uiconfig.h
+++ b/src/uiconfig.h
@@ -1,0 +1,65 @@
+/*
+** Copyright (C) 2026 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+#ifndef VICTRON_GUIV2_UICONFIG_H
+#define VICTRON_GUIV2_UICONFIG_H
+
+#include <QObject>
+#include <QUrl>
+#include <QQmlEngine>
+#include <qqmlintegration.h>
+
+class QJSEngine;
+
+namespace Victron {
+namespace VenusOS {
+
+class UiConfig : public QObject
+{
+	Q_OBJECT
+	QML_ELEMENT
+	QML_SINGLETON
+	Q_PROPERTY(bool animationEnabled READ animationEnabled WRITE setAnimationEnabled NOTIFY animationEnabledChanged FINAL)
+	Q_PROPERTY(bool applicationVisible READ isApplicationVisible WRITE setApplicationVisible NOTIFY applicationVisibleChanged FINAL)
+	Q_PROPERTY(QUrl demoImageFileName READ demoImageFileName CONSTANT FINAL)
+	Q_PROPERTY(bool msaaEnabled READ msaaEnabled WRITE setMsaaEnabled NOTIFY msaaEnabledChanged FINAL)
+	Q_PROPERTY(bool needsWasmKeyboardHandler READ needsWasmKeyboardHandler WRITE setNeedsWasmKeyboardHandler NOTIFY needsWasmKeyboardHandlerChanged FINAL)
+
+public:
+	static UiConfig* create(QQmlEngine *engine = nullptr, QJSEngine *jsEngine = nullptr);
+
+	bool isApplicationVisible() const;
+	void setApplicationVisible(bool v);
+
+	bool animationEnabled() const;
+	void setAnimationEnabled(bool v);
+
+	QUrl demoImageFileName() const;
+
+	bool msaaEnabled() const;
+	void setMsaaEnabled(bool e);
+
+	bool needsWasmKeyboardHandler() const;
+	void setNeedsWasmKeyboardHandler(bool needsWasmKeyboardHandler);
+
+
+Q_SIGNALS:
+	void animationEnabledChanged();
+	void applicationVisibleChanged();
+	void msaaEnabledChanged();
+	void needsWasmKeyboardHandlerChanged();
+
+private:
+	explicit UiConfig(QQmlEngine* engine);
+	bool m_animationEnabled = true;
+	bool m_applicationVisible = true;
+	bool m_msaaEnabled = true;
+	bool m_needsWasmKeyboardHandler = false;
+};
+
+} /* VenusOS */
+} /* Victron */
+
+#endif // VICTRON_GUIV2_UICONFIG_H


### PR DESCRIPTION
On certain low-power devices, animations should be disabled by default in order to improve user experience.
To facilitate this, a command line argument (and query parameter) has now been added to allow disabling all animations in the UI.

UI-related configuration has also been refactored out of the BackendConnection singleton and into a new UiConfig singleton.

Contributes to issue #3044