### PR TITLE
EVCS: show auto mode source and hide charge current in auto mode

### DIFF
--- a/pages/evcs/EvChargerPage.qml
+++ b/pages/evcs/EvChargerPage.qml
@@ -136,25 +136,17 @@ DevicePage {
 		ListText {
 			//% "Auto mode source"
 			text: qsTrId("evcs_auto_mode_source")
-			//% "Internal (EV Charging Station)"
-			readonly property string evcsInternalText: qsTrId("evcs_auto_mode_source_evcs_internal")
-			readonly property string externalSourceName: {
-				if (gxAutoModeSource.valid && gxAutoModeSource.value !== undefined && gxAutoModeSource.value !== null) {
-					const sourceText = String(gxAutoModeSource.value).trim()
-					if (sourceText.length > 0) {
-						return sourceText
-					}
-				}
-				//% "GX device"
-				return qsTrId("gx_device")
-			}
-			//: %1 = source string from /GxAutoMode/Source, or "GX" when not available
+			readonly property string externalSourceName: (gxAutoModeSource.value ?? "")
+					//% "GX device"
+					|| qsTrId("gx_device")
+			//: %1 = source string from /GxAutoMode/Source, or "GX device" when not available
 			//% "External (%1)"
-			secondaryText: Number(dataItem.value) === 1
+			secondaryText: dataItem.value === 1
 						   ? qsTrId("evcs_auto_mode_source_external_with_source").arg(externalSourceName)
-						   : evcsInternalText
+						   //% "Internal (EV Charging Station)"
+						   : qsTrId("evcs_auto_mode_source_evcs_internal")
 			dataItem.uid: evCharger.serviceUid + "/GxAutoMode/Enabled"
-			preferredVisible: dataItem.valid && Number(chargeMode.dataItem.value) === VenusOS.Evcs_Mode_Auto
+			preferredVisible: dataItem.valid && chargeMode.dataItem.value === VenusOS.Evcs_Mode_Auto
 
 			VeQuickItem {
 				id: gxAutoModeSource

--- a/pages/evcs/EvChargerPage.qml
+++ b/pages/evcs/EvChargerPage.qml
@@ -133,10 +133,39 @@ DevicePage {
 			writeAccessLevel: VenusOS.User_AccessType_User
 		}
 
+		ListText {
+			//% "Auto mode source"
+			text: qsTrId("evcs_auto_mode_source")
+			//% "Internal (EV Charging Station)"
+			readonly property string evcsInternalText: qsTrId("evcs_auto_mode_source_evcs_internal")
+			readonly property string externalSourceName: {
+				if (gxAutoModeSource.valid && gxAutoModeSource.value !== undefined && gxAutoModeSource.value !== null) {
+					const sourceText = String(gxAutoModeSource.value).trim()
+					if (sourceText.length > 0) {
+						return sourceText
+					}
+				}
+				//% "GX device"
+				return qsTrId("gx_device")
+			}
+			//: %1 = source string from /GxAutoMode/Source, or "GX" when not available
+			//% "External (%1)"
+			secondaryText: Number(dataItem.value) === 1
+						   ? qsTrId("evcs_auto_mode_source_external_with_source").arg(externalSourceName)
+						   : evcsInternalText
+			dataItem.uid: evCharger.serviceUid + "/GxAutoMode/Enabled"
+			preferredVisible: dataItem.valid && Number(chargeMode.dataItem.value) === VenusOS.Evcs_Mode_Auto
+
+			VeQuickItem {
+				id: gxAutoModeSource
+				uid: evCharger.serviceUid + "/GxAutoMode/Source"
+			}
+		}
+
 		ListEvcsSetCurrentSpinBox {
 			serviceUid: evCharger.serviceUid
 			text: CommonWords.charge_current
-			interactive: dataItem.valid && chargeMode.dataItem.value === VenusOS.Evcs_Mode_Manual
+			preferredVisible: dataItem.valid && chargeMode.dataItem.value === VenusOS.Evcs_Mode_Manual
 		}
 
 		ListSwitch {


### PR DESCRIPTION
- add Auto mode source row below Charge mode
- show row only when mode is Auto and GxAutoMode path is available
- use GxAutoMode/Source for external label when present, fallback to External (GX device)
- show charge current only in Manual mode