### PR TITLE
Settings: ev charger consumption and production limits

### DIFF
--- a/pages/boat/Temperatures.qml
+++ b/pages/boat/Temperatures.qml
@@ -72,6 +72,8 @@ Row {
 		id: batteryTemperatureColumn
 		spacing: Theme.geometry_boatPage_temperature_temperatureColumn_spacing
 
+		visible: Global.system && Global.system.battery && !isNaN(Global.system.battery.temperature)
+
 		ColumnHeader {
 			//% "Battery"
 			text: qsTrId("boat_page_temperature_battery_label")

--- a/pages/evcs/EvChargerPage.qml
+++ b/pages/evcs/EvChargerPage.qml
@@ -147,6 +147,14 @@ DevicePage {
 			writeAccessLevel: VenusOS.User_AccessType_User
 		}
 
+		AcLimitsConsumptionSettings {
+			bindPrefix: root.bindPrefix
+		}
+
+		AcLimitsProductionSettings {
+			bindPrefix: root.bindPrefix
+		}
+
 		ListNavigation {
 			text: CommonWords.setup
 			preferredVisible: !root.energyMeterMode || allowedRoles.valid


### PR DESCRIPTION
Fixes issue https://github.com/victronenergy/gui-v2/issues/3076.

There is also tiny fix for the boat page when the system has no battery and temperatures are displayed, the battery header label should not be visible.