### PR TITLE
CAN-bus: add NMEA2000 inbound alerts setting

### DIFF
--- a/data/mock/conf/services/smartswitch.json
+++ b/data/mock/conf/services/smartswitch.json
@@ -7,6 +7,7 @@
     "com.victronenergy.settings": {
         "/Settings/Canbus/vecan0/Profile": 0,
         "/Settings/Canbus/vecan1/Profile": 1,
+        "/Settings/Vecan/vecan1/AlertsInEnable": 0,
         "/Settings/Vecan/vecan1/N2kGatewayEnabled": 0,
         "/Settings/Vecan/vecan1/VenusUniqueId": 1
     },

--- a/pages/settings/PageSettingsCanbus.qml
+++ b/pages/settings/PageSettingsCanbus.qml
@@ -81,6 +81,13 @@ Page {
 			}
 
 			ListSwitch {
+				//% "NMEA2000 inbound alerts"
+				text: qsTrId("settings_canbus_nmea2000in_alerts")
+				dataItem.uid: root._vecanSettingsPrefix + "/AlertsInEnable"
+				preferredVisible: root._isVecan && dataItem.valid
+			}
+
+			ListSwitch {
 				//% "Reverse current polarity"
 				text: qsTrId("settings_canbus_rvc_reverse_current_polarity")
 				dataItem.uid: root._rvcSettingsPrefix + "/ReverseCurrent"


### PR DESCRIPTION
Ref: https://github.com/victronenergy/venus/issues/1586

Added a toggle switch for a new capability under Ve.Can.

<img width="1106" height="715" alt="image" src="https://github.com/user-attachments/assets/0a98fd2c-4845-4114-b20d-5301be2aa5b7" />
