### PR TITLE
Portrait: fix clicks on first button of navigation bar "more" dialog

### DIFF
--- a/components/dialogs/NavBarMoreDialog.qml
+++ b/components/dialogs/NavBarMoreDialog.qml
@@ -118,8 +118,8 @@ ModalDialog {
 				checked: true
 				enabled: false
 			}
-			onCurrentIndexChanged: {
-				root.buttonClicked(currentIndex)
+			onButtonClicked: (pageIndex) => {
+				root.buttonClicked(pageIndex)
 			}
 		}
 	}


### PR DESCRIPTION
Use onButtonClicked handler rather than onCurrentIndexChanged. The default currentIndex is zero, so if you click the first button, the currentIndex does not change and the signal handler does not fire.

Fixes #3161