### PR TITLE
EV: Update "Last EV contact" path to new API

### DIFF
--- a/data/mock/conf/services/ev.json
+++ b/data/mock/conf/services/ev.json
@@ -13,7 +13,7 @@
         "/Position/Latitude": 52.0907,
         "/Position/Longitude": 5.1214,
         "/BatteryTemperature": 22,
-        "/LastEvContact": 1704067200,
+        "/LastUpdated/EvContact": 1704067200,
         "/CustomName": "Model 3",
         "/DeviceInstance": 288,
         "/ProductId": 0,

--- a/pages/ev/EvPage.qml
+++ b/pages/ev/EvPage.qml
@@ -114,7 +114,7 @@ DevicePage {
 			//% "Last contact"
 			text: qsTrId("ev_last_contact")
 			secondaryText: dataItem.valid ? Utils.formatTimestamp(new Date(dataItem.value * 1000), ClockTime.dateTime) : ""
-			dataItem.uid: root.bindPrefix + "/LastEvContact"
+			dataItem.uid: root.bindPrefix + "/LastUpdated/EvContact"
 			preferredVisible: dataItem.valid
 		}
 


### PR DESCRIPTION
The previous path `/LastEvContact` was removed in favour of `/LastUpdated/EvContact`, the meaning is the same.

Required for Venus OS v3.80