### PR TITLE
UI: ensure stack view is visible when pages are pushed

### DIFF
--- a/components/PageStack.qml
+++ b/components/PageStack.qml
@@ -101,13 +101,15 @@ StackView {
 			root._topPageUrl = ""
 		}
 
-		if (root.depth === 0) {
-			// When the first page is added to the stack, move the stack into view.
+		if (root.state !== "opened") {
+			// When the stack is closed or hidden, push the first page without any animation and
+			// slide the stack into view.
 			const newPage = root.push(objectOrUrl, properties, StackView.Immediate)
 			fakePushAnimation.duration = _animationDuration(operation)
 			root.state = "opened"
 			return newPage
 		} else {
+			// Otherwise, push the push onto the visible stack, possibly with an animation.
 			return root.push(objectOrUrl, properties, _adjustedStackOperation(operation))
 		}
 	}


### PR DESCRIPTION
When deciding whether to change to the "opened" state, check the current state rather than the stack depth, in case the stack has a page but has not yet entered the "opened" state (and thus is now not visible in the main view).

Fixes #3036