### PR TITLE
Fix/wasm ios orphaned touch recovery

### DIFF
--- a/wasm/index.html
+++ b/wasm/index.html
@@ -610,11 +610,18 @@
         // reacting to touch until the page is reloaded. See
         // https://github.com/victronenergy/gui-v2/issues/3087.
         //
-        // This guard tracks active touch pointers and, when a pointer is
-        // provably orphaned, synthesizes the missing pointerup into the Qt
-        // window element so Qt cleans up its state. The synthetic release is
-        // preceded by a pointermove away from the press position so that the
-        // release cannot complete the orphaned press into a spurious click.
+        // This guard repairs two related WebKit/Qt failure modes, both of
+        // which corrupt Qt's touch state the same way:
+        // 1. a touch pointer whose pointerup/pointercancel is never delivered
+        //    (orphaned pointer) - flushed once it is provably orphaned;
+        // 2. a properly delivered pointercancel: Qt (up to at least 6.9)
+        //    removes touch points from its bookkeeping only on pointerup, so
+        //    a cancelled touch leaks a permanently-pressed point - repaired
+        //    by delivering the missing pointerup after the cancel. This is
+        //    the mode observed on iOS 27.
+        // Synthetic releases are preceded by a pointermove away from the
+        // press position so that the release cannot complete a stuck press
+        // into a spurious click.
         (function() {
             'use strict';
 
@@ -693,28 +700,36 @@
                 if (e.pointerType !== 'touch' || e[SYNTHETIC]) return;
                 // A new primary touch means the browser considers no other
                 // touch active: everything still tracked is orphaned. A new
-                // non-primary touch may be a genuine second finger, so then
-                // only release pointers that have been silent for a while.
-                flushOrphans(e.isPrimary ? 'new primary touch' : 'stale pointer on new touch',
-                             e.isPrimary ? 0 : 5000, e.pointerId);
+                // non-primary touch may be a genuine second finger and is
+                // left alone.
+                if (e.isPrimary)
+                    flushOrphans('new primary touch', 0, e.pointerId);
                 tracked.set(e.pointerId, {target: e.composedPath()[0] || e.target, lastSeen: Date.now()});
             }, true);
 
-            window.addEventListener('pointermove', function(e) {
-                const entry = tracked.get(e.pointerId);
-                if (entry && !e[SYNTHETIC]) entry.lastSeen = Date.now();
+            window.addEventListener('pointerup', function(e) {
+                if (!e[SYNTHETIC]) tracked.delete(e.pointerId);
             }, true);
 
-            for (const type of ['pointerup', 'pointercancel']) {
-                window.addEventListener(type, function(e) {
-                    if (!e[SYNTHETIC]) tracked.delete(e.pointerId);
-                }, true);
-            }
+            // Failure mode 2: Qt removes a touch point from its bookkeeping
+            // only on pointerup, so a pointercancel leaves the point
+            // registered forever - with the same consequences as a pointer
+            // that never ends. Deliver the missing pointerup after Qt has
+            // processed the cancel (Qt stops propagation of pointer events,
+            // so a bubble-phase listener would never run; a task runs after
+            // the whole dispatch).
+            window.addEventListener('pointercancel', function(e) {
+                if (e[SYNTHETIC] || e.pointerType !== 'touch') return;
+                const entry = tracked.get(e.pointerId) || { target: e.composedPath()[0] || e.target };
+                tracked.delete(e.pointerId);
+                const id = e.pointerId;
+                setTimeout(function() { releasePointer(id, entry, 'pointercancel leak repair'); }, 0);
+            }, true);
 
-            // touchstart reports all current touches: a single touch while
-            // multiple pointers are tracked proves the older ones are
-            // orphaned. The 500ms minimum age protects the pointer belonging
-            // to this very touch (its pointerdown was dispatched just before).
+            // touchstart also reports all current touches: a single touch
+            // while multiple pointers are tracked proves the older ones are
+            // orphaned (failure mode 1). The 500ms minimum age protects the
+            // pointer belonging to this very touch.
             window.addEventListener('touchstart', function(e) {
                 if (e.touches.length === 1 && tracked.size > 1)
                     flushOrphans('single remaining touch', 500);
@@ -743,7 +758,8 @@
                     window.addEventListener(type, function(e) {
                         append(type + ' id=' + e.pointerId + ' primary=' + e.isPrimary
                                 + ' type=' + e.pointerType + ' trusted=' + e.isTrusted
-                                + ' x=' + Math.round(e.clientX) + ' y=' + Math.round(e.clientY));
+                                + ' x=' + Math.round(e.clientX) + ' y=' + Math.round(e.clientY)
+                                + ' tracked=' + tracked.size);
                     }, true);
                 }
                 for (const type of ['touchstart', 'touchend', 'touchcancel']) {
@@ -754,6 +770,15 @@
                 document.addEventListener('visibilitychange', function() {
                     append('visibilitychange hidden=' + document.hidden);
                 });
+                for (const type of ['pagehide', 'pageshow', 'focus', 'blur']) {
+                    window.addEventListener(type, function(e) {
+                        append(type + (e.persisted !== undefined ? ' persisted=' + e.persisted : ''));
+                    });
+                }
+                append('touch-guard v3 active'
+                        + ' standalone=' + (navigator.standalone === true)
+                        + ' display-mode-standalone=' + window.matchMedia('(display-mode: standalone)').matches
+                        + ' ' + location.href);
                 return append;
             }
         })();

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -593,5 +593,170 @@
             watchdogHit = false
         }
     </script>
+    <script type="text/javascript">
+        // ---- Touch input recovery guard ---------------------------------
+        //
+        // On iOS, system gestures that start on the page - the home-indicator
+        // swipe, App Switcher and Control Center swipes - deliver a trusted
+        // pointerdown (+ pointermoves) to the page, after which iOS takes over
+        // the gesture and never delivers the matching pointerup/pointercancel.
+        // This affects Safari, standalone home-screen webapps and WKWebView
+        // (as used by the VRM app).
+        //
+        // The Qt WASM platform plugin keeps such a touch point registered
+        // forever (it is only removed on pointerup, see QTBUG-147635), and one
+        // permanently-pressed touch point wedges Qt Quick's touch-to-mouse
+        // synthesis, so every MouseArea-based control in the application stops
+        // reacting to touch until the page is reloaded. See
+        // https://github.com/victronenergy/gui-v2/issues/3087.
+        //
+        // This guard tracks active touch pointers and, when a pointer is
+        // provably orphaned, synthesizes the missing pointerup into the Qt
+        // window element so Qt cleans up its state. The synthetic release is
+        // preceded by a pointermove away from the press position so that the
+        // release cannot complete the orphaned press into a spurious click.
+        (function() {
+            'use strict';
+
+            const params = new URLSearchParams(window.location.search);
+            const overlay = params.has('touchlog') ? createOverlay() : null;
+            const log = function(message) {
+                console.log('[touch-guard] ' + message);
+                if (overlay) overlay(message);
+            };
+
+            // Qt calls setPointerCapture()/releasePointerCapture() unguarded
+            // from its pointer event handlers. For a pointer the browser no
+            // longer considers active these throw NotFoundError, which would
+            // abort Qt's handler halfway through. Make them non-throwing.
+            for (const fn of ['setPointerCapture', 'releasePointerCapture']) {
+                const orig = Element.prototype[fn];
+                Element.prototype[fn] = function(id) {
+                    try { return orig.call(this, id); } catch (e) { /* pointer no longer active */ }
+                };
+            }
+
+            const tracked = new Map(); // pointerId -> {target, lastSeen}
+            const SYNTHETIC = '__touchGuardSynthetic';
+
+            // Find the Qt client area element inside the #screen shadow DOM.
+            // Synthetic events dispatched outside Qt's element tree never
+            // reach Qt's listeners.
+            function qtWindowElement(fallback) {
+                const walk = function(container) {
+                    const all = [container].concat(Array.from(container.querySelectorAll('*')));
+                    for (const el of all) {
+                        if (el.shadowRoot) {
+                            const hit = el.shadowRoot.querySelector('div.qt-window-contents')
+                                    || walk(el.shadowRoot);
+                            if (hit) return hit;
+                        }
+                    }
+                    return null;
+                };
+                const screen = document.querySelector('#screen');
+                return (screen && walk(screen)) || fallback || screen || document.body;
+            }
+
+            function releasePointer(id, entry, reason) {
+                const el = qtWindowElement(entry.target);
+                // Release at the top edge of the app, far away from typical
+                // stuck-press positions (system gestures start at the bottom
+                // edge): a MouseArea only emits a click when the release
+                // happens inside it.
+                const rect = (document.querySelector('#screen') || el).getBoundingClientRect();
+                const x = rect.left + rect.width / 2;
+                const y = rect.top + 2;
+                for (const move of [true, false]) {
+                    const ev = new PointerEvent(move ? 'pointermove' : 'pointerup', {
+                        bubbles: true, composed: true, cancelable: true,
+                        pointerId: id, pointerType: 'touch', isPrimary: true,
+                        clientX: x, clientY: y,
+                        pressure: move ? 1 : 0, button: move ? -1 : 0, buttons: move ? 1 : 0,
+                    });
+                    ev[SYNTHETIC] = true;
+                    el.dispatchEvent(ev);
+                }
+                log('released orphaned touch pointer ' + id + ' (' + reason + ')');
+            }
+
+            function flushOrphans(reason, minAgeMs, exceptId) {
+                const now = Date.now();
+                for (const [id, entry] of Array.from(tracked)) {
+                    if (id === exceptId || now - entry.lastSeen < minAgeMs) continue;
+                    tracked.delete(id);
+                    releasePointer(id, entry, reason);
+                }
+            }
+
+            window.addEventListener('pointerdown', function(e) {
+                if (e.pointerType !== 'touch' || e[SYNTHETIC]) return;
+                // A new primary touch means the browser considers no other
+                // touch active: everything still tracked is orphaned. A new
+                // non-primary touch may be a genuine second finger, so then
+                // only release pointers that have been silent for a while.
+                flushOrphans(e.isPrimary ? 'new primary touch' : 'stale pointer on new touch',
+                             e.isPrimary ? 0 : 5000, e.pointerId);
+                tracked.set(e.pointerId, {target: e.composedPath()[0] || e.target, lastSeen: Date.now()});
+            }, true);
+
+            window.addEventListener('pointermove', function(e) {
+                const entry = tracked.get(e.pointerId);
+                if (entry && !e[SYNTHETIC]) entry.lastSeen = Date.now();
+            }, true);
+
+            for (const type of ['pointerup', 'pointercancel']) {
+                window.addEventListener(type, function(e) {
+                    if (!e[SYNTHETIC]) tracked.delete(e.pointerId);
+                }, true);
+            }
+
+            // touchstart reports all current touches: a single touch while
+            // multiple pointers are tracked proves the older ones are
+            // orphaned. The 500ms minimum age protects the pointer belonging
+            // to this very touch (its pointerdown was dispatched just before).
+            window.addEventListener('touchstart', function(e) {
+                if (e.touches.length === 1 && tracked.size > 1)
+                    flushOrphans('single remaining touch', 500);
+            }, true);
+
+            // A gesture cannot legitimately continue once the page is hidden.
+            document.addEventListener('visibilitychange', function() {
+                if (document.hidden) flushOrphans('page hidden', 0);
+            });
+            window.addEventListener('pagehide', function() { flushOrphans('page hidden', 0); });
+
+            // Optional on-screen event log for on-device debugging: ?touchlog
+            function createOverlay() {
+                const div = document.createElement('div');
+                div.style.cssText = 'position:fixed;left:0;bottom:0;max-height:40%;overflow-y:auto;'
+                        + 'z-index:99999;background:rgba(0,0,0,0.75);color:#0f0;'
+                        + 'font:10px monospace;padding:4px;pointer-events:none;white-space:pre;';
+                document.body.appendChild(div);
+                const append = function(message) {
+                    div.textContent += new Date().toISOString().substr(11, 12) + ' ' + message + '\n';
+                    while (div.childNodes.length && div.textContent.length > 4000)
+                        div.textContent = div.textContent.substring(div.textContent.indexOf('\n') + 1);
+                    div.scrollTop = div.scrollHeight;
+                };
+                for (const type of ['pointerdown', 'pointerup', 'pointercancel']) {
+                    window.addEventListener(type, function(e) {
+                        append(type + ' id=' + e.pointerId + ' primary=' + e.isPrimary
+                                + ' type=' + e.pointerType + ' trusted=' + e.isTrusted
+                                + ' x=' + Math.round(e.clientX) + ' y=' + Math.round(e.clientY));
+                    }, true);
+                }
+                for (const type of ['touchstart', 'touchend', 'touchcancel']) {
+                    window.addEventListener(type, function(e) {
+                        append(type + ' touches=' + e.touches.length);
+                    }, true);
+                }
+                document.addEventListener('visibilitychange', function() {
+                    append('visibilitychange hidden=' + document.hidden);
+                });
+                return append;
+            }
+        })();
+    </script>
   </body>
 </html>

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -596,41 +596,35 @@
     <script type="text/javascript">
         // ---- Touch input recovery guard ---------------------------------
         //
-        // On iOS, system gestures that start on the page - the home-indicator
-        // swipe, App Switcher and Control Center swipes - deliver a trusted
-        // pointerdown (+ pointermoves) to the page, after which iOS takes over
-        // the gesture and never delivers the matching pointerup/pointercancel.
-        // This affects Safari, standalone home-screen webapps and WKWebView
-        // (as used by the VRM app).
+        // Workaround for a bug in the Qt WASM platform plugin: it removes a
+        // touch point from its per-pointer bookkeeping only on pointerup, so
+        // a touch that ends with pointercancel stays registered forever. The
+        // leaked, permanently-pressed touch point is then included in every
+        // later touch event and wedges Qt Quick's touch-to-mouse synthesis:
+        // all MouseArea-based controls stop reacting to touch until the page
+        // is reloaded, while the UI keeps rendering.
         //
-        // The Qt WASM platform plugin keeps such a touch point registered
-        // forever (it is only removed on pointerup, see QTBUG-147635), and one
-        // permanently-pressed touch point wedges Qt Quick's touch-to-mouse
-        // synthesis, so every MouseArea-based control in the application stops
-        // reacting to touch until the page is reloaded. See
-        // https://github.com/victronenergy/gui-v2/issues/3087.
+        // System gestures that start on the page trigger exactly this: the
+        // browser delivers pointerdown, the OS takes the gesture over, and
+        // the page receives pointercancel. Known triggers are the iOS
+        // home-indicator/App Switcher/Control Center swipes in standalone
+        // home-screen webapps (https://github.com/victronenergy/gui-v2/
+        // issues/3087, QTBUG-147635) and the Android system back gesture
+        // (QTBUG-141505).
         //
-        // This guard repairs two related WebKit/Qt failure modes, both of
-        // which corrupt Qt's touch state the same way:
-        // 1. a touch pointer whose pointerup/pointercancel is never delivered
-        //    (orphaned pointer) - flushed once it is provably orphaned;
-        // 2. a properly delivered pointercancel: Qt (up to at least 6.9)
-        //    removes touch points from its bookkeeping only on pointerup, so
-        //    a cancelled touch leaks a permanently-pressed point - repaired
-        //    by delivering the missing pointerup after the cancel. This is
-        //    the mode observed on iOS 27.
-        // Synthetic releases are preceded by a pointermove away from the
-        // press position so that the release cannot complete a stuck press
-        // into a spurious click.
+        // Fixed upstream by qtbase commit 9147c250 ("wasm: remove pointer
+        // ids on pointercancel"), first released in Qt 6.10.2; not
+        // backported to 6.8/6.9 LTS. This workaround is needed until gui-v2
+        // builds against a fixed Qt.
+        //
+        // The workaround: after Qt has processed a pointercancel, deliver
+        // the synthetic pointerup it needs to clean up its state. As a
+        // safety net, pointers whose end event never arrived at all
+        // (provably orphaned) are released the same way. The synthetic
+        // release is preceded by a pointermove away from the press position
+        // so that it cannot complete the stuck press into a spurious click.
         (function() {
             'use strict';
-
-            const params = new URLSearchParams(window.location.search);
-            const overlay = params.has('touchlog') ? createOverlay() : null;
-            const log = function(message) {
-                console.log('[touch-guard] ' + message);
-                if (overlay) overlay(message);
-            };
 
             // Qt calls setPointerCapture()/releasePointerCapture() unguarded
             // from its pointer event handlers. For a pointer the browser no
@@ -684,7 +678,7 @@
                     ev[SYNTHETIC] = true;
                     el.dispatchEvent(ev);
                 }
-                log('released orphaned touch pointer ' + id + ' (' + reason + ')');
+                console.log('[touch-guard] released touch pointer ' + id + ' (' + reason + ')');
             }
 
             function flushOrphans(reason, minAgeMs, exceptId) {
@@ -698,10 +692,10 @@
 
             window.addEventListener('pointerdown', function(e) {
                 if (e.pointerType !== 'touch' || e[SYNTHETIC]) return;
-                // A new primary touch means the browser considers no other
-                // touch active: everything still tracked is orphaned. A new
-                // non-primary touch may be a genuine second finger and is
-                // left alone.
+                // Safety net: a new primary touch means the browser considers
+                // no other touch active, so everything still tracked is
+                // orphaned. A new non-primary touch may be a genuine second
+                // finger and is left alone.
                 if (e.isPrimary)
                     flushOrphans('new primary touch', 0, e.pointerId);
                 tracked.set(e.pointerId, {target: e.composedPath()[0] || e.target, lastSeen: Date.now()});
@@ -711,24 +705,21 @@
                 if (!e[SYNTHETIC]) tracked.delete(e.pointerId);
             }, true);
 
-            // Failure mode 2: Qt removes a touch point from its bookkeeping
-            // only on pointerup, so a pointercancel leaves the point
-            // registered forever - with the same consequences as a pointer
-            // that never ends. Deliver the missing pointerup after Qt has
-            // processed the cancel (Qt stops propagation of pointer events,
-            // so a bubble-phase listener would never run; a task runs after
-            // the whole dispatch).
+            // The actual workaround: deliver the missing pointerup after Qt
+            // has processed the cancel. Scheduled as a task because Qt stops
+            // propagation of pointer events, so a bubble-phase listener
+            // would never run.
             window.addEventListener('pointercancel', function(e) {
                 if (e[SYNTHETIC] || e.pointerType !== 'touch') return;
                 const entry = tracked.get(e.pointerId) || { target: e.composedPath()[0] || e.target };
                 tracked.delete(e.pointerId);
                 const id = e.pointerId;
-                setTimeout(function() { releasePointer(id, entry, 'pointercancel leak repair'); }, 0);
+                setTimeout(function() { releasePointer(id, entry, 'pointercancel'); }, 0);
             }, true);
 
-            // touchstart also reports all current touches: a single touch
-            // while multiple pointers are tracked proves the older ones are
-            // orphaned (failure mode 1). The 500ms minimum age protects the
+            // Safety net: touchstart reports all current touches, so a
+            // single touch while multiple pointers are tracked proves the
+            // older ones are orphaned. The 500ms minimum age protects the
             // pointer belonging to this very touch.
             window.addEventListener('touchstart', function(e) {
                 if (e.touches.length === 1 && tracked.size > 1)
@@ -740,47 +731,6 @@
                 if (document.hidden) flushOrphans('page hidden', 0);
             });
             window.addEventListener('pagehide', function() { flushOrphans('page hidden', 0); });
-
-            // Optional on-screen event log for on-device debugging: ?touchlog
-            function createOverlay() {
-                const div = document.createElement('div');
-                div.style.cssText = 'position:fixed;left:0;bottom:0;max-height:40%;overflow-y:auto;'
-                        + 'z-index:99999;background:rgba(0,0,0,0.75);color:#0f0;'
-                        + 'font:10px monospace;padding:4px;pointer-events:none;white-space:pre;';
-                document.body.appendChild(div);
-                const append = function(message) {
-                    div.textContent += new Date().toISOString().substr(11, 12) + ' ' + message + '\n';
-                    while (div.childNodes.length && div.textContent.length > 4000)
-                        div.textContent = div.textContent.substring(div.textContent.indexOf('\n') + 1);
-                    div.scrollTop = div.scrollHeight;
-                };
-                for (const type of ['pointerdown', 'pointerup', 'pointercancel']) {
-                    window.addEventListener(type, function(e) {
-                        append(type + ' id=' + e.pointerId + ' primary=' + e.isPrimary
-                                + ' type=' + e.pointerType + ' trusted=' + e.isTrusted
-                                + ' x=' + Math.round(e.clientX) + ' y=' + Math.round(e.clientY)
-                                + ' tracked=' + tracked.size);
-                    }, true);
-                }
-                for (const type of ['touchstart', 'touchend', 'touchcancel']) {
-                    window.addEventListener(type, function(e) {
-                        append(type + ' touches=' + e.touches.length);
-                    }, true);
-                }
-                document.addEventListener('visibilitychange', function() {
-                    append('visibilitychange hidden=' + document.hidden);
-                });
-                for (const type of ['pagehide', 'pageshow', 'focus', 'blur']) {
-                    window.addEventListener(type, function(e) {
-                        append(type + (e.persisted !== undefined ? ' persisted=' + e.persisted : ''));
-                    });
-                }
-                append('touch-guard v3 active'
-                        + ' standalone=' + (navigator.standalone === true)
-                        + ' display-mode-standalone=' + window.matchMedia('(display-mode: standalone)').matches
-                        + ' ' + location.href);
-                return append;
-            }
         })();
     </script>
   </body>


### PR DESCRIPTION
## Summary

Touch input in the WASM app can die permanently — while the UI keeps rendering and updating — after the OS takes over a touch gesture that started on the page. On iOS home-screen webapps this happens on every home-indicator / App Switcher / Control Center swipe. On Android it happens with system back gesture, or bottom swipe up on the home indicator to reveal app switcher.

This PR adds a small, self-contained "touch input recovery guard" to `wasm/index.html` that works around the underlying Qt bug. No reload, no C++/QML changes, no effect on desktop or GX devices.

Fixes #3087.

## Root cause
  
This is a bug in the Qt WASM platform plugin, not in WebKit and not in gui-v2:

1. When the OS takes over a gesture (iOS bottom-edge swipes, Android back gesture), the browser correctly delivers `pointerdown` followed by **`pointercancel`** to the page. Verified with on-device event logging on iOS 27.
2. The Qt WASM platform plugin (`qwasmwindowclientarea.cpp` / `qwasmwindow.cpp`) keeps a per-pointer touch map, but removes entries **only on `pointerup`** — a touch ending in `pointercancel` leaks a permanently-registered, permanently-pressed touch point.
3. That stale point is included in every subsequent touch event Qt delivers, which wedges Qt Quick's touch→mouse synthesis (`touchMouseId`). Since gui-v2's tap surfaces are largely MouseArea-based (`PressArea`, `ListPressArea`, `idleModeMouseArea`), effectively all touch input goes dead until the page is reloaded.

## Upstream status

Reported upstream as [QTBUG-141505](https://qt-project.atlassian.net/browse/QTBUG-141505) (Android back gesture, closed/fixed) and [QTBUG-147635](https://qt-project.atlassian.net/browse/QTBUG-147635) (this iOS symptom, still open, not yet linked to the root cause).

Fixed by a one-line change in qtbase:
[`9147c25004` — "wasm: remove pointer ids on pointercancel"](https://github.com/qt/qtbase/commit/9147c25004) (Dec 2025, `Pick-to: 6.10 6.11`).

| Qt version | Contains the fix |
|---|---|
| 6.8.x (gui-v2 wasm toolchain: **6.8.3**) | ❌ no backport |
| 6.9.x (incl. 6.9.3) | ❌ no backport |
| 6.10.0 / 6.10.1 | ❌ |
| **6.10.2+** | ✅ |
| 6.11+ / dev | ✅ |

## The workaround
  
A capture-phase script block in `wasm/index.html`:

- After Qt has processed a trusted `pointercancel`, it dispatches the missing synthetic `pointerup` into Qt's client-area element (inside the `#screen` shadow DOM) so Qt cleans up its per-pointer state — the exact cleanup the upstream fix performs internally. The release is preceded by a `pointermove` away from
  the press position so it cannot complete the stuck press into a spurious click.
- As a safety net, touch pointers whose end event never arrived at all are released the same way, but only on provable triggers (page hidden, a new *primary* touch, a `touchstart` reporting a single remaining touch).
- `Element.prototype.setPointerCapture`/`releasePointerCapture` are wrapped to be non-throwing, because Qt calls them unguarded and a `NotFoundError` for an inactive pointer aborts Qt's event handler mid-dispatch.

## Validation

- **On device (iPhone, iOS 27 → Cerbo GX):** swiping to the App Switcher previously left touch dead until reload; with the guard, the log shows `pointercancel` followed by the guard's repair, and touch works immediately after returning.
- **On device (Samsung, Android 16 → Cerbo GX):** swiping to the App Switcher previously left touch dead until reload; with the guard, the log shows `pointercancel` followed by the guard's repair, and touch works immediately after returning.
- **Headless (Chromium + CDP trusted touch injection against the wasm build):** baseline taps/flicks unaffected; cancel-ending and never-ending gestures both recover; the repair itself causes no page change.

## Notes

- VRM ships its own `index.html`, so it needs the same guard (coordination required).
- This entire script block can be dropped once the wasm toolchain moves to Qt ≥ 6.10.2 (or the upstream fix is backported to 6.8/6.9 LTS).
- Suggested upstream follow-up: comment on QTBUG-147635 linking QTBUG-141505 and `9147c25004`, noting the mechanism reproduces on iOS standalone webapps, and request an LTS backport.
