### PR TITLE
Updates to unit handling

### DIFF
--- a/src/enums.h
+++ b/src/enums.h
@@ -64,6 +64,9 @@ public:
 		Units_None = 0,
 		Units_Amp,
 		Units_AmpHour,
+		Units_AmpHourPerKilometre,
+		Units_AmpHourPerMile,
+		Units_AmpHourPerNauticalMile,
 		Units_CardinalDirection,
 		Units_Energy_KiloWattHour,
 		Units_Foot,
@@ -105,9 +108,8 @@ public:
 		Units_WattHourPerKilometre,
 		Units_WattHourPerMile,
 		Units_WattHourPerNauticalMile,
-		Units_AmpHourPerKilometre,
-		Units_AmpHourPerMile,
-		Units_AmpHourPerNauticalMile,
+
+		Units_Type_Max = Units_WattHourPerNauticalMile
 	};
 	Q_ENUM(Units_Type)
 

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -31,6 +31,9 @@ static const std::vector<UnitMetaData> UnitTable {
 	{         EmptyString,   Victron::VenusOS::Enums::Units_None,                       Victron::VenusOS::Enums::Units_Scale_None,      Unit::Default,                  0   },
 	{                 "A",   Victron::VenusOS::Enums::Units_Amp,                        Victron::VenusOS::Enums::Units_Scale_Tera,      Unit::Default,                  1   },
 	{                "Ah",   Victron::VenusOS::Enums::Units_AmpHour,                    Victron::VenusOS::Enums::Units_Scale_Tera,      Unit::Default,                  1   },
+	{             "Ah/km",   Victron::VenusOS::Enums::Units_AmpHourPerKilometre,        Victron::VenusOS::Enums::Units_Scale_None,      Unit::AmpHourPerKilometre,      0   },
+	{             "Ah/mi",   Victron::VenusOS::Enums::Units_AmpHourPerMile,             Victron::VenusOS::Enums::Units_Scale_None,      Unit::AmpHourPerMile,           0   },
+	{             "Ah/NM",   Victron::VenusOS::Enums::Units_AmpHourPerNauticalMile,     Victron::VenusOS::Enums::Units_Scale_None,      Unit::AmpHourPerNauticalMile,   0   },
 	{       DegreesSymbol,   Victron::VenusOS::Enums::Units_CardinalDirection,          Victron::VenusOS::Enums::Units_Scale_None,      Unit::Default,                  0   },
 	{               "kWh",   Victron::VenusOS::Enums::Units_Energy_KiloWattHour,        Victron::VenusOS::Enums::Units_Scale_Tera,      Unit::Default,                  3   },
 	{                "ft",   Victron::VenusOS::Enums::Units_Foot,                       Victron::VenusOS::Enums::Units_Scale_None,      Unit::Foot,                     0   },
@@ -72,10 +75,6 @@ static const std::vector<UnitMetaData> UnitTable {
 	{             "Wh/km",   Victron::VenusOS::Enums::Units_WattHourPerKilometre,       Victron::VenusOS::Enums::Units_Scale_None,      Unit::WattHourPerKilometre,     0   },
 	{             "Wh/mi",   Victron::VenusOS::Enums::Units_WattHourPerMile,            Victron::VenusOS::Enums::Units_Scale_None,      Unit::WattHourPerMile,          0   },
 	{             "Wh/NM",   Victron::VenusOS::Enums::Units_WattHourPerNauticalMile,    Victron::VenusOS::Enums::Units_Scale_None,      Unit::WattHourPerNauticalMile,  0   },
-	{             "Ah/km",   Victron::VenusOS::Enums::Units_AmpHourPerKilometre,        Victron::VenusOS::Enums::Units_Scale_None,      Unit::AmpHourPerKilometre,      0   },
-	{             "Ah/mi",   Victron::VenusOS::Enums::Units_AmpHourPerMile,             Victron::VenusOS::Enums::Units_Scale_None,      Unit::AmpHourPerMile,           0   },
-	{             "Ah/NM",   Victron::VenusOS::Enums::Units_AmpHourPerNauticalMile,     Victron::VenusOS::Enums::Units_Scale_None,      Unit::AmpHourPerNauticalMile,   0   },
-
 };
 
 inline const UnitMetaData &unitMeta(Victron::VenusOS::Enums::Units_Type unit)
@@ -83,8 +82,8 @@ inline const UnitMetaData &unitMeta(Victron::VenusOS::Enums::Units_Type unit)
 	const auto index = static_cast<std::size_t>(unit);
 	Q_ASSERT(index < UnitTable.size());
 	Q_ASSERT(UnitTable[index].unit == unit);
-	Q_ASSERT(unit >= Victron::VenusOS::Enums::Units_None && unit <= Victron::VenusOS::Enums::Units_AmpHourPerNauticalMile);
-	if (unit < Victron::VenusOS::Enums::Units_None || unit > Victron::VenusOS::Enums::Units_AmpHourPerNauticalMile) {
+	Q_ASSERT(unit >= Victron::VenusOS::Enums::Units_None && unit <= Victron::VenusOS::Enums::Units_Type_Max);
+	if (unit < Victron::VenusOS::Enums::Units_None || unit > Victron::VenusOS::Enums::Units_Type_Max) {
 		return UnitTable[Victron::VenusOS::Enums::Units_None];
 	}
 	return UnitTable[index];

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -21,60 +21,61 @@ static const QString EmptyString = QString();
 struct UnitMetaData {
 	QString label;
 	Victron::VenusOS::Enums::Units_Type unit = Victron::VenusOS::Enums::Units_None;
+	Victron::VenusOS::Enums::Units_Scale maximumScale = Victron::VenusOS::Enums::Units_Scale_None;
 	Unit::Type veUnit = Unit::Default;
 	int decimals = 0;
-	bool scalable = false;
 };
 
 static const std::vector<UnitMetaData> UnitTable {
-	//              label                 unit                                        veUnit           defaultDecimals  scalable
-	{         EmptyString,   Victron::VenusOS::Enums::Units_None,                     Unit::Default,                0,   false   },
-	{                 "A",   Victron::VenusOS::Enums::Units_Amp,                      Unit::Default,                1,   true    },
-	{                "Ah",   Victron::VenusOS::Enums::Units_AmpHour,                  Unit::Default,                1,   true    },
-	{       DegreesSymbol,   Victron::VenusOS::Enums::Units_CardinalDirection,        Unit::Default,                0,   false   },
-	{               "kWh",   Victron::VenusOS::Enums::Units_Energy_KiloWattHour,      Unit::Default,                3,   true    },
-	{                "ft",   Victron::VenusOS::Enums::Units_Foot,                     Unit::Foot,                   0,   false   },
-	{               "hPa",   Victron::VenusOS::Enums::Units_Hectopascal,              Unit::Default,                1,   false   },
-	{                "Hz",   Victron::VenusOS::Enums::Units_Hertz,                    Unit::Default,                1,   true    },
-	{                "km",   Victron::VenusOS::Enums::Units_Kilometre,                Unit::Kilometre,              0,   false   },
-	{               "kPa",   Victron::VenusOS::Enums::Units_Kilopascal,               Unit::Default,                0,   false   },
-	{               "lux",   Victron::VenusOS::Enums::Units_Lux,                      Unit::Default,                0,   false   },
-	{                 "m",   Victron::VenusOS::Enums::Units_Metre,                    Unit::Metre,                  0,   true    },
-	{  "µg/" + CubicMetre,   Victron::VenusOS::Enums::Units_MicrogramPerCubicMeter,   Unit::Default,                1,   false   },
-	{                "mi",   Victron::VenusOS::Enums::Units_Mile,                     Unit::Mile,                   0,   false   },
-	{                "NM",   Victron::VenusOS::Enums::Units_Nautical_Mile,            Unit::NauticalMile,           0,   false   },
-	{                "Nm",   Victron::VenusOS::Enums::Units_NewtonMeter,              Unit::Default,                0,   false   },
-	{               "ppm",   Victron::VenusOS::Enums::Units_PartsPerMillion,          Unit::Default,                0,   false   },
-	{                 "%",   Victron::VenusOS::Enums::Units_Percentage,               Unit::Default,                0,   false   },
-	{         EmptyString,   Victron::VenusOS::Enums::Units_PowerFactor,              Unit::Default,                3,   false   },
-	{               "RPM",   Victron::VenusOS::Enums::Units_RevolutionsPerMinute,     Unit::RevolutionsPerMinute,   0,   true    },
-	{              "km/h",   Victron::VenusOS::Enums::Units_Speed_KilometresPerHour,  Unit::KilometresPerHour,      0,   true    },
-	{                "kn",   Victron::VenusOS::Enums::Units_Speed_Knots,              Unit::Knots,                  0,   false   },
-	{               "m/s",   Victron::VenusOS::Enums::Units_Speed_MetresPerSecond,    Unit::MetresPerSecond,        0,   true    },
-	{               "mph",   Victron::VenusOS::Enums::Units_Speed_MilesPerHour,       Unit::MilesPerHour,           0,   false   },
-	{ DegreesSymbol + "C",   Victron::VenusOS::Enums::Units_Temperature_Celsius,      Unit::Celsius,                0,   false   },
-	{ DegreesSymbol + "F",   Victron::VenusOS::Enums::Units_Temperature_Fahrenheit,   Unit::Fahrenheit,             0,   false   },
-	{ DegreesSymbol + "K",   Victron::VenusOS::Enums::Units_Temperature_Kelvin,       Unit::Kelvin,                 0,   false   },
-	{                 "d",   Victron::VenusOS::Enums::Units_Time_Day,                 Unit::Default,                0,   false   },
-	{                 "h",   Victron::VenusOS::Enums::Units_Time_Hour,                Unit::Default,                0,   false   },
-	{                 "m",   Victron::VenusOS::Enums::Units_Time_Minute,              Unit::Default,                0,   false   },
-	{                 "s",   Victron::VenusOS::Enums::Units_Time_Second,              Unit::Default,                0,   false   },
-	{                "VA",   Victron::VenusOS::Enums::Units_VoltAmpere,               Unit::Default,                1,   true    },
-	{               "var",   Victron::VenusOS::Enums::Units_VoltAmpereReactive,       Unit::Default,                1,   true    },
-	{                 "V",   Victron::VenusOS::Enums::Units_Volt_AC,                  Unit::Default,                1,   true    },
-	{                 "V",   Victron::VenusOS::Enums::Units_Volt_DC,                  Unit::Default,                2,   true    },
-	{          CubicMetre,   Victron::VenusOS::Enums::Units_Volume_CubicMetre,        Unit::CubicMetre,             3,   true    },
-	{               "gal",   Victron::VenusOS::Enums::Units_Volume_GallonImperial,    Unit::ImperialGallon,         0,   false   },
-	{               "gal",   Victron::VenusOS::Enums::Units_Volume_GallonUS,          Unit::UsGallon,               0,   false   },
-	{         LitreSymbol,   Victron::VenusOS::Enums::Units_Volume_Litre,             Unit::Litre,                  0,   true    },
-	{                 "W",   Victron::VenusOS::Enums::Units_Watt,                     Unit::Default,                0,   true    },
-	{              "W/m2",   Victron::VenusOS::Enums::Units_WattsPerSquareMetre,      Unit::Default,                0,   true    },
-	{             "Wh/km",   Victron::VenusOS::Enums::Units_WattHourPerKilometre,     Unit::WattHourPerKilometre,   0,   false   },
-	{             "Wh/mi",   Victron::VenusOS::Enums::Units_WattHourPerMile,          Unit::WattHourPerMile,        0,   false   },
-	{             "Wh/NM",   Victron::VenusOS::Enums::Units_WattHourPerNauticalMile,  Unit::WattHourPerNauticalMile,0,   false   },
-	{             "Ah/km",   Victron::VenusOS::Enums::Units_AmpHourPerKilometre,      Unit::AmpHourPerKilometre,    0,   false   },
-	{             "Ah/mi",   Victron::VenusOS::Enums::Units_AmpHourPerMile,           Unit::AmpHourPerMile,         0,   false   },
-	{             "Ah/NM",   Victron::VenusOS::Enums::Units_AmpHourPerNauticalMile,   Unit::AmpHourPerNauticalMile, 0,   false   },
+	//              label    unit                                                       maximumScale                                    veUnit                          defaultDecimals
+	{         EmptyString,   Victron::VenusOS::Enums::Units_None,                       Victron::VenusOS::Enums::Units_Scale_None,      Unit::Default,                  0   },
+	{                 "A",   Victron::VenusOS::Enums::Units_Amp,                        Victron::VenusOS::Enums::Units_Scale_Tera,      Unit::Default,                  1   },
+	{                "Ah",   Victron::VenusOS::Enums::Units_AmpHour,                    Victron::VenusOS::Enums::Units_Scale_Tera,      Unit::Default,                  1   },
+	{       DegreesSymbol,   Victron::VenusOS::Enums::Units_CardinalDirection,          Victron::VenusOS::Enums::Units_Scale_None,      Unit::Default,                  0   },
+	{               "kWh",   Victron::VenusOS::Enums::Units_Energy_KiloWattHour,        Victron::VenusOS::Enums::Units_Scale_Tera,      Unit::Default,                  3   },
+	{                "ft",   Victron::VenusOS::Enums::Units_Foot,                       Victron::VenusOS::Enums::Units_Scale_None,      Unit::Foot,                     0   },
+	{               "hPa",   Victron::VenusOS::Enums::Units_Hectopascal,                Victron::VenusOS::Enums::Units_Scale_None,      Unit::Default,                  1   },
+	{                "Hz",   Victron::VenusOS::Enums::Units_Hertz,                      Victron::VenusOS::Enums::Units_Scale_Tera,      Unit::Default,                  1   },
+	{                "km",   Victron::VenusOS::Enums::Units_Kilometre,                  Victron::VenusOS::Enums::Units_Scale_None,      Unit::Kilometre,                0   },
+	{               "kPa",   Victron::VenusOS::Enums::Units_Kilopascal,                 Victron::VenusOS::Enums::Units_Scale_None,      Unit::Default,                  0   },
+	{               "lux",   Victron::VenusOS::Enums::Units_Lux,                        Victron::VenusOS::Enums::Units_Scale_None,      Unit::Default,                  0   },
+	{                 "m",   Victron::VenusOS::Enums::Units_Metre,                      Victron::VenusOS::Enums::Units_Scale_Kilo,      Unit::Metre,                    0   },
+	{  "µg/" + CubicMetre,   Victron::VenusOS::Enums::Units_MicrogramPerCubicMeter,     Victron::VenusOS::Enums::Units_Scale_None,      Unit::Default,                  1   },
+	{                "mi",   Victron::VenusOS::Enums::Units_Mile,                       Victron::VenusOS::Enums::Units_Scale_None,      Unit::Mile,                     0   },
+	{                "NM",   Victron::VenusOS::Enums::Units_Nautical_Mile,              Victron::VenusOS::Enums::Units_Scale_None,      Unit::NauticalMile,             0   },
+	{                "Nm",   Victron::VenusOS::Enums::Units_NewtonMeter,                Victron::VenusOS::Enums::Units_Scale_None,      Unit::Default,                  0   },
+	{               "ppm",   Victron::VenusOS::Enums::Units_PartsPerMillion,            Victron::VenusOS::Enums::Units_Scale_None,      Unit::Default,                  0   },
+	{                 "%",   Victron::VenusOS::Enums::Units_Percentage,                 Victron::VenusOS::Enums::Units_Scale_None,      Unit::Default,                  0   },
+	{         EmptyString,   Victron::VenusOS::Enums::Units_PowerFactor,                Victron::VenusOS::Enums::Units_Scale_None,      Unit::Default,                  3   },
+	{               "RPM",   Victron::VenusOS::Enums::Units_RevolutionsPerMinute,       Victron::VenusOS::Enums::Units_Scale_None,      Unit::RevolutionsPerMinute,     0   },
+	{              "km/h",   Victron::VenusOS::Enums::Units_Speed_KilometresPerHour,    Victron::VenusOS::Enums::Units_Scale_None,      Unit::KilometresPerHour,        0   },
+	{                "kn",   Victron::VenusOS::Enums::Units_Speed_Knots,                Victron::VenusOS::Enums::Units_Scale_None,      Unit::Knots,                    0   },
+	{               "m/s",   Victron::VenusOS::Enums::Units_Speed_MetresPerSecond,      Victron::VenusOS::Enums::Units_Scale_Kilo,      Unit::MetresPerSecond,          0   },
+	{               "mph",   Victron::VenusOS::Enums::Units_Speed_MilesPerHour,         Victron::VenusOS::Enums::Units_Scale_None,      Unit::MilesPerHour,             0   },
+	{ DegreesSymbol + "C",   Victron::VenusOS::Enums::Units_Temperature_Celsius,        Victron::VenusOS::Enums::Units_Scale_None,      Unit::Celsius,                  0   },
+	{ DegreesSymbol + "F",   Victron::VenusOS::Enums::Units_Temperature_Fahrenheit,     Victron::VenusOS::Enums::Units_Scale_None,      Unit::Fahrenheit,               0   },
+	{ DegreesSymbol + "K",   Victron::VenusOS::Enums::Units_Temperature_Kelvin,         Victron::VenusOS::Enums::Units_Scale_None,      Unit::Kelvin,                   0   },
+	{                 "d",   Victron::VenusOS::Enums::Units_Time_Day,                   Victron::VenusOS::Enums::Units_Scale_None,      Unit::Default,                  0   },
+	{                 "h",   Victron::VenusOS::Enums::Units_Time_Hour,                  Victron::VenusOS::Enums::Units_Scale_None,      Unit::Default,                  0   },
+	{                 "m",   Victron::VenusOS::Enums::Units_Time_Minute,                Victron::VenusOS::Enums::Units_Scale_None,      Unit::Default,                  0   },
+	{                 "s",   Victron::VenusOS::Enums::Units_Time_Second,                Victron::VenusOS::Enums::Units_Scale_None,      Unit::Default,                  0   },
+	{                "VA",   Victron::VenusOS::Enums::Units_VoltAmpere,                 Victron::VenusOS::Enums::Units_Scale_Tera,      Unit::Default,                  1   },
+	{               "var",   Victron::VenusOS::Enums::Units_VoltAmpereReactive,         Victron::VenusOS::Enums::Units_Scale_Tera,      Unit::Default,                  1   },
+	{                 "V",   Victron::VenusOS::Enums::Units_Volt_AC,                    Victron::VenusOS::Enums::Units_Scale_Tera,      Unit::Default,                  1   },
+	{                 "V",   Victron::VenusOS::Enums::Units_Volt_DC,                    Victron::VenusOS::Enums::Units_Scale_Tera,      Unit::Default,                  2   },
+	{          CubicMetre,   Victron::VenusOS::Enums::Units_Volume_CubicMetre,          Victron::VenusOS::Enums::Units_Scale_None,      Unit::CubicMetre,               3   },
+	{               "gal",   Victron::VenusOS::Enums::Units_Volume_GallonImperial,      Victron::VenusOS::Enums::Units_Scale_None,      Unit::ImperialGallon,           0   },
+	{               "gal",   Victron::VenusOS::Enums::Units_Volume_GallonUS,            Victron::VenusOS::Enums::Units_Scale_None,      Unit::UsGallon,                 0   },
+	{         LitreSymbol,   Victron::VenusOS::Enums::Units_Volume_Litre,               Victron::VenusOS::Enums::Units_Scale_Kilo,      Unit::Litre,                    0   },
+	{                 "W",   Victron::VenusOS::Enums::Units_Watt,                       Victron::VenusOS::Enums::Units_Scale_Tera,      Unit::Default,                  0   },
+	{              "W/m2",   Victron::VenusOS::Enums::Units_WattsPerSquareMetre,        Victron::VenusOS::Enums::Units_Scale_Tera,      Unit::Default,                  0   },
+	{             "Wh/km",   Victron::VenusOS::Enums::Units_WattHourPerKilometre,       Victron::VenusOS::Enums::Units_Scale_None,      Unit::WattHourPerKilometre,     0   },
+	{             "Wh/mi",   Victron::VenusOS::Enums::Units_WattHourPerMile,            Victron::VenusOS::Enums::Units_Scale_None,      Unit::WattHourPerMile,          0   },
+	{             "Wh/NM",   Victron::VenusOS::Enums::Units_WattHourPerNauticalMile,    Victron::VenusOS::Enums::Units_Scale_None,      Unit::WattHourPerNauticalMile,  0   },
+	{             "Ah/km",   Victron::VenusOS::Enums::Units_AmpHourPerKilometre,        Victron::VenusOS::Enums::Units_Scale_None,      Unit::AmpHourPerKilometre,      0   },
+	{             "Ah/mi",   Victron::VenusOS::Enums::Units_AmpHourPerMile,             Victron::VenusOS::Enums::Units_Scale_None,      Unit::AmpHourPerMile,           0   },
+	{             "Ah/NM",   Victron::VenusOS::Enums::Units_AmpHourPerNauticalMile,     Victron::VenusOS::Enums::Units_Scale_None,      Unit::AmpHourPerNauticalMile,   0   },
+
 };
 
 inline const UnitMetaData &unitMeta(Victron::VenusOS::Enums::Units_Type unit)
@@ -201,6 +202,11 @@ QString Units::defaultUnitString(VenusOS::Enums::Units_Type unit, Victron::Units
 	return unitMeta(unit).label;
 }
 
+VenusOS::Enums::Units_Scale Units::maximumUnitScale(VenusOS::Enums::Units_Type unit) const
+{
+	return unitMeta(unit).maximumScale;
+}
+
 QString Units::scaleToString(VenusOS::Enums::Units_Scale scale) const {
 	switch (scale) {
 	case VenusOS::Enums::Units_Scale_Tera:
@@ -215,11 +221,6 @@ QString Units::scaleToString(VenusOS::Enums::Units_Scale scale) const {
 	default:
 		return QString();
 	}
-}
-
-bool Units::isScalingSupported(VenusOS::Enums::Units_Type unit) const
-{
-	return unitMeta(unit).scalable;
 }
 
 // Returns the physical quantity as a tuple of strings: { number, unit }.
@@ -279,7 +280,8 @@ quantityInfo Units::getDisplayTextWithHysteresis(VenusOS::Enums::Units_Type unit
 
 	// scale value if the unit of measure is scalable
 	// check format hints for display override value
-	if (isScalingSupported(unit) && !(formatHints & Units::FormatHint::NoScaling)) {
+	const Victron::VenusOS::Enums::Units_Scale maxScale = maximumUnitScale(unit);
+	if (maxScale > VenusOS::Enums::Units_Scale_None && !(formatHints & Units::FormatHint::NoScaling)) {
 		qreal scaleMatch = !qIsNaN(unitMatchValue) ? unitMatchValue : scaledValue;
 
 		// Kilowatthour is already in kilos, normalize to plain watthours before scaling
@@ -312,8 +314,7 @@ quantityInfo Units::getDisplayTextWithHysteresis(VenusOS::Enums::Units_Type unit
 
 		// For some units, do not scale beyond the kilo range, as we don't want to display them in
 		// mega/tera/giga format.
-		if (unit == VenusOS::Enums::Units_Volume_Litre
-				|| unit == VenusOS::Enums::Units_Metre) {
+		if (maxScale == VenusOS::Enums::Units_Scale_Kilo) {
 			if (isOverLimit(scaleMatch, VenusOS::Enums::Units_Scale_Kilo, previousScale)) {
 				quantity.unit = QStringLiteral("k%1").arg(defaultUnitString(unit));
 				quantity.scale = VenusOS::Enums::Units_Scale_Kilo;

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -64,7 +64,7 @@ static const std::vector<UnitMetaData> UnitTable {
 	{                 "s",   Victron::VenusOS::Enums::Units_Time_Second,                Victron::VenusOS::Enums::Units_Scale_None,      Unit::Default,                  0   },
 	{                "VA",   Victron::VenusOS::Enums::Units_VoltAmpere,                 Victron::VenusOS::Enums::Units_Scale_Tera,      Unit::Default,                  1   },
 	{               "var",   Victron::VenusOS::Enums::Units_VoltAmpereReactive,         Victron::VenusOS::Enums::Units_Scale_Tera,      Unit::Default,                  1   },
-	{                 "V",   Victron::VenusOS::Enums::Units_Volt_AC,                    Victron::VenusOS::Enums::Units_Scale_Tera,      Unit::Default,                  1   },
+	{                 "V",   Victron::VenusOS::Enums::Units_Volt_AC,                    Victron::VenusOS::Enums::Units_Scale_Tera,      Unit::Default,                  0   },
 	{                 "V",   Victron::VenusOS::Enums::Units_Volt_DC,                    Victron::VenusOS::Enums::Units_Scale_Tera,      Unit::Default,                  2   },
 	{          CubicMetre,   Victron::VenusOS::Enums::Units_Volume_CubicMetre,          Victron::VenusOS::Enums::Units_Scale_None,      Unit::CubicMetre,               3   },
 	{               "gal",   Victron::VenusOS::Enums::Units_Volume_GallonImperial,      Victron::VenusOS::Enums::Units_Scale_None,      Unit::ImperialGallon,           0   },
@@ -98,6 +98,21 @@ const QLocale *formattingLocale()
 {
 	static const QLocale locale = QLocale::c();
 	return &locale;
+}
+
+bool hasDecimalPlaces(qreal num)
+{
+	return qAbs(num - std::floor(num)) > 0;
+}
+
+qreal roundToDecimals(qreal num, int decimals)
+{
+	// This is useful for rounding the number before converting it to a fixed string with
+	// QString::number(). Otherwise, we get some anomalies e.g. where 10.555 becomes "10.55" instead
+	// of "10.56" due to floating-point conversions.
+	const qreal vFixedMultiplier = std::pow(10, decimals);
+	const int vFixed = qRound(num * vFixedMultiplier);
+	return (1.0*vFixed) / vFixedMultiplier;
 }
 
 }
@@ -277,15 +292,15 @@ quantityInfo Units::getDisplayTextWithHysteresis(VenusOS::Enums::Units_Type unit
 
 	qreal scaledValue = value;
 
-	// scale value if the unit of measure is scalable
-	// check format hints for display override value
+	// Determine the scaling to be used for the number:
+	// - set quantity.scale to the desired scale
+	// - update scaledValue to match the applied scale
 	const Victron::VenusOS::Enums::Units_Scale maxScale = maximumUnitScale(unit);
 	if (maxScale > VenusOS::Enums::Units_Scale_None && !(formatHints & Units::FormatHint::NoScaling)) {
 		qreal scaleMatch = !qIsNaN(unitMatchValue) ? unitMatchValue : scaledValue;
 
 		// Kilowatthour is already in kilos, normalize to plain watthours before scaling
 		if (unit == VenusOS::Enums::Units_Energy_KiloWattHour) {
-			quantity.unit = QStringLiteral("Wh");
 			scaledValue = 1000.0 * scaledValue;
 			scaleMatch = 1000.0 * scaleMatch;
 		}
@@ -315,62 +330,147 @@ quantityInfo Units::getDisplayTextWithHysteresis(VenusOS::Enums::Units_Type unit
 		// mega/tera/giga format.
 		if (maxScale == VenusOS::Enums::Units_Scale_Kilo) {
 			if (isOverLimit(scaleMatch, VenusOS::Enums::Units_Scale_Kilo, previousScale)) {
-				quantity.unit = QStringLiteral("k%1").arg(defaultUnitString(unit));
 				quantity.scale = VenusOS::Enums::Units_Scale_Kilo;
 				scaledValue = scaledValue / 1000.0;
 			}
 		} else {
 			for (const auto scale : scales) {
 				if (isOverLimit(scaleMatch, scale, previousScale)) {
-					quantity.unit = scaleToString(scale) + quantity.unit;
-					quantity.scale = scale;
 					scaledValue = scaledValue / qPow(10, 3*scale);
+					quantity.scale = scale;
 					break;
 				}
 			}
+		}
 
-			// If value is zero prefer kWh instead of Wh
-			if (scaledValue == 0 && unit == VenusOS::Enums::Units_Energy_KiloWattHour) {
-				quantity.unit = defaultUnitString(unit, formatHints);
+		// If the unscaled value is over 4 digits (i.e. over 9999), scale up to the next magnitude.
+		// Otherwise, 9999.9Hz becomes 10000Hz instead of 10.0kHz.
+		if (quantity.scale < maxScale && qAbs(scaledValue) > 9999 && qIsNaN(unitMatchValue)) {
+			quantity.scale = static_cast<VenusOS::Enums::Units_Scale>(static_cast<int>(quantity.scale) + 1);
+			scaledValue /= 1000.0;
+		}
+
+		// Now that the scale is configured, adjust the unit symbol string accordingly.
+		if (unit == VenusOS::Enums::Units_Energy_KiloWattHour) {
+			// quantity.unit is already set to "kWh" (the default).
+			// If value is zero, prefer the default "kWh" instead of "Wh". For other non-kilo
+			// values, use the appropriate string (Wh, MWh, etc).
+			if (qAbs(scaledValue) > 0 && quantity.scale != VenusOS::Enums::Units_Scale_Kilo) {
+				quantity.unit = scaleToString(quantity.scale) + QStringLiteral("Wh");
+			}
+		} else {
+			quantity.unit = scaleToString(quantity.scale) + quantity.unit;
+		}
+	}
+
+	// Determine the number of decimals.
+	if (!(formatHints & Units::FormatHint::NoDecimalAdjustment)) {
+		if (quantity.scale == VenusOS::Enums::Units_Scale_None && unit == VenusOS::Enums::Units_Energy_KiloWattHour) {
+			// If kilowatt-hours have not been scaled avoid decimals.
+			decimals = 0;
+		} else if ((unit == VenusOS::Enums::Units_Amp || unit == VenusOS::Enums::Units_Volt_DC)
+				&& quantity.scale == VenusOS::Enums::Units_Scale_None
+				&& qAbs(value) > 100
+				&& qRound(qAbs(value)) < 10000) { // If value will round up to 10000 and be scaled up, use the default decimals instead
+			// For Amps and DC Volts, if the value is over 100 and would be displayed in the base
+			// unit, use zero decimals.
+			decimals = 0;
+		}
+	}
+	if (decimals < 0) {
+		decimals = defaultUnitDecimals(unit);
+	}
+
+	// For particular power and energy units, when value > 9999, ignore the default decimals and
+	// adjust the decimals such that the fixed number has four digits in total.
+	// E.g. for Watts, the default decimals=0, but ignore that in these examples:
+	//  10499W -> 10.50kW (instead of 10kW with zero decimals)
+	//  999999W -> 1000MW (zero decimals is fine, there are four digits exactly)
+	//  12345678W -> 12.35MW (instead of 10kW with zero decimals)
+	//
+	// This special adjustment is not required when the unscaled value is <= 9999, because that
+	// allows for showing four digits or less - e.g. we would show 999W or 9999W without decimals.
+	if (!(formatHints & Units::FormatHint::NoDecimalAdjustment)) {
+		switch (unit) {
+		case VenusOS::Enums::Units_AmpHour:
+		case VenusOS::Enums::Units_Energy_KiloWattHour:
+		case VenusOS::Enums::Units_VoltAmpere:
+		case VenusOS::Enums::Units_VoltAmpereReactive:
+		case VenusOS::Enums::Units_Watt:
+		{
+			qreal normalizedValue = value;
+			if (unit == VenusOS::Enums::Units_Energy_KiloWattHour) {
+				normalizedValue *= 1000; // convert to Wh
+			}
+			if (qAbs(normalizedValue) > 9999) {
+				// For the scaled value, get the number of digits before the decimal. Used a fixed
+				// number string to determine this consistently (instead of continously dividing
+				// scaledValue by 10) to avoid floating-point issues.
+				int wholeNumberLength = formattingLocale()->toString(scaledValue, 'f', 0).length();
+				if (value < 0) {
+					wholeNumberLength--; // disregard the minus
+				}
+
+				// Calculate the number of decimals required to have four digits in total in the
+				// fixed string.
+				if (!hasDecimalPlaces(scaledValue) && wholeNumberLength == 4) {
+					// Use zero decimals if that would give us the same value with 4 digits.
+					decimals = 0;
+				} else if (qAbs(scaledValue) < 1) {
+					// For real numbers between 0-1, the leading zero already adds an extra digit,
+					// so add three digits here instead of four.
+					decimals = 3;
+				} else {
+					// Add as many digits as needed to have four digits in total.
+					decimals = qMax(0, 4 - wholeNumberLength);
+				}
+
+				// Create the preliminary fixed number.
+				quantity.number = formattingLocale()->toString(roundToDecimals(scaledValue, decimals), 'f', decimals);
+
+				// Get the number of digits in the fixed number, including decimals.
+				int totalDigitCount = quantity.number.length();
+				if (decimals > 0) {
+					totalDigitCount--; // disregard the decimal point
+				}
+				if (value < 0) {
+					totalDigitCount--;  // disregard the minus
+				}
+
+				// Pad the number with extra zeros.
+				const int decimalsToAdd = 4 - totalDigitCount;
+				if (decimalsToAdd > 0) {
+					if (decimals == 0) {
+						quantity.number += '.';
+					}
+					quantity.number.resize(quantity.number.size() + decimalsToAdd, '0');
+				}
+			}
+			break;
+		}
+		default:
+			break;
+		}
+	}
+
+	// For all other cases, create a fixed number based on the default decimals for this unit.
+	if (quantity.number.isEmpty()) {
+		scaledValue = roundToDecimals(scaledValue, decimals);
+		quantity.number = formattingLocale()->toString(scaledValue, 'f', decimals);
+
+		// We prefer four digits, so use zero decimals if that would give us the same value with
+		// four digits (e.g. "1000.0" could just be "1000" instead). This is true if:
+		// - the qreal number has no decimal places
+		// - in the fixed number, there are exactly four digits before the decimal (excluding minus)
+		if (!(formatHints & Units::FormatHint::NoDecimalAdjustment)
+				&& decimals > 0
+				&& !hasDecimalPlaces(scaledValue)) {
+			const int decimalIndex = quantity.number.indexOf('.');
+			 if ((value > 0 && decimalIndex == 4) || (value < 0 && decimalIndex == 5)) {
+				quantity.number = quantity.number.mid(0, decimalIndex);
 			}
 		}
 	}
-
-	auto numberOfDigits = [](int value) -> int {
-		int digits = 0;
-		while (value) {
-			value /= 10;
-			digits++;
-		}
-		return digits;
-	};
-
-	// If kilowatt-hours have not been scaled avoid decimals
-	if (!(formatHints & Units::FormatHint::NoDecimalAdjustment) && quantity.scale == VenusOS::Enums::Units_Scale_None && unit == VenusOS::Enums::Units_Energy_KiloWattHour) {
-		decimals = 0;
-	}
-
-	// If the scaled value is large then possibly clip the decimals by 1 or 2 fractional digits depending on initial decimals.
-	// Only apply this logic to scaled values with 2 non fractional digits if the units are not Units_Volt_DC.
-	// i.e. don't clip decimals for values like 53.35 V DC.
-	decimals = decimals < 0 ? defaultUnitDecimals(unit) : decimals;
-	const int digits = numberOfDigits(static_cast<int>(scaledValue));
-	if (!(formatHints & Units::FormatHint::NoDecimalAdjustment) && (unit != VenusOS::Enums::Units_Volt_DC || digits > 2)) {
-		if (digits >= 4) {
-			decimals = 0;
-		} else if (digits == 3) {
-			decimals = decimals >= 3 ? 1 : 0;
-		} else if (digits == 2) {
-			decimals = decimals >= 3 ? 2
-				: decimals >= 1 ? 1
-				: 0;
-		}
-	}
-
-	const qreal vFixedMultiplier = std::pow(10, decimals);
-	const int vFixed = qRound(scaledValue * vFixedMultiplier);
-	scaledValue = (1.0*vFixed) / vFixedMultiplier;
-	quantity.number = formattingLocale()->toString(scaledValue, 'f', decimals);
 
 	return quantity;
 }

--- a/src/units.h
+++ b/src/units.h
@@ -65,9 +65,8 @@ public:
 
 	Q_INVOKABLE int defaultUnitDecimals(VenusOS::Enums::Units_Type unit) const;
 	Q_INVOKABLE QString defaultUnitString(VenusOS::Enums::Units_Type unit, Victron::Units::Units::FormatHints formatHints = NoFormatHints) const;
-
+	Q_INVOKABLE VenusOS::Enums::Units_Scale maximumUnitScale(VenusOS::Enums::Units_Type unit) const;
 	Q_INVOKABLE QString scaleToString(VenusOS::Enums::Units_Scale scale) const;
-	Q_INVOKABLE bool isScalingSupported(VenusOS::Enums::Units_Type unit) const;
 
 	Q_INVOKABLE quantityInfo getDisplayText(
 		VenusOS::Enums::Units_Type unit,

--- a/tests/units/tst_units.qml
+++ b/tests/units/tst_units.qml
@@ -10,6 +10,65 @@ import QtTest
 TestCase {
 	name: "UnitsTest"
 
+	function expectedAdjustedQuantity(unit, value, fixedNumbers, fixedNumberScale) {
+		const baseUnitSymbol = Units.defaultUnitString(unit)
+
+		if (isNaN(value)) {
+			return { number: "--", unit: baseUnitSymbol, scale: VenusOS.Units_Scale_None }
+		} else if (unit === VenusOS.Units_Watt && Math.abs(value) < 1) {
+			// For Watts, values < abs(1.0) are always converted to zero, regardless of decimals.
+			return { number: "0", unit: baseUnitSymbol, scale: VenusOS.Units_Scale_None }
+		}
+
+		// Scale up if there are more than 4 digits.
+		let scale = VenusOS.Units_Scale_None
+		let scaledValue = value
+		if (Math.abs(value) > 9999) {
+			while (scale < Units.maximumUnitScale(unit)) {
+				scaledValue /= 1000
+				scale++
+				if (Math.abs(scaledValue) <= 9999) {
+					break
+				}
+			}
+		}
+
+		// Now set the desired fixed number depending on the unit type.
+		let fixedNumber
+		const unitsWith4Precision = [ VenusOS.Units_AmpHour, VenusOS.Units_Energy_KiloWattHour, VenusOS.Units_VoltAmpere, VenusOS.Units_VoltAmpereReactive, VenusOS.Units_Watt ]
+		if (Math.abs(value) > 9999 && unitsWith4Precision.indexOf(unit) >= 0) {
+			fixedNumber = scaledValue.toPrecision(4)
+		} else {
+			let decimals
+			if (Math.abs(value) > 100 && Math.abs(value) <= 9999 && (unit === VenusOS.Units_Amp || unit === VenusOS.Units_Volt_DC)) {
+				// Use 0 decimals when over 100 A or 100 V (DC).
+				decimals = 0
+			} else {
+				decimals = Units.defaultUnitDecimals(unit)
+			}
+			fixedNumber = scaledValue.toFixed(decimals)
+		}
+
+		if (parseInt(fixedNumber) === parseFloat(fixedNumber)) {
+			const fixedWithoutDecimals = scaledValue.toFixed(0)
+			if ((scaledValue < 0 && fixedWithoutDecimals.length === 5) // disregard minus symbol if present
+				   || (scaledValue > 0 && fixedWithoutDecimals.length === 4)) {
+				// Use zero decimals if that would give us the same value with 4 digits.
+				fixedNumber = fixedWithoutDecimals
+			}
+		}
+
+		if (fixedNumber === "-0") {
+			fixedNumber = "0"
+		}
+
+		return {
+			number: fixedNumber,
+			unit: Units.scaleToString(scale) + baseUnitSymbol,
+			scale: scale
+		}
+	}
+
 	function test_getDisplayText_data() {
 		function dataRow(unit, value, scale, fixedNumbers) {
 			const symbol = Units.defaultUnitString(unit)
@@ -32,9 +91,11 @@ TestCase {
 				default: break;
 			}
 			let expectedSymbol = Units.scaleToString(scale) + symbol
-			const tag = "%1 %2 -> %3 %4"
+			const adjusted = expectedAdjustedQuantity(unit, value, fixedNumbers, scale)
+			const tag = "%1 %2 -> nonAdjusted=%3%4, adjusted=%5%6"
 					.arg(value.toString()).arg(unitTag)
-					.arg("[%1]".arg(fixedNumbers.join(", "))).arg(expectedSymbol)
+					.arg(fixedNumbers[Units.defaultUnitDecimals(unit)]).arg(expectedSymbol)
+					.arg(adjusted.number).arg(adjusted.unit)
 			return {
 				tag: tag,
 				unit: unit,
@@ -43,7 +104,8 @@ TestCase {
 					fixedNumbers: fixedNumbers,
 					symbol: expectedSymbol,
 					scale: scale,
-				}
+				},
+				adjusted: adjusted
 			}
 		}
 
@@ -52,8 +114,8 @@ TestCase {
 			return [ v.toFixed(0), v.toFixed(1), v.toFixed(2), v.toFixed(3) ]
 		}
 
-		const unscaledTestValues = [ 0, 0.1234, 0.8888, 0.9999, 1, 88.8888, 99.9999, 123.4567, 888.8888, 999.9999, 1234.5678, 8888.8888, 9999.9999 ]
-		const scaledTestValues = [ 12345.6789, 88888.8888, 99999.9999, 123456.7899, 888888.8888, 999999.9999 ]
+		const unscaledTestValues = [ 0, 0.1234, 0.8888, 0.9999, 1, 12, 88.8888, 99.9999, 123, 123.4567, 888.8888, 999.9999, 1234, 1234.5678, 8888.8888 ]
+		const scaledTestValues = [  9999.9999, 12345.6789, 88888.8888, 99999.9999, 123456.7899, 888888.8888, 999999.9999 ]
 
 		// Expected results for unscaled values.
 		const expectedUnscaled = unscaledTestValues.map(v => ({ value: v, fixedNumbers: fixedNumbersForValue(v) }))
@@ -65,6 +127,7 @@ TestCase {
 		// Expected results for values that are expected to scale to the kilo range.
 		// E.g. for value 12345.6789, the test row is { value: 12345.6789, fixedNumbers: [ "12", "12.3", "12.35, "12.346" ] }
 		const expectedKilo = scaledTestValues.map(v => ({ value: v, fixedNumbers: fixedNumbersForValue(v / 1000) }))
+		const expectedNegativeKilo = scaledTestValues.map(v => ({ value: v * -1, fixedNumbers: fixedNumbersForValue(v / 1000 * -1) }))
 
 		// Expected results for values that are expected to scale to the mega range.
 		// E.g. for value 12345.6789, the test row is { value: 12345678.9, fixedNumbers: [ "12", "12.3", "12.35, "12.346" ] }
@@ -97,6 +160,9 @@ TestCase {
 				for (expectedInfo of expectedKilo) {
 					data.push(dataRow(unit, expectedInfo.value, VenusOS.Units_Scale_Kilo, expectedInfo.fixedNumbers))
 				}
+				for (expectedInfo of expectedNegativeKilo) {
+					data.push(dataRow(unit, expectedInfo.value, VenusOS.Units_Scale_Kilo, expectedInfo.fixedNumbers))
+				}
 			}
 			if (Units.maximumUnitScale(unit) >= VenusOS.Units_Scale_Mega) {
 				for (expectedInfo of expectedMega) {
@@ -124,6 +190,7 @@ TestCase {
 			VenusOS.Units_Time_Minute, // as above
 			VenusOS.Units_Time_Second, // as above
 		]
+
 		for (let i = 0; i <= VenusOS.Units_Type_Max; ++i) {
 			if (exceptions.indexOf(i) < 0) {
 				addDataRows(i)
@@ -133,21 +200,18 @@ TestCase {
 	}
 
 	function test_getDisplayText(data) {
-		// TODO currently for Watts, getDisplayText() returns an adjusted number even when
-		// Units.NoDecimalAdjustment is specified. Fix this and restore this test.
-		if (data.unit === VenusOS.Units_Watt) {
-			return
-		}
-
 		const baseUnitSymbol = Units.defaultUnitString(data.unit)
 		let decimals
 		let quantity
+
+		// For Watts, any number between -1 to 1 (exclusive) becomes zero, to ignore potential noise.
+		const overrideExpectedNumber = data.unit === VenusOS.Units_Watt && Math.abs(data.value) < 1 ? "0" : undefined
 
 		// When decimals = -1 and formatHints = NoDecimalAdjustment, the result should contain a
 		// fixed number with the default number of decimals for that unit. The resulting number
 		// should also be scaled if needed (e.g. 123456W becomes 12.34kW).
 		quantity = Units.getDisplayText(data.unit, data.value, -1, Units.NoDecimalAdjustment)
-		compare(quantity.number, data.nonAdjusted.fixedNumbers[Units.defaultUnitDecimals(data.unit)])
+		compare(quantity.number, overrideExpectedNumber ?? data.nonAdjusted.fixedNumbers[Units.defaultUnitDecimals(data.unit)])
 		compare(quantity.unit, Units.scaleToString(data.nonAdjusted.scale) + baseUnitSymbol)
 		compare(quantity.scale, data.nonAdjusted.scale)
 
@@ -155,7 +219,7 @@ TestCase {
 		// for that amount of decimals.
 		for (decimals = 0; decimals <= 3; ++decimals) {
 			quantity = Units.getDisplayText(data.unit, data.value, decimals, Units.NoDecimalAdjustment)
-			compare(quantity.number, data.nonAdjusted.fixedNumbers[decimals], decimals)
+			compare(quantity.number, overrideExpectedNumber ?? data.nonAdjusted.fixedNumbers[decimals])
 			compare(quantity.unit, Units.scaleToString(data.nonAdjusted.scale) + baseUnitSymbol, decimals)
 			compare(quantity.scale, data.nonAdjusted.scale, decimals)
 		}
@@ -170,11 +234,18 @@ TestCase {
 				if (unscaledNumber === "-0") {
 					unscaledNumber = "0"
 				}
-				compare(quantity.number, unscaledNumber) // expect an unscaled value
+				compare(quantity.number, overrideExpectedNumber ?? unscaledNumber) // expect an unscaled value
 				compare(quantity.unit, baseUnitSymbol) // expect the unit symbol without any scaling
 				compare(quantity.scale, VenusOS.Units_Scale_None) // expect no scaling has been applied
 			}
 		}
+
+		// When the default decimals, scaling and decimal adjustments are used, the resulting
+		// number should be scaled and formatted as needed.
+		quantity = Units.getDisplayText(data.unit, data.value)
+		compare(quantity.number, overrideExpectedNumber ?? data.adjusted.number)
+		compare(quantity.unit, data.adjusted.unit)
+		compare(quantity.scale, data.adjusted.scale)
 	}
 
 	function test_timeUnits_data() {
@@ -315,20 +386,23 @@ TestCase {
 		compare(quantity.unit, "TWh")
 
 		// choose scale based on different anchor value
-		quantity = Units.getDisplayText(unit, 19567890123, -1, Units.NoFormatHints, 123456789)
+		quantity = Units.getDisplayText(unit, 19567890123, 0, Units.NoFormatHints, 123456789)
 		compare(quantity.number, "19568")
 		compare(quantity.unit, "GWh")
 	}
 
 	function test_unitFormatHints() {
 		const unit = VenusOS.Units_Metre
-		var quantity = Units.getDisplayText(unit, 19.5678)
+		let quantity
+
+		quantity = Units.getDisplayText(unit, 19.5678)
 		compare(quantity.number, "20")
 		compare(quantity.unit, "m")
 
 		// default internal scaling algorithm ignores passed function parameters
+		// and uses four digits where possible
 		quantity = Units.getDisplayText(unit, 19.5678, 2)
-		compare(quantity.number, "19.6")
+		compare(quantity.number, "19.57")
 		compare(quantity.unit, "m")
 
 		// force internal scaling algorithm to adhere to function parameters
@@ -346,16 +420,14 @@ TestCase {
 		compare(quantity.number, "195.68")
 		compare(quantity.unit, "km")
 
-		// unscaled value correctly round to no decimal places
-		// (TODO: passing in decimal places does not result in displayed decimal places)
+		// unscaled value correctly round to two decimal places
 		quantity = Units.getDisplayText(unit, 195678, 2, Units.NoScaling)
-		compare(quantity.number, "195678")
+		compare(quantity.number, "195678.00")
 		compare(quantity.unit, "m")
 
-		// unscaled value correctly round to no decimal places
-		// (TODO: passing in decimal places rounds to whole value instead of displaying decimals places)
+		// unscaled value correctly round to two decimal places
 		quantity = Units.getDisplayText(unit, 195678.5, 2, Units.NoScaling)
-		compare(quantity.number, "195679")
+		compare(quantity.number, "195678.50")
 		compare(quantity.unit, "m")
 	}
 

--- a/tests/units/tst_units.qml
+++ b/tests/units/tst_units.qml
@@ -10,8 +10,202 @@ import QtTest
 TestCase {
 	name: "UnitsTest"
 
-	QuantityInfo {
-		id: info
+	function test_getDisplayText_data() {
+		function dataRow(unit, value, scale, fixedNumbers) {
+			const symbol = Units.defaultUnitString(unit)
+			if (unit !== VenusOS.Units_None && unit !== VenusOS.Units_PowerFactor) {
+				console.assert(symbol, "no symbol for unit: %1".arg(unit))
+			}
+
+			// Create a unique unit tag in order to avoid duplicate data tags.
+			let unitTag = symbol
+			switch (unit) {
+				// If the symbol is empty, set a hardcoded string id.
+				case VenusOS.Units_None: unitTag = "(Units_None)"; break;
+				case VenusOS.Units_PowerFactor: unitTag = "(PF)"; break;
+				// Distinguish between AC vs DC volts.
+				case VenusOS.Units_Volt_AC: unitTag += " (AC)"; break;
+				case VenusOS.Units_Volt_DC: unitTag += " (DC)"; break;
+				// Distinguish between imperial vs US gallons.
+				case VenusOS.Units_Volume_GallonImperial: unitTag += " (Imp)"; break;
+				case VenusOS.Units_Volume_GallonUS: unitTag += " (US)"; break;
+				default: break;
+			}
+			let expectedSymbol = Units.scaleToString(scale) + symbol
+			const tag = "%1 %2 -> %3 %4"
+					.arg(value.toString()).arg(unitTag)
+					.arg("[%1]".arg(fixedNumbers.join(", "))).arg(expectedSymbol)
+			return {
+				tag: tag,
+				unit: unit,
+				value: value,
+				nonAdjusted: {
+					fixedNumbers: fixedNumbers,
+					symbol: expectedSymbol,
+					scale: scale,
+				}
+			}
+		}
+
+		// Returns an array of the value with [0,1,2,3] decimals.
+		function fixedNumbersForValue(v) {
+			return [ v.toFixed(0), v.toFixed(1), v.toFixed(2), v.toFixed(3) ]
+		}
+
+		const unscaledTestValues = [ 0, 0.1234, 0.8888, 0.9999, 1, 88.8888, 99.9999, 123.4567, 888.8888, 999.9999, 1234.5678, 8888.8888, 9999.9999 ]
+		const scaledTestValues = [ 12345.6789, 88888.8888, 99999.9999, 123456.7899, 888888.8888, 999999.9999 ]
+
+		// Expected results for unscaled values.
+		const expectedUnscaled = unscaledTestValues.map(v => ({ value: v, fixedNumbers: fixedNumbersForValue(v) }))
+
+		// Expected results for (unscaled) negative values, excluding the first (zero) entry in unscaledTestValues.
+		let expectedNegativeUnscaled = unscaledTestValues.slice(1).map(v => ({ value: v * -1, fixedNumbers: fixedNumbersForValue(v * -1) }))
+		expectedNegativeUnscaled[0].fixedNumbers = ["0", "-0.1", "-0.12", "-0.123"] // fix the first number so that it is not "-0"
+
+		// Expected results for values that are expected to scale to the kilo range.
+		// E.g. for value 12345.6789, the test row is { value: 12345.6789, fixedNumbers: [ "12", "12.3", "12.35, "12.346" ] }
+		const expectedKilo = scaledTestValues.map(v => ({ value: v, fixedNumbers: fixedNumbersForValue(v / 1000) }))
+
+		// Expected results for values that are expected to scale to the mega range.
+		// E.g. for value 12345.6789, the test row is { value: 12345678.9, fixedNumbers: [ "12", "12.3", "12.35, "12.346" ] }
+		const expectedMega = scaledTestValues.map(v => ({ value: v * 1000, fixedNumbers: fixedNumbersForValue(v / 1000) }))
+
+		// Expected results for values that are expected to scale to the giga range.
+		// E.g. for value 12345.6789, the test row is { value: 12345678900, fixedNumbers: [ "12", "12.3", "12.35, "12.346" ] }
+		const expectedGiga = scaledTestValues.map(v => ({ value: v * 1000 * 1000, fixedNumbers: fixedNumbersForValue(v / 1000) }))
+
+		// Expected results for values that are expected to scale to the tera range.
+		// E.g. for value 12345.6789, the test row is { value: 12345678900000, fixedNumbers: [ "12", "12.3", "12.35, "12.346" ] }
+		const expectedTera = scaledTestValues.map(v => ({ value: v * 1000 * 1000 * 1000, fixedNumbers: fixedNumbersForValue(v / 1000) }))
+
+
+		let data = []
+
+		// For each unit, add a data row for each scale test value, with an array containing the
+		// expected quantity text for [0,1,2,3] decimals.
+		function addDataRows(unit) {
+			data.push(dataRow(unit, NaN, VenusOS.Units_Scale_None, ["--","--","--","--"]))
+
+			let expectedInfo
+			for (expectedInfo of expectedUnscaled) {
+				data.push(dataRow(unit, expectedInfo.value, VenusOS.Units_Scale_None, expectedInfo.fixedNumbers))
+			}
+			for (expectedInfo of expectedNegativeUnscaled) {
+				data.push(dataRow(unit, expectedInfo.value, VenusOS.Units_Scale_None, expectedInfo.fixedNumbers))
+			}
+			if (Units.maximumUnitScale(unit) >= VenusOS.Units_Scale_Kilo) {
+				for (expectedInfo of expectedKilo) {
+					data.push(dataRow(unit, expectedInfo.value, VenusOS.Units_Scale_Kilo, expectedInfo.fixedNumbers))
+				}
+			}
+			if (Units.maximumUnitScale(unit) >= VenusOS.Units_Scale_Mega) {
+				for (expectedInfo of expectedMega) {
+					data.push(dataRow(unit, expectedInfo.value, VenusOS.Units_Scale_Mega, expectedInfo.fixedNumbers))
+				}
+			}
+			if (Units.maximumUnitScale(unit) >= VenusOS.Units_Scale_Giga) {
+				for (expectedInfo of expectedGiga) {
+					data.push(dataRow(unit, expectedInfo.value, VenusOS.Units_Scale_Giga, expectedInfo.fixedNumbers))
+				}
+			}
+			if (Units.maximumUnitScale(unit) >= VenusOS.Units_Scale_Tera) {
+				for (expectedInfo of expectedTera) {
+					data.push(dataRow(unit, expectedInfo.value, VenusOS.Units_Scale_Tera, expectedInfo.fixedNumbers))
+				}
+			}
+		}
+
+		const exceptions = [
+			VenusOS.Units_CardinalDirection, // see test_windDirection()
+			VenusOS.Units_Energy_KiloWattHour, // see test_kiloWattHour()
+			VenusOS.Units_Percentage, // see test_percentage()
+			VenusOS.Units_Time_Day, // see test_timeUnits()
+			VenusOS.Units_Time_Hour, // as above
+			VenusOS.Units_Time_Minute, // as above
+			VenusOS.Units_Time_Second, // as above
+		]
+		for (let i = 0; i <= VenusOS.Units_Type_Max; ++i) {
+			if (exceptions.indexOf(i) < 0) {
+				addDataRows(i)
+			}
+		}
+		return data
+	}
+
+	function test_getDisplayText(data) {
+		// TODO currently for Watts, getDisplayText() returns an adjusted number even when
+		// Units.NoDecimalAdjustment is specified. Fix this and restore this test.
+		if (data.unit === VenusOS.Units_Watt) {
+			return
+		}
+
+		const baseUnitSymbol = Units.defaultUnitString(data.unit)
+		let decimals
+		let quantity
+
+		// When decimals = -1 and formatHints = NoDecimalAdjustment, the result should contain a
+		// fixed number with the default number of decimals for that unit. The resulting number
+		// should also be scaled if needed (e.g. 123456W becomes 12.34kW).
+		quantity = Units.getDisplayText(data.unit, data.value, -1, Units.NoDecimalAdjustment)
+		compare(quantity.number, data.nonAdjusted.fixedNumbers[Units.defaultUnitDecimals(data.unit)])
+		compare(quantity.unit, Units.scaleToString(data.nonAdjusted.scale) + baseUnitSymbol)
+		compare(quantity.scale, data.nonAdjusted.scale)
+
+		// When custom decimals are specified, the result should match the fixedNumbers entry
+		// for that amount of decimals.
+		for (decimals = 0; decimals <= 3; ++decimals) {
+			quantity = Units.getDisplayText(data.unit, data.value, decimals, Units.NoDecimalAdjustment)
+			compare(quantity.number, data.nonAdjusted.fixedNumbers[decimals], decimals)
+			compare(quantity.unit, Units.scaleToString(data.nonAdjusted.scale) + baseUnitSymbol, decimals)
+			compare(quantity.scale, data.nonAdjusted.scale, decimals)
+		}
+
+		// When the NoScaling flag is specified, the resulting number should be the same as the
+		// source value, with the preferred decimals.
+		// Only test numbers for the base and kilo scales, to avoid going over MAX_INT.
+		if (data.nonAdjusted.scale === VenusOS.Units_Scale_None || data.nonAdjusted.scale === VenusOS.Units_Scale_Kilo) {
+			for (decimals = 0; decimals <= 3; ++decimals) {
+				quantity = Units.getDisplayText(data.unit, data.value, decimals, Units.NoDecimalAdjustment | Units.NoScaling)
+				let unscaledNumber = isNaN(data.value) ? "--" : data.value.toFixed(decimals)
+				if (unscaledNumber === "-0") {
+					unscaledNumber = "0"
+				}
+				compare(quantity.number, unscaledNumber) // expect an unscaled value
+				compare(quantity.unit, baseUnitSymbol) // expect the unit symbol without any scaling
+				compare(quantity.scale, VenusOS.Units_Scale_None) // expect no scaling has been applied
+			}
+		}
+	}
+
+	function test_timeUnits_data() {
+		return [
+			{ unit: VenusOS.Units_Time_Day, symbol: "d" },
+			{ unit: VenusOS.Units_Time_Hour, symbol: "h" },
+			{ unit: VenusOS.Units_Time_Minute, symbol: "m" },
+			{ unit: VenusOS.Units_Time_Second, symbol: "s" },
+		]
+	}
+
+	function test_timeUnits(data) {
+		compare(Units.defaultUnitString(data.unit), data.symbol)
+		compare(Units.defaultUnitDecimals(data.unit), 0)
+		compare(Units.maximumUnitScale(data.unit), VenusOS.Units_Scale_None)
+
+		// There are currently no min/max constraints on time units, so getDisplayText() should just
+		// return the given number with the appropriate symbol.
+		let quantity
+		quantity = Units.getDisplayText(data.unit, NaN)
+		compare(quantity.unit, data.symbol)
+		compare(quantity.number, "--")
+		quantity = Units.getDisplayText(data.unit, 0)
+		compare(quantity.unit, data.symbol)
+		compare(quantity.number, "0")
+		quantity = Units.getDisplayText(data.unit, 1)
+		compare(quantity.unit, data.symbol)
+		compare(quantity.number, "1")
+		quantity = Units.getDisplayText(data.unit, 100)
+		compare(quantity.unit, data.symbol)
+		compare(quantity.number, "100")
 	}
 
 	function expect(type, value, number, unit, hysteresis = false) {
@@ -31,47 +225,6 @@ TestCase {
 		console.log("Testing value", value, "(" + Units.defaultUnitString(type) +") ->", numberOut + unitOut)
 		compare(numberOut, number)
 		compare(unitOut, unit)
-	}
-
-	function test_unitsLabel() {
-		expect(VenusOS.Units_None, 1, "1", "")
-		expect(VenusOS.Units_Amp, 1, "1.0", "A")
-		expect(VenusOS.Units_AmpHour, 1, "1.0", "Ah")
-		expect(VenusOS.Units_CardinalDirection, 1, "1", Units.degreesSymbol + " direction_north")
-		expect(VenusOS.Units_Energy_KiloWattHour, 1, "1000", "Wh")
-		expect(VenusOS.Units_Foot, 1, "1", "ft")
-		expect(VenusOS.Units_Hectopascal, 1, "1.0", "hPa")
-		expect(VenusOS.Units_Hertz, 1, "1.0", "Hz")
-		expect(VenusOS.Units_Kilopascal, 1, "1", "kPa")
-		expect(VenusOS.Units_Lux, 1, "1", "lux")
-		expect(VenusOS.Units_MicrogramPerCubicMeter, 1, "1.0", "µg/m³")
-		expect(VenusOS.Units_Metre, 1, "1", "m")
-		expect(VenusOS.Units_NewtonMeter, 1, "1", "Nm")
-		expect(VenusOS.Units_PartsPerMillion, 1, "1", "ppm")
-		expect(VenusOS.Units_Percentage, 1, "1", "%")
-		expect(VenusOS.Units_PowerFactor, 1, "1.000", "")
-		expect(VenusOS.Units_RevolutionsPerMinute, 1, "1", "RPM")
-		expect(VenusOS.Units_Speed_KilometresPerHour, 1, "1", "km/h")
-		expect(VenusOS.Units_Speed_Knots, 1, "1", "kn")
-		expect(VenusOS.Units_Speed_MetresPerSecond, 1, "1", "m/s")
-		expect(VenusOS.Units_Speed_MilesPerHour, 1, "1", "mph")
-		expect(VenusOS.Units_Temperature_Celsius, 1, "1", Units.degreesSymbol + "C")
-		expect(VenusOS.Units_Temperature_Fahrenheit, 1, "1", Units.degreesSymbol + "F")
-		expect(VenusOS.Units_Temperature_Kelvin, 1, "1", Units.degreesSymbol + "K")
-		expect(VenusOS.Units_Time_Day, 1, "1", "d")
-		expect(VenusOS.Units_Time_Hour, 1, "1", "h")
-		expect(VenusOS.Units_Time_Minute, 1, "1", "m")
-		expect(VenusOS.Units_Time_Second, 1, "1", "s")
-		expect(VenusOS.Units_VoltAmpere, 1, "1.0", "VA")
-		expect(VenusOS.Units_VoltAmpereReactive, 1, "1.0", "var")
-		expect(VenusOS.Units_Volt_AC, 1, "1.0", "V")
-		expect(VenusOS.Units_Volt_DC, 1, "1.00", "V")
-		expect(VenusOS.Units_Volume_CubicMetre, 1, "1.000", "m³")
-		expect(VenusOS.Units_Volume_GallonImperial, 1, "1", "gal")
-		expect(VenusOS.Units_Volume_GallonUS, 1, "1", "gal")
-		expect(VenusOS.Units_Volume_Litre, 1, "1", "ℓ")
-		expect(VenusOS.Units_Watt, 1, "1", "W")
-		expect(VenusOS.Units_WattsPerSquareMetre, 1, "1", "W/m2")
 	}
 
 	function test_percentage() {
@@ -103,140 +256,6 @@ TestCase {
 		expect(VenusOS.Units_CardinalDirection, 23.6, "24", "° direction_northeast")
 	}
 
-	function test_powerFactor() {
-		expect(VenusOS.Units_PowerFactor, NaN, "--", "")
-		expect(VenusOS.Units_PowerFactor, -1234, "-1234", "")
-		expect(VenusOS.Units_PowerFactor, -100, "-100.0", "")
-		expect(VenusOS.Units_PowerFactor, -15.55, "-15.55", "")
-		expect(VenusOS.Units_PowerFactor, -1, "-1.000", "")
-		expect(VenusOS.Units_PowerFactor, -0.255, "-0.255", "")
-		expect(VenusOS.Units_PowerFactor, -0.25, "-0.250", "")
-		expect(VenusOS.Units_PowerFactor, -0.1, "-0.100", "")
-		expect(VenusOS.Units_PowerFactor, 0, "0.000", "")
-		expect(VenusOS.Units_PowerFactor, 0.1, "0.100", "")
-		expect(VenusOS.Units_PowerFactor, 0.25, "0.250", "")
-		expect(VenusOS.Units_PowerFactor, 0.255, "0.255", "")
-		expect(VenusOS.Units_PowerFactor, 1, "1.000", "")
-		expect(VenusOS.Units_PowerFactor, 15.55, "15.55", "")
-		expect(VenusOS.Units_PowerFactor, 100, "100.0", "")
-		expect(VenusOS.Units_PowerFactor, 1234, "1234", "")
-	}
-
-	function test_precisionZero() {
-		var units = [VenusOS.Units_Volume_Litre,
-					 VenusOS.Units_Volume_GallonImperial,
-					 VenusOS.Units_Volume_GallonUS,
-					 VenusOS.Units_Watt,
-					 VenusOS.Units_WattsPerSquareMetre,
-					 VenusOS.Units_Temperature_Celsius,
-					 VenusOS.Units_Temperature_Fahrenheit,
-					 VenusOS.Units_Temperature_Kelvin,
-					 VenusOS.Units_Metre,
-					 VenusOS.Units_Kilometre,
-					 VenusOS.Units_Foot,
-					 VenusOS.Units_Mile,
-					 VenusOS.Units_NauticalMile,
-					 VenusOS.Units_RevolutionsPerMinute]
-
-		for (const unit of units) {
-			const unitString = Units.defaultUnitString(unit)
-
-			expect(unit, NaN, "--", unitString)
-			expect(unit, 0, "0", unitString)
-			expect(unit, 0.4, "0", unitString)
-			if (unit === VenusOS.Units_Watt) {
-				expect(unit, 0.55, "0", unitString)
-				expect(unit, 0.9, "0", unitString)
-				expect(unit, 1.1, "1", unitString)
-			} else {
-				expect(unit, 0.55, "1", unitString)
-			}
-			expect(unit, 14, "14", unitString)
-			expect(unit, 15.5, "16", unitString)
-			expect(unit, 100, "100", unitString)
-			expect(unit, 1234, "1234", unitString)
-
-			if (Units.isScalingSupported(unit)) {
-				if (unit === VenusOS.Units_Volume_Litre
-						|| unit === VenusOS.Units_Metre) {
-					expect(unit, 12345, "12", "k" + unitString)
-					expect(unit, 123456789, "123457", "k" + unitString)
-				} else {
-					expect(unit, 12345, "12", "k" + unitString)
-					expect(unit, 123456789, "123", "M" + unitString)
-					expect(unit, 123456789012, "123", "G" + unitString)
-					expect(unit, 123456789012345, "123", "T" + unitString)
-				}
-			} else {
-				expect(unit, 1234, "1234", unitString)
-				expect(unit, 12345, "12345", unitString)
-				expect(unit, 123456789, "123456789", unitString)
-			}
-		}
-	}
-
-	function test_precisionOne() {
-		var units = [VenusOS.Units_VoltAmpere,
-					 VenusOS.Units_Amp,
-					 VenusOS.Units_Hertz,
-					 VenusOS.Units_AmpHour,
-					 VenusOS.Units_Hectopascal]
-
-		for (const unit of units) {
-			const unitString = Units.defaultUnitString(unit)
-
-			expect(unit, NaN, "--", unitString)
-			expect(unit, 0, "0.0", unitString)
-			expect(unit, 0.4, "0.4", unitString)
-			expect(unit, 0.54, "0.5", unitString)
-			expect(unit, 0.55, "0.6", unitString)
-			expect(unit, 14, "14.0", unitString)
-			expect(unit, 15.5, "15.5", unitString)
-			expect(unit, 100, "100", unitString)
-			expect(unit, 1234, "1234", unitString)
-
-			if (Units.isScalingSupported(unit)) {
-				expect(unit, 12345, "12.3", "k" + unitString)
-				expect(unit, 123456789, "123", "M" + unitString)
-				expect(unit, 123556789012, "124", "G" + unitString)
-				expect(unit, 123456789012345, "123", "T" + unitString)
-			} else {
-				expect(unit, 12345, "12345", unitString)
-				expect(unit, 123456789, "123456789", unitString)
-			}
-		}
-	}
-
-	function test_precisionTwo() {
-		var units = [
-			VenusOS.Units_Volt_DC
-		]
-
-		for (const unit of units) {
-			const unitString = Units.defaultUnitString(unit)
-
-			expect(unit, NaN, "--", unitString)
-			expect(unit, 0, "0.00", unitString)
-			expect(unit, 0.64, "0.64", unitString)
-			expect(unit, 0.254, "0.25", unitString)
-			expect(unit, 0.255, "0.26", unitString)
-			expect(unit, 14, "14.00", unitString)
-			expect(unit, 15.55, "15.55", unitString)
-			expect(unit, 100, "100", unitString)
-			expect(unit, 1234, "1234", unitString)
-
-			if (Units.isScalingSupported(unit)) {
-				expect(unit, 12345, "12.35", "k" + unitString)
-				expect(unit, 123456789, "123", "M" + unitString)
-				expect(unit, 123556789012, "124", "G" + unitString)
-				expect(unit, 123456789012345, "123", "T" + unitString)
-			} else {
-				expect(unit, 12345, "12345", unitString)
-				expect(unit, 123456789, "123456789", unitString)
-			}
-		}
-	}
-
 	function test_kiloWattHour() {
 		const unit = VenusOS.Units_Energy_KiloWattHour
 
@@ -256,25 +275,6 @@ TestCase {
 		expect(unit, 12345, "12.35", "MWh")
 		expect(unit, 123456789, "123.5", "GWh")
 		expect(unit, 123456789012, "123.5", "TWh")
-	}
-
-	function test_volumeCubicMetre() {
-		const unit = VenusOS.Units_Volume_CubicMetre
-
-		expect(unit, NaN, "--", "m³")
-		expect(unit, 0, "0.000", "m³")
-		expect(unit, 0.0005, "0.001", "m³")
-		expect(unit, 0.005, "0.005", "m³")
-		expect(unit, 0.554, "0.554", "m³")
-		expect(unit, 0.5555, "0.556", "m³")
-		expect(unit, 14.1234, "14.12", "m³")
-		expect(unit, 15.5123, "15.51", "m³")
-		expect(unit, 100.3134, "100.3", "m³")
-		expect(unit, 1234.59551, "1235", "m³")
-		expect(unit, 12345.5, "12.35", "km³")
-		expect(unit, 123456789, "123.5", "Mm³")
-		expect(unit, 123456789012, "123.5", "Gm³")
-		expect(unit, 123456789012345, "123.5", "Tm³")
 	}
 
 	function test_hysteresis() {
@@ -359,77 +359,6 @@ TestCase {
 		compare(quantity.unit, "m")
 	}
 
-	function test_precision() {
-		const unit = VenusOS.Units_Watt
-		var quantity = Units.getDisplayText(unit, 1.9612345)
-		compare(quantity.number, "2")
-
-		quantity = Units.getDisplayText(unit, 1.9612345, 1)
-		compare(quantity.number, "2.0")
-
-		quantity = Units.getDisplayText(unit, 1.9612345, 2)
-		compare(quantity.number, "1.96")
-
-		quantity = Units.getDisplayText(unit, 1.9612345, 3)
-		compare(quantity.number, "1.961")
-
-		quantity = Units.getDisplayText(unit, 1.9612345, 4)
-		compare(quantity.number, "1.9612")
-	}
-
-	function test_unitNone() {
-		expect(VenusOS.Units_None, NaN, "--", "")
-		expect(VenusOS.Units_None, 123, "123", "")
-		expect(VenusOS.Units_None, 12345678, "12345678", "")
-	}
-
-	function test_partsPerMillion() {
-		const unit = VenusOS.Units_PartsPerMillion
-		const unitString = Units.defaultUnitString(unit)
-
-		expect(unit, NaN, "--", unitString)
-		expect(unit, 0, "0", unitString)
-		expect(unit, 400, "400", unitString)
-		expect(unit, 425, "425", unitString)
-		expect(unit, 1000, "1000", unitString)
-		expect(unit, 5000, "5000", unitString)
-		expect(unit, 40000, "40000", unitString)
-	}
-
-	function test_microgramPerCubicMeter() {
-		const unit = VenusOS.Units_MicrogramPerCubicMeter
-		const unitString = Units.defaultUnitString(unit)
-
-		expect(unit, NaN, "--", unitString)
-		expect(unit, 0, "0.0", unitString)
-		expect(unit, 0.4, "0.4", unitString)
-		expect(unit, 0.54, "0.5", unitString)
-		expect(unit, 0.55, "0.6", unitString)
-		expect(unit, 2.2, "2.2", unitString)
-		expect(unit, 10.5, "10.5", unitString)
-		expect(unit, 100, "100", unitString)
-		expect(unit, 250.7, "251", unitString)
-		expect(unit, 999.9, "1000", unitString)
-		expect(unit, 1000, "1000", unitString)
-	}
-
-	function test_lux() {
-		const unit = VenusOS.Units_Lux
-		const unitString = Units.defaultUnitString(unit)
-
-		expect(unit, NaN, "--", unitString)
-		expect(unit, 0, "0", unitString)
-		expect(unit, 1, "1", unitString)
-		expect(unit, 10, "10", unitString)
-		expect(unit, 100, "100", unitString)
-		expect(unit, 244, "244", unitString)
-		expect(unit, 1000, "1000", unitString)
-		expect(unit, 10472, "10472", unitString)
-		expect(unit, 13026.67, "13027", unitString)
-		expect(unit, 65535, "65535", unitString)
-		expect(unit, 144284, "144284", unitString)
-	}
-
 	function test_coordinate_data() {
 		// Note: directions are not translated in the tests, so the qtTrId translation ids are used
 		// directly here.
@@ -477,5 +406,9 @@ TestCase {
 		// Degrees, decimal minutes
 		compare(Units.formatLatitude(data.latitude.input, VenusOS.GpsData_Format_DegreesMinutes), data.latitude.dm)
 		compare(Units.formatLongitude(data.longitude.input, VenusOS.GpsData_Format_DegreesMinutes), data.longitude.dm)
+	}
+
+	QuantityInfo {
+		id: info
 	}
 }


### PR DESCRIPTION
This fixes issues #3002 and #2900 by resolving inconsistencies in the decimal adjustments for units. This produces the desired behaviour, where:

- Specifying `Units.NoDecimalAdjustment` never adjusts the decimals, and always provides a number with the requested number of decimals
- Otherwise, the default decimals for the unit are applied, unless the unit is one of:    
    - Watt (W)
    - Watt hour (Wh)
    - Amp (A)
    - Amp hour (Ah)
    - Amp hour reactive (var)

For example, for 10499W, show "10.50kW" (with two decimals to create four digits in total) instead of "10kW" (which it would be if the default zero decimals for Watts was applied).

This last point resolves #3002, so that for example, the Brief page will show `98.21kW` and `98.96kW` instead of just `98kW`:

<img width="1824" height="1240" alt="image" src="https://github.com/user-attachments/assets/702badd3-38eb-4516-83b0-0bad4e9d60f9" />
