### PR TITLE
Battery: fix layout for cell measurements

### DIFF
--- a/cmake/ModuleVenus_Sources.cmake
+++ b/cmake/ModuleVenus_Sources.cmake
@@ -103,6 +103,7 @@ set (VictronVenusOS_QML_MODULE_SOURCES
     components/SegmentedButtonRow.qml
     components/SeparatorBar.qml
     components/SettingsColumn.qml
+    components/SettingsFlow.qml
     components/SettingSync.qml
     components/SliderSettingSync.qml
     components/ShinyProgressArc.qml

--- a/components/SettingsFlow.qml
+++ b/components/SettingsFlow.qml
@@ -1,31 +1,31 @@
 /*
-** Copyright (C) 2025 Victron Energy B.V.
+** Copyright (C) 2026 Victron Energy B.V.
 ** See LICENSE.txt for license information.
 */
 
 import QtQuick
 import Victron.VenusOS
 
-// TODO, ideally make a C++ Column-based type that is a focus scope, instead of making a QML type here
+// TODO, ideally make a C++ Flow-based type that is a focus scope, instead of making a QML type here
 // and redirecting the children using a default property alias.
 FocusScope {
 	id: root
 
-	// Allow the column to be filtered out by VisibleItemModel, similar to an AbstractListItem.
+	// Allow the flow to be filtered out by VisibleItemModel, similar to an AbstractListItem.
 	property bool preferredVisible: true
 	property bool effectiveVisible: preferredVisible
 
-	property alias spacing: contentColumn.spacing
-	property alias leftPadding: contentColumn.leftPadding
-	property alias rightPadding: contentColumn.rightPadding
-	property alias topPadding: contentColumn.topPadding
-	property alias bottomPadding: contentColumn.bottomPadding
+	property alias spacing: contentFlow.spacing
+	property alias leftPadding: contentFlow.leftPadding
+	property alias rightPadding: contentFlow.rightPadding
+	property alias topPadding: contentFlow.topPadding
+	property alias bottomPadding: contentFlow.bottomPadding
 
 	readonly property KeyNavigationListHelper __keyNavHelper: keyNavHelper
-	default property alias _data: contentColumn.data
+	default property alias _data: contentFlow.data
 
-	implicitWidth: contentColumn.implicitWidth
-	implicitHeight: contentColumn.implicitHeight
+	implicitWidth: contentFlow.implicitWidth
+	implicitHeight: contentFlow.implicitHeight
 
 	// Allow Utils.acceptsKeyNavigation() to accept moving focus to this item.
 	focusPolicy: effectiveVisible ? Qt.TabFocus : Qt.NoFocus
@@ -44,14 +44,14 @@ FocusScope {
 	KeyNavigationListHelper {
 		id: keyNavHelper
 
-		itemCount: contentColumn.children.length
+		itemCount: contentFlow.children.length
 		itemAtIndex: (index) => {
-			return contentColumn.children[index]
+			return contentFlow.children[index]
 		}
 	}
 
-	Column {
-		id: contentColumn
+	Flow {
+		id: contentFlow
 		width: parent.width
 		height: parent.height
 	}

--- a/pages/settings/devicelist/battery/PageLynxIonBatteryInfo.qml
+++ b/pages/settings/devicelist/battery/PageLynxIonBatteryInfo.qml
@@ -131,48 +131,48 @@ Page {
 				text: qsTrId("lynxionbatteryinfo_cell_measurements_section_header")
 			}
 
-			SettingsColumn {
+			SettingsFlow {
 				width: parent ? parent.width : 0
+				spacing: Theme.geometry_gradientList_spacing
+				leftPadding: Theme.geometry_page_content_horizontalMargin
+				rightPadding: Theme.geometry_page_content_horizontalMargin
 
 				Repeater {
-					model: Math.ceil(nrOfCellsPerBattery.value / 2)
+					model: nrOfCellsPerBattery.value
 
-					delegate: Row {
-						property int rowIndex: index * 2 + 1
+					delegate: ListQuantityGroup {
+						required property int index
+						property int cellIndex: index + 1
 
-						width: parent.width
-						spacing: Theme.geometry_gradientList_spacing
+						width: Theme.screenSize === Theme.Portrait
+							// In portrait, show all cells in a single column.
+							? parent.width - (2 * Theme.geometry_page_content_horizontalMargin)
+							// In landscape, show two cells per row.
+							: (parent.width - 2*Theme.geometry_page_content_horizontalMargin - Theme.geometry_gradientList_spacing) / 2
+						rightInset: 0
+						leftInset: 0
+						bottomInset: 0
 
-						Repeater {
-							model: 2
+						//% "Cell #%1"
+						text: qsTrId("lynxionbatteryinfo_cell_number").arg(cellIndex)
+						model: QuantityObjectModel {
+							filterType: QuantityObjectModel.HasValue
 
-							delegate: ListQuantityGroup {
-								property int cellIndex: rowIndex + index
+							QuantityObject { object: cellVoltage; unit: VenusOS.Units_Volt_DC; decimals: 3 }
+							QuantityObject { object: cellTemperature; unit: Global.systemSettings.temperatureUnit }
+						}
+						preferredVisible: cellVoltage.valid
 
-								width: parent.width / 2 - (Theme.geometry_gradientList_spacing / 2)
+						VeQuickItem {
+							id: cellVoltage
+							uid: root.bindPrefix + "/Battery/" + batteryRequestId.value + "/Cell/" + cellIndex + "/Voltage"
+						}
 
-								//% "Cell #%1"
-								text: qsTrId("lynxionbatteryinfo_cell_number").arg(cellIndex)
-								model: QuantityObjectModel {
-									filterType: QuantityObjectModel.HasValue
-
-									QuantityObject { object: cellVoltage; unit: VenusOS.Units_Volt_DC; decimals: 3 }
-									QuantityObject { object: cellTemperature; unit: Global.systemSettings.temperatureUnit }
-								}
-								preferredVisible: cellVoltage.valid
-
-								VeQuickItem {
-									id: cellVoltage
-									uid: root.bindPrefix + "/Battery/" + batteryRequestId.value + "/Cell/" + cellIndex + "/Voltage"
-								}
-
-								VeQuickItem {
-									id: cellTemperature
-									uid: root.bindPrefix + "/Battery/" + batteryRequestId.value + "/Cell/" + cellIndex + "/Temperature"
-									sourceUnit: Units.unitToVeUnit(VenusOS.Units_Temperature_Celsius)
-									displayUnit: Units.unitToVeUnit(Global.systemSettings.temperatureUnit)
-								}
-							}
+						VeQuickItem {
+							id: cellTemperature
+							uid: root.bindPrefix + "/Battery/" + batteryRequestId.value + "/Cell/" + cellIndex + "/Temperature"
+							sourceUnit: Units.unitToVeUnit(VenusOS.Units_Temperature_Celsius)
+							displayUnit: Units.unitToVeUnit(Global.systemSettings.temperatureUnit)
 						}
 					}
 				}


### PR DESCRIPTION
Rework the layout for battery cell measurements to use a Flow instead of a Column+Row, so that hidden cell items are taken out of the layout instead of creating blank spaces. Add SettingsFlow to allow key navigation between the items in the flow.

Also remove the leftInset and rightInset for cell list items as this was causing extra spacing between the items, due to
7ff96441bf7a505f17bc181db4222c173c6926d6 which moved the GradientListView leftMargin/rightMargin into the ListItem leftInset/rightInset. Move these insets values to the overall Flow leftPadding/rightPadding instead.

Fixes #3082

<img width="912" height="620" alt="image" src="https://github.com/user-attachments/assets/23a48e36-3077-4dd7-99b6-a4efd9ac9a43" />
