### PR TITLE
Overview: fix column width and position in AC/DC loads drilldowns

### DIFF
--- a/pages/loads/AcLoadListPage.qml
+++ b/pages/loads/AcLoadListPage.qml
@@ -46,7 +46,7 @@ Page {
 					equalWidthColumns: true
 
 					// Set rightPadding to align with the columns in the delegates.
-					rightPadding: Theme.geometry_icon_size_medium + tableListItem.rightPadding
+					rightPadding: Theme.geometry_icon_size_medium + tableListItem.horizontalContentPadding
 					summaryModel: [
 						{ text: "", unit: VenusOS.Units_None },
 						{ text: "", unit: VenusOS.Units_None },
@@ -129,8 +129,8 @@ Page {
 			name: device ? device.name : ""
 			power: powerItem.value ?? NaN
 			current: root.measurements.singlePhaseCurrentValid ? root.measurements.current : NaN
-			columnWidth: ListView.view.headerItem?.contentItem?.columnWidth ?? NaN
-			columnSpacing: ListView.view.headerItem?.contentItem?.columnSpacing ?? 0
+			columnWidth: ListView.view.headerItem?.contentItem?.columnWidth ?? Theme.geometry_loadListPage_defaultColumnWidth
+			columnSpacing: ListView.view.headerItem?.contentItem?.columnSpacing ?? Theme.geometry_quantityTable_horizontalSpacing_large
 
 			// this is an AC device, so only show amps in PreferAmps mode,
 			// and only if we are not displaying the multiple-phases table above

--- a/pages/loads/DcLoadListPage.qml
+++ b/pages/loads/DcLoadListPage.qml
@@ -48,7 +48,7 @@ Page {
 					equalWidthColumns: true
 
 					// Set rightPadding to align with the columns in the delegates.
-					rightPadding: Theme.geometry_icon_size_medium + tableListItem.rightPadding
+					rightPadding: Theme.geometry_icon_size_medium + tableListItem.horizontalContentPadding
 					summaryModel: [
 						{ text: "", unit: VenusOS.Units_None },
 						{ text: "", unit: VenusOS.Units_None },
@@ -106,8 +106,8 @@ Page {
 			power: dcDevice.power ?? NaN
 			current: dcDevice.current ?? NaN
 			temperature: temperatureItem.value ?? NaN
-			columnWidth: ListView.view.headerItem?.contentItem?.columnWidth ?? NaN
-			columnSpacing: ListView.view.headerItem?.contentItem?.columnSpacing ?? 0
+			columnWidth: ListView.view.headerItem?.contentItem?.columnWidth ?? Theme.geometry_loadListPage_defaultColumnWidth
+			columnSpacing: ListView.view.headerItem?.contentItem?.columnSpacing ?? Theme.geometry_quantityTable_horizontalSpacing_large
 
 			// this is a DC device, so prefer Amps in Mixed display mode,
 			// but only if we are not displaying the multiple-dcsystems table above

--- a/themes/geometry/FiveInch.json
+++ b/themes/geometry/FiveInch.json
@@ -576,6 +576,7 @@
     "geometry_batteryListPage_item_verticalSpacing": 2,
 
     "geometry_loadListPage_item_height": 68,
+    "geometry_loadListPage_defaultColumnWidth": 128,
 
     "geometry_rangeSlider_labelWidth": 70,
 

--- a/themes/geometry/Portrait.json
+++ b/themes/geometry/Portrait.json
@@ -576,6 +576,7 @@
     "geometry_batteryListPage_item_verticalSpacing": 2,
 
     "geometry_loadListPage_item_height": 68,
+    "geometry_loadListPage_defaultColumnWidth": 128,
 
     "geometry_rangeSlider_labelWidth": 60,
 

--- a/themes/geometry/SevenInch.json
+++ b/themes/geometry/SevenInch.json
@@ -576,6 +576,7 @@
     "geometry_batteryListPage_item_verticalSpacing": 2,
 
     "geometry_loadListPage_item_height": 68,
+    "geometry_loadListPage_defaultColumnWidth": 128,
 
     "geometry_rangeSlider_labelWidth": 80,
 


### PR DESCRIPTION
Avoid cramped columns in the AC/DC loads drilldowns by setting a default column width in the load delegates. Otherwise, if there is no table header (which can happen if there is only one list item) the column width and column spacing are zero.

Also adjust the rightPadding of the table headers, so that when they are present, the text in the header column aligns with those in the columns of the delegates below.

Fixes #3041