### PR TITLE
Settings: MQTT access add paired devices option

### DIFF
--- a/components/listitems/ListMqttAccessSwitch.qml
+++ b/components/listitems/ListMqttAccessSwitch.qml
@@ -6,10 +6,24 @@
 import QtQuick
 import Victron.VenusOS
 
-ListSwitch {
+ListRadioButtonGroup {
 	//% "MQTT Access"
 	text: qsTrId("settings_services_mqtt_access")
 	dataItem.uid: Global.systemSettings.serviceUid + "/Settings/Services/MqttLocal"
+
+	optionModel: [
+		{ display: CommonWords.off, value: 0 },
+		//% "Paired devices only"
+		{ display: qsTrId("settings_services_mqtt_access_paired_devices_only"), value: 2, readOnly: !tokenUsers.valid || tokenUsers.value === "[]"},
+		{ display: CommonWords.on, value: 1 },
+	]
+
+	onOptionClicked: function (index) {
+		if (index == 0 && tokenUsers.valid && tokenUsers.value !== "[]") {
+			//% "Turning MQTT Access off also disables paired MQTT devices until access is enabled again."
+			Global.showToastNotification(VenusOS.Notification_Warning, qsTrId("settings_services_mqtt_access_warning_paired_devices"), 10000)
+		}
+	}
 
 	MouseArea {
 		anchors.fill: parent
@@ -23,5 +37,10 @@ ListSwitch {
 	VeQuickItem {
 		id: securityProfile
 		uid: Global.systemSettings.serviceUid + "/Settings/System/SecurityProfile"
+	}
+
+	VeQuickItem {
+		id: tokenUsers
+		uid: Global.venusPlatform.serviceUid + "/Tokens/Users"
 	}
 }


### PR DESCRIPTION
Contributes to https://github.com/victronenergy/venus/issues/1648

- Turns the MQTT access switch into a radio group.
- Warns the user with a toast when MQTT is disabled while there are still devices paired.

<img width="799" height="479" alt="image" src="https://github.com/user-attachments/assets/7eb27c13-4567-4f40-9fc8-7d8aa0bd3aa0" />

<img width="801" height="480" alt="image" src="https://github.com/user-attachments/assets/2634bd2c-f4ef-4185-b8fb-d240d5ecf5f5" />
