### PR TITLE
Tests: improve ui compare test tool

### DIFF
--- a/tools/uicompare/CompareView.qml
+++ b/tools/uicompare/CompareView.qml
@@ -5,302 +5,250 @@ import QtQuick.Layouts
 Item {
 	id: root
 
-	property string fileName
-	property string leftImageUri
-	property string rightImageUri
-	property int comparisonMode: 0  // 0=side-by-side, 1=overlay
+	required property int resultStatus
+	required property bool imagesIdentical
+	required property string fileName
+
 	property real zoomLevel: overlayZoomSlider.value
+	property int comparisonMode: 0 // 0 = diff overlay, 1 = candidate overlay
+	property real cropLineX: width / 2
 
-	Column {
-		anchors.fill: parent
-		spacing: 4
+	readonly property string baselineImageUri: !fileName || resultStatus === CompareModel.NoBaselineImage ? ""
+			: "file:image-captures-baseline/" + fileName
+	readonly property string candidateImageUri: !fileName || resultStatus === CompareModel.NoCandidateImage ? ""
+			: "file:image-captures/" + fileName
+	readonly property bool bothImagesExist: baselineImageUri.length > 0 && candidateImageUri.length > 0
 
-		// Mode selector toolbar
-		Rectangle {
+	// Mode selector toolbar
+	Rectangle {
+		id: modeSelector
+		width: parent.width
+		height: toolBarLayout.height + 8
+		color: "#f5f5f5"
+		border.color: "#ddd"
+
+		RowLayout {
+			id: toolBarLayout
 			width: parent.width
-			height: 40
-			color: "#f5f5f5"
-			border.color: "#ddd"
+			anchors.verticalCenter: parent.verticalCenter
+
+			Text {
+				text: root.resultStatus === CompareModel.NoBaselineImage ? "Nothing to compare: baseline image missing"
+					: root.resultStatus === CompareModel.NoCandidateImage ? "Nothing to compare: candidate image missing"
+					: root.imagesIdentical ? "Nothing to compare: baseline and candidate images are identical"
+					: ""
+				font.pixelSize: 16
+				leftPadding: 16
+				visible: !modeButtonsLayout.visible
+			}
 
 			RowLayout {
-				anchors.centerIn: parent
+				id: modeButtonsLayout
+				Layout.fillWidth: false
 				spacing: 8
+				visible: root.resultStatus === CompareModel.ComparisonReady && !root.imagesIdentical
 
 				Text {
-					text: "Mode:"
-					font.pixelSize: 11
+					text: "Compare images:"
+					leftPadding: 16
+					font.pixelSize: 16
 				}
 
 				Button {
-					text: "Side by Side"
+					text: "Diff overlay"
 					checked: root.comparisonMode === 0
 					onClicked: root.comparisonMode = 0
-					checkable: true
 					autoExclusive: true
 				}
 
 				Button {
-					text: "Overlay"
+					text: "Candidate overlay"
 					checked: root.comparisonMode === 1
 					onClicked: root.comparisonMode = 1
-					checkable: true
 					autoExclusive: true
 				}
-
-				Item { Layout.fillWidth: true }
 
 				// Opacity slider for overlay mode
 				RowLayout {
 					Text {
 						text: "Opacity:"
-						font.pixelSize: 10
+						font.pixelSize: 12
 					}
 					Slider {
 						id: overlayOpacitySlider
 						from: 0
 						to: 1
 						value: 0.5
-						Layout.preferredWidth: 100
+						Layout.preferredWidth: 200
 					}
 				}
 
-				// Zoom controls
-				RowLayout {
-					Text {
-						text: "Zoom:"
-						font.pixelSize: 10
-					}
-					Slider {
-						id: overlayZoomSlider
-						from: 0.8
-						to: 10
-						value: 1.0
-						Layout.preferredWidth: 100
-					}
-					Button {
-						text: "1:1"
-						onClicked: overlayZoomSlider.value = 1.0
-					}
+				CheckBox {
+					id: cropLineCheckBox
+					text: "Crop line (right click to move)"
 				}
-
-
-			}
-		}
-
-		// Comparison display area
-		Rectangle {
-			width: parent.width
-			height: parent.height - 44
-			color: "#2a2a2a"
-
-			Flickable {
-				id: flickable
-				anchors.fill: parent
-				contentWidth: comparisonLoader.item ? comparisonLoader.item.width * root.zoomLevel : width
-				contentHeight: comparisonLoader.item ? comparisonLoader.item.height * root.zoomLevel : height
-				boundsBehavior: Flickable.StopAtBounds
-
-				Loader {
-					id: comparisonLoader
-					x: (flickable.contentWidth > flickable.width) ? 0 : (flickable.width - width * root.zoomLevel) / 2
-					y: (flickable.contentHeight > flickable.height) ? 0 : (flickable.height - height * root.zoomLevel) / 2
-					scale: root.zoomLevel
-					transformOrigin: Item.TopLeft
-
-					sourceComponent: {
-						switch (root.comparisonMode) {
-						case 0: return sideBySideComponent
-						case 1: return overlayComponent
-						case 2: return differenceComponent
-						case 3: return flickerComponent
-						default: return sideBySideComponent
-						}
-					}
-				}
-
-				ScrollBar.vertical: ScrollBar { }
-				ScrollBar.horizontal: ScrollBar { }
 			}
 
-			// Mouse wheel zoom
-			MouseArea {
-				anchors.fill: parent
-				acceptedButtons: Qt.NoButton
-				onWheel: (wheel) => {
-					if (wheel.modifiers & Qt.ControlModifier) {
-						if (wheel.angleDelta.y > 0) {
-							overlayZoomSlider.value = Math.min(4.0, root.zoomLevel + 0.1)
-						} else {
-							overlayZoomSlider.value = Math.max(0.25, root.zoomLevel - 0.1)
-						}
-						wheel.accepted = true
-					}
+			Item {
+				Layout.fillWidth: true
+			}
+
+			// Zoom controls
+			RowLayout {
+				Layout.rightMargin: 8
+
+				Text {
+					text: "Zoom:"
+					font.pixelSize: 12
+				}
+				Slider {
+					id: overlayZoomSlider
+					from: 0.5
+					to: 5
+					value: 1.0
+					Layout.preferredWidth: 200
+				}
+				Button {
+					text: "1:1"
+					onClicked: overlayZoomSlider.value = 1.0
 				}
 			}
 		}
 	}
 
-	// Side-by-side comparison (original with slider)
-	Component {
-		id: sideBySideComponent
+	// Comparison display area
+	Rectangle {
+		anchors {
+			left: parent.left
+			right: parent.right
+			top: modeSelector.bottom
+			bottom: parent.bottom
+		}
+		color: "#2a2a2a"
+		z: -1 // prevent image from panning over the toolbar
 
-		Item {
-			readonly property bool leftExists: leftImage.status === Image.Ready
-			readonly property bool rightExists: rightImage.status === Image.Ready
-			readonly property bool bothExist: leftExists && rightExists
+		Flickable {
+			id: flickable
+			anchors.fill: parent
+			contentWidth: comparisonContainer.width * root.zoomLevel
+			contentHeight: comparisonContainer.height * root.zoomLevel
+			boundsBehavior: Flickable.StopAtBounds
 
-			implicitWidth: Math.max(leftImage.implicitWidth, rightImage.implicitWidth)
-			implicitHeight: Math.max(leftImage.implicitHeight, rightImage.implicitHeight)
+			Item {
+				id: comparisonContainer
+				x: (flickable.contentWidth > flickable.width) ? 0 : (flickable.width - width * root.zoomLevel) / 2
+				y: (flickable.contentHeight > flickable.height) ? 0 : (flickable.height - height * root.zoomLevel) / 2
+				width: mainImage.width
+				height: mainImage.height
+				scale: root.zoomLevel
+				transformOrigin: Item.TopLeft
 
-			Image {
-				id: leftImage
-				source: leftImageUri && leftImageUri.length > 0 ? leftImageUri : ""
-				fillMode: Image.Pad
-				visible: leftExists
+				Image {
+					id: mainImage
+					source: baselineImageUri.length > 0 ? baselineImageUri : candidateImageUri
+				}
+
+				Loader {
+					active: root.resultStatus === CompareModel.ComparisonReady && !root.imagesIdentical
+					sourceComponent: overlayComponent
+				}
 			}
 
-			Rectangle {
+			ScrollBar.vertical: ScrollBar { }
+			ScrollBar.horizontal: ScrollBar { }
+		}
+
+		// Mouse wheel zoom
+		MouseArea {
+			anchors.fill: parent
+			acceptedButtons: Qt.NoButton
+			onWheel: (wheel) => {
+				if (wheel.modifiers & Qt.ControlModifier) {
+					if (wheel.angleDelta.y > 0) {
+						overlayZoomSlider.value = Math.min(overlayZoomSlider.to, root.zoomLevel + 0.1)
+					} else {
+						overlayZoomSlider.value = Math.max(overlayZoomSlider.from, root.zoomLevel - 0.1)
+					}
+					wheel.accepted = true
+				}
+			}
+		}
+	}
+
+	// Missing image indicator
+	Rectangle {
+		anchors.centerIn: parent
+		width: missingImageText.implicitWidth + 40
+		height: missingImageText.implicitHeight + 20
+		border.color: "white"
+		color: "orange"
+		radius: 4
+		visible: root.resultStatus !== CompareModel.ComparisonPending && !root.bothImagesExist
+
+		Text {
+			id: missingImageText
+			anchors.centerIn: parent
+			text: root.baselineImageUri.length === 0 && root.candidateImageUri.length > 0 ? "Candidate image only (baseline missing)"
+				: root.baselineImageUri.length > 0 && root.candidateImageUri.length === 0 ? "Baseline image only (candidate missing)"
+				: ""
+			color: "white"
+			font.bold: true
+			font.pixelSize: 32
+		}
+	}
+
+	Component {
+		id: overlayComponent
+
+		Item {
+			implicitWidth: candidateImage.implicitWidth
+			implicitHeight: candidateImage.implicitHeight
+
+			Item {
 				anchors {
 					left: parent.left
 					top: parent.top
 					bottom: parent.bottom
 				}
-				width: bothExist ? sliderRect.x : (rightExists ? parent.width : 0)
+				width: overlayCropLine.visible ? Math.min(root.cropLineX, parent.width) : parent.width
 				clip: true
 
 				Image {
-					id: rightImage
-					source: rightImageUri && rightImageUri.length > 0 ? rightImageUri : ""
-					fillMode: Image.Pad
-					visible: rightExists
+					id: candidateImage
+					source: root.comparisonMode === 0 ? "image://difference/" + root.fileName : root.candidateImageUri
+					opacity: overlayOpacitySlider.value
 				}
 			}
 
-			// Slider only visible when both images exist
+			// Slider for changing the visible part of the overlay. Can be dragged with left
+			// mouse button, or clicking anywhere with the right mouse button will move it.
 			Rectangle {
-				id: sliderRect
-				x: parent.width / 2
-				y: 0
-				width: 3
-				height: parent.height
+				id: overlayCropLine
+				anchors.verticalCenter: parent.verticalCenter
+				x: root.cropLineX
+				width: 8
+				height: flickable.height * 2
 				color: "#00BCD4"
-				visible: bothExist
-			}
+				visible: cropLineCheckBox.checked && root.resultStatus === CompareModel.ComparisonReady && !root.imagesIdentical
 
-			// Missing image indicator for baseline (left)
-			Rectangle {
-				anchors.centerIn: parent
-				width: missingLeftText.implicitWidth + 40
-				height: missingLeftText.implicitHeight + 20
-				color: "#FF9800"
-				radius: 4
-				visible: !leftExists && rightExists
-
-				Text {
-					id: missingLeftText
-					anchors.centerIn: parent
-					text: "Baseline image missing"
-					color: "white"
-					font.bold: true
-					font.pixelSize: 32
-				}
-			}
-
-			// Missing image indicator for candidate (right)
-			Rectangle {
-				anchors.centerIn: parent
-				width: missingRightText.implicitWidth + 40
-				height: missingRightText.implicitHeight + 20
-				color: "#FF9800"
-				radius: 4
-				visible: leftExists && !rightExists
-
-				Text {
-					id: missingRightText
-					anchors.centerIn: parent
-					text: "Candidate image missing"
-					color: "white"
-					font.bold: true
-					font.pixelSize: 32
+				MouseArea {
+					anchors.fill: parent
+					drag.target: parent
+					drag.axis: Drag.XAxis
 				}
 			}
 
 			MouseArea {
 				anchors.fill: parent
-				enabled: bothExist
-				onClicked: sliderRect.x = mouseX
-				onPressAndHold: sliderRect.x = mouseX
-				onPressed: sliderRect.x = mouseX
+				enabled: overlayCropLine.visible
+				acceptedButtons: Qt.RightButton
+				onClicked: root.cropLineX = mouseX
+				onPressAndHold: root.cropLineX = mouseX
+				onPressed: root.cropLineX = mouseX
 				onPositionChanged: {
 					if (pressed) {
-						sliderRect.x = mouseX
+						root.cropLineX = mouseX
 					}
-				}
-			}
-		}
-	}
-
-	// Overlay comparison
-	Component {
-		id: overlayComponent
-
-		Item {
-			readonly property bool baseExists: baseImage.status === Image.Ready
-			readonly property bool overlayExists: overlayImage.status === Image.Ready
-
-			implicitWidth: Math.max(baseImage.implicitWidth, overlayImage.implicitWidth)
-			implicitHeight: Math.max(baseImage.implicitHeight, overlayImage.implicitHeight)
-
-			Image {
-				id: baseImage
-				source: leftImageUri && leftImageUri.length > 0 ? leftImageUri : ""
-				fillMode: Image.Pad
-				visible: baseExists
-			}
-
-			Image {
-				id: overlayImage
-				source: rightImageUri && rightImageUri.length > 0 ? rightImageUri : ""
-				fillMode: Image.Pad
-				opacity: overlayOpacitySlider.value
-				visible: overlayExists
-			}
-
-			// Missing image indicator for baseline
-			Rectangle {
-				anchors.centerIn: parent
-				width: missingBaseText.implicitWidth + 40
-				height: missingBaseText.implicitHeight + 20
-				color: "#FF9800"
-				radius: 4
-				visible: !baseExists && overlayExists
-
-				Text {
-					id: missingBaseText
-					anchors.centerIn: parent
-					text: "Baseline image missing"
-					color: "white"
-					font.bold: true
-					font.pixelSize: 32
-				}
-			}
-
-			// Missing image indicator for candidate
-			Rectangle {
-				anchors.centerIn: parent
-				width: missingOverlayText.implicitWidth + 40
-				height: missingOverlayText.implicitHeight + 20
-				color: "#FF9800"
-				radius: 4
-				visible: baseExists && !overlayExists
-
-				Text {
-					id: missingOverlayText
-					anchors.centerIn: parent
-					text: "Candidate image missing"
-					color: "white"
-					font.bold: true
-					font.pixelSize: 32
 				}
 			}
 		}

--- a/tools/uicompare/ImageListView.qml
+++ b/tools/uicompare/ImageListView.qml
@@ -4,28 +4,46 @@ import QtQuick.Controls
 ListView {
 	id: root
 
-	property string currentFilename
+	property var currentResult: ({})
 
 	delegate: ImageListViewDelegate {
+		required property int index
+		readonly property int fileNameSeparatorIndex: fileName.indexOf('-')
+
 		width: ListView.view.width - listViewScrollBar.width
-		onClicked: (index, fileName) => {
+		height: 80
+		title: fileName.substring(4, fileNameSeparatorIndex) // start at 4 to skip "tst_" prefix
+		secondaryTitle: fileName.substring(fileNameSeparatorIndex + 1)
+		imageSize: Qt.size(height, height)
+
+		onClicked: {
 			root.currentIndex = index
-			root.currentFilename = fileName
 		}
 	}
 	highlight: Rectangle {
-		color: "#E3F2FD"
+		z: 1
+		color: "transparent"
 		border.color: "#2196F3"
 		border.width: 2
 		radius: 4
 	}
 	highlightFollowsCurrentItem: true
 	highlightMoveDuration: 100
+	keyNavigationEnabled: true
+	focus: true
+
+	onCurrentIndexChanged: {
+		currentResult = root.model.get(currentIndex)
+	}
 
 	// Auto-select first item when model is populated
-	onCountChanged: {
-		if (count > 0 && currentIndex < 0) {
-			currentIndex = 0
+	Connections {
+		target: root.model
+
+		function onFirstResultAvailable() {
+			if (root.currentIndex < 0) {
+				root.currentIndex = 0
+			}
 		}
 	}
 

--- a/tools/uicompare/ImageListViewDelegate.qml
+++ b/tools/uicompare/ImageListViewDelegate.qml
@@ -1,116 +1,93 @@
 import QtQuick
-import QtQuick.Layouts
 
-Item {
+MouseArea {
 	id: root
 
-	readonly property var splitName: model.text.split("-")
-	readonly property bool isIdentical: model.identical
-	readonly property bool isPassing: model.similarity >= 0.999
-	readonly property bool hasError: model.errorMessage && model.errorMessage.length > 0
-	readonly property color statusColor: hasError ? "#F44336" : (isIdentical ? "#4CAF50" : (isPassing ? "#4CAF50" : "#FFC107"))
+	required property string title
+	required property string secondaryTitle
+	required property size imageSize
+	required property string fileName
 
-	signal clicked(index : int, fileName : string)
+	required property int status
+	required property real mse
+	required property string errorMessage
 
-	implicitHeight: column.height + column.anchors.margins * 2
+	readonly property bool ready: status !== CompareModel.ComparisonPending
+	readonly property real similarity: 1 - (mse / (255 * 255 * 4))
+	readonly property bool isIdentical: Math.round(mse) === 0
+	readonly property bool isPassing: ready && mse < ListView.view.model.errorTolerance
+	readonly property bool hasError: ready && errorMessage.length > 0
+	readonly property color statusColor: isPassing || isIdentical ? "#4CAF50"
+			: status === CompareModel.ComparisonPending
+				|| status === CompareModel.NoBaselineImage
+				|| status === CompareModel.NoCandidateImage ? "orange"
+			: "#F44336"
+
+	implicitHeight: column.implicitHeight + column.anchors.margins * 2
+
+	Rectangle {
+		id: statusBadge
+		anchors {
+			left: parent.left
+			leftMargin: 8
+			top: column.top
+			bottom: column.bottom
+		}
+		width: 8
+		radius: 4
+		color: root.statusColor
+	}
 
 	Column {
 		id: column
 		width: parent.width
 		anchors {
 			top: parent.top
-			left: parent.left
-			right: parent.right
+			bottom: parent.bottom
+			left: statusBadge.right
+			right: thumbnail.left
 			margins: 8
 		}
 		spacing: 4
 
-		// Header with status indicator
-		Item {
+		Text {
 			width: parent.width
-			height: 40
-
-			Rectangle {
-				id: statusBadge
-				anchors.left: parent.left
-				anchors.verticalCenter: parent.verticalCenter
-				width: 8
-				height: 30
-				radius: 4
-				color: statusColor
-			}
-
-			Column {
-				id: headerColumn
-				anchors {
-					left: statusBadge.right
-					leftMargin: 8
-					right: metricsColumn.left
-					rightMargin: 4
-					verticalCenter: parent.verticalCenter
-				}
-
-				Text {
-					id: sectionText
-					text: splitName[0].replace("tst_", "")
-					font.capitalization: Font.Capitalize
-					font.bold: true
-					width: headerColumn.width
-					elide: Text.ElideRight
-				}
-				Text {
-					id: subSectionText
-					text: splitName.length > 1 ? splitName[1] : ""
-					font.pixelSize: 10
-					color: "#666"
-					width: headerColumn.width
-					elide: Text.ElideRight
-				}
-			}
-
-			Column {
-				id: metricsColumn
-				anchors.right: parent.right
-				anchors.verticalCenter: parent.verticalCenter
-				spacing: 2
-
-				Text {
-					id: similarityText
-					anchors.right: parent.right
-					text: hasError ? "⚠" : (isIdentical ? "✓ " : "") + ((model.similarity * 100).toFixed(2) + "%")
-					font.pixelSize: 10
-					color: statusColor
-					font.bold: true
-				}
-				Text {
-					id: errorText
-					anchors.right: parent.right
-					text: hasError ? model.errorMessage : ("Δ " + model.error.toFixed(2))
-					font.pixelSize: 9
-					color: hasError ? statusColor : "#666"
-					elide: Text.ElideRight
-					width: Math.min(implicitWidth, 100)
-				}
-			}
+			text: root.title
+			font.pixelSize: 16
+			font.capitalization: Font.Capitalize
+			font.bold: true
+			elide: Text.ElideRight
 		}
 
-		// Difference thumbnail
-		Image {
-			id: differenceImage
+		Text {
 			width: parent.width
-			height: 140
-			source: model.text && model.text.length > 0 ? ("image://difference/" + model.text) : ""
-			sourceSize: Qt.size(width, 140)
-			fillMode: Image.PreserveAspectFit
-			visible: source.toString().length > 0
+			text: root.secondaryTitle
+			font.pixelSize: 14
+			color: "#666"
+			elide: Text.ElideRight
+		}
+
+		Text {
+			text: root.errorMessage ? root.errorMessage
+				: root.isIdentical ? "✓"
+				: "⚠ %1%".arg((root.similarity * 100).toFixed(3))
+			font.pixelSize: 16
+			color: root.statusColor
+			font.bold: true
 		}
 	}
 
-	MouseArea {
-		anchors.fill: parent
-		onClicked: {
-			root.clicked(index, model.text)
+	// Difference thumbnail
+	Image {
+		id: thumbnail
+		anchors {
+			right: parent.right
+			rightMargin: 8
 		}
+		width: root.imageSize.width
+		height: root.imageSize.height
+		source: root.fileName && root.fileName.length > 0 ? ("image://difference/" + root.fileName) : ""
+		sourceSize: root.imageSize
+		fillMode: Image.PreserveAspectFit
 	}
 }
-

--- a/tools/uicompare/Main.qml
+++ b/tools/uicompare/Main.qml
@@ -15,9 +15,11 @@ Window {
 
 	ColumnLayout {
 		anchors.fill: parent
+		spacing: 0
+
 		Toolbar {
 			id: toolbar
-			Layout.preferredHeight: 70
+			Layout.preferredHeight: 80
 			Layout.fillWidth: true
 
 			totalCount: testModel.count
@@ -26,46 +28,43 @@ Window {
 			missingBaselineCount: testModel.missingBaselineCount
 			missingCandidateCount: testModel.missingCandidateCount
 
-			onFilterChanged: (filterMode) => testModel.setFilterMode(filterMode)
+			onFilterChanged: (filterMode) => {
+				listView.currentIndex = -1
+				testModel.setFilterMode(filterMode)
+			}
 		}
 
 		SplitView {
 			Layout.fillHeight: true
 			Layout.fillWidth: true
+			z: -1 // scroll list view beneath the toolbar
 			orientation: Qt.Horizontal
 
-			ImageListView {
-				id: listView
-				SplitView.preferredWidth: 310
+			Rectangle { // background behind the list view
+				SplitView.preferredWidth: 360
 				SplitView.minimumWidth: 100
 				SplitView.maximumWidth: 600
-				model: testModel
-				clip: true
 
-				// Update currentFilename when currentIndex changes
-				onCurrentIndexChanged: {
-					if (currentIndex >= 0) {
-						const fileName = testModel.data(testModel.index(currentIndex, 0), 0x0101) // TextRole
-						if (fileName && fileName.length > 0) {
-							currentFilename = fileName
-						}
-					} else {
-						currentFilename = ""
-					}
+				ImageListView {
+					id: listView
+					anchors.fill: parent
+					model: testModel
 				}
 			}
+
 			CompareView {
 				id: compareView
 				SplitView.fillWidth: true
-
-				fileName: listView.currentFilename
-				leftImageUri: listView.currentFilename ? ("file:image-captures-baseline/" + listView.currentFilename) : ""
-				rightImageUri: listView.currentFilename ? ("file:image-captures/" +  listView.currentFilename) : ""
+				SplitView.fillHeight: true
+				z: -1 // do not allow comparison image to pan above the list view
+				resultStatus: listView.currentResult.status ?? CompareModel.ComparisonPending
+				imagesIdentical: listView.currentResult.mse === undefined ? false : Math.round(listView.currentResult.mse) === 0
+				fileName: listView.currentResult.fileName ?? ""
 			}
 		}
 
 		Rectangle {
-			Layout.preferredHeight: 24
+			Layout.preferredHeight: 30
 			Layout.fillWidth: true
 			color: "#f5f5f5"
 			border.color: "#ddd"
@@ -73,8 +72,8 @@ Window {
 
 			Text {
 				anchors.centerIn: parent
-				text: listView.currentFilename || "Select an image to compare"
-				font.pixelSize: 11
+				text: compareView.fileName || "Select an image to compare"
+				font.pixelSize: 14
 				color: "#666"
 			}
 		}
@@ -82,5 +81,6 @@ Window {
 
 	CompareModel {
 		id: testModel
+		errorTolerance: 10.0
 	}
 }

--- a/tools/uicompare/Toolbar.qml
+++ b/tools/uicompare/Toolbar.qml
@@ -14,24 +14,59 @@ Rectangle {
 
 	signal filterChanged(filterMode : int)
 
+	implicitWidth: toolBarLayout.implicitWidth
+	implicitHeight: toolBarLayout.implicitHeight
 	color: "#f5f5f5"
 	border.color: "#ddd"
 	border.width: 1
 
+	component StatisticDisplay : ColumnLayout {
+		required property string title
+		required property string number
+		required property color numberColor
+
+		spacing: 0
+
+		Text {
+			Layout.alignment: Text.AlignHCenter
+			Layout.preferredWidth: 60
+			horizontalAlignment: Text.AlignHCenter
+			text: number
+			font.pixelSize: 18
+			font.bold: true
+			color: numberColor
+			leftPadding: 4
+			rightPadding: 4
+		}
+
+		Text {
+			Layout.alignment: Text.AlignHCenter
+			horizontalAlignment: Text.AlignHCenter
+			text: title
+			font.pixelSize: 12
+			color: "#666"
+			leftPadding: 4
+			rightPadding: 4
+		}
+	}
+
 	RowLayout {
+		id: toolBarLayout
+
 		anchors.fill: parent
 		anchors.margins: 8
 		spacing: 12
 
 		// Statistics display
 		Rectangle {
-			Layout.preferredWidth: 280
+			Layout.preferredWidth: toolBarContentLayout.implicitWidth
 			Layout.fillHeight: true
 			color: "#fff"
 			border.color: "#ddd"
 			radius: 4
 
 			ColumnLayout {
+				id: toolBarContentLayout
 				anchors.centerIn: parent
 				spacing: 2
 
@@ -44,80 +79,35 @@ Rectangle {
 
 				RowLayout {
 					Layout.alignment: Qt.AlignHCenter
-					spacing: 16
 
-					Column {
-						Text {
-							anchors.horizontalCenter: parent.horizontalCenter
-							text: root.totalCount
-							font.pixelSize: 18
-							font.bold: true
-						}
-						Text {
-							text: "Total"
-							font.pixelSize: 9
-							color: "#666"
-						}
+					StatisticDisplay {
+						title: "Total"
+						number: root.totalCount
+						numberColor: "black"
 					}
 
-					Column {
-						Text {
-							anchors.horizontalCenter: parent.horizontalCenter
-							text: root.passCount
-							font.pixelSize: 18
-							font.bold: true
-							color: "#4CAF50"
-						}
-						Text {
-							text: "Pass"
-							font.pixelSize: 9
-							color: "#666"
-						}
+					StatisticDisplay {
+						title: "Pass"
+						number: root.passCount
+						numberColor: "#4CAF50"
 					}
 
-					Column {
-						Text {
-							anchors.horizontalCenter: parent.horizontalCenter
-							text: root.failCount
-							font.pixelSize: 18
-							font.bold: true
-							color: "#F44336"
-						}
-						Text {
-							text: "Fail"
-							font.pixelSize: 9
-							color: "#666"
-						}
+					StatisticDisplay {
+						title: "Fail"
+						number: root.failCount
+						numberColor: "#F44336"
 					}
 
-					Column {
-						Text {
-							anchors.horizontalCenter: parent.horizontalCenter
-							text: root.missingBaselineCount
-							font.pixelSize: 18
-							font.bold: true
-							color: "#FF9800"
-						}
-						Text {
-							text: "No Base"
-							font.pixelSize: 9
-							color: "#666"
-						}
+					StatisticDisplay {
+						title: "No baseline"
+						number: root.missingBaselineCount
+						numberColor: "orange"
 					}
 
-					Column {
-						Text {
-							anchors.horizontalCenter: parent.horizontalCenter
-							text: root.missingCandidateCount
-							font.pixelSize: 18
-							font.bold: true
-							color: "#FF9800"
-						}
-						Text {
-							text: "No Cand"
-							font.pixelSize: 9
-							color: "#666"
-						}
+					StatisticDisplay {
+						title: "No candidate"
+						number: root.missingCandidateCount
+						numberColor: "orange"
 					}
 				}
 			}

--- a/tools/uicompare/comparemodel.cpp
+++ b/tools/uicompare/comparemodel.cpp
@@ -23,8 +23,7 @@ public:
         // Scan baseline directory
         QDir baselineDir("image-captures-baseline");
         if (baselineDir.exists() && !baselineDir.isEmpty() && baselineDir.isReadable()) {
-            const QStringList fileList = baselineDir.entryList(QStringList() << "*.*", QDir::Files);
-            allFiles.append(fileList);
+            allFiles = baselineDir.entryList(QStringList() << "*.*", QDir::Files, QDir::Name);
         } else {
             qDebug() << "Baseline directory not exist/is empty/not accessible";
         }
@@ -32,11 +31,13 @@ public:
         // Scan candidate directory
         QDir candidateDir("image-captures");
         if (candidateDir.exists() && !candidateDir.isEmpty() && candidateDir.isReadable()) {
-            const QStringList fileList = candidateDir.entryList(QStringList() << "*.*", QDir::Files);
-            for (const QString &file : fileList) {
-                if (!allFiles.contains(file)) {
-                    allFiles.append(file);
-                }
+            const QStringList candidateFiles = candidateDir.entryList(QStringList() << "*.*", QDir::Files, QDir::Name);
+            if (candidateFiles != allFiles) {
+                // Add the candidate files into allFiles and sort the result.
+                QSet allFilesSet(allFiles.constBegin(), allFiles.constEnd());
+                allFilesSet.unite(QSet(candidateFiles.constBegin(), candidateFiles.constEnd()));
+                allFiles = QList<QString>(allFilesSet.constBegin(), allFilesSet.constEnd());
+                allFiles.sort();
             }
         } else {
             qDebug() << "Candidate directory not exist/is empty/not accessible";
@@ -58,8 +59,8 @@ private:
 class ComparisonWorker : public QRunnable
 {
 public:
-    ComparisonWorker(CompareModel *model, const QString &fileName, const CompareModel::ImageResult &preValidated)
-        : m_model(model), m_fileName(fileName), m_preValidated(preValidated)
+    ComparisonWorker(CompareModel *model, const QString &fileName)
+        : m_model(model), m_fileName(fileName)
     {
         setAutoDelete(true);
     }
@@ -76,101 +77,79 @@ public:
         }, Qt::QueuedConnection);
     }
 
+    int squaredDifference(const QRgb &rgb1, const QRgb &rgb2) const
+    {
+        const int aDiff = qAlpha(rgb1) - qAlpha(rgb2);
+        const int rDiff = qRed(rgb1) - qRed(rgb2);
+        const int gDiff = qGreen(rgb1) - qGreen(rgb2);
+        const int bDiff = qBlue(rgb1) - qBlue(rgb2);
+        return (aDiff * aDiff) + (rDiff * rDiff) + (gDiff * gDiff) + (bDiff * bDiff);
+    }
+
     CompareModel::ImageResult compare(const QString fileName) const
     {
-        CompareModel::ImageResult result;
-        result.fileName = fileName;
-
-        // Check if we have pre-validated this image
-        if (m_preValidated.fileName == fileName) {
-            // If validation failed, return error result
-            if (!m_preValidated.baselineExists || !m_preValidated.candidateExists || !m_preValidated.sizesMatch) {
-                result.similarity = 0.0;
-                result.meanError = 255.0;
-                result.valid = false;
-                result.identical = false;
-                result.pending = false;
-                return result;
-            }
-        }
-
-        QString baselinePath = "image-captures-baseline/" + fileName;
-        QString candidatePath = "image-captures/" + fileName;
+        const QString baselinePath = "image-captures-baseline/" + fileName;
+        const QString candidatePath = "image-captures/" + fileName;
 
         // Load images for comparison
         QImage a(baselinePath);
         QImage b(candidatePath);
+        if (a.format() != QImage::Format_ARGB32) {
+            a = a.convertToFormat(QImage::Format_ARGB32);
+        }
+        if (b.format() != QImage::Format_ARGB32) {
+            b = b.convertToFormat(QImage::Format_ARGB32);
+        }
 
-        // Double-check images loaded successfully (in case validation was skipped)
+        CompareModel::ImageResult result;
+
         if (a.isNull() || b.isNull() || a.size() != b.size()) {
-            result.valid = false;
-            result.identical = false;
-            result.pending = false;
-            result.similarity = 0.0;
-            result.meanError = 255.0;
-
             if (a.isNull() && !b.isNull()) {
+                result.status = CompareModel::NoBaselineImage;
                 result.errorMessage = "Baseline image missing";
-                result.baselineExists = false;
-                result.candidateExists = true;
             } else if (!a.isNull() && b.isNull()) {
+                result.status = CompareModel::NoCandidateImage;
                 result.errorMessage = "Candidate image missing";
-                result.baselineExists = true;
-                result.candidateExists = false;
-            } else if (a.isNull() && b.isNull()) {
+            } else if (a.isNull() && !b.isNull()) {
+                result.status = CompareModel::ComparisonReady;
                 result.errorMessage = "Both images missing";
-                result.baselineExists = false;
-                result.candidateExists = false;
-            } else if (a.size() != b.size()) {
+            } else {
+                result.status = CompareModel::ComparisonReady;
                 result.errorMessage = QString("Size mismatch: %1x%2 vs %3x%4")
                                          .arg(a.width()).arg(a.height())
                                          .arg(b.width()).arg(b.height());
-                result.baselineExists = true;
-                result.candidateExists = true;
-                result.sizesMatch = false;
-                result.baselineSize = a.size();
-                result.candidateSize = b.size();
             }
             return result;
         }
 
         const int width = a.width();
         const int height = a.height();
-
         quint64 totalDiff = 0;
+
         for (int y = 0; y < height; ++y) {
+            const uchar *scanLineA = a.constScanLine(y);
+            const uchar *scanLineB = b.constScanLine(y);
+            const QRgb *pixelA = reinterpret_cast<const QRgb*>(scanLineA);
+            const QRgb *pixelB = reinterpret_cast<const QRgb*>(scanLineB);
+
             for (int x = 0; x < width; ++x) {
-                const QRgb rgb1 = a.pixel(x, y);
-                const QRgb rgb2 = b.pixel(x, y);
-                totalDiff += qAbs(qRed(rgb1) - qRed(rgb2))
-                             + qAbs(qGreen(rgb1) - qGreen(rgb2))
-                             + qAbs(qBlue(rgb1) - qBlue(rgb2))
-                             + qAbs(qAlpha(rgb1) - qAlpha(rgb2));
+                const QRgb &rgb1 = pixelA[x];
+                const QRgb &rgb2 = pixelB[x];
+                totalDiff += squaredDifference(rgb1, rgb2);
             }
         }
-        const double meanError = totalDiff / (width * height * 4.0);
-        const double similarity = 1.0 - (meanError / 255.0);
 
-        result.similarity = similarity;
-        result.meanError = meanError;
-        result.valid = true;
-        result.identical = (totalDiff == 0);
-        result.pending = false;
-        result.errorMessage = QString();
-        result.baselineExists = true;
-        result.candidateExists = true;
-        result.sizesMatch = true;
-        result.baselineSize = a.size();
-        result.candidateSize = b.size();
-
+        // Mean squared error = total difference / (image size * number of channels)
+        result.mse = static_cast<double>(totalDiff) / (width * height * 4);
+        result.status = CompareModel::ComparisonReady;
         return result;
     }
 
 private:
-    CompareModel::ImageResult m_preValidated;
     QPointer<CompareModel> m_model;
     QString m_fileName;
 };
+
 
 CompareModel::CompareModel(QObject *parent)
     : QAbstractListModel(parent)
@@ -181,9 +160,6 @@ CompareModel::CompareModel(QObject *parent)
 
     // Limit threads to avoid overwhelming the system
     m_threadPool->setMaxThreadCount(qMax(2, QThread::idealThreadCount() / 2));
-
-    // Don't automatically run discovery/validation/comparison
-    // Let the UI trigger it when ready
 }
 
 CompareModel::~CompareModel()
@@ -198,11 +174,9 @@ CompareModel::~CompareModel()
 QHash<int, QByteArray> CompareModel::roleNames() const
 {
     static QHash<int, QByteArray> roles {
-        { TitleRole, "title" },
-        { TextRole, "text" },
-        { SimilarityRole, "similarity" },
-        { MeanErrorRole, "error" },
-        { IdenticalRole, "identical"},
+        { FileNameRole, "fileName" },
+        { StatusRole, "status"},
+        { MeanSquaredErrorRole, "mse" },
         { ErrorMessageRole, "errorMessage"},
     };
     return roles;
@@ -221,51 +195,22 @@ QVariant CompareModel::data(const QModelIndex &index, int role) const
         return QVariant();
     }
 
+    auto result = m_results.constFind(m_data.at(row));
+
     switch(role) {
-    case TitleRole:
+    case FileNameRole:
         return m_data.at(row);
-    case TextRole:
-        return m_data.at(row);
-    case SimilarityRole: {
-        return getResultData(m_data.at(row)).similarity;
+    case StatusRole: {
+        return result == m_results.constEnd() ? ComparisonPending : result->status;
     }
-    case MeanErrorRole: {
-        return getResultData(m_data.at(row)).meanError;
-    }
-    case IdenticalRole: {
-        return getResultData(m_data.at(row)).identical;
+    case MeanSquaredErrorRole: {
+        return result == m_results.constEnd() ? ImageResult::DefaultMse : result->mse;
     }
     case ErrorMessageRole: {
-        return getResultData(m_data.at(row)).errorMessage;
+        return result == m_results.constEnd() ? QString() : result->errorMessage;
     }
     }
     return QVariant();
-}
-
-bool CompareModel::setData(const QModelIndex &index, const QVariant &value, int role)
-{
-    if (index.isValid()) {
-        int row = index.row();
-        if(row < 0 || row >= m_data.count()) {
-            return false;
-        }
-
-        switch(role) {
-        case TitleRole:
-            m_data[row] = value.toString();
-            break;
-        case TextRole:
-            m_data[row] = value.toString();
-            break;
-        default:
-            return false;
-        }
-
-        emit dataChanged(index, index, {role});
-
-        return true;
-    }
-    return false;
 }
 
 void CompareModel::discoverImages()
@@ -277,72 +222,44 @@ void CompareModel::discoverImages()
     m_threadPool->start(worker);
 }
 
-void CompareModel::validateImages()
-{
-    qDebug() << "Starting image validation...";
-    int validCount = 0;
-    int missingBaseline = 0;
-    int missingCandidate = 0;
-    int sizeMismatch = 0;
-
-    for (const QString &fileName : m_allData) {
-        validateImage(fileName);
-        const ImageResult &result = m_results.value(fileName);
-
-        if (!result.baselineExists) {
-            missingBaseline++;
-        }
-        if (!result.candidateExists) {
-            missingCandidate++;
-        }
-        if (result.baselineExists && result.candidateExists && !result.sizesMatch) {
-            sizeMismatch++;
-        }
-        if (result.baselineExists && result.candidateExists && result.sizesMatch) {
-            validCount++;
-        }
-    }
-
-    qDebug() << "Image validation complete:"
-             << validCount << "valid pairs,"
-             << missingBaseline << "missing baseline,"
-             << missingCandidate << "missing candidate,"
-             << sizeMismatch << "size mismatches";
-}
-
 void CompareModel::startComparisons()
 {
-    qDebug() << "Starting image comparisons...";
-    int skipped = 0;
-    int started = 0;
+    const qreal requiredSimilarity = 1 - (m_errorTolerance / (255 * 255 * 4));
+    qDebug() << qPrintable(QStringLiteral("Starting image comparisons with MSE errorTolerance=%1. Image comparison passes when image similarity is least %2%.")
+                .arg(m_errorTolerance)
+                .arg(QString::number(requiredSimilarity * 100, 'f', 3)));
 
-    // Start async comparisons for all files that passed validation
+    m_comparisonTimer.start();
+
     for (const QString &fileName : m_allData) {
-        // Check if we have validation results
-        if (m_results.contains(fileName)) {
-            const ImageResult &result = m_results.value(fileName);
-
-            // Only compare if both images exist and sizes match
-            if (result.baselineExists && result.candidateExists && result.sizesMatch) {
-                startAsyncComparison(fileName);
-                started++;
-            } else {
-                // Validation error already stored in result
-                skipped++;
-            }
-        } else {
-            // No validation result, start comparison anyway (will validate inside compare())
-            startAsyncComparison(fileName);
-            started++;
-        }
+        // Queue the comparison task
+        ComparisonWorker *worker = new ComparisonWorker(this, fileName);
+        m_threadPool->start(worker);
     }
-
-    qDebug() << "Comparison started for" << started << "images, skipped" << skipped << "invalid images";
 }
 
 void CompareModel::refresh()
 {
     discoverImages();
+}
+
+QVariantMap CompareModel::get(int index) const
+{
+    QVariantMap map;
+    if (index < 0 || index >= m_data.length()) {
+        return map;
+    }
+
+    auto result = m_results.constFind(m_data.at(index));
+    if (result == m_results.constEnd()) {
+        return map;
+    }
+
+    map.insert(QStringLiteral("fileName"), m_data.at(index));
+    map.insert(QStringLiteral("status"), result->status);
+    map.insert(QStringLiteral("mse"), result->mse);
+    map.insert(QStringLiteral("errorMessage"), result->errorMessage);
+    return map;
 }
 
 void CompareModel::onDiscoveryComplete(const QStringList &fileNames)
@@ -360,7 +277,6 @@ void CompareModel::onDiscoveryComplete(const QStringList &fileNames)
     endResetModel();
     emit countChanged();
 
-    validateImages();
     startComparisons();
 }
 
@@ -380,28 +296,28 @@ bool CompareModel::passesFilter(const QString &fileName) const
         return true;  // Show all
     }
 
-    ImageResult result = getResultData(fileName);
+    auto result = m_results.constFind(fileName);
+    if (result == m_results.constEnd()) {
+        return false;
+    }
 
     // Filter modes 3 and 4 need to check error messages even if result is invalid
     if (m_filterMode == 3) {
         // Missing Baseline - show images where baseline is missing
-        return result.errorMessage == "Baseline image missing";
+        return result->status == NoBaselineImage;
     } else if (m_filterMode == 4) {
         // Missing Candidate - show images where candidate is missing
-        return result.errorMessage == "Candidate image missing";
+        return result->status == NoCandidateImage;
     }
 
-    if (!result.valid) {
+    if (result->status != ComparisonReady) {
         return false;
     }
 
-    // Use meanError for more precise comparison (0.255 corresponds to 99.9% similarity)
-    const double errorThreshold = 0.255;
-
     if (m_filterMode == 1) {
-        return result.meanError <= errorThreshold;  // Pass only
+        return result->mse <= m_errorTolerance;  // Pass only
     } else if (m_filterMode == 2) {
-        return result.meanError > errorThreshold;  // Fail only
+        return result->mse > m_errorTolerance;  // Fail only
     }
 
     return true;
@@ -419,132 +335,21 @@ void CompareModel::setFilterMode(int mode)
     }
 }
 
-int CompareModel::count()
+void CompareModel::setErrorTolerance(qreal errorTolerance)
+{
+    if (m_data.count() > 0) {
+        qWarning() << "Error: cannot change error tolerance after model is populated!";
+        return;
+    }
+    if (errorTolerance != m_errorTolerance) {
+        m_errorTolerance = errorTolerance;
+        emit errorToleranceChanged();
+    }
+}
+
+int CompareModel::count() const
 {
     return m_data.count();
-}
-
-int CompareModel::exactMatchCount()
-{
-    int exact = 0;
-    for (const QString &fileName : m_allData) {
-        if (getResultData(fileName).identical) {
-            exact++;
-        }
-    }
-    return exact;
-}
-
-int CompareModel::passCount()
-{
-    int pass = 0;
-    const double errorThreshold = 0.255;  // Corresponds to 99.9% similarity
-    for (const QString &fileName : m_allData) {
-        ImageResult result = getResultData(fileName);
-        if (result.valid && result.meanError <= errorThreshold) {
-            pass++;
-        }
-    }
-    return pass;
-}
-
-int CompareModel::failedCount()
-{
-    int fail = 0;
-    const double errorThreshold = 0.255;  // Corresponds to 99.9% similarity
-    for (const QString &fileName : m_allData) {
-        ImageResult result = getResultData(fileName);
-        if (result.valid && result.meanError > errorThreshold) {
-            fail++;
-        }
-    }
-    return fail;
-}
-
-int CompareModel::missingBaselineCount()
-{
-    int missing = 0;
-    for (const QString &fileName : m_allData) {
-        ImageResult result = getResultData(fileName);
-        if (result.errorMessage == "Baseline image missing") {
-            missing++;
-        }
-    }
-    return missing;
-}
-
-int CompareModel::missingCandidateCount()
-{
-    int missing = 0;
-    for (const QString &fileName : m_allData) {
-        ImageResult result = getResultData(fileName);
-        if (result.errorMessage == "Candidate image missing") {
-            missing++;
-        }
-    }
-    return missing;
-}
-
-void CompareModel::validateImage(const QString &fileName)
-{
-    QString baselinePath = "image-captures-baseline/" + fileName;
-    QString candidatePath = "image-captures/" + fileName;
-
-    ImageResult result;
-    result.fileName = fileName;
-    result.baselineExists = QFile::exists(baselinePath);
-    result.candidateExists = QFile::exists(candidatePath);
-    result.sizesMatch = false;
-
-    if (!result.baselineExists && result.candidateExists) {
-        result.errorMessage = "Baseline image missing";
-        m_results.insert(fileName, result);
-        return;
-    }
-
-    if (result.baselineExists && !result.candidateExists) {
-        result.errorMessage = "Candidate image missing";
-        m_results.insert(fileName, result);
-        return;
-    }
-
-    if (!result.baselineExists && !result.candidateExists) {
-        result.errorMessage = "Both images missing";
-        m_results.insert(fileName, result);
-        return;
-    }
-
-    // Both exist, check sizes
-    QImage baselineImg(baselinePath);
-    QImage candidateImg(candidatePath);
-
-    result.baselineSize = baselineImg.size();
-    result.candidateSize = candidateImg.size();
-
-    if (baselineImg.size() != candidateImg.size()) {
-        result.errorMessage = QString("Size mismatch: %1x%2 vs %3x%4")
-                                  .arg(baselineImg.width()).arg(baselineImg.height())
-                                  .arg(candidateImg.width()).arg(candidateImg.height());
-        result.sizesMatch = false;
-        m_results.insert(fileName, result);
-        return;
-    }
-
-    result.sizesMatch = true;
-    result.errorMessage = QString();
-    m_results.insert(fileName, result);
-}
-
-CompareModel::ImageResult CompareModel::getResultData(const QString fileName) const
-{
-    if (!m_results.contains(fileName)) {
-        // Return a pending result - comparison is in progress or queued
-        ImageResult result;
-        result.pending = true;
-        result.errorMessage = "Comparing...";
-        return result;
-    }
-    return m_results.value(fileName);
 }
 
 void CompareModel::onComparisonComplete(const QString &fileName, const ImageResult &result)
@@ -561,26 +366,32 @@ void CompareModel::onComparisonComplete(const QString &fileName, const ImageResu
     }
 
     // Update counts
-    emit passCountChanged();
-    emit failedCountChanged();
-    emit exactMatchCountChanged();
-    emit missingBaselineCountChanged();
-    emit missingCandidateCountChanged();
-}
-
-void CompareModel::startAsyncComparison(const QString &fileName)
-{
-    // Mark as pending (preserve existing validation data if present)
-    ImageResult pendingResult;
-    pendingResult.fileName = fileName;
-    if (m_results.contains(fileName)) {
-        pendingResult = m_results.value(fileName);
+    switch (result.status) {
+    case ComparisonPending:
+        break;
+    case ComparisonReady:
+        if (result.mse > m_errorTolerance) {
+            m_failedCount++;
+            emit failedCountChanged();
+        } else {
+            m_passCount++;
+            emit passCountChanged();
+        }
+        break;
+    case NoBaselineImage:
+        m_missingBaselineCount++;
+        emit missingBaselineCountChanged();
+        break;
+    case NoCandidateImage:
+        m_missingCandidateCount++;
+        emit missingCandidateCountChanged();
+        break;
     }
-    pendingResult.pending = true;
-    pendingResult.errorMessage = "Pending...";
-    m_results.insert(fileName, pendingResult);
 
-    // Queue the comparison task
-    ComparisonWorker *worker = new ComparisonWorker(this, fileName, m_results.value(fileName));
-    m_threadPool->start(worker);
+    if (row == 0) {
+        emit firstResultAvailable();
+    }
+    if (m_results.count() == m_allData.count()) {
+        qDebug() << "Image comparisons completed in" << m_comparisonTimer.elapsed() << "ms";
+    }
 }

--- a/tools/uicompare/comparemodel.h
+++ b/tools/uicompare/comparemodel.h
@@ -6,13 +6,14 @@
 #include <QHash>
 #include <QSize>
 #include <QThreadPool>
+#include <QElapsedTimer>
 
 class CompareModel : public QAbstractListModel
 {
     Q_OBJECT
     QML_ELEMENT
+    Q_PROPERTY(qreal errorTolerance READ errorTolerance WRITE setErrorTolerance NOTIFY errorToleranceChanged)
     Q_PROPERTY(int count READ count NOTIFY countChanged)
-    Q_PROPERTY(int exactMatchCount READ exactMatchCount NOTIFY exactMatchCountChanged)
     Q_PROPERTY(int passCount READ passCount NOTIFY passCountChanged)
     Q_PROPERTY(int failedCount READ failedCount NOTIFY failedCountChanged)
     Q_PROPERTY(int missingBaselineCount READ missingBaselineCount NOTIFY missingBaselineCountChanged)
@@ -20,52 +21,49 @@ class CompareModel : public QAbstractListModel
     Q_PROPERTY(int filterMode READ filterMode WRITE setFilterMode NOTIFY filterModeChanged)
 
 public:
-    enum RoleNames {
-        TitleRole = Qt::DisplayRole,
-        TextRole = Qt::UserRole,
-        SimilarityRole,
-        MeanErrorRole,
-        IdenticalRole,
+    enum Role {
+        FileNameRole = Qt::DisplayRole,
+        StatusRole,
+        MeanSquaredErrorRole,
         ErrorMessageRole,
     };
+    Q_ENUM(Role);
+
+    enum ComparisonResult {
+        ComparisonPending,
+        ComparisonReady,
+        NoBaselineImage,
+        NoCandidateImage,
+    };
+    Q_ENUM(ComparisonResult);
 
     struct ImageResult
     {
-        // The file to be compared
-        QString fileName;
+         // The default is the max MSE, i.e. comparison fails for all pixels in all channels.
+        static constexpr qreal DefaultMse = (255 * 255) * 4;
 
-        // Validation state
-        bool baselineExists = false;
-        bool candidateExists = false;
-        bool sizesMatch = false;
-        QSize baselineSize;
-        QSize candidateSize;
-
-        // Comparison results
-        double similarity = 0.0;
-        double meanError = 0.0;
-        bool valid = false;
-        bool identical = false;
-        bool pending = false;
         QString errorMessage;
+        qreal mse = DefaultMse;
+        int status = ComparisonPending;
     };
 
     explicit CompareModel(QObject *parent = 0);
     ~CompareModel();
 
-    int count();
-    int exactMatchCount();
-    int passCount();
-    int failedCount();
-    int missingBaselineCount();
-    int missingCandidateCount();
+    qreal errorTolerance() const { return m_errorTolerance; }
+    void setErrorTolerance(qreal errorTolerance);
+
+    int count() const;
+
+    int passCount() const { return m_passCount; }
+    int failedCount() const { return m_failedCount; }
+    int missingBaselineCount() const { return m_missingBaselineCount; }
+    int missingCandidateCount() const { return m_missingCandidateCount; }
     int filterMode() const { return m_filterMode; }
 
     Q_INVOKABLE void setFilterMode(int mode);
-    Q_INVOKABLE void discoverImages();
-    Q_INVOKABLE void validateImages();
-    Q_INVOKABLE void startComparisons();
     Q_INVOKABLE void refresh();
+    Q_INVOKABLE QVariantMap get(int index) const;
 
     Q_INVOKABLE void onComparisonComplete(const QString &filename, const CompareModel::ImageResult &result);
     Q_INVOKABLE void onDiscoveryComplete(const QStringList &filenames);
@@ -74,32 +72,35 @@ protected:
     // QAbstractItemModel interface
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     QVariant data(const QModelIndex &index, int role) const override;
-    bool setData(const QModelIndex &index, const QVariant &value, int role) override;
     QHash<int, QByteArray> roleNames() const override;
 
 Q_SIGNALS:
+    void errorToleranceChanged();
     void countChanged();
-    void exactMatchCountChanged();
     void passCountChanged();
     void failedCountChanged();
     void missingBaselineCountChanged();
     void missingCandidateCountChanged();
     void filterModeChanged();
+    void firstResultAvailable();
 
 private:
-    void discoverImagesFromFileSystem();
+    void discoverImages();
+    void startComparisons();
     void applyFilter();
-    void startAsyncComparison(const QString &filename);
-    void validateImage(const QString &filename);
-
-    ImageResult getResultData(QString filename) const;
     bool passesFilter(const QString &filename) const;
 
     QHash<QString, ImageResult> m_results;
     QList<QString> m_allData;
     QList<QString> m_data;
+    QElapsedTimer m_comparisonTimer;
     QThreadPool *m_threadPool = nullptr;
+    qreal m_errorTolerance = 255.0;
     int m_filterMode = 0;  // 0=all, 1=pass, 2=fail, 3=missing baseline, 4=missing candidate
+    int m_passCount = 0;
+    int m_failedCount = 0;
+    int m_missingBaselineCount = 0;
+    int m_missingCandidateCount = 0;
 };
 
 #endif // COMPAREMODEL_H

--- a/tools/uicompare/imageprovider.cpp
+++ b/tools/uicompare/imageprovider.cpp
@@ -15,7 +15,6 @@ void ImageProvider::setImageDirectories(const QString &baselineDirectory, const 
     }
 }
 
-
 QImage ImageProvider::requestImage(const QString &id, QSize *size, const QSize &requestedSize)
 {
     if (id.isEmpty()) {
@@ -24,6 +23,14 @@ QImage ImageProvider::requestImage(const QString &id, QSize *size, const QSize &
 
     QImage img1(m_baselineDirectory + id);
     QImage img2(m_candidateDirectory + id);
+
+    // Source image formats should be ARGB32, but check just in case.
+    if (img1.format() != QImage::Format_ARGB32) {
+        img1 = img1.convertToFormat(QImage::Format_ARGB32);
+    }
+    if (img2.format() != QImage::Format_ARGB32) {
+        img2 = img2.convertToFormat(QImage::Format_ARGB32);
+    }
 
     if (img1.isNull() && img2.isNull()) {
         return QImage();
@@ -43,33 +50,45 @@ QImage ImageProvider::requestImage(const QString &id, QSize *size, const QSize &
         return QImage();
     }
 
-    QImage diffImage(img1.width(), img1.height(), QImage::Format_ARGB32);
+    const int width = img1.width();
+    const int height = img1.height();
+    QImage diffImage(width, height, QImage::Format_ARGB32);
     if (size) {
         *size = diffImage.size();
     }
 
-    quint64 totalDiff = 0;
-    for (int y = 0; y < img1.height(); ++y) {
-        for (int x = 0; x < img1.width(); ++x) {
-            const QRgb rgb1 = img1.pixel(x, y);
-            const QRgb rgb2 = img2.pixel(x, y);
-            totalDiff += qAbs(qRed(rgb1) - qRed(rgb2))
-                         + qAbs(qGreen(rgb1) - qGreen(rgb2))
-                         + qAbs(qBlue(rgb1) - qBlue(rgb2))
-                         + qAbs(qAlpha(rgb1) - qAlpha(rgb2));
+    uchar* diffImageData = diffImage.bits();
+    int diffBytesPerLine = diffImage.bytesPerLine();
+
+    for (int y = 0; y < height; ++y) {
+        const uchar *scanLineA = img1.constScanLine(y);
+        const uchar *scanLineB = img2.constScanLine(y);
+        const QRgb *pixelA = reinterpret_cast<const QRgb*>(scanLineA);
+        const QRgb *pixelB = reinterpret_cast<const QRgb*>(scanLineB);
+        QRgb* diffRowData = reinterpret_cast<QRgb*>(diffImageData + y * diffBytesPerLine);
+
+        for (int x = 0; x < width; ++x) {
+            const QRgb &rgb1 = pixelA[x];
+            const QRgb &rgb2 = pixelB[x];
+            QRgb &pixelValue = diffRowData[x];
 
             if (rgb1 == rgb2) {
-                diffImage.setPixel(x, y, rgb1);
+                // Pixel is same in both images, so copy it into the diff image.
+                pixelValue = rgb1;
             } else {
                 // Use full red to emphasize difference. Show green from new image, blue from old image.
                 // TODO improve the generated image??
-                diffImage.setPixel(x, y, qRgba(255, qGreen(rgb2), qBlue(rgb1), 255));
+                pixelValue = qRgba(255, qGreen(rgb2), qBlue(rgb1), 255);
             }
         }
     }
-    
+
     if (requestedSize.isValid() && !requestedSize.isEmpty()) {
-        return diffImage.scaled(requestedSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+        const QImage scaledDiffImage = diffImage.scaled(requestedSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+        if (size) {
+            *size = scaledDiffImage.size();
+        }
+        return scaledDiffImage;
     }
     return diffImage;
 }


### PR DESCRIPTION
Reduce the time it takes to load the application and process the image comparisons, and also make various UI improvements.

C++ helper changes:
- speed up image comparisons by using QImage::constScanLine() and direct pixel access instead of QImage::pixel()
- similarly speed up ImageProvider::requestImage() by using direct pixel access instead of QImage::pixel() and QImage::setPixel()
- simplify the ImageResult struct and store a single 'status' property to track the result state
- replace similarity, mean error and identical roles with a single 'mse' role for the mean squared error
- remove unused CompareModel::setData() as model data is never changed from the UI
- avoid pre-validating images and just check the image sizes in the worker thread before comparing the images; this means the app loads immediately instead of appearing to hang in a busy state while validation is performed
- cache counts for pass/fail/etc to avoid recalculations
- sort file list by name

UI improvements:
- show missing images in orange as this may be valid; show comparison failures in red
- place result thumbnail on right side of list delegate and reduce thumbnail source size to reduce delegate load time
- prevent main image from panning over other parts of the UI
- do not attempt to load missing candidate or baseline images
- add a diff image mode that overlays the diff image
- hide comparison mode buttons when images cannot be compared
- show first image when first result is available
- increase font sizes for legibility
- provide key navigation for results list view
- clean up duplicated code and remove unused components