### PR TITLE
WASM: avoid pulling all Controls styles into the static build

### DIFF
--- a/tools/uicompare/CompareView.qml
+++ b/tools/uicompare/CompareView.qml
@@ -1,5 +1,5 @@
 import QtQuick
-import QtQuick.Controls
+import QtQuick.Controls.Basic
 import QtQuick.Layouts
 
 Item {

--- a/tools/uicompare/ImageListView.qml
+++ b/tools/uicompare/ImageListView.qml
@@ -1,5 +1,5 @@
 import QtQuick
-import QtQuick.Controls
+import QtQuick.Controls.Basic
 
 ListView {
 	id: root

--- a/tools/uicompare/Main.qml
+++ b/tools/uicompare/Main.qml
@@ -1,8 +1,7 @@
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Window
-import QtQuick.Controls
-import QtQuick.Dialogs
+import QtQuick.Controls.Basic
 
 Window {
 	width: 1280

--- a/tools/uicompare/Main.qml
+++ b/tools/uicompare/Main.qml
@@ -1,8 +1,7 @@
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Window
-import QtQuick.Controls
-import QtQuick.Dialogs
+import QtQuick.Controls.Basic
 
 Window {
 	id: root

--- a/tools/uicompare/Toolbar.qml
+++ b/tools/uicompare/Toolbar.qml
@@ -1,6 +1,6 @@
 import QtQuick
 import QtQuick.Layouts
-import QtQuick.Controls
+import QtQuick.Controls.Basic
 
 Rectangle {
 	id: root


### PR DESCRIPTION
Reworked after review: the original approach excluded QZXing entirely from the WASM build, but as @blammit pointed out, the [EE Bus settings page](https://github.com/victronenergy/gui-v2/blob/main/pages/settings/PageSettingsEebus.qml#L76) explicitly forces `ListLink_Mode_QRCode`, so QR rendering via QZXing **is** reachable on WASM. QZXing now stays in the build on all platforms.

The size win is preserved anyway: qzxing itself is small (~120 KB) — the real weight was its transitive QtQuickControls2 dependency, which made `qt_import_qml_plugins` pull every Controls style plugin (Material, Fusion, Universal, Imagine, FluentWinUI3 ≈ 7.7 MB) into the statically linked binary. This PR removes that dependency at the source:

- Bump the qzxing submodule to drop its QtQuickControls2 dependency and unqualified Controls imports (https://github.com/victronenergy/qzxing/pull/3 — must merge first)
- Switch `tools/uicompare` to `QtQuick.Controls.Basic` imports so the tool doesn't reintroduce the style pull-in

All builds from identical toolchain: Qt 6.8.3 wasm_singlethread, MinSizeRel.

| Configuration | .wasm (uncompressed) | .wasm (gzip -9) |
|---|---|---|
| Before (all Controls styles linked) | 35,751,542 bytes (34.1 MiB) | 15,739,886 bytes (15.0 MiB) |
| After (Basic style only, QZXing excluded — previous approach) | 31,615,474 bytes (30.2 MiB) | 13,992,236 bytes (13.3 MiB) |
| **After (Basic style only, QZXing included — this PR)** | **31,732,154 bytes (30.3 MiB)** | **14,031,798 bytes (13.4 MiB)** |
| **Saved vs before** | **4,019,388 bytes (−11.2%)** | **1,708,088 bytes (−10.9%)** |

Verified in the final binary: QZXing symbols present (QR pairing functional), and only the Basic Controls style is compiled in — Material, Fusion, Universal, Imagine and FluentWinUI3 no longer appear.