### PR TITLE
Dialogs: fix position of modal dialogs

### DIFF
--- a/components/dialogs/ColorWheelDialog.qml
+++ b/components/dialogs/ColorWheelDialog.qml
@@ -55,8 +55,6 @@ ModalDialog {
 		]
 	}
 
-	leftMargin: Theme.geometry_colorWheelDialog_horizontalMargin
-	rightMargin: Theme.geometry_colorWheelDialog_horizontalMargin
 	dialogDoneOptions: VenusOS.ModalDialog_DoneOptions_NoOptions
 
 	header: Item {

--- a/components/dialogs/ModalDialog.qml
+++ b/components/dialogs/ModalDialog.qml
@@ -106,14 +106,16 @@ T.Dialog {
 	rest of the app. Specifying 'width' and 'height' instead of only 'implicitWidth' and 'implicitHeight' for ModalDialog
 	makes it scale properly when you shrink the window. See https://bugreports.qt.io/browse/QTBUG-127068
 	*/
-	implicitWidth: Math.max(
-		implicitBackgroundWidth + leftInset + rightInset,
-		implicitContentWidth + leftPadding + rightPadding)
-	implicitHeight: Math.max(
-		implicitBackgroundHeight + topInset + bottomInset,
-		implicitContentHeight + topPadding + bottomPadding + implicitHeaderHeight + implicitFooterHeight)
-	width: Math.min(Theme.geometry_screen_width, implicitWidth)
-	height: Math.min(Theme.geometry_screen_height, implicitHeight)
+	width: Math.min(
+		Theme.geometry_screen_width,
+		Math.max(
+			implicitBackgroundWidth + leftInset + rightInset,
+			implicitContentWidth + leftPadding + rightPadding))
+	height: Math.min(
+		Theme.geometry_screen_height,
+		Math.max(
+			implicitBackgroundHeight + topInset + bottomInset,
+			implicitContentHeight + topPadding + bottomPadding + implicitHeaderHeight + implicitFooterHeight))
 	modal: true
 	topPadding: topInset + Theme.geometry_modalDialog_topPadding
 	bottomPadding: bottomInset + Theme.geometry_modalDialog_bottomPadding

--- a/components/dialogs/SolarDailyHistoryDialog.qml
+++ b/components/dialogs/SolarDailyHistoryDialog.qml
@@ -48,14 +48,18 @@ T.Dialog {
 	// Use x/y positioning instead of anchors, so that the dialog can be moved by DialogDragger.
 	x: (Theme.geometry_screen_width - width) / 2
 	y: (Theme.geometry_screen_height - height) / 2
-	implicitWidth: Math.max(
-		implicitBackgroundWidth + leftInset + rightInset,
-		implicitContentWidth + leftPadding + rightPadding) / Global.scalingRatio
-	implicitHeight: Math.max(
-		implicitBackgroundHeight + topInset + bottomInset,
-		implicitContentHeight + topPadding + bottomPadding + implicitHeaderHeight + implicitFooterHeight) / Global.scalingRatio
-	leftMargin: Theme.geometry_solarDailyHistoryDialog_horizontalMargin
-	rightMargin: Theme.geometry_solarDailyHistoryDialog_horizontalMargin
+
+	// As for ModalDialog, set the explicit width/height so that the position is correct in Wasm.
+	width: Math.min(
+		Theme.geometry_screen_width,
+		Math.max(
+			implicitBackgroundWidth + leftInset + rightInset,
+			implicitContentWidth + leftPadding + rightPadding))
+	height: Math.min(
+		Theme.geometry_screen_height,
+		Math.max(
+			implicitBackgroundHeight + topInset + bottomInset,
+			implicitContentHeight + topPadding + bottomPadding + implicitHeaderHeight + implicitFooterHeight))
 	modal: true
 	focus: Global.keyNavigationEnabled
 

--- a/themes/geometry/FiveInch.json
+++ b/themes/geometry/FiveInch.json
@@ -355,7 +355,6 @@
     "geometry_iochannel_status_minimum_width": 48,
     "geometry_iochannel_statusBackground_bottomPadding": 4,
 
-    "geometry_colorWheelDialog_horizontalMargin": 24,
     "geometry_colorWheelDialog_leftPadding": 48,
     "geometry_colorWheelDialog_rightPadding": 24,
     "geometry_colorWheelDialog_topPadding": 0,

--- a/themes/geometry/Portrait.json
+++ b/themes/geometry/Portrait.json
@@ -355,7 +355,6 @@
     "geometry_iochannel_status_minimum_width": 48,
     "geometry_iochannel_statusBackground_bottomPadding": 4,
 
-    "geometry_colorWheelDialog_horizontalMargin": 0,
     "geometry_colorWheelDialog_leftPadding": 12,
     "geometry_colorWheelDialog_rightPadding": 12,
     "geometry_colorWheelDialog_topPadding": 0,

--- a/themes/geometry/SevenInch.json
+++ b/themes/geometry/SevenInch.json
@@ -355,12 +355,11 @@
     "geometry_iochannel_status_minimum_width": 48,
     "geometry_iochannel_statusBackground_bottomPadding": 4,
 
-    "geometry_colorWheelDialog_horizontalMargin": 128,
     "geometry_colorWheelDialog_leftPadding": 48,
     "geometry_colorWheelDialog_rightPadding": 24,
     "geometry_colorWheelDialog_topPadding": 0,
     "geometry_colorWheelDialog_bottomPadding": 24,
-    "geometry_colorWheelDialog_spacing": 24,
+    "geometry_colorWheelDialog_spacing": 48,
     "geometry_colorWheelDialog_mode_button_verticalMargin": 18,
     "geometry_colorWheelDialog_mode_button_width": 90,
     "geometry_colorWheelDialog_mode_button_height": 40,


### PR DESCRIPTION
Use the width/height properties rather than the implicitWidth/ implicitHeight to set the geometry of ModalDialog. Otherwise when the implicitWidth/implicitHeight of the contentItem changes (e.g. if the item is being laid out) then the dialog geometry does not update and so the dialog's x/y position is incorrect. This bug is only seen on Wasm, due to the scaling ratio that is applied to the window geometry.

Make a similar update to SolarDailyHistoryDialog for consistency. Also, the implicitWidth/implicitHeight there should not refer to Global.scalingRatio anyway, as this causes external changes to affect the implicit geometry.

Also, in the ColorWheelDialog, increase the horizontal space between the color wheel and the preset grid in 7" mode to align more closely with the design.

Fixes #3049