### PR TITLE
Settings: allow MQTT Access list item to be opened by UI tests and key nav

### DIFF
--- a/components/listitems/ListMqttAccessSwitch.qml
+++ b/components/listitems/ListMqttAccessSwitch.qml
@@ -7,6 +7,8 @@ import QtQuick
 import Victron.VenusOS
 
 ListRadioButtonGroup {
+	id: root
+
 	//% "MQTT Access"
 	text: qsTrId("settings_services_mqtt_access")
 	dataItem.uid: Global.systemSettings.serviceUid + "/Settings/Services/MqttLocal"
@@ -18,19 +20,28 @@ ListRadioButtonGroup {
 		{ display: CommonWords.on, value: 1 },
 	]
 
+	background: ListSettingBackground {
+		color: root.flat ? "transparent" : Theme.color_listItem_background
+		indicatorColor: root.backgroundIndicatorColor
+
+		ListPressArea {
+			anchors.fill: parent
+			enabled: root.interactive
+			onClicked: {
+				if (securityProfile.value === VenusOS.Security_Profile_Indeterminate) {
+					//% "A Security Profile must be configured before the network services can be enabled, see Settings - General"
+					Global.showToastNotification(VenusOS.Notification_Info, qsTrId("settings_security_warning_profile_configuration_order"), 10000)
+					return
+				}
+				root.click()
+			}
+		}
+	}
+
 	onOptionClicked: function (index) {
 		if (index == 0 && tokenUsers.valid && tokenUsers.value !== "[]") {
 			//% "Turning MQTT Access off also disables paired MQTT devices until access is enabled again."
 			Global.showToastNotification(VenusOS.Notification_Warning, qsTrId("settings_services_mqtt_access_warning_paired_devices"), 10000)
-		}
-	}
-
-	MouseArea {
-		anchors.fill: parent
-		enabled: securityProfile.value === VenusOS.Security_Profile_Indeterminate
-		onClicked: {
-			//% "A Security Profile must be configured before the network services can be enabled, see Settings - General"
-			Global.showToastNotification(VenusOS.Notification_Info, qsTrId("settings_security_warning_profile_configuration_order"), 10000)
 		}
 	}
 


### PR DESCRIPTION
Use a standard ListItem background to process mouse events, instead of a custom MouseArea, as the UI test attempts to click the underlying touch area for the ListItem and thus cannot trigger the custom MouseArea.