### PR TITLE
WASM: instrument compile and instantiate phases with performance timing

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -454,10 +454,34 @@ EM_JS(bool, hasNativeVirtualKeyboard, (), {
 		|| (/Macintosh/i.test(navigator.userAgent) && navigator.maxTouchPoints && navigator.maxTouchPoints > 1);
 });
 
+EM_JS(void, wasmPerfMark, (const char *name), {
+	const label = UTF8ToString(name);
+	try { performance.mark(label); } catch (e) {}
+	console.log("[WASM Perf] " + label + " [t=" + performance.now().toFixed(1) + "ms]");
+});
+
 #endif
+
+// Log a named startup phase to the browser console and DevTools performance
+// timeline, in the same format as the [WASM Perf] entries in wasm/index.html.
+// No-op on non-WASM builds.
+static inline void perfMark(const char *phase)
+{
+#if defined(VENUS_WEBASSEMBLY_BUILD)
+	wasmPerfMark(phase);
+#else
+	Q_UNUSED(phase);
+#endif
+}
 
 int main(int argc, char *argv[])
 {
+#if defined(VENUS_WEBASSEMBLY_BUILD)
+	// Timestamp Qt log lines so browser console output can be correlated with
+	// the [WASM Perf] entries logged by wasm/index.html.
+	qSetMessagePattern(QStringLiteral("[%{time process}] %{if-category}%{category}: %{endif}%{message}"));
+#endif
+	perfMark("main() entered");
 	qInfo().nospace() << "Victron gui version: v" << PROJECT_VERSION_MAJOR << "." << PROJECT_VERSION_MINOR << "." << PROJECT_VERSION_PATCH;
 
 	// Must set the default QSurfaceFormat before creating the app object.
@@ -505,6 +529,7 @@ int main(int argc, char *argv[])
 	qputenv("QT_SCALE_FACTOR", scaleAsQByteArray);
 
 	QGuiApplication app(argc, argv);
+	perfMark("QGuiApplication created");
 	QGuiApplication::setApplicationName("Venus");
 	QGuiApplication::setApplicationVersion("2.0");
 
@@ -521,6 +546,7 @@ int main(int argc, char *argv[])
 	QZXing::registerQMLImageProvider(engine);
 
 	initBackend(&enableFpsCounter, &skipSplashScreen);
+	perfMark("backend initialized");
 	QObject::connect(&engine, &QQmlEngine::quit, &app, &QGuiApplication::quit);
 
 	/* Force construction of screen blanker */
@@ -542,6 +568,7 @@ int main(int argc, char *argv[])
 	languageLoader->setFontUrlPrefix(fontUrlPrefix);
 #endif
 	languageLoader->init(); // load the translation catalogue.
+	perfMark("translations loaded");
 
 	/* Force construction of gui plugin loader */
 	Victron::VenusOS::GuiPluginLoader *guiPluginLoader = Victron::VenusOS::GuiPluginLoader::create(&engine);
@@ -550,12 +577,14 @@ int main(int argc, char *argv[])
 	Victron::VenusOS::FrameRateModel* fpsCounter = Victron::VenusOS::FrameRateModel::create();
 
 	QQmlComponent component(&engine, QUrl(QStringLiteral("qrc:/venus-gui-v2/Main.qml")));
+	perfMark("Main.qml compiled");
 	if (component.isError()) {
 		qWarning() << component.errorString();
 		return EXIT_FAILURE;
 	}
 
 	QScopedPointer<QObject> object(component.beginCreate(engine.rootContext()));
+	perfMark("root object instantiated (beginCreate)");
 	const auto window = qobject_cast<QQuickWindow *>(object.data());
 
 #if defined(VENUS_WEBASSEMBLY_BUILD)
@@ -576,9 +605,20 @@ int main(int argc, char *argv[])
 
 	engine.setIncubationController(window->incubationController());
 
+#if defined(VENUS_WEBASSEMBLY_BUILD)
+	// Report when the first frame reaches the browser: this is when the QML
+	// splash becomes visible, well before the asynchronously loaded scene.
+	// WASM uses the single-threaded basic render loop, so a direct connection
+	// is safe here.
+	QObject::connect(window, &QQuickWindow::frameSwapped, window,
+		[] { perfMark("first frame rendered (QML splash visible)"); },
+		Qt::ConnectionType(Qt::DirectConnection | Qt::SingleShotConnection));
+#endif
+
 	/* Write to window properties here to perform any additional initialization
 	   before initial binding evaluation. */
 	component.completeCreate();
+	perfMark("root object completed (completeCreate)");
 
 	if (skipSplashScreen) {
 		QMetaObject::invokeMethod(window, "skipSplashScreen");
@@ -598,5 +638,6 @@ int main(int argc, char *argv[])
 		window->showFullScreen();
 	}
 
+	perfMark("window shown, entering event loop");
 	return app.exec();
 }

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -511,6 +511,16 @@
                 loadingBarText.textContent = 'Downloading...';
 
                 const perfLog = [];
+                // Log with the absolute page time so console output can be
+                // correlated with wall-clock observations and Qt-side logs.
+                const logPerf = (line) => {
+                    perfLog.push(line);
+                    console.log(`[WASM Perf] ${line} [t=${performance.now().toFixed(1)}ms]`);
+                };
+                // Named marks show up in the DevTools Performance timeline.
+                const perfMark = (name) => {
+                    try { performance.mark(name); } catch (e) {}
+                };
                 const tInitStart = performance.now();
 
                 // Preload WASM with progress
@@ -535,19 +545,20 @@
                 const wasmSizeMB = (wasmBinary.byteLength / (1024 * 1024)).toFixed(2);
                 const wireSizeMB = wasmPreload.compressedSize ? (wasmPreload.compressedSize / (1024 * 1024)).toFixed(2) : null;
                 const sizeInfo = wireSizeMB ? `${wireSizeMB} MB wire / ${wasmSizeMB} MB uncompressed` : `${wasmSizeMB} MB uncompressed`;
-                perfLog.push(`Download: ${downloadMs.toFixed(1)}ms (${sizeInfo})`);
-                console.log(`[WASM Perf] Download complete: ${downloadMs.toFixed(1)}ms (${sizeInfo})`);
+                perfMark('wasm-download-end');
+                logPerf(`Download: ${downloadMs.toFixed(1)}ms (${sizeInfo})`);
 
                 loadingBar.width.baseVal.value = loadingBarContainer.width.baseVal.value;
                 loadingBarText.textContent = 'Compiling...';
 
                 // Compile WASM binary into a WebAssembly.Module
+                perfMark('wasm-compile-start');
                 const tCompileStart = performance.now();
                 const wasmModule = await WebAssembly.compile(wasmBinary);
                 const tCompileEnd = performance.now();
+                perfMark('wasm-compile-end');
                 const compileMs = tCompileEnd - tCompileStart;
-                perfLog.push(`Compile: ${compileMs.toFixed(1)}ms`);
-                console.log(`[WASM Perf] Compile complete: ${compileMs.toFixed(1)}ms`);
+                logPerf(`Compile: ${compileMs.toFixed(1)}ms`);
 
                 loadingBarText.textContent = 'Instantiating...';
 
@@ -568,15 +579,17 @@
 
                 // Use instantiateWasm to intercept instantiation with timing
                 let tInstantiateEnd = 0;
+                let tRuntimeInitEnd = 0;
                 const instance = await qtLoad({
                     arguments: argumentList,
                     instantiateWasm: (imports, successCallback) => {
+                        perfMark('wasm-instantiate-start');
                         const tInstStart = performance.now();
                         WebAssembly.instantiate(wasmModule, imports).then(instance => {
                             tInstantiateEnd = performance.now();
+                            perfMark('wasm-instantiate-end');
                             const instantiateMs = tInstantiateEnd - tInstStart;
-                            perfLog.push(`Instantiate: ${instantiateMs.toFixed(1)}ms`);
-                            console.log(`[WASM Perf] Instantiate complete: ${instantiateMs.toFixed(1)}ms`);
+                            logPerf(`Instantiate: ${instantiateMs.toFixed(1)}ms`);
                             successCallback(instance, wasmModule);
                         }).catch(e => {
                             // Instantiation is where out-of-memory failures surface
@@ -589,15 +602,14 @@
                         return {};
                     },
                     qt: {
+                        // qtloader.js invokes onLoaded at Emscripten's
+                        // onRuntimeInitialized, which is before main() runs: Qt and
+                        // QML startup happen after this point, and are measured
+                        // below and by the [WASM Perf] marks in src/main.cpp.
                         onLoaded: () => {
-                            const tLoaded = performance.now();
-                            const qtInitMs = tLoaded - tInstantiateEnd;
-                            const totalMs = tLoaded - tInitStart;
-                            perfLog.push(`Qt/QML init: ${qtInitMs.toFixed(1)}ms`);
-                            perfLog.push(`Total: ${totalMs.toFixed(1)}ms`);
-                            console.log(`[WASM Perf] Qt/QML init complete: ${qtInitMs.toFixed(1)}ms`);
-                            console.log(`[WASM Perf] Total load time: ${totalMs.toFixed(1)}ms`);
-                            console.log(`[WASM Perf] Summary:\n` + perfLog.map(l => `  ${l}`).join('\n'));
+                            tRuntimeInitEnd = performance.now();
+                            perfMark('wasm-runtime-initialized');
+                            logPerf(`Emscripten runtime init: ${(tRuntimeInitEnd - tInstantiateEnd).toFixed(1)}ms`);
                             showUi(screen);
                         },
                         onExit: exitData =>
@@ -612,6 +624,16 @@
                         containerElements: [screen],
                     }
                 });
+
+                // qtLoad() resolves after main() has run: QGuiApplication and the
+                // QML engine are set up and app.exec() has unwound back to the
+                // browser event loop. Asynchronous QML scene loading continues
+                // after this; see the [WASM Perf] marks logged from src/main.cpp.
+                const tMainDone = performance.now();
+                perfMark('wasm-qt-main-done');
+                logPerf(`Qt main() + QML engine setup: ${(tMainDone - tRuntimeInitEnd).toFixed(1)}ms`);
+                logPerf(`Total (to Qt event loop): ${(tMainDone - tInitStart).toFixed(1)}ms`);
+                console.log(`[WASM Perf] Summary:\n` + perfLog.map(l => `  ${l}`).join('\n'));
             } catch (e) {
                 console.error(e);
                 console.error(e.stack);

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -366,7 +366,7 @@
                     wasmBinary.set(chunk, pos);
                     pos += chunk.length;
                 }
-                var contentLength = response.headers.get('content-length');
+                const contentLength = response.headers.get('content-length');
                 return { wasmBinary: wasmBinary, compressedSize: contentLength ? parseInt(contentLength, 10) : null };
             } catch (e) {
                 console.error(e);
@@ -567,8 +567,7 @@
                 }
 
                 // Use instantiateWasm to intercept instantiation with timing
-                var tInstantiateEnd = 0;
-                const tQtLoadStart = performance.now();
+                let tInstantiateEnd = 0;
                 const instance = await qtLoad({
                     arguments: argumentList,
                     instantiateWasm: (imports, successCallback) => {
@@ -579,6 +578,13 @@
                             perfLog.push(`Instantiate: ${instantiateMs.toFixed(1)}ms`);
                             console.log(`[WASM Perf] Instantiate complete: ${instantiateMs.toFixed(1)}ms`);
                             successCallback(instance, wasmModule);
+                        }).catch(e => {
+                            // Instantiation is where out-of-memory failures surface
+                            // on low-memory devices; without this the page hangs
+                            // silently at "Instantiating...".
+                            console.error(e);
+                            console.error(e.stack);
+                            showLoadError(e, 'Error instantiating application!');
                         });
                         return {};
                     },

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -307,6 +307,7 @@
         async function preloadWasm(url, onProgress) {
             try {
                 let total = null;
+                let exactSize = false;
                 // This is needed, since the reported size is the compressed size
                 // but the downloaded size is shown as uncompressed size, since the browser decompresses it
                 const sizeResp = await fetch('venus-gui-v2.wasm.size');
@@ -342,6 +343,7 @@
 
                 if (sizeResp.ok) {
                     total = parseInt(await sizeResp.text(), 10);
+                    exactSize = Number.isFinite(total) && total > 0;
                 } else {
                     // should not be needed, but just in case?
                     const estimatedCompressionRatio = 0.4; // Assume 40% as compressed size
@@ -352,22 +354,41 @@
 
                 const reader = response.body.getReader();
                 let received = 0;
-                let chunks = [];
+                // When the exact uncompressed size is known, stream directly into a
+                // preallocated buffer: accumulating chunks and assembling a copy
+                // afterwards doubles the peak memory use on low-memory devices.
+                let buffer = exactSize ? new Uint8Array(total) : null;
+                const chunks = [];
                 while (true) {
                     const {done, value} = await reader.read();
                     if (done) break;
-                    chunks.push(value);
+                    if (buffer && received + value.length <= buffer.length) {
+                        buffer.set(value, received);
+                    } else {
+                        if (buffer) {
+                            // The .size file under-reported the actual size
+                            chunks.push(buffer.subarray(0, received));
+                            buffer = null;
+                        }
+                        chunks.push(value);
+                    }
                     received += value.length;
                     onProgress(received, total);
                 }
-                let wasmBinary = new Uint8Array(received);
-                let pos = 0;
-                for (let chunk of chunks) {
-                    wasmBinary.set(chunk, pos);
-                    pos += chunk.length;
+                let wasmBinary;
+                if (buffer) {
+                    // subarray trims a .size over-report without copying
+                    wasmBinary = buffer.length === received ? buffer : buffer.subarray(0, received);
+                } else {
+                    wasmBinary = new Uint8Array(received);
+                    let pos = 0;
+                    for (const chunk of chunks) {
+                        wasmBinary.set(chunk, pos);
+                        pos += chunk.length;
+                    }
                 }
-                const contentLength = response.headers.get('content-length');
-                return { wasmBinary: wasmBinary, compressedSize: contentLength ? parseInt(contentLength, 10) : null };
+                const compressedLength = response.headers.get('content-length');
+                return { wasmBinary: wasmBinary, compressedSize: compressedLength ? parseInt(compressedLength, 10) : null };
             } catch (e) {
                 console.error(e);
                 console.error(e.stack);
@@ -572,7 +593,7 @@
                     }
                 });
 
-                const wasmBinary = wasmPreload.wasmBinary;
+                let wasmBinary = wasmPreload.wasmBinary;
                 const tDownloadEnd = performance.now();
                 const downloadMs = tDownloadEnd - tInitStart;
                 const wasmSizeMB = (wasmBinary.byteLength / (1024 * 1024)).toFixed(2);
@@ -590,6 +611,11 @@
                 const wasmModule = await WebAssembly.compile(wasmBinary);
                 const tCompileEnd = performance.now();
                 perfMark('wasm-compile-end');
+                // Drop the source bytes: the compiled module supersedes them, and
+                // the closures below would otherwise keep them referenced (tens of
+                // MB) for the lifetime of the app.
+                wasmBinary = null;
+                wasmPreload.wasmBinary = null;
                 const compileMs = tCompileEnd - tCompileStart;
                 logPerf(`Compile: ${compileMs.toFixed(1)}ms`);
 

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -441,6 +441,38 @@
             tspan.setAttribute('y', Math.round(barY + barH + 29));
         }
 
+        // Log main-thread stalls to the console. On engines with the Long Tasks
+        // API every task blocking the main thread for >50ms is reported;
+        // elsewhere fall back to detecting gaps between animation frames.
+        function observeMainThreadStalls() {
+            try {
+                if (typeof PerformanceObserver !== 'undefined'
+                        && PerformanceObserver.supportedEntryTypes
+                        && PerformanceObserver.supportedEntryTypes.includes('longtask')) {
+                    new PerformanceObserver((list) => {
+                        for (const entry of list.getEntries()) {
+                            console.log(`[WASM Perf] Main thread blocked for ${entry.duration.toFixed(0)}ms [t=${entry.startTime.toFixed(1)}ms]`);
+                        }
+                    }).observe({type: 'longtask', buffered: true});
+                    return;
+                }
+            } catch (e) {
+                // Diagnostics only; fall through to the animation frame fallback.
+            }
+            let lastFrame = performance.now();
+            // requestAnimationFrame does not fire while the tab is hidden; reset
+            // the baseline on visibility changes so that is not reported as a stall.
+            document.addEventListener('visibilitychange', () => { lastFrame = performance.now(); });
+            function frameGapCheck(now) {
+                if (now - lastFrame > 200 && !document.hidden) {
+                    console.log(`[WASM Perf] Main thread stalled for ~${(now - lastFrame).toFixed(0)}ms [t=${now.toFixed(1)}ms]`);
+                }
+                lastFrame = now;
+                requestAnimationFrame(frameGapCheck);
+            }
+            requestAnimationFrame(frameGapCheck);
+        }
+
         async function init()
         {
             const spinner = document.querySelector('#qtspinner');
@@ -521,6 +553,7 @@
                 const perfMark = (name) => {
                     try { performance.mark(name); } catch (e) {}
                 };
+                observeMainThreadStalls();
                 const tInitStart = performance.now();
 
                 // Preload WASM with progress

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -567,14 +567,15 @@
                 }
 
                 // Use instantiateWasm to intercept instantiation with timing
+                var tInstantiateEnd = 0;
                 const tQtLoadStart = performance.now();
                 const instance = await qtLoad({
                     arguments: argumentList,
                     instantiateWasm: (imports, successCallback) => {
                         const tInstStart = performance.now();
                         WebAssembly.instantiate(wasmModule, imports).then(instance => {
-                            const tInstEnd = performance.now();
-                            const instantiateMs = tInstEnd - tInstStart;
+                            tInstantiateEnd = performance.now();
+                            const instantiateMs = tInstantiateEnd - tInstStart;
                             perfLog.push(`Instantiate: ${instantiateMs.toFixed(1)}ms`);
                             console.log(`[WASM Perf] Instantiate complete: ${instantiateMs.toFixed(1)}ms`);
                             successCallback(instance, wasmModule);
@@ -584,11 +585,11 @@
                     qt: {
                         onLoaded: () => {
                             const tLoaded = performance.now();
-                            const qtInitMs = tLoaded - tQtLoadStart;
+                            const qtInitMs = tLoaded - tInstantiateEnd;
                             const totalMs = tLoaded - tInitStart;
-                            perfLog.push(`Qt init (instantiate to onLoaded): ${qtInitMs.toFixed(1)}ms`);
+                            perfLog.push(`Qt/QML init: ${qtInitMs.toFixed(1)}ms`);
                             perfLog.push(`Total: ${totalMs.toFixed(1)}ms`);
-                            console.log(`[WASM Perf] Qt init complete: ${qtInitMs.toFixed(1)}ms`);
+                            console.log(`[WASM Perf] Qt/QML init complete: ${qtInitMs.toFixed(1)}ms`);
                             console.log(`[WASM Perf] Total load time: ${totalMs.toFixed(1)}ms`);
                             console.log(`[WASM Perf] Summary:\n` + perfLog.map(l => `  ${l}`).join('\n'));
                             showUi(screen);

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -366,7 +366,8 @@
                     wasmBinary.set(chunk, pos);
                     pos += chunk.length;
                 }
-                return wasmBinary;
+                var contentLength = response.headers.get('content-length');
+                return { wasmBinary: wasmBinary, compressedSize: contentLength ? parseInt(contentLength, 10) : null };
             } catch (e) {
                 console.error(e);
                 console.error(e.stack);
@@ -509,8 +510,11 @@
                 loadingBar.width.baseVal.value = '0';
                 loadingBarText.textContent = 'Downloading...';
 
+                const perfLog = [];
+                const tInitStart = performance.now();
+
                 // Preload WASM with progress
-                const wasmBinary = await preloadWasm('venus-gui-v2.wasm', (received, total) => {
+                const wasmPreload = await preloadWasm('venus-gui-v2.wasm', (received, total) => {
                     if (total) {
                         const ratio = Math.min(received / total, 1);
                         const percent = (ratio * 100).toFixed(1);
@@ -525,8 +529,27 @@
                     }
                 });
 
+                const wasmBinary = wasmPreload.wasmBinary;
+                const tDownloadEnd = performance.now();
+                const downloadMs = tDownloadEnd - tInitStart;
+                const wasmSizeMB = (wasmBinary.byteLength / (1024 * 1024)).toFixed(2);
+                const wireSizeMB = wasmPreload.compressedSize ? (wasmPreload.compressedSize / (1024 * 1024)).toFixed(2) : null;
+                const sizeInfo = wireSizeMB ? `${wireSizeMB} MB wire / ${wasmSizeMB} MB uncompressed` : `${wasmSizeMB} MB uncompressed`;
+                perfLog.push(`Download: ${downloadMs.toFixed(1)}ms (${sizeInfo})`);
+                console.log(`[WASM Perf] Download complete: ${downloadMs.toFixed(1)}ms (${sizeInfo})`);
+
                 loadingBar.width.baseVal.value = loadingBarContainer.width.baseVal.value;
-                loadingBarText.textContent = 'Loading application...';
+                loadingBarText.textContent = 'Compiling...';
+
+                // Compile WASM binary into a WebAssembly.Module
+                const tCompileStart = performance.now();
+                const wasmModule = await WebAssembly.compile(wasmBinary);
+                const tCompileEnd = performance.now();
+                const compileMs = tCompileEnd - tCompileStart;
+                perfLog.push(`Compile: ${compileMs.toFixed(1)}ms`);
+                console.log(`[WASM Perf] Compile complete: ${compileMs.toFixed(1)}ms`);
+
+                loadingBarText.textContent = 'Instantiating...';
 
                 let defaultMqttArg = (location.protocol === 'https:' ? 'wss://' : 'ws://') + document.location.host + '/websocket-mqtt'
                 let argumentList = needsDefaultArgs ? ['--mqtt', defaultMqttArg] : [];
@@ -543,11 +566,33 @@
                     );
                 }
 
+                // Use instantiateWasm to intercept instantiation with timing
+                const tQtLoadStart = performance.now();
                 const instance = await qtLoad({
                     arguments: argumentList,
-                    wasmBinary: wasmBinary,
+                    instantiateWasm: (imports, successCallback) => {
+                        const tInstStart = performance.now();
+                        WebAssembly.instantiate(wasmModule, imports).then(instance => {
+                            const tInstEnd = performance.now();
+                            const instantiateMs = tInstEnd - tInstStart;
+                            perfLog.push(`Instantiate: ${instantiateMs.toFixed(1)}ms`);
+                            console.log(`[WASM Perf] Instantiate complete: ${instantiateMs.toFixed(1)}ms`);
+                            successCallback(instance, wasmModule);
+                        });
+                        return {};
+                    },
                     qt: {
-                        onLoaded: () => showUi(screen),
+                        onLoaded: () => {
+                            const tLoaded = performance.now();
+                            const qtInitMs = tLoaded - tQtLoadStart;
+                            const totalMs = tLoaded - tInitStart;
+                            perfLog.push(`Qt init (instantiate to onLoaded): ${qtInitMs.toFixed(1)}ms`);
+                            perfLog.push(`Total: ${totalMs.toFixed(1)}ms`);
+                            console.log(`[WASM Perf] Qt init complete: ${qtInitMs.toFixed(1)}ms`);
+                            console.log(`[WASM Perf] Total load time: ${totalMs.toFixed(1)}ms`);
+                            console.log(`[WASM Perf] Summary:\n` + perfLog.map(l => `  ${l}`).join('\n'));
+                            showUi(screen);
+                        },
                         onExit: exitData =>
                         {
                             let exitMsg = 'Application exit';


### PR DESCRIPTION
Do not merge: diagnostics only. CC @chriadam.

Split the monolithic qtLoad() call into explicit WebAssembly.compile() and WebAssembly.instantiate() steps with performance.now() annotations, logging each phase to the console.

Helps diagnose browser engine lockups on Marine MFD devices with limited CPU/memory.

Further improved the analytics to determine where time is spent.

Added main thread blocker.

Result: 6.3s of the 12.5s startup (50%) is runtime QML compilation, which is result of CMakeLists.txt:33: `NO_CACHEGEN` set to `ON`.

<img width="4032" height="2268" alt="IMG_0727" src="https://github.com/user-attachments/assets/9661abbd-1d38-4fc2-a023-9f5b5d6d7ed9" />
