### PR TITLE
AC System: rename "RS devices" to "Inverters"

### DIFF
--- a/pages/settings/devicelist/rs/PageRsSystem.qml
+++ b/pages/settings/devicelist/rs/PageRsSystem.qml
@@ -95,8 +95,8 @@ Page {
 			}
 
 			ListNavigation {
-				//% "RS devices"
-				text: qsTrId("settings_rs_devices")
+				//% "Inverters"
+				text: qsTrId("settings_rssystem_inverters")
 				onClicked: {
 					Global.pageManager.pushPage("/pages/settings/devicelist/rs/PageRsSystemDevices.qml",
 							{ "title": text, "bindPrefix": root.bindPrefix })


### PR DESCRIPTION
The PageRsSystem is shown for any AC System drilldown. The devices which are exposed under the RS System are inverter devices, so the list navigation item should have the appropriately specific "Inverters" text.

Contributes to issue #3155