### PR TITLE
Mbath/solar overview layout fix

### DIFF
--- a/components/OverviewLayoutConditions.qml
+++ b/components/OverviewLayoutConditions.qml
@@ -20,6 +20,8 @@ QtObject {
 	// Affects whether DcInputWidget(s) are shown.
 	readonly property bool showDcInputs: Global.dcInputs?.model.count ?? 0 > 0
 	onShowDcInputsChanged: conditionChanged()
+	readonly property int dcInputCount: Global.dcInputs?.model.count ?? 0
+	onDcInputCountChanged: conditionChanged()
 
 	// Affects whether SolarYieldWidget is shown, and its widget size.
 	readonly property bool showSolar: Global.solarInputs.inputCount > 0

--- a/components/widgets/SolarYieldWidget.qml
+++ b/components/widgets/SolarYieldWidget.qml
@@ -12,7 +12,8 @@ OverviewWidget {
 
 	readonly property bool _showPhases: Global.solarInputs.pvInverterDevices.count === 1
 			&& Global.solarInputs.devices.count === 0
-	readonly property bool _showGraph: Global.solarInputs.pvInverterDevices.count === 0
+	readonly property bool _canShowGraph: Global.solarInputs.pvInverterDevices.count === 0
+	readonly property bool _showGraph: _canShowGraph && root.size >= VenusOS.OverviewWidget_Size_M
 
 	onClicked: {
 		const singleDeviceOnly = (Global.solarInputs.devices.count + Global.solarInputs.pvInverterDevices.count) === 1
@@ -30,7 +31,7 @@ OverviewWidget {
 	title: CommonWords.solar
 	type: VenusOS.OverviewWidget_Type_Solar
 	enabled: true
-	preferredSize: _showPhases || _showGraph
+	preferredSize: _showPhases || _canShowGraph
 			? VenusOS.OverviewWidget_PreferredSize_PreferLarge
 			: VenusOS.OverviewWidget_PreferredSize_Any
 	bottomPadding: _showGraph
@@ -63,7 +64,8 @@ OverviewWidget {
 				if (root.size >= VenusOS.OverviewWidget_Size_M) {
 					if (root._showPhases) {
 						return phaseComponent
-					} else if (root._showGraph) {
+						} else if (root._showGraph) {
+						// Only show the history graph when the widget is large enough for it.
 						return historyComponent
 					}
 				}


### PR DESCRIPTION
# Overview: Fix Solar widget layout to restore 4-widget left-column display

## Investigation

Release 1.3.6 gave:

**Screenshot 1**: *Functionality pre May*
<img width="2409" height="850" alt="image" src="https://github.com/user-attachments/assets/83ce52e9-9936-475d-a840-cc8365b20ce4" />

After recent changes, suspect  https://github.com/victronenergy/gui-v2/commit/04407b47d8b71e3f15d058140667b7c888e613ac , it was found that the Alternator (4th widget) would not display on either the WASM or GX display. Investigation revealed that the layout system was designed to support more than 3 widgets (see table below), but two bugs were blocking this functionality.

**Screenshot 2**: *Expected 4 widgets; Alternator not appearing*
<img width="2428" height="905" alt="image" src="https://github.com/user-attachments/assets/7dc14c69-95a9-42ca-a685-a011d2797171" />


Root causes identified:

1. **No relayout trigger when DC input count changes**: When the Alternator service was created (adding a second DC input where Wind already existed), no layout recalculation was triggered. The `showDcInputs` boolean remained true for both cases—it only signals when DC inputs transition from none→some or some→none, not when the count changes within existing inputs.

2. **Solar widget consuming excessive space**: When a relayout eventually occurred, the Solar widget's history graph was displayed at M-size even with 4 widgets, consuming vertical space that prevented the 4th widget from fitting (see Screenshot 2 - Solar displayed with large empty space).

**Screenshot 3**: *Relayout occurred but Solar widget oversized with suppressed history; 4th widget still cannot fit*
<img width="1277" height="806" alt="Screenshot 2026-06-08 at 12 42 05" src="https://github.com/user-attachments/assets/175a1275-fc12-475d-bdd5-821cc0ce985c" />


## Solution

Three commits restore the greater than 3  layout functionality:

### Commit 1: Overview: suppress Solar history graph when 4+ widgets are displayed
- Adds `_showHistoryGraph` property to Solar widget that suppresses the history graph when `totalLeftWidgetCount > 3`
- Updates Solar's `preferredSize` and `bottomPadding` to depend on actual history graph visibility rather than always showing it at M-size
- Frees up vertical space so a 4th widget can fit

### Commit 2: Overview: relayout when DC input count changes
- Adds `dcInputCount` property to `OverviewLayoutConditions` that tracks the actual count of DC inputs
- Signals `conditionChanged()` whenever the count changes, not just when DC inputs go from none→some or some→none
- Ensures relayout happens when a new DC input service is created (or any DC input count change)

### Commit 3: Solar: avoid oversized layout when history graph is suppressed
- Updates Solar's `OverviewElectricalQuantityLabel` Layout.fillHeight to use `_showHistoryGraph` instead of `_showGraph`
- Prevents visual oversizing/empty space when history graph is not displayed
- Produces the desired 4-widget layout (see Screenshot 3)

**Screenshot(s) 4**: *Final result with all three fixes applied; Alternator displays as 4th widget, before alternator starts, alternator running and then alternator shut down.*
<img width="2428" height="894" alt="image" src="https://github.com/user-attachments/assets/248bc0f3-413a-402c-a604-a4dd4dbfe6cd" />
<img width="2433" height="897" alt="image" src="https://github.com/user-attachments/assets/331392c6-d2af-4857-9fd9-4de90adb79eb" />
<img width="2428" height="901" alt="image" src="https://github.com/user-attachments/assets/73f433aa-3387-4cd5-acb3-18eb39d037dd" />



## Widget Sizing Reference

The underlying sizing algorithm (unchanged) supports the following layout patterns:

| Widgets in column | Large preference pattern | Resulting sizes |
|---|---|---|
| 1 | Any | XL |
| 2 | Any | L, L |
| 3 | 0 prefer-large | M, M, M |
| 3 | 1 prefer-large | L + S + S |
| 3 | 2 prefer-large | L + S + S |
| 3 | 3+ prefer-large | M, M, M |
| 4 | 0 prefer-large | S, S, S, S |
| 4 | 1 prefer-large | L + XS + XS + XS |
| 4 | 2 prefer-large | L + XS + XS + XS |
| 4 | 3+ prefer-large | S, S, S, S |
| 5+ | Any | all XS |

These fixes enable the 4-widget case to work as designed, specifically:
- **Grid + Solar + Wind + Alternator**: Solar becomes PreferLarge when not suppressing history (3 widgets), but switches to Any when history is suppressed (4 widgets), allowing the layout to use L + XS + XS + XS sizing.

## Testing

- Verify Alternator service appears as 4th widget in Overview after it is created (no WASM reload needed)
- Confirm Solar history graph is visible with 1-3 widgets in left column
- Confirm Solar history graph is suppressed with 4+ widgets in left column