### PR TITLE
Tests: add headless mode for UI Compare and helper script

### DIFF
--- a/data/mock/conf/README.md
+++ b/data/mock/conf/README.md
@@ -11,6 +11,10 @@ To use mock data in the browser, append `?mock` or `?mock=<config>` to the `inde
 
 If --mock is set but no configuration is specified, the 'maximal' configuration is used.
 
+Also, if --mock-conf is set, the --mock option is implied. For example, the above command could also just be:
+
+    ./venus-gui-v2 --mock-conf multi-rs  # the --mock arg is optional, since --mock-conf is set
+
 
 ## Available mock configurations
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -277,7 +277,13 @@ void initBackend(bool *enableFpsCounter, bool *skipSplashScreen)
 	}
 
 	parser.process(filteredArgs);
-	QString mockConfigName = parser.value(mockConfig);
+
+	// Load a UI test configuration if --ui-test is specified.
+	Victron::VenusOS::UiTestConfiguration uiTestConf;
+	uiTestConf.load(parser.value(uiTest));
+
+	// Load the specified --mock-conf option.
+	QString mockConfName = parser.value(mockConfig);
 
 	Victron::VenusOS::BackendConnection *backend = Victron::VenusOS::BackendConnection::create();
 	if (parser.isSet(mqttAddress) || parser.isSet(mqttPortalId)) {
@@ -310,16 +316,10 @@ void initBackend(bool *enableFpsCounter, bool *skipSplashScreen)
 		}
 	} else if (parser.isSet(mqttPortalId)) {
 		backend->setType(Victron::VenusOS::BackendConnection::MqttSource, calculateMqttAddressFromPortalId(parser.value(mqttPortalId)));
-	} else if (parser.isSet(mockMode) || !mockConfigName.isEmpty()) {
+	} else if (parser.isSet(mockMode) || !mockConfName.isEmpty() || uiTestConf.hasMockConfiguration()) {
+		// Use the mock backend if --mock or --mock-conf are set, or if the --ui-test option
+		// requires the mock backend.
 		backend->setType(Victron::VenusOS::BackendConnection::MockSource);
-		if (parser.isSet(noMockTimers)) {
-			mockTimersEnabled = false;
-		}
-		if (mockConfigName.isEmpty()) {
-			mockConfigName = "maximal";
-		}
-		// Do not load the mock configuration until ui-test has been parsed, as the UI test config
-		// may specify a mock configuration.
 	} else {
 #if defined(VENUS_WEBASSEMBLY_BUILD)
 		backend->setUsername(queryMqttUser);
@@ -346,22 +346,31 @@ void initBackend(bool *enableFpsCounter, bool *skipSplashScreen)
 #endif
 	}
 
-	// Load any mock config before the UI test config, in case the latter overrides any values.
-	if (backend->type() == Victron::VenusOS::BackendConnection::MockSource
-			&& !mockConfigName.isEmpty()) {
-		Victron::VenusOS::MockManager::create()->loadConfiguration(QString(":/data/mock/conf/%1.json").arg(mockConfigName));
-	}
-
-	// Load the --ui-test option, if specified.
-	const QString uiTestConf = parser.value(uiTest);
-	if (!uiTestConf.isEmpty()) {
+	// Load the UI test configuration if --ui-test is specified.
+	if (uiTestConf.isValid()) {
 		Victron::VenusOS::UiTest::create()->loadConfiguration(uiTestConf);
 	}
 
-	// If --no-mock-timers is set, it overrides any value set by the UI test configuration.
-	if (parser.isSet(noMockTimers)
-			&& backend->type() == Victron::VenusOS::BackendConnection::MockSource) {
-		Victron::VenusOS::MockManager::create()->setTimersActive(mockTimersEnabled);
+	// Set up the mock backend.
+	if (backend->type() == Victron::VenusOS::BackendConnection::MockSource) {
+		Victron::VenusOS::MockManager *mockManager = Victron::VenusOS::MockManager::create();
+		if (parser.isSet(noMockTimers)) {
+			mockTimersEnabled = false;
+		}
+		mockManager->setTimersActive(mockTimersEnabled);
+
+		if (!mockConfName.isEmpty() && uiTestConf.hasMockConfiguration()) {
+			qFatal() << "Error: --mock-conf was set but --ui-test" << parser.value(uiTest)
+					 << "already specifies a mock configuration:" << uiTestConf.dirName();
+		}
+		if (mockConfName.isEmpty()) {
+			// Use "maximal" as the default mock configuration, if none is set.
+			mockConfName = "maximal";
+		}
+
+		// Load the mock configuration.
+		const QString confJson = QString(":/data/mock/conf/%1.json").arg(mockConfName);
+		mockManager->loadConfiguration(confJson);
 	}
 
 	if (parser.isSet(fpsCounter) || queryFpsCounter.contains(QStringLiteral("enable"))) {

--- a/src/mockmanager.h
+++ b/src/mockmanager.h
@@ -24,12 +24,12 @@ public:
 	bool timersActive() const;
 	void setTimersActive(bool active);
 
+	bool loadConfiguration(const QString &fileName);
+
 	Q_INVOKABLE void setValue(const QString &uid, const QVariant &value);
 	Q_INVOKABLE QVariant value(const QString &uid) const;
 	Q_INVOKABLE void removeValue(const QString &uid);
 	Q_INVOKABLE void removeServices(const QString &serviceType);
-
-	Q_INVOKABLE bool loadConfiguration(const QString &fileName);
 	Q_INVOKABLE void dumpValues();
 
 	static MockManager* create(QQmlEngine *engine = nullptr, QJSEngine *jsEngine = nullptr);

--- a/src/uitest.cpp
+++ b/src/uitest.cpp
@@ -24,21 +24,22 @@
 
 using namespace Victron::VenusOS;
 
-UiTest* UiTest::create(QQmlEngine *, QJSEngine *)
-{
-	static UiTest* object = new UiTest();
-	return object;
-}
-
-UiTest::UiTest(QObject *parent)
-	: QObject(parent)
+UiTestConfiguration::UiTestConfiguration()
 {
 }
 
-void UiTest::loadConfiguration(const QString &relativeTestDir)
+UiTestConfiguration::~UiTestConfiguration()
 {
-	const QString confName = relativeTestDir.mid(relativeTestDir.lastIndexOf('/') + 1);
-	const QString filePath = QString(":/tests/ui/%1/%2.json").arg(relativeTestDir).arg(confName);
+}
+
+void UiTestConfiguration::load(const QString &dirName)
+{
+	if (dirName.isEmpty()) {
+		qCFatal(venusGuiTest) << "Cannot load empty test configuration!";
+	}
+
+	const QString confName = dirName.mid(dirName.lastIndexOf('/') + 1);
+	const QString filePath = QString(":/tests/ui/%1/%2.json").arg(dirName).arg(confName);
 
 	QFile file(filePath);
 	if (!file.open(QFile::ReadOnly | QFile::Text)) {
@@ -52,10 +53,43 @@ void UiTest::loadConfiguration(const QString &relativeTestDir)
 				   << parseError.errorString() << "from file:" << filePath;
 	}
 
-	qCInfo(venusGuiTest) << "Loaded test configuration:" << filePath;
-
+	m_dirName = dirName;
 	m_settings = doc.object().toVariantMap();
-	m_relativeTestDir = relativeTestDir;
+
+	qCInfo(venusGuiTest) << "Loaded test configuration:" << filePath;
+}
+
+QString UiTestConfiguration::dirName() const
+{
+	return m_dirName;
+}
+
+const QVariantMap &UiTestConfiguration::settingsMap() const
+{
+	return m_settings;
+}
+
+bool UiTestConfiguration::hasMockConfiguration() const
+{
+	return m_settings.contains("Mock");
+}
+
+
+UiTest* UiTest::create(QQmlEngine *, QJSEngine *)
+{
+	static UiTest* object = new UiTest();
+	return object;
+}
+
+UiTest::UiTest(QObject *parent)
+	: QObject(parent)
+{
+}
+
+void UiTest::loadConfiguration(const UiTestConfiguration &conf)
+{
+	m_settings = conf.settingsMap();
+	m_relativeTestDir = conf.dirName();
 
 	// Read general configuration values.
 	const QVariant logLevel = settingValue("Logging");
@@ -89,7 +123,7 @@ void UiTest::loadConfiguration(const QString &relativeTestDir)
 	// Read 'Tests' configuration values.
 	m_testFileNames = m_settings.value("Tests").toStringList();
 	if (m_testFileNames.isEmpty()) {
-		qCFatal(venusGuiTest) << "UiTest: no tests have been defined in test conf:" << filePath;
+		qCFatal(venusGuiTest) << "UiTest: no tests have been defined in test:" << conf.dirName();
 	}
 
 	emit testCaseCountChanged();

--- a/src/uitest.h
+++ b/src/uitest.h
@@ -12,6 +12,28 @@
 namespace Victron {
 namespace VenusOS {
 
+class UiTestConfiguration
+{
+public:
+	UiTestConfiguration();
+	~UiTestConfiguration();
+
+	// Loads a configuration from the specified directory. This is a relative dir under tests/ui,
+	// and it must contain a JSON file of the same name.
+	// E.g. if dirName="smoke/mock-maximal", then this attempts to load a JSON file from
+	// qrc:tests/ui/smoke/mock-maximal/mock-maximal.json.
+	void load(const QString &dirName);
+
+	bool isValid() const { return !dirName().isEmpty(); }
+	QString dirName() const;
+	const QVariantMap &settingsMap() const;
+	bool hasMockConfiguration() const;
+
+private:
+	QVariantMap m_settings;
+	QString m_dirName;
+};
+
 /*
 	Configures and executes the UI testing.
 
@@ -55,12 +77,7 @@ public:
 	};
 	Q_ENUM(Status);
 
-	// Loads a configuration from the specified directory. This is a relative dir under tests/ui,
-	// and it must contain a JSON file of the same name.
-	// E.g. if confDir="smoke/mock-maximal", then this attempts to load a JSON file from
-	// qrc:tests/ui/smoke/mock-maximal/mock-maximal.json.
-	void loadConfiguration(const QString &relativeTestDir);
-
+	void loadConfiguration(const UiTestConfiguration &conf);
 	Q_INVOKABLE void start();
 
 	Status status() const;

--- a/tools/ui_capture_and_compare.py
+++ b/tools/ui_capture_and_compare.py
@@ -10,7 +10,9 @@ also optionally launches the UI Compare tool to visually show the comparisons.
 For example, to compare the gui-v2 UI between the 'main' branch and the current working branch,
 using the "maximal" mock configuration and the default "smoke/mock-maximal" UI test:
 
-    python tools/ui_capture_and_compare.py --qt-dir=~/Qt/6.8.3/gcc_64 --ui-test smoke/mock-maximal --mock-conf maximal
+    python tools/ui_capture_and_compare.py
+        --qt-dir=~/Qt/6.8.3/gcc_64
+        --ui-test smoke/mock-maximal
 
 Build directories will be created in the system temp location, unless specified otherwise by the
 --baseline-dir, --candidate-dir and --uicompare-dir options.
@@ -24,21 +26,26 @@ How it works
 The script creates multiple gui-v2 builds in temporary directories and runs gui-v2 in ui-test mode
 before collating the generated images.
 
-For example, this compares images between tag v1.3.9 and my-feature-branch:
+For example, this compares images between tag v1.3.9 and my-feature-branch, using the "barebones"
+mock configuration with the "smoke/generic-capture" UI test:
 
 python tools/ui_capture_and_compare.py
     --qt-dir=~/Qt/6.8.3/gcc_64
     --baseline=v1.3.9
     --candidate=my-feature-branch
+    --ui-test smoke/generic-capture
+    --mock-conf barebones
 
 The above command triggers a sequence as follows:
 
 1. a) Checks out the 'v1.3.9' tag
    b) Builds gui-v2 in <tmp>/build-gui-v2-baseline
-   c) Runs venus-gui-v2 binary from this build with --ui-test to generate a set of baseline images
+   c) Runs venus-gui-v2 binary from this build to generate a set of baseline images
+      (with arguments: --mock-conf barebones --ui-test smoke/generic-capture)
 2. a) Checks out the 'my-feature-branch' tag
    b) Builds gui-v2 in <tmp>/build-gui-v2-candidate
-   c) Runs venus-gui-v2 binary from this build with --ui-test to generate a set of candidate images
+   c) Runs venus-gui-v2 binary from this build to generate a set of candidate images
+      (with arguments: --mock-conf barebones --ui-test smoke/generic-capture)
 3. Checks out the original branch used prior to step 1 (if different from the candidate ref) to
    restore the previous repo state.
 4. a) Builds tools/uicompare in <tmp>/build-gui-v2-uicompare
@@ -65,7 +72,7 @@ DRY_RUN = False
 
 # --- Utility functions ---
 
-def run_command(cmd, cwd=None, check=True):
+def run_command(cmd, cwd=None, check=True, env=None):
     '''Run a command, printing it and streaming output. Returns CompletedProcess.'''
     print(f'\n> {" ".join(cmd)}')
     if DRY_RUN:
@@ -73,17 +80,19 @@ def run_command(cmd, cwd=None, check=True):
     else:
         if cwd:
             print(f'  (in {cwd})')
-        result = subprocess.run(cmd, cwd=cwd, check=check)
+        result = subprocess.run(cmd, cwd=cwd, check=check, env=env)
         return result
 
 
-def start_and_wait(binary, cwd=None):
+def start_and_wait(binary, cwd=None, args=None):
     '''Starts a process and blocks until the process is finished.'''
-    print(f'\n > {binary}')
+    args = args or []
+    args.insert(0, binary)
+    print(f'\n > {" ".join(args)}')
     if not DRY_RUN:
         if not os.path.exists(binary):
             sys.exit(f'Error: binary not found at {binary}')
-        binary_process = subprocess.Popen([binary], cwd=cwd)
+        binary_process = subprocess.Popen(args, cwd=cwd)
         result = binary_process.wait()
         if result:
             print(f'Error: binary {binary} exited with non-zero code: {result}')
@@ -173,7 +182,7 @@ def cmake_build(source_dir, build_dir, qt_dir, extra_cmake_args=None, jobs=None)
 
 # --- Image generation ---
 
-def generate_images(build_dir, ui_test, mock_conf=None):
+def generate_images(build_dir, ui_test, mock_conf=None, offscreen=False):
     '''Run venus-gui-v2 with the specified UI test to generate image captures.'''
     binary = find_binary(build_dir, 'venus-gui-v2')
     if not DRY_RUN and not os.path.exists(binary):
@@ -183,7 +192,8 @@ def generate_images(build_dir, ui_test, mock_conf=None):
     if mock_conf:
         cmd.append('--mock')
         cmd.append(f'--mock-conf={mock_conf}')
-    run_command(cmd, cwd=build_dir)
+    env = {**os.environ, 'QT_QPA_PLATFORM': 'offscreen'} if offscreen else None
+    run_command(cmd, cwd=build_dir, env=env)
 
 
 def copy_images_to_uicompare(baseline_dir, candidate_dir, uicompare_dir):
@@ -230,9 +240,12 @@ if __name__ == '__main__':
     parser.add_argument('--candidate', default='', help='The gui-v2 candidate branch/sha1/tag. Default: current branch or sha1')
     parser.add_argument('--ui-test', required=True, help=f'gui-v2 argument: The UI test configuration to run')
     parser.add_argument('--mock-conf', help=f'gui-v2 argument: the mock configuration to use, if mock mode is desired')
+    parser.add_argument('--headless', action='store_true', default=False, help='Run image generation and comparison without showing the UI')
     parser.add_argument('--clean-up', action='store_true', default=False, help='Delete all build directories on exit')
     parser.add_argument('--skip-baseline', action='store_true', default=False, help='Skip baseline build and image generation')
     parser.add_argument('--skip-candidate', action='store_true', default=False, help='Skip candidate build and image generation')
+    parser.add_argument('-e', '--error-tolerance', help='UI Compare argument: MSE error tolerance threshold for image comparisons')
+    parser.add_argument('-o', '--output', help='UI Compare argument: output file for JSON comparison results (only in headless mode)')
     parser.add_argument('-j', '--jobs', type=int, default=(os.cpu_count() or 16)/2, help='Number of parallel build jobs')
     parser.add_argument('-n', '--dry-run', action='store_true', help='Run the script without actually triggering any actions')
     args = parser.parse_args()
@@ -269,7 +282,7 @@ if __name__ == '__main__':
             print(f'\n=== Generate images for baseline "{baseline_ref}" in {args.baseline_dir} ===')
             git_checkout(baseline_ref)
             cmake_build(source_dir, args.baseline_dir, qt_dir, jobs=args.jobs)
-            generate_images(args.baseline_dir, args.ui_test, mock_conf=args.mock_conf)
+            generate_images(args.baseline_dir, args.ui_test, mock_conf=args.mock_conf, offscreen=args.headless)
 
         if args.skip_candidate:
             print('Skipping candidate build and image generation...')
@@ -277,7 +290,7 @@ if __name__ == '__main__':
             print(f'\n=== Generate images for candidate "{candidate_ref}" in {args.candidate_dir} ===')
             git_checkout(candidate_ref)
             cmake_build(source_dir, args.candidate_dir, qt_dir, jobs=args.jobs)
-            generate_images(args.candidate_dir, args.ui_test, mock_conf=args.mock_conf)
+            generate_images(args.candidate_dir, args.ui_test, mock_conf=args.mock_conf, offscreen=args.headless)
 
         if git_current_branch_or_sha1() != original_ref:
             print('\n=== Restore original branch ===')
@@ -288,7 +301,14 @@ if __name__ == '__main__':
         cmake_build(uicompare_source, args.uicompare_dir, qt_dir, jobs=args.jobs)
         uicompare_binary = find_binary(args.uicompare_dir, 'uicompare')
         copy_images_to_uicompare(args.baseline_dir, args.candidate_dir, args.uicompare_dir)
-        start_and_wait(uicompare_binary, cwd=args.uicompare_dir)
+        uicompare_args = []
+        if args.headless:
+            uicompare_args.append('--headless')
+        if args.output:
+            uicompare_args.append(f'--output={args.output}')
+        if args.error_tolerance is not None:
+            uicompare_args.append(f'--error-tolerance={args.error_tolerance}')
+        start_and_wait(uicompare_binary, cwd=args.uicompare_dir, args=uicompare_args)
 
         print('\nDone!')
 

--- a/tools/uicompare/CMakeLists.txt
+++ b/tools/uicompare/CMakeLists.txt
@@ -18,6 +18,7 @@ qt_add_qml_module(uicompare
     QML_FILES Main.qml ImageListView.qml CompareView.qml ImageListViewDelegate.qml Toolbar.qml
     SOURCES applicationsettings.h applicationsettings.cpp
     SOURCES comparemodel.h comparemodel.cpp
+    SOURCES imagecomparator.h imagecomparator.cpp
     SOURCES imageprovider.h imageprovider.cpp
 )
 

--- a/tools/uicompare/ImageListViewDelegate.qml
+++ b/tools/uicompare/ImageListViewDelegate.qml
@@ -9,15 +9,15 @@ MouseArea {
 	required property string fileName
 
 	required property int status
+	required property bool passed
+	required property bool identical
 	required property real mse
 	required property string errorMessage
 
 	readonly property bool ready: status !== CompareModel.ResultPending
 	readonly property real similarity: 1 - (mse / (255 * 255 * 4))
-	readonly property bool isIdentical: Math.round(mse) === 0
-	readonly property bool isPassing: ready && mse < ListView.view.model.errorTolerance
 	readonly property bool hasError: ready && errorMessage.length > 0
-	readonly property color statusColor: isPassing || isIdentical ? "#4CAF50"
+	readonly property color statusColor: passed || identical ? "#4CAF50"
 			: status === CompareModel.ResultPending
 				|| status === CompareModel.NoBaselineImage
 				|| status === CompareModel.NoCandidateImage ? "orange"
@@ -69,7 +69,7 @@ MouseArea {
 
 		Text {
 			text: root.errorMessage ? root.errorMessage
-				: root.isIdentical ? "✓"
+				: root.identical ? "✓"
 				: "⚠ %1%".arg((root.similarity * 100).toFixed(3))
 			font.pixelSize: 16
 			color: root.statusColor

--- a/tools/uicompare/Main.qml
+++ b/tools/uicompare/Main.qml
@@ -5,13 +5,17 @@ import QtQuick.Controls
 import QtQuick.Dialogs
 
 Window {
+	id: root
+
+	required property real errorTolerance
+
 	width: 1280
 	height: 800
 	visible: true
 	title: qsTr("UI Compare")
 
 	// On startup, begin the image comparisons.
-	Component.onCompleted: Qt.callLater(testModel.refresh)
+	Component.onCompleted: Qt.callLater(testModel.load)
 
 	ColumnLayout {
 		anchors.fill: parent
@@ -22,11 +26,11 @@ Window {
 			Layout.preferredHeight: 80
 			Layout.fillWidth: true
 
-			totalCount: testModel.count
+			totalCount: testModel.totalCount
 			passCount: testModel.passCount
-			failCount: testModel.failedCount
-			missingBaselineCount: testModel.missingBaselineCount
-			missingCandidateCount: testModel.missingCandidateCount
+			failCount: testModel.failCount
+			noBaselineCount: testModel.noBaselineCount
+			noCandidateCount: testModel.noCandidateCount
 
 			onFilterChanged: (filterMode) => {
 				listView.currentIndex = -1
@@ -81,6 +85,6 @@ Window {
 
 	CompareModel {
 		id: testModel
-		errorTolerance: 10.0
+		errorTolerance: root.errorTolerance
 	}
 }

--- a/tools/uicompare/README.md
+++ b/tools/uicompare/README.md
@@ -45,6 +45,13 @@ The comparison tool provides a split-pane interface with the following features:
 - Displays the currently selected image filename
 
 
+## Headless mode
+
+Run with the `--headless` option to perform image comparisons without showing the GUI application.
+
+In headless mode, you can also set `--output` with a file path, where the comparison results will be written in JSON format.
+
+
 ## TODO
 
 - Add keyboard shortcuts

--- a/tools/uicompare/Toolbar.qml
+++ b/tools/uicompare/Toolbar.qml
@@ -8,8 +8,8 @@ Rectangle {
 	property int totalCount: 0
 	property int passCount: 0
 	property int failCount: 0
-	property int missingBaselineCount: 0
-	property int missingCandidateCount: 0
+	property int noBaselineCount: 0
+	property int noCandidateCount: 0
 	property int filterMode: 0  // 0=all, 1=pass, 2=fail, 3=missing baseline, 4=missing candidate
 
 	signal filterChanged(filterMode : int)
@@ -100,13 +100,13 @@ Rectangle {
 
 					StatisticDisplay {
 						title: "No baseline"
-						number: root.missingBaselineCount
+						number: root.noBaselineCount
 						numberColor: "orange"
 					}
 
 					StatisticDisplay {
 						title: "No candidate"
-						number: root.missingCandidateCount
+						number: root.noCandidateCount
 						numberColor: "orange"
 					}
 				}

--- a/tools/uicompare/comparemodel.cpp
+++ b/tools/uicompare/comparemodel.cpp
@@ -1,174 +1,16 @@
 #include "comparemodel.h"
+#include "imagecomparator.h"
 
-#include <QImage>
-#include <QRunnable>
-#include <QPointer>
-#include <QCoreApplication>
-#include <QFile>
-#include <QDir>
-
-class DiscoveryWorker : public QRunnable
-{
-public:
-    DiscoveryWorker(CompareModel *model)
-        : m_model(model)
-    {
-        setAutoDelete(true);
-    }
-
-    void run() override
-    {
-        QStringList allFiles;
-        
-        // Scan baseline directory
-        QDir baselineDir("image-captures-baseline");
-        if (baselineDir.exists() && !baselineDir.isEmpty() && baselineDir.isReadable()) {
-            allFiles = baselineDir.entryList(QStringList() << "*.*", QDir::Files, QDir::Name);
-        } else {
-            qDebug() << "Cannot find images in baseline directory:" << baselineDir.absolutePath();
-        }
-
-        // Scan candidate directory
-        QDir candidateDir("image-captures-candidate");
-        if (candidateDir.exists() && !candidateDir.isEmpty() && candidateDir.isReadable()) {
-            const QStringList candidateFiles = candidateDir.entryList(QStringList() << "*.*", QDir::Files, QDir::Name);
-            if (candidateFiles != allFiles) {
-                // Add the candidate files into allFiles and sort the result.
-                QSet allFilesSet(allFiles.constBegin(), allFiles.constEnd());
-                allFilesSet.unite(QSet(candidateFiles.constBegin(), candidateFiles.constEnd()));
-                allFiles = QList<QString>(allFilesSet.constBegin(), allFilesSet.constEnd());
-                allFiles.sort();
-            }
-        } else {
-            qDebug() << "Cannot find images in candidate directory:" << candidateDir.absolutePath();
-        }
-
-        // Send results back to UI thread
-        QPointer<CompareModel> modelPtr(m_model);
-        QMetaObject::invokeMethod(qApp, [modelPtr, allFiles]() {
-            if (modelPtr) {
-                modelPtr->onDiscoveryComplete(allFiles);
-            }
-        }, Qt::QueuedConnection);
-    }
-
-private:
-    QPointer<CompareModel> m_model;
-};
-
-class ComparisonWorker : public QRunnable
-{
-public:
-    ComparisonWorker(CompareModel *model, const QString &fileName)
-        : m_model(model), m_fileName(fileName)
-    {
-        setAutoDelete(true);
-    }
-
-    void run() override
-    {
-        auto result = compare(m_fileName);
-
-        QPointer<CompareModel> modelPtr(m_model);
-        QMetaObject::invokeMethod(qApp, [modelPtr, fileName = m_fileName, result]() {
-            if (modelPtr) {
-                modelPtr->onComparisonComplete(fileName, result);
-            }
-        }, Qt::QueuedConnection);
-    }
-
-    int squaredDifference(const QRgb &rgb1, const QRgb &rgb2) const
-    {
-        const int aDiff = qAlpha(rgb1) - qAlpha(rgb2);
-        const int rDiff = qRed(rgb1) - qRed(rgb2);
-        const int gDiff = qGreen(rgb1) - qGreen(rgb2);
-        const int bDiff = qBlue(rgb1) - qBlue(rgb2);
-        return (aDiff * aDiff) + (rDiff * rDiff) + (gDiff * gDiff) + (bDiff * bDiff);
-    }
-
-    CompareModel::ImageResult compare(const QString fileName) const
-    {
-        const QString baselinePath = "image-captures-baseline/" + fileName;
-        const QString candidatePath = "image-captures-candidate/" + fileName;
-
-        // Load images for comparison
-        QImage a(baselinePath);
-        QImage b(candidatePath);
-        if (a.format() != QImage::Format_ARGB32) {
-            a = a.convertToFormat(QImage::Format_ARGB32);
-        }
-        if (b.format() != QImage::Format_ARGB32) {
-            b = b.convertToFormat(QImage::Format_ARGB32);
-        }
-
-        CompareModel::ImageResult result;
-
-        if (a.isNull() || b.isNull() || a.size() != b.size()) {
-            if (a.isNull() && !b.isNull()) {
-                result.status = CompareModel::NoBaselineImage;
-                result.errorMessage = "Baseline image missing";
-            } else if (!a.isNull() && b.isNull()) {
-                result.status = CompareModel::NoCandidateImage;
-                result.errorMessage = "Candidate image missing";
-            } else if (a.isNull() && b.isNull()) {
-                result.status = CompareModel::ResultReady;
-                result.errorMessage = "Both images missing";
-            } else {
-                result.status = CompareModel::ResultReady;
-                result.errorMessage = QString("Size mismatch: %1x%2 vs %3x%4")
-                                         .arg(a.width()).arg(a.height())
-                                         .arg(b.width()).arg(b.height());
-            }
-            return result;
-        }
-
-        const int width = a.width();
-        const int height = a.height();
-        quint64 totalDiff = 0;
-
-        for (int y = 0; y < height; ++y) {
-            const uchar *scanLineA = a.constScanLine(y);
-            const uchar *scanLineB = b.constScanLine(y);
-            const QRgb *pixelA = reinterpret_cast<const QRgb*>(scanLineA);
-            const QRgb *pixelB = reinterpret_cast<const QRgb*>(scanLineB);
-
-            for (int x = 0; x < width; ++x) {
-                const QRgb &rgb1 = pixelA[x];
-                const QRgb &rgb2 = pixelB[x];
-                totalDiff += squaredDifference(rgb1, rgb2);
-            }
-        }
-
-        // Mean squared error = total difference / (image size * number of channels)
-        result.mse = static_cast<double>(totalDiff) / (width * height * 4);
-        result.status = CompareModel::ResultReady;
-        return result;
-    }
-
-private:
-    QPointer<CompareModel> m_model;
-    QString m_fileName;
-};
-
+#include <cmath>
 
 CompareModel::CompareModel(QObject *parent)
     : QAbstractListModel(parent)
-    , m_threadPool(new QThreadPool(this))
 {
-    // Register the custom type for use in queued connections
-    qRegisterMetaType<CompareModel::ImageResult>("CompareModel::ImageResult");
-
-    // Limit threads to avoid overwhelming the system
-    m_threadPool->setMaxThreadCount(qMax(2, QThread::idealThreadCount() / 2));
-}
-
-CompareModel::~CompareModel()
-{
-    // Cancel all pending tasks and wait for active ones to complete
-    if (m_threadPool) {
-        m_threadPool->clear();  // Remove queued tasks
-        m_threadPool->waitForDone(5000);  // Wait up to 5 seconds for active tasks
-    }
+    ImageComparator *comparator = ImageComparator::instance();
+    connect(comparator, &ImageComparator::discoveryComplete,
+            this, &CompareModel::onDiscoveryComplete);
+    connect(comparator, &ImageComparator::comparisonComplete,
+            this, &CompareModel::onComparisonComplete);
 }
 
 QHash<int, QByteArray> CompareModel::roleNames() const
@@ -176,6 +18,8 @@ QHash<int, QByteArray> CompareModel::roleNames() const
     static QHash<int, QByteArray> roles {
         { FileNameRole, "fileName" },
         { StatusRole, "status"},
+        { PassedRole, "passed"},
+        { IdenticalRole, "identical"},
         { MeanSquaredErrorRole, "mse" },
         { ErrorMessageRole, "errorMessage"},
     };
@@ -200,47 +44,18 @@ QVariant CompareModel::data(const QModelIndex &index, int role) const
     switch(role) {
     case FileNameRole:
         return m_data.at(row);
-    case StatusRole: {
+    case StatusRole:
         return result == m_results.constEnd() ? ResultPending : result->status;
-    }
-    case MeanSquaredErrorRole: {
-        return result == m_results.constEnd() ? ImageResult::DefaultMse : result->mse;
-    }
-    case ErrorMessageRole: {
+    case PassedRole:
+        return result == m_results.constEnd() ? false : resultPassed(*result);
+    case IdenticalRole:
+        return result == m_results.constEnd() ? false : resultIsIdentical(*result);
+    case MeanSquaredErrorRole:
+        return result == m_results.constEnd() ? ImageComparator::ComparisonResult::DefaultMse : result->mse;
+    case ErrorMessageRole:
         return result == m_results.constEnd() ? QString() : result->errorMessage;
     }
-    }
     return QVariant();
-}
-
-void CompareModel::discoverImages()
-{
-    qDebug() << "Starting async image discovery...";
-    
-    // Queue the discovery task
-    DiscoveryWorker *worker = new DiscoveryWorker(this);
-    m_threadPool->start(worker);
-}
-
-void CompareModel::startComparisons()
-{
-    const qreal requiredSimilarity = 1 - (m_errorTolerance / (255 * 255 * 4));
-    qDebug() << qPrintable(QStringLiteral("Starting image comparisons with MSE errorTolerance=%1. Image comparison passes when image similarity is least %2%.")
-                .arg(m_errorTolerance)
-                .arg(QString::number(requiredSimilarity * 100, 'f', 3)));
-
-    m_comparisonTimer.start();
-
-    for (const QString &fileName : m_allData) {
-        // Queue the comparison task
-        ComparisonWorker *worker = new ComparisonWorker(this, fileName);
-        m_threadPool->start(worker);
-    }
-}
-
-void CompareModel::refresh()
-{
-    discoverImages();
 }
 
 QVariantMap CompareModel::get(int index) const
@@ -257,6 +72,8 @@ QVariantMap CompareModel::get(int index) const
 
     map.insert(QStringLiteral("fileName"), m_data.at(index));
     map.insert(QStringLiteral("status"), result->status);
+    map.insert(QStringLiteral("passed"), resultPassed(*result));
+    map.insert(QStringLiteral("identical"), resultIsIdentical(*result));
     map.insert(QStringLiteral("mse"), result->mse);
     map.insert(QStringLiteral("errorMessage"), result->errorMessage);
     return map;
@@ -264,20 +81,17 @@ QVariantMap CompareModel::get(int index) const
 
 void CompareModel::onDiscoveryComplete(const QStringList &fileNames)
 {
-    qDebug() << "Image discovery complete. Found" << fileNames.count() << "images";
-    
     beginResetModel();
     m_allData.clear();
     m_data.clear();
     m_results.clear();
-    
+
     m_allData = fileNames;
     applyFilter();
-    
+
     endResetModel();
     emit countChanged();
-
-    startComparisons();
+    emit totalCountChanged();
 }
 
 void CompareModel::applyFilter()
@@ -301,12 +115,9 @@ bool CompareModel::passesFilter(const QString &fileName) const
         return false;
     }
 
-    // Filter modes 3 and 4 need to check error messages even if result is invalid
     if (m_filterMode == 3) {
-        // Missing Baseline - show images where baseline is missing
         return result->status == NoBaselineImage;
     } else if (m_filterMode == 4) {
-        // Missing Candidate - show images where candidate is missing
         return result->status == NoCandidateImage;
     }
 
@@ -323,6 +134,15 @@ bool CompareModel::passesFilter(const QString &fileName) const
     return true;
 }
 
+void CompareModel::load()
+{
+    const qreal requiredSimilarity = 1 - (m_errorTolerance / (255 * 255 * 4));
+    qDebug() << qPrintable(QStringLiteral("Starting image comparisons with MSE errorTolerance=%1. Image comparison passes when image similarity is at least %2%.")
+                .arg(m_errorTolerance)
+                .arg(QString::number(requiredSimilarity * 100, 'f', 3)));
+    ImageComparator::instance()->start();
+}
+
 void CompareModel::setFilterMode(int mode)
 {
     if (m_filterMode != mode) {
@@ -337,14 +157,20 @@ void CompareModel::setFilterMode(int mode)
 
 void CompareModel::setErrorTolerance(qreal errorTolerance)
 {
-    if (m_data.count() > 0) {
-        qWarning() << "Error: cannot change error tolerance after model is populated!";
+    if (m_results.count() > 0) {
+        qWarning() << "Error tolerance cannot be changed after comparator has started!";
         return;
     }
+
     if (errorTolerance != m_errorTolerance) {
         m_errorTolerance = errorTolerance;
         emit errorToleranceChanged();
     }
+}
+
+ImageComparator *CompareModel::comparator() const
+{
+    return ImageComparator::instance();
 }
 
 int CompareModel::count() const
@@ -352,46 +178,66 @@ int CompareModel::count() const
     return m_data.count();
 }
 
-void CompareModel::onComparisonComplete(const QString &fileName, const ImageResult &result)
+void CompareModel::onComparisonComplete(const QString &fileName, const ImageComparator::ComparisonResult &result)
 {
     // Store the result
     m_results.insert(fileName, result);
 
-    // Find the row index
-    int row = m_data.indexOf(fileName);
-    if (row >= 0) {
-        // Emit dataChanged for this row
-        QModelIndex idx = index(row);
-        emit dataChanged(idx, idx);
-    }
+    const int prevPassCount = m_passCount;
+    const int prevFailCount = m_failCount;
+    const int prevNoBaselineCount = m_noBaselineCount;
+    const int prevNoCandidateCount = m_noCandidateCount;
 
     // Update counts
     switch (result.status) {
-    case ResultPending:
+    case ImageComparator::ResultPending:
         break;
-    case ResultReady:
-        if (result.mse > m_errorTolerance) {
-            m_failedCount++;
-            emit failedCountChanged();
-        } else {
+    case ImageComparator::ResultReady:
+        if (result.mse <= m_errorTolerance) {
             m_passCount++;
-            emit passCountChanged();
+        } else {
+            m_failCount++;
         }
         break;
-    case NoBaselineImage:
-        m_missingBaselineCount++;
-        emit missingBaselineCountChanged();
+    case ImageComparator::NoBaselineImage:
+        m_noBaselineCount++;
         break;
-    case NoCandidateImage:
-        m_missingCandidateCount++;
-        emit missingCandidateCountChanged();
+    case ImageComparator::NoCandidateImage:
+        m_noCandidateCount++;
         break;
+    }
+
+    // Find the row index
+    const int row = m_data.indexOf(fileName);
+    if (row >= 0) {
+        const QModelIndex idx = index(row);
+        emit dataChanged(idx, idx);
+    }
+
+    if (prevPassCount != m_passCount) {
+        emit passCountChanged();
+    }
+    if (prevFailCount != m_failCount) {
+        emit failCountChanged();
+    }
+    if (prevNoBaselineCount != m_noBaselineCount) {
+        emit noBaselineCountChanged();
+    }
+    if (prevNoCandidateCount != m_noCandidateCount) {
+        emit noCandidateCountChanged();
     }
 
     if (row == 0) {
         emit firstResultAvailable();
     }
-    if (m_results.count() == m_allData.count()) {
-        qDebug() << "Image comparisons completed in" << m_comparisonTimer.elapsed() << "ms";
-    }
+}
+
+bool CompareModel::resultPassed(const ImageComparator::ComparisonResult &result) const
+{
+    return result.status == ResultReady && result.mse <= m_errorTolerance;
+}
+
+bool CompareModel::resultIsIdentical(const ImageComparator::ComparisonResult &result) const
+{
+    return result.status == ResultReady && result.mse <= m_errorTolerance && std::round(result.mse) == 0;
 }

--- a/tools/uicompare/comparemodel.h
+++ b/tools/uicompare/comparemodel.h
@@ -4,9 +4,8 @@
 #include <qqmlintegration.h>
 #include <QAbstractListModel>
 #include <QHash>
-#include <QSize>
-#include <QThreadPool>
-#include <QElapsedTimer>
+
+#include "imagecomparator.h"
 
 class CompareModel : public QAbstractListModel
 {
@@ -14,59 +13,51 @@ class CompareModel : public QAbstractListModel
     QML_ELEMENT
     Q_PROPERTY(qreal errorTolerance READ errorTolerance WRITE setErrorTolerance NOTIFY errorToleranceChanged)
     Q_PROPERTY(int count READ count NOTIFY countChanged)
+    Q_PROPERTY(int totalCount READ totalCount NOTIFY totalCountChanged)
     Q_PROPERTY(int passCount READ passCount NOTIFY passCountChanged)
-    Q_PROPERTY(int failedCount READ failedCount NOTIFY failedCountChanged)
-    Q_PROPERTY(int missingBaselineCount READ missingBaselineCount NOTIFY missingBaselineCountChanged)
-    Q_PROPERTY(int missingCandidateCount READ missingCandidateCount NOTIFY missingCandidateCountChanged)
+    Q_PROPERTY(int failCount READ failCount NOTIFY failCountChanged)
+    Q_PROPERTY(int noBaselineCount READ noBaselineCount NOTIFY noBaselineCountChanged)
+    Q_PROPERTY(int noCandidateCount READ noCandidateCount NOTIFY noCandidateCountChanged)
+    Q_PROPERTY(ImageComparator *comparator READ comparator CONSTANT)
     Q_PROPERTY(int filterMode READ filterMode WRITE setFilterMode NOTIFY filterModeChanged)
 
 public:
     enum Role {
         FileNameRole = Qt::DisplayRole,
         StatusRole,
+        PassedRole, // true if mse <= error threshold
+        IdenticalRole, // true if passed and round(mse) = 0
         MeanSquaredErrorRole,
         ErrorMessageRole,
     };
     Q_ENUM(Role);
 
     enum ResultStatus {
-        ResultPending,
-        ResultReady,
-        NoBaselineImage,
-        NoCandidateImage,
+        ResultPending = ImageComparator::ResultPending,
+        ResultReady = ImageComparator::ResultReady,
+        NoBaselineImage = ImageComparator::NoBaselineImage,
+        NoCandidateImage = ImageComparator::NoCandidateImage,
     };
     Q_ENUM(ResultStatus);
 
-    struct ImageResult
-    {
-         // The default is the max MSE, i.e. comparison fails for all pixels in all channels.
-        static constexpr qreal DefaultMse = (255 * 255) * 4;
+    explicit CompareModel(QObject *parent = nullptr);
 
-        QString errorMessage;
-        qreal mse = DefaultMse;
-        int status = ResultPending;
-    };
+    int count() const;
+    int totalCount() const { return m_allData.count(); }
+    int passCount() const { return m_passCount; }
+    int failCount() const { return m_failCount; }
+    int noBaselineCount() const { return m_noBaselineCount; }
+    int noCandidateCount() const { return m_noCandidateCount; }
 
-    explicit CompareModel(QObject *parent = 0);
-    ~CompareModel();
+    int filterMode() const { return m_filterMode; }
+    ImageComparator *comparator() const;
 
     qreal errorTolerance() const { return m_errorTolerance; }
     void setErrorTolerance(qreal errorTolerance);
 
-    int count() const;
-
-    int passCount() const { return m_passCount; }
-    int failedCount() const { return m_failedCount; }
-    int missingBaselineCount() const { return m_missingBaselineCount; }
-    int missingCandidateCount() const { return m_missingCandidateCount; }
-    int filterMode() const { return m_filterMode; }
-
+    Q_INVOKABLE void load();
     Q_INVOKABLE void setFilterMode(int mode);
-    Q_INVOKABLE void refresh();
     Q_INVOKABLE QVariantMap get(int index) const;
-
-    Q_INVOKABLE void onComparisonComplete(const QString &filename, const CompareModel::ImageResult &result);
-    Q_INVOKABLE void onDiscoveryComplete(const QStringList &filenames);
 
 protected:
     // QAbstractItemModel interface
@@ -77,30 +68,31 @@ protected:
 Q_SIGNALS:
     void errorToleranceChanged();
     void countChanged();
+    void totalCountChanged();
     void passCountChanged();
-    void failedCountChanged();
-    void missingBaselineCountChanged();
-    void missingCandidateCountChanged();
+    void failCountChanged();
+    void noBaselineCountChanged();
+    void noCandidateCountChanged();
     void filterModeChanged();
     void firstResultAvailable();
 
 private:
-    void discoverImages();
-    void startComparisons();
+    void onDiscoveryComplete(const QStringList &filenames);
+    void onComparisonComplete(const QString &filename, const ImageComparator::ComparisonResult &result);
     void applyFilter();
     bool passesFilter(const QString &filename) const;
+    bool resultPassed(const ImageComparator::ComparisonResult &result) const;
+    bool resultIsIdentical(const ImageComparator::ComparisonResult &result) const;
 
-    QHash<QString, ImageResult> m_results;
+    QHash<QString, ImageComparator::ComparisonResult> m_results;
     QList<QString> m_allData;
     QList<QString> m_data;
-    QElapsedTimer m_comparisonTimer;
-    QThreadPool *m_threadPool = nullptr;
-    qreal m_errorTolerance = 255.0;
+    qreal m_errorTolerance = 0;
     int m_filterMode = 0;  // 0=all, 1=pass, 2=fail, 3=missing baseline, 4=missing candidate
     int m_passCount = 0;
-    int m_failedCount = 0;
-    int m_missingBaselineCount = 0;
-    int m_missingCandidateCount = 0;
+    int m_failCount = 0;
+    int m_noBaselineCount = 0;
+    int m_noCandidateCount = 0;
 };
 
 #endif // COMPAREMODEL_H

--- a/tools/uicompare/imagecomparator.cpp
+++ b/tools/uicompare/imagecomparator.cpp
@@ -1,0 +1,217 @@
+/*
+** Copyright (C) 2026 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+#include "imagecomparator.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QImage>
+#include <QPointer>
+#include <QRunnable>
+#include <QThread>
+
+class ImageDiscoveryWorker : public QRunnable
+{
+public:
+    ImageDiscoveryWorker(ImageComparator *comparator)
+        : m_comparator(comparator)
+    {
+        setAutoDelete(true);
+    }
+
+    void run() override
+    {
+        QStringList allFiles;
+
+        // Scan baseline directory
+        QDir baselineDir("image-captures-baseline");
+        if (baselineDir.exists() && !baselineDir.isEmpty() && baselineDir.isReadable()) {
+            allFiles = baselineDir.entryList(QStringList() << "*.*", QDir::Files, QDir::Name);
+        } else {
+            qDebug() << "Cannot find images in baseline directory:" << baselineDir.absolutePath();
+        }
+
+        // Scan candidate directory
+        QDir candidateDir("image-captures-candidate");
+        if (candidateDir.exists() && !candidateDir.isEmpty() && candidateDir.isReadable()) {
+            const QStringList candidateFiles = candidateDir.entryList(QStringList() << "*.*", QDir::Files, QDir::Name);
+            if (candidateFiles != allFiles) {
+                // Add the candidate files into allFiles and sort the result.
+                QSet allFilesSet(allFiles.constBegin(), allFiles.constEnd());
+                allFilesSet.unite(QSet(candidateFiles.constBegin(), candidateFiles.constEnd()));
+                allFiles = QList<QString>(allFilesSet.constBegin(), allFilesSet.constEnd());
+                allFiles.sort();
+            }
+        } else {
+            qDebug() << "Cannot find images in candidate directory:" << candidateDir.absolutePath();
+        }
+
+        // Send results back to the comparator's thread
+        QPointer<ImageComparator> ptr(m_comparator);
+        QMetaObject::invokeMethod(qApp, [ptr, allFiles]() {
+            if (ptr) {
+                ptr->onDiscoveryComplete(allFiles);
+            }
+        }, Qt::QueuedConnection);
+    }
+
+private:
+    QPointer<ImageComparator> m_comparator;
+};
+
+class ImageComparisonWorker : public QRunnable
+{
+public:
+    ImageComparisonWorker(ImageComparator *comparator, const QString &fileName)
+        : m_comparator(comparator), m_fileName(fileName)
+    {
+        setAutoDelete(true);
+    }
+
+    void run() override
+    {
+        auto result = compare(m_fileName);
+
+        QPointer<ImageComparator> ptr(m_comparator);
+        QMetaObject::invokeMethod(qApp, [ptr, fileName = m_fileName, result]() {
+            if (ptr) {
+                ptr->onComparisonComplete(fileName, result);
+            }
+        }, Qt::QueuedConnection);
+    }
+
+    int squaredDifference(const QRgb &rgb1, const QRgb &rgb2) const
+    {
+        const int aDiff = qAlpha(rgb1) - qAlpha(rgb2);
+        const int rDiff = qRed(rgb1) - qRed(rgb2);
+        const int gDiff = qGreen(rgb1) - qGreen(rgb2);
+        const int bDiff = qBlue(rgb1) - qBlue(rgb2);
+        return (aDiff * aDiff) + (rDiff * rDiff) + (gDiff * gDiff) + (bDiff * bDiff);
+    }
+
+    ImageComparator::ComparisonResult compare(const QString &fileName) const
+    {
+        const QString baselinePath = "image-captures-baseline/" + fileName;
+        const QString candidatePath = "image-captures-candidate/" + fileName;
+
+        // Load images for comparison
+        QImage a(baselinePath);
+        QImage b(candidatePath);
+        if (a.format() != QImage::Format_ARGB32) {
+            a = a.convertToFormat(QImage::Format_ARGB32);
+        }
+        if (b.format() != QImage::Format_ARGB32) {
+            b = b.convertToFormat(QImage::Format_ARGB32);
+        }
+
+        ImageComparator::ComparisonResult result;
+
+        if (a.isNull() || b.isNull() || a.size() != b.size()) {
+            if (a.isNull() && !b.isNull()) {
+                result.status = ImageComparator::NoBaselineImage;
+                result.errorMessage = "Baseline image missing";
+            } else if (!a.isNull() && b.isNull()) {
+                result.status = ImageComparator::NoCandidateImage;
+                result.errorMessage = "Candidate image missing";
+            } else if (a.isNull() && b.isNull()) {
+                result.status = ImageComparator::ResultReady;
+                result.errorMessage = "Both images missing";
+            } else {
+                result.status = ImageComparator::ResultReady;
+                result.errorMessage = QString("Size mismatch: %1x%2 vs %3x%4")
+                                         .arg(a.width()).arg(a.height())
+                                         .arg(b.width()).arg(b.height());
+            }
+            return result;
+        }
+
+        const int width = a.width();
+        const int height = a.height();
+        quint64 totalDiff = 0;
+
+        for (int y = 0; y < height; ++y) {
+            const uchar *scanLineA = a.constScanLine(y);
+            const uchar *scanLineB = b.constScanLine(y);
+            const QRgb *pixelA = reinterpret_cast<const QRgb*>(scanLineA);
+            const QRgb *pixelB = reinterpret_cast<const QRgb*>(scanLineB);
+
+            for (int x = 0; x < width; ++x) {
+                const QRgb &rgb1 = pixelA[x];
+                const QRgb &rgb2 = pixelB[x];
+                totalDiff += squaredDifference(rgb1, rgb2);
+            }
+        }
+
+        // Mean squared error = total difference / (image size * number of channels)
+        result.mse = static_cast<double>(totalDiff) / (width * height * 4);
+        result.status = ImageComparator::ResultReady;
+        return result;
+    }
+
+private:
+    QPointer<ImageComparator> m_comparator;
+    QString m_fileName;
+};
+
+
+ImageComparator::ImageComparator(QObject *parent)
+    : QObject(parent)
+{
+    qRegisterMetaType<ImageComparator::ComparisonResult>("ImageComparator::ComparisonResult");
+}
+
+ImageComparator::~ImageComparator()
+{
+    // Cancel all pending tasks and wait for active ones to complete
+    if (m_threadPool) {
+        m_threadPool->clear();  // Remove queued tasks
+        m_threadPool->waitForDone(5000);    // Wait up to 5 seconds for active tasks
+    }
+}
+
+void ImageComparator::start()
+{
+    if (m_threadPool) {
+        qWarning() << "Comparator already started!";
+        return;
+    }
+
+    m_threadPool = new QThreadPool(this);
+    m_threadPool->setMaxThreadCount(qMax(2, QThread::idealThreadCount() / 2));
+
+    qDebug() << "Looking for baseline and candidate images...";
+    m_threadPool->start(new ImageDiscoveryWorker(this));
+}
+
+void ImageComparator::onDiscoveryComplete(const QStringList &filenames)
+{
+    qDebug() << "Image discovery complete. Found" << filenames.count() << "images";
+
+    m_fileCount = filenames.count();
+    emit discoveryComplete(filenames);
+
+    m_comparisonTimer.start();
+    for (const QString &fileName : filenames) {
+        ImageComparisonWorker *worker = new ImageComparisonWorker(this, fileName);
+        m_threadPool->start(worker);
+    }
+}
+
+void ImageComparator::onComparisonComplete(const QString &filename, const ImageComparator::ComparisonResult &result)
+{
+    m_comparedCount++;
+    emit comparisonComplete(filename, result);
+
+    if (m_comparedCount == m_fileCount) {
+        qDebug() << "Image comparisons completed in" << m_comparisonTimer.elapsed() << "ms";
+        emit allComparisonsComplete();
+    }
+}
+
+ImageComparator *ImageComparator::instance()
+{
+    static ImageComparator *comparator = new ImageComparator;
+    return comparator;
+}

--- a/tools/uicompare/imagecomparator.h
+++ b/tools/uicompare/imagecomparator.h
@@ -1,0 +1,66 @@
+/*
+** Copyright (C) 2026 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+#ifndef IMAGECOMPARATOR_H
+#define IMAGECOMPARATOR_H
+
+#include <qqmlintegration.h>
+#include <QObject>
+#include <QElapsedTimer>
+#include <QThreadPool>
+
+class ImageDiscoveryWorker;
+class ImageComparisonWorker;
+
+class ImageComparator : public QObject
+{
+    Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("Created in C++")
+
+public:
+    enum ResultStatus {
+        ResultPending,
+        ResultReady,
+        NoBaselineImage,
+        NoCandidateImage,
+    };
+
+    struct ComparisonResult
+    {
+        static constexpr qreal DefaultMse = 255.0 * 255.0 * 4.0; // Maximum error
+        QString errorMessage;
+        qreal mse = DefaultMse;
+        int status = ResultPending;
+    };
+
+    ~ImageComparator();
+    int fileCount() const { return m_fileCount; }
+
+    Q_INVOKABLE void start();
+
+    // internal
+    void onDiscoveryComplete(const QStringList &filenames);
+    void onComparisonComplete(const QString &filename, const ImageComparator::ComparisonResult &result);
+
+    static ImageComparator *instance();
+
+Q_SIGNALS:
+    void discoveryComplete(const QStringList &filenames);
+    void comparisonComplete(const QString &filename, const ImageComparator::ComparisonResult &result);
+    void allComparisonsComplete();
+
+private:
+    friend class ImageDiscoveryWorker;
+    friend class ImageComparisonWorker;
+    explicit ImageComparator(QObject *parent = nullptr);
+
+    QElapsedTimer m_comparisonTimer;
+    QThreadPool *m_threadPool = nullptr;
+    int m_comparedCount = 0;
+    int m_fileCount = 0;
+};
+
+#endif // IMAGECOMPARATOR_H

--- a/tools/uicompare/main.cpp
+++ b/tools/uicompare/main.cpp
@@ -1,25 +1,137 @@
+/*
+** Copyright (C) 2026 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+#include <QCommandLineParser>
+#include <QFile>
+#include <QFileInfo>
 #include <QGuiApplication>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QQmlApplicationEngine>
 #include <QQmlComponent>
 #include <QQuickWindow>
 #include "applicationsettings.h"
+#include "imagecomparator.h"
 #include "imageprovider.h"
+
+#include <iostream>
 
 #define APP_INITIAL_X 20
 #define APP_INITIAL_Y 20
 #define APP_INITIAL_WIDTH 800
 #define APP_INITIAL_HEIGHT 600
 
-int main(int argc, char *argv[])
+static int runHeadless(QCoreApplication *app, const QString &outputPath, qreal errorTolerance)
 {
-    qputenv("QT_QUICK_CONTROLS_STYLE", QByteArray("Basic"));
+    QJsonArray results;
+    ImageComparator *comparator = ImageComparator::instance();
 
-    QGuiApplication app(argc, argv);
+    struct Totals {
+        int passCount = 0;
+        int failCount = 0;
+        int noBaselineCount = 0;
+        int noCandidateCount = 0;
+    } totals;
+
+    QObject::connect(comparator, &ImageComparator::comparisonComplete, app,
+            [&](const QString &filename, const ImageComparator::ComparisonResult &result) {
+        QString statusText;
+        std::string debugText;
+        switch (result.status) {
+        case ImageComparator::ResultReady:
+        {
+            const bool pass = result.mse <= errorTolerance;
+            statusText = pass ? QStringLiteral("passed") : QStringLiteral("failed");
+            debugText = pass ? "." : "F";
+            if (pass) {
+                totals.passCount++;
+            } else {
+                totals.failCount++;
+            }
+            break;
+        }
+        case ImageComparator::NoBaselineImage:
+            statusText = QStringLiteral("no_baseline");
+            debugText = "(NB)";
+            totals.noBaselineCount++;
+            break;
+        case ImageComparator::NoCandidateImage:
+            statusText = QStringLiteral("no_candidate");
+            debugText = "(NC)";
+            totals.noCandidateCount++;
+            break;
+        default:
+            statusText = QString();
+            debugText = "?";
+            break;
+        }
+
+        if (!outputPath.isEmpty()) {
+            QJsonObject obj;
+            obj[QStringLiteral("file_name")] = filename;
+            obj[QStringLiteral("status")] = statusText;
+            obj[QStringLiteral("mse")] = result.mse;
+            if (!result.errorMessage.isEmpty()) {
+                obj[QStringLiteral("error")] = result.errorMessage;
+            }
+            results.append(obj);
+        }
+        std::cout << debugText;
+        if (results.count() == comparator->fileCount()) {
+            std::cout << "\n";
+        }
+        std::cout.flush();
+    });
+
+    QObject::connect(comparator, &ImageComparator::allComparisonsComplete, app, [&]() {
+        qDebug() << "\n*** Image comparison summary ***";
+        qDebug() << "Total:" << comparator->fileCount();
+        qDebug() << "Passed:" << totals.passCount;
+        qDebug() << "Failed:" << totals.failCount;
+        qDebug() << "Missing baseline:" << totals.noBaselineCount;
+        qDebug() << "Missing candidate:" << totals.noCandidateCount;
+
+        if (!outputPath.isEmpty()) {
+            QJsonObject jsonRoot;
+            jsonRoot["error_tolerance"] = errorTolerance;
+            jsonRoot["results"] = results;
+
+            QJsonObject summary;
+            summary["total"] = comparator->fileCount();
+            summary["passed"] = totals.passCount;
+            summary["failed"] = totals.failCount;
+            summary["no_baseline"] = totals.noBaselineCount;
+            summary["no_candidate"] = totals.noCandidateCount;
+            jsonRoot["summary"] = summary;
+
+            QJsonDocument doc(jsonRoot);
+            QFile file(outputPath);
+            if (file.open(QIODevice::WriteOnly)) {
+                file.write(doc.toJson(QJsonDocument::Indented));
+                file.close();
+                qDebug() << "Results written to" << QFileInfo(file).absoluteFilePath();
+            } else {
+                qWarning() << "Failed to write results to output file:" << QFileInfo(file).absoluteFilePath();
+            }
+        }
+        qApp->quit();
+    });
+
+    ImageComparator::instance()->start();
+    return app->exec();
+}
+
+static int runGui(QGuiApplication *app, qreal errorTolerance)
+{
     QQmlApplicationEngine engine;
     ImageProvider *imageProvider = new ImageProvider("image-captures-baseline/", "image-captures-candidate/");
     ApplicationSettings settings;
+
     QObject::connect(&engine, &QQmlApplicationEngine::destroyed,
-                     &app, []() { QCoreApplication::exit(1); },
+                     app, []() { QCoreApplication::exit(1); },
                      Qt::QueuedConnection);
 
     QQmlComponent component(&engine, "uicompare", "Main");
@@ -34,6 +146,7 @@ int main(int argc, char *argv[])
     engine.addImageProvider(QLatin1String("difference"), imageProvider);
 
     QScopedPointer<QObject> object(component.beginCreate(engine.rootContext()));
+    component.setInitialProperties(object.data(), { { "errorTolerance", errorTolerance } });
     const auto window = qobject_cast<QQuickWindow *>(object.data());
     window->setX(settings.value(ApplicationSettings::WindowX, APP_INITIAL_X).toInt());
     window->setY(settings.value(ApplicationSettings::WindowY, APP_INITIAL_Y).toInt());
@@ -44,7 +157,7 @@ int main(int argc, char *argv[])
     window->show();
     QObject::connect(&engine, &QQmlApplicationEngine::quit, &QGuiApplication::quit);
 
-    int ret = app.exec();
+    const int ret = app->exec();
 
     settings.setValue(ApplicationSettings::WindowX, window->x());
     settings.setValue(ApplicationSettings::WindowY, window->y());
@@ -52,5 +165,37 @@ int main(int argc, char *argv[])
     settings.setValue(ApplicationSettings::WindowHeight, window->height());
 
     return ret;
+}
 
+static void initApplication(QCoreApplication *app, QCommandLineParser *parser)
+{
+    parser->addHelpOption();
+    parser->addOption({"headless", "Run in headless mode (no UI)"});
+    parser->addOption({{"error-tolerance", "e"}, "MSE error tolerance threshold", "value", "10.0"});
+    parser->addOption({{"output", "o"}, "Output JSON file path (only in headless mode)", "path", QString()});
+    parser->process(*app);
+}
+
+int main(int argc, char *argv[])
+{
+    bool headless = false;
+    for (int i = 1; i < argc; ++i) {
+        if (qstrcmp(argv[i], "--headless") == 0) {
+            headless = true;
+            break;
+        }
+    }
+
+    if (headless) {
+        QCoreApplication app(argc, argv);
+        QCommandLineParser parser;
+        initApplication(&app, &parser);
+        return runHeadless(&app, parser.value("output"), parser.value("error-tolerance").toDouble());
+    } else {
+        qputenv("QT_QUICK_CONTROLS_STYLE", QByteArray("Basic"));
+        QGuiApplication app(argc, argv);
+        QCommandLineParser parser;
+        initApplication(&app, &parser);
+        return runGui(&app, parser.value("error-tolerance").toDouble());
+    }
 }


### PR DESCRIPTION
Allow UI Compare and ui_capture_and_compare.py to be run without a GUI:

- Extract image comparison logic from CompareModel into a separate ImageComparator class
- Add --headless flag to UI Compare so it can be run without a GUI app, and also an --output flag to write the results to a JSON file
- Add --headless and --output flags to ui_capture_and_compare.py; for gui-v2, the headless flag sets QT_QPA_PLATFORM=offscreen, and for UI Compare, the flags are passed onto the uicompare binary.

Also move ImageListViewDelegate's "pass" and "identical" calculations into CompareModel as model roles so that the model can ensure these are calculated consistently with the error tolerance.