### PR TITLE
UI: add top gradient to list views on the page stack

### DIFF
--- a/components/GradientListView.qml
+++ b/components/GradientListView.qml
@@ -16,7 +16,16 @@ BaseListView {
 		bottomPadding: Theme.geometry_gradientList_bottomMargin
 	}
 
-	ViewGradient {
-		anchors.bottom: root.bottom
+	Binding {
+		when: root.parent?.__is_venus_gui_page__ === true
+		target: root.parent
+		property: "showTopGradient"
+		value: !root.atYBeginning
+	}
+	Binding {
+		when: root.parent?.__is_venus_gui_page__ === true
+		target: root.parent
+		property: "showBottomGradient"
+		value: !root.atYEnd
 	}
 }

--- a/components/Page.qml
+++ b/components/Page.qml
@@ -22,6 +22,9 @@ FocusScope {
 	property int topLeftButton: VenusOS.StatusBar_LeftButton_None
 	property int topRightButton: VenusOS.StatusBar_RightButton_None
 
+	property bool showTopGradient
+	property bool showBottomGradient
+
 	// Optional function that is called when the stack is about to pop this page. Return true if
 	// the page can be popped, or false to deny it and remain on the page.
 	// Takes one argument: the page to which the stack will be popped (null if popping all pages)

--- a/components/SwipeViewPage.qml
+++ b/components/SwipeViewPage.qml
@@ -17,8 +17,6 @@ Page {
 	required property url iconSource
 	required property string url
 	required property SwipeView view
-	property bool showTopGradient
-	property bool showBottomGradient
 
 	// Allow animations if this is the current page, or when dragging between pages
 	animationEnabled: defaultAnimationEnabled && visible

--- a/pages/AuxCardsPage.qml
+++ b/pages/AuxCardsPage.qml
@@ -10,6 +10,8 @@ Page {
 	id: root
 
 	implicitHeight: Theme.geometry_controlCard_height
+	showTopGradient: cardsView.orientation === Qt.Vertical && !cardsView.atYBeginning
+	showBottomGradient: cardsView.orientation === Qt.Vertical && !cardsView.atYEnd
 
 	//: Name of the Switch Controls feature
 	//% "Switches"

--- a/pages/ControlCardsPage.qml
+++ b/pages/ControlCardsPage.qml
@@ -15,6 +15,8 @@ Page {
 		: (cardsView.count > 2 ? Theme.geometry_controlCard_minimumWidth : Theme.geometry_controlCard_maximumWidth)
 
 	topLeftButton: VenusOS.StatusBar_LeftButton_ControlsActive
+	showTopGradient: cardsView.orientation === Qt.Vertical && !cardsView.atYBeginning
+	showBottomGradient: cardsView.orientation === Qt.Vertical && !cardsView.atYEnd
 
 	//% "Controls"
 	title: qsTrId("control_cards_title")

--- a/pages/MainView.qml
+++ b/pages/MainView.qml
@@ -229,18 +229,6 @@ FocusScope {
 				id: swipePageModel
 				view: swipeView
 			}
-
-			// For portrait: show top/bottom gradients when user has scrolled the view.
-			ViewGradient {
-				z: 1
-				visible: swipeView.currentItem?.showTopGradient ?? false
-				rotation: 180
-			}
-			ViewGradient {
-				z: 1
-				visible: swipeView.currentItem?.showBottomGradient ?? false
-				anchors.bottom: parent.bottom
-			}
 		}
 
 		NavBar {
@@ -473,6 +461,20 @@ FocusScope {
 			id: auxCardsComponent
 			AuxCardsPage {}
 		}
+	}
+
+	// Show top and bottom gradients when user has scrolled the view.
+	ViewGradient {
+		y: statusBar.height
+		visible: root.currentPage?.showTopGradient ?? false
+		rotation: 180
+	}
+	ViewGradient {
+		anchors {
+			bottom: parent.bottom
+			bottomMargin: pageStack.opened || cardsLoader.viewActive ? 0 : Theme.geometry_navigationBar_height
+		}
+		visible: root.currentPage?.showBottomGradient ?? false
 	}
 
 	StatusBar {

--- a/pages/NotificationsPage.qml
+++ b/pages/NotificationsPage.qml
@@ -14,9 +14,11 @@ SwipeViewPage {
 	url: "qrc:/qt/qml/Victron/VenusOS/pages/NotificationsPage.qml"
 	topLeftButton: VenusOS.StatusBar_LeftButton_ControlsInactive
 	focusPolicy: notificationsView.count > 0 ? Qt.TabFocus : Qt.NoFocus
-	showTopGradient: Theme.screenSize === Theme.Portrait && !notificationsView.atYBeginning
+	showTopGradient: !notificationsView.atYBeginning
 
-	GradientListView {
+	// Use BaseListView instead of GradientListView, otherwise Page::showBottomGradient will show
+	// a gradient that overlaps with the "Silence alarm" button in portrait layout.
+	BaseListView {
 		id: notificationsView
 
 		height: parent.height - (silenceButtonLoader.active ? silenceButtonLoader.height : 0)
@@ -71,6 +73,14 @@ SwipeViewPage {
 				radius: Theme.geometry_listItem_radius
 				onReleased: NotificationModel.acknowledge(del.modelId)
 			}
+		}
+
+		ScrollBar.vertical: ScrollBar {
+			topPadding: Theme.geometry_gradientList_topMargin
+		}
+
+		ViewGradient {
+			anchors.bottom: parent.bottom
 		}
 
 		Component {

--- a/pages/SettingsPage.qml
+++ b/pages/SettingsPage.qml
@@ -20,7 +20,6 @@ SwipeViewPage {
 	url: "qrc:/qt/qml/Victron/VenusOS/pages/SettingsPage.qml"
 	topLeftButton: VenusOS.StatusBar_LeftButton_ControlsInactive
 	focusPolicy: Qt.TabFocus
-	showTopGradient: Theme.screenSize === Theme.Portrait && !settingsListView.atYBeginning
 
 	function goToConnectivityPage(pageId) {
 		const page = Global.pageManager.pushPage(connectivityListItem.pageSource, connectivityListItem.pageProperties, PageStack.Immediate)


### PR DESCRIPTION
Instead of only showing the top gradient in the main views, show it within pages on the stack as well.

---

Here is a screenshot. As discussed with Serj, we want to show the gradient on the top as well, and not just the bottom:

<img width="1824" height="1240" alt="image" src="https://github.com/user-attachments/assets/fdecd0e8-5bff-48af-962e-ebd6d16797ac" />
