### PR TITLE
Wasm: prevent mobile WebViews from closing the on-screen keyboard

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -426,24 +426,70 @@ EM_JS(int, getWindowInnerHeight, (), {
 	return window.innerHeight;
 });
 
-EM_JS(void, setContentEditable, (bool editable), {
-	// Work-around Qt Android issue where keyboard constantly pops up (see QTBUG-88803)
-	const android = /Android/i.test(navigator.userAgent);
-	if (android) {
-		const inputs = document.querySelectorAll('input[type="text"]');
-		for (let i = 0; i < inputs.length; i++) {
-			const input = inputs[i];
-			const rect = input.getBoundingClientRect();
-
-			// Qt <input> has no identifier so identify using off-screen co-ordinates.
-			if (rect.x === -1000 && rect.y === -1000) {
-				input.style.visibility = editable ? "visible" : "hidden";
-				if (editable) {
-					input.focus();
-				}
+EM_JS(void, setInputMethodActive, (bool active), {
+	// Keep the browser's on-screen keyboard open while a Qt item accepts input.
+	//
+	// The keyboard is open exactly while Qt's hidden IME <input> element (created
+	// by QWasmInputContext, recognizable by its 'data-qinputcontext' JS property)
+	// holds DOM focus. Qt calls preventDefault() on all pointer events, which is
+	// supposed to suppress the browser's synthesized compatibility mouse events,
+	// but older mobile WebViews (e.g. Raymarine/Garmin MFDs) still fire them after
+	// touchend - or run context-menu handling after a long press - which blurs
+	// the IME input onto <body> and closes the keyboard right after it opened.
+	// See https://github.com/victronenergy/venus-html5-app/issues/558
+	//
+	// Two defenses, both armed only while a Qt item accepting input method has
+	// active focus:
+	//
+	// 1. Cancel touchend to suppress the compatibility machinery at the source
+	//    (the classic "FastClick" technique, implemented by exactly these old
+	//    WebViews). Qt is unaffected: it consumes pointerup, which fires before
+	//    touchend, and never uses the compatibility mouse events.
+	//
+	// 2. As a safety net for steal paths not covered by 1, restore focus when
+	//    the IME input blurs and shortly after nothing but <body> holds focus.
+	//    Qt's intentional keyboard dismissal is unaffected: it deactivates the
+	//    field first (disarming this guard, synchronously before any queued
+	//    callback runs) and refocuses its canvas rather than <body>.
+	Module.qtInputMethodActive = active;
+	if (Module.qtImeFocusGuardInstalled)
+		return;
+	Module.qtImeFocusGuardInstalled = true;
+	document.addEventListener("touchend", function(e) {
+		if (!Module.qtInputMethodActive)
+			return;
+		// Only cancel touches on Qt-owned elements: the container elements the
+		// embedder passed to qtLoad() (Qt renders in a shadow DOM inside them,
+		// so event retargeting makes the container itself the target of touches
+		// on the Qt UI) and the light-DOM IME input. Leaves any surrounding DOM
+		// of the embedding page (e.g. VRM) untouched while the keyboard is open.
+		var target = e.target;
+		var qtOwned = target["data-qinputcontext"] !== undefined
+			|| (Module.qtContainerElements || []).some(function(container) {
+				return container === target || container.contains(target);
+			});
+		if (qtOwned)
+			e.preventDefault();
+	}, { passive: false, capture: true });
+	document.addEventListener("focusout", function(e) {
+		var input = e.target;
+		if (!input || input["data-qinputcontext"] === undefined)
+			return;
+		// One frame is enough for an intentional focus move to land on its new
+		// target; exact timing is not critical, as the guard re-arms on every
+		// focusout of the IME input, so even a steal arriving later (e.g. a
+		// delayed compatibility click) re-triggers it.
+		if (Module.qtImeRestoreRaf !== undefined)
+			cancelAnimationFrame(Module.qtImeRestoreRaf);
+		Module.qtImeRestoreRaf = requestAnimationFrame(function() {
+			Module.qtImeRestoreRaf = undefined;
+			if (Module.qtInputMethodActive
+					&& document.activeElement === document.body
+					&& input.isConnected) {
+				input.focus({ preventScroll: true });
 			}
-		}
-	}
+		});
+	}, true);
 });
 
 EM_JS(bool, hasNativeVirtualKeyboard, (), {
@@ -560,8 +606,8 @@ int main(int argc, char *argv[])
 
 #if defined(VENUS_WEBASSEMBLY_BUILD)
 	QObject::connect(window, &QQuickWindow::activeFocusItemChanged, [window] {
-		const bool editable = window->activeFocusItem() != nullptr && (window->activeFocusItem()->flags() & QQuickItem::ItemAcceptsInputMethod);
-		setContentEditable(editable);
+		const bool acceptsInputMethod = window->activeFocusItem() != nullptr && (window->activeFocusItem()->flags() & QQuickItem::ItemAcceptsInputMethod);
+		setInputMethodActive(acceptsInputMethod);
 	});
 #endif
 


### PR DESCRIPTION
On MFD browsers (Raymarine Lighthouse, Garmin) the on-screen keyboard appeared on tap and immediately closed again. The keyboard is open exactly while Qt's hidden IME <input> (QWasmInputContext) holds DOM focus. Qt cancels all pointer events, which per spec suppresses the browser's synthesized compatibility mouse events, but these older Chromium WebViews fire them anyway after touchend - or run context-menu handling after a long press - moving focus from the IME input to <body> and closing the keyboard right after it opened.

Two defenses, armed only while a Qt item accepting input method has active focus:

1. Cancel touchend to suppress the compatibility machinery at the source. Qt is unaffected: it consumes pointerup, which fires before touchend, and never uses the compatibility mouse events.
2. As a safety net, restore focus to the IME input when it blurs and one frame later nothing but <body> holds focus. Intentional keyboard dismissal is unaffected: it disarms the guard first and refocuses the canvas rather than <body>.

This replaces the QTBUG-88803 workaround, which has been a no-op since the Qt 6.8.3 upgrade: it located the hidden input by its pre-6.8 off-screen position (-1000,-1000), which no longer matches.

Fixes https://github.com/victronenergy/venus-html5-app/issues/558

Tested and working via html5 on Raymarine Axiom 12, iPad OS 27 beta. Directly on iPhone with iOS 27 beta, and Android 16.