### PR TITLE
Wasm: normalize generic deleteContent input events to backspace

### DIFF
--- a/wasm/index.html
+++ b/wasm/index.html
@@ -951,5 +951,42 @@
             };
         })();
     </script>
+    <script type="text/javascript">
+        // ---- Virtual keyboard backspace normalization --------------------
+        //
+        // Qt's WASM input context only synthesizes backspace/delete for the
+        // directional inputTypes "deleteContentBackward"/"...Forward" and
+        // drops other deletion inputTypes. Virtual keyboards that drive the
+        // editor via generic editing commands (Garmin OneHelm's embedded
+        // WebKit, https://github.com/victronenergy/gui-v2/issues/3153)
+        // produce the direction-agnostic "deleteContent" instead, with
+        // keydown reported as key="Unidentified"/keyCode=229 — so backspace
+        // never reaches the QML text field.
+        //
+        // Rewrite "deleteContent" to "deleteContentBackward" on Qt's hidden
+        // IME <input> (identified by the "data-qinputcontext" JS property Qt
+        // sets on it) before Qt sees the event: a capture-phase listener on
+        // document runs first, and the own property shadows the read-only
+        // prototype getter. Semantically safe: both mean "delete selection,
+        // else the character before the cursor". Reported upstream as
+        // QTBUG-149393; needed until gui-v2 builds against a fixed Qt.
+        (function() {
+            'use strict';
+
+            document.addEventListener('input', function(event) {
+                const target = event.target;
+                if (!target
+                        || target.tagName !== 'INPUT'
+                        || typeof target['data-qinputcontext'] === 'undefined'
+                        || event.inputType !== 'deleteContent') {
+                    return;
+                }
+                Object.defineProperty(event, 'inputType', {
+                    configurable: true,
+                    value: 'deleteContentBackward'
+                });
+            }, true);
+        })();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
Qt's WASM input context only synthesizes `Qt::Key_Backspace`/`Qt::Key_Delete` for the directional inputTypes `deleteContentBackward`/`deleteContentForward` and silently drops the direction-agnostic `deleteContent` (Input Events Level 2). Virtual keyboards that drive the browser editor through generic editing commands rather than key events produce exactly that: WebKit maps `EditAction::Delete` and `EditAction::TypingDeleteSelection` to `"deleteContent"` (`WebCore/editing/EditCommand.cpp`), and the accompanying keydown is `key="Unidentified"`/`keyCode=229`, so Qt gets no usable signal from the keyboard event either. Result: the hidden IME `<input>` mutates but backspace never reaches the QML field. Seen in the field on Garmin OneHelm's embedded WebKit (#3153).

This adds a capture-phase document listener that rewrites `inputType` to `deleteContentBackward` on input events targeting Qt's hidden IME input (identified by the `data-qinputcontext` property Qt sets on it), before Qt's own listener runs. Semantically safe: `deleteContent` means "delete selection, direction unspecified" and backspace deletes the selection if present, else the previous character — identical in every reachable case. No mainstream browser emits `deleteContent` for a plain backspace (Blink does not implement that inputType at all), so this is inert outside the affected devices.

Based on the workaround suggested by the reporter in #3153.

### Verification

Reproduced and verified headlessly against the current wasm build (Playwright driving the app to the root password field, injecting `input` events on Qt's hidden IME input — emulating what Garmin's WebKit delivers natively):

| Injected event | without this PR | with this PR |
|---|---|---|
| `inputType: "deleteContent"` | ignored (the #3153 bug) | deletes one character |
| `inputType: "deleteContentBackward"` (control) | deletes one character | deletes one character |

Synthetic events exercise the same listener path as Garmin's trusted native events, but this has not been validated on real OneHelm hardware — confirmation by the reporter on-device is needed before merging.

Unfixed upstream as of Qt 6.8/6.9 LTS and dev; reported as [QTBUG-149393](https://bugreports.qt.io/browse/QTBUG-149393), after which this workaround can be dropped once gui-v2 builds against a fixed Qt. Note: VRM ships its own `index.html` and needs the same shim.

Fixes #3153
