### PR TITLE
Switches: allow type changes, hide some settings depending on product id

### DIFF
--- a/components/listitems/ListIOChannelTypeRadioButtonGroup.qml
+++ b/components/listitems/ListIOChannelTypeRadioButtonGroup.qml
@@ -15,6 +15,7 @@ ListRadioButtonGroup {
 	text: qsTrId("iochannel_type_buttongroup_type")
 	dataItem.uid: root.ioChannel.uid + "/Settings/Type"
 	preferredVisible: dataItem.valid
+	writeAccessLevel: VenusOS.User_AccessType_User
 	secondaryTextColor: root.ioChannel.hasValidType ? Theme.color_listItem_secondaryText : Theme.color_critical
 	optionModel: {
 		let options = []

--- a/pages/settings/devicelist/iochannel/PageSwitchableOutput.qml
+++ b/pages/settings/devicelist/iochannel/PageSwitchableOutput.qml
@@ -152,6 +152,7 @@ Page {
 				text: qsTrId("page_switchable_output_startup_state")
 				dataItem.uid: root.switchableOutput.uid + "/Settings/StartupState"
 				preferredVisible: dataItem.valid
+				showAccessLevel: productId.isAurelia ? VenusOS.User_AccessType_Installer : VenusOS.User_AccessType_User
 				interactive: _writeable
 				optionModel: [
 					{ display: CommonWords.off, value: 0 },
@@ -166,6 +167,7 @@ Page {
 				text: qsTrId("page_switchable_output_startup_dim_level")
 				secondaryText: startupDimLevel.valid ? startupDimLevel.value === -1 ? qsTrId("page_switchable_output_startup_state_restore_from_memory") : startupDimLevel.value + "%" : ""
 				preferredVisible: startupDimLevel.valid
+				showAccessLevel: productId.isAurelia ? VenusOS.User_AccessType_Installer : VenusOS.User_AccessType_User
 				interactive: _writeable
 				onClicked: Global.pageManager.pushPage(dimStartupStateComponent, { title: text })
 


### PR DESCRIPTION
- Make the 'Type' writable at the user access level.
- Hide 'Startup switch state' and 'Startup dim level' for the user access level on Aurelia products.

Fixes #2941