### PR TITLE
BLE sensors: add BLE bridge pairing and reorganize settings

### DIFF
--- a/cmake/ModuleVenus_Sources.cmake
+++ b/cmake/ModuleVenus_Sources.cmake
@@ -200,6 +200,7 @@ set (VictronVenusOS_QML_MODULE_SOURCES
     components/dialogs/SecurityProfilePasswordDialog.qml
     components/dialogs/SolarDailyHistoryDialog.qml
     components/dialogs/TimeSelectorDialog.qml
+    components/dialogs/UnpairDialog.qml
 
     components/listitems/ListAcInError.qml
     components/listitems/ListActiveAcInput.qml
@@ -230,6 +231,7 @@ set (VictronVenusOS_QML_MODULE_SOURCES
     components/listitems/ListMotorDriveGear.qml
     components/listitems/ListMqttAccessSwitch.qml
     components/listitems/ListMountStateButton.qml
+    components/listitems/ListPairingModeButton.qml
     components/listitems/ListAcInPositionRadioButtonGroup.qml
     components/listitems/ListOutputBatteryRadioButtonGroup.qml
     components/listitems/ListPvInverterPositionRadioButtonGroup.qml
@@ -239,6 +241,7 @@ set (VictronVenusOS_QML_MODULE_SOURCES
     components/listitems/ListGeneratorAutoStartSwitch.qml
     components/listitems/ListTemperatureRelay.qml
     components/listitems/ListTextStatus.qml
+    components/listitems/ListUnpairButton.qml
     components/listitems/ListVoltageCurrentPower.qml
     components/listitems/ListVolumeUnitRadioButtonGroup.qml
 

--- a/components/dialogs/UnpairDialog.qml
+++ b/components/dialogs/UnpairDialog.qml
@@ -1,0 +1,18 @@
+/*
+** Copyright (C) 2026 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+ModalWarningDialog {
+	required property string name
+
+	//% "Unpairing %1"
+	title: qsTrId("unpairing_confirm_title").arg(name)
+
+	//% "This will disconnect the device and it will need to be paired again to reconnect."
+	description: qsTrId("unpairing_confirm_description")
+	dialogDoneOptions: VenusOS.ModalDialog_DoneOptions_OkAndCancel
+}

--- a/components/listitems/ListPairingModeButton.qml
+++ b/components/listitems/ListPairingModeButton.qml
@@ -1,0 +1,45 @@
+/*
+** Copyright (C) 2026 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+ListButton {
+	id: root
+
+	required property string countDownUid
+
+	//% "Pairing mode"
+	text: qsTrId("mqtt_devices_pairing_mode")
+	secondaryText: readOnly
+			  //: %1 = number of seconds remaining
+			  //% "Active \u2022 %1s remaining"
+			? qsTrId("mqtt_devices_pairing_active").arg(pairingCountDown.secondsRemaining)
+			  //% "Activate"
+			: qsTrId("mqtt_devices_pairing_activate")
+	readOnly: pairingCountDown.secondsRemaining > 0
+	writeAccessLevel: VenusOS.User_AccessType_User
+
+	VeQuickItem {
+		id: pairingCountDown
+
+		property bool notificationShown
+		readonly property int secondsRemaining: value || 0
+
+		uid: root.countDownUid
+		onSecondsRemainingChanged: {
+			if (secondsRemaining > 0) {
+				if (!notificationShown) {
+					Global.showToastNotification(VenusOS.Notification_Info,
+							//% "Pairing mode enabled for %1 seconds"
+							qsTrId("mqtt_devices_pairing_enabled").arg(secondsRemaining), 5000)
+				}
+				notificationShown = true
+			} else {
+				notificationShown = false
+			}
+		}
+	}
+}

--- a/components/listitems/ListUnpairButton.qml
+++ b/components/listitems/ListUnpairButton.qml
@@ -1,0 +1,15 @@
+/*
+** Copyright (C) 2026 Victron Energy B.V.
+** See LICENSE.txt for license information.
+*/
+
+import QtQuick
+import Victron.VenusOS
+
+ListButton {
+	//% "Unpair"
+	secondaryText: qsTrId("devices_pairing_unpair")
+	writeAccessLevel: VenusOS.User_AccessType_User
+	buttonBorderColor: Theme.color_red
+	buttonBackgroundColor: Theme.color_darkRed
+}

--- a/data/mock/PlatformImpl.qml
+++ b/data/mock/PlatformImpl.qml
@@ -10,6 +10,10 @@ Item {
 	id: root
 
 	property var userTokens: []
+	property var bleUserTokens: [
+		{ token_name: "ble_token/ble_gw/Living Room" },
+		{ token_name: "ble_token/ble_gw/Garage" },
+	]
 
 	function setPlatformValue(path, value) {
 		MockManager.setValue(Global.venusPlatform.serviceUid + path, value)
@@ -30,8 +34,23 @@ Item {
 		root.userTokens = temp
 	}
 
+	function removeBleToken(tokenName) {
+		let temp = root.bleUserTokens.slice()
+		for (let i = 0; i < temp.length; ++i) {
+			if (temp[i].token_name === tokenName) {
+				temp.splice(i, 1)
+				break
+			}
+		}
+		root.bleUserTokens = temp
+	}
+
 	onUserTokensChanged: {
 		setPlatformValue("/Tokens/Users", JSON.stringify(userTokens))
+	}
+
+	onBleUserTokensChanged: {
+		setPlatformValue("/BleTokens/Users", JSON.stringify(bleUserTokens))
 	}
 
 	// Set /Tokens/Users according to the available evcharger services.
@@ -78,6 +97,11 @@ Item {
 		id: pairingRemove
 		uid: Global.venusPlatform.serviceUid + "/Tokens/Remove"
 		onValueChanged: root.removeToken(value)
+	}
+
+	VeQuickItem {
+		uid: Global.venusPlatform.serviceUid + "/BleTokens/Remove"
+		onValueChanged: root.removeBleToken(value)
 	}
 
 	Timer {

--- a/pages/settings/PageSettingsBleSensors.qml
+++ b/pages/settings/PageSettingsBleSensors.qml
@@ -40,66 +40,22 @@ Page {
 				dataItem.uid: Global.systemSettings.serviceUid + "/Settings/Services/BleSensors"
 			}
 
-			ListSwitch {
-				id: contScan
-				//% "Continuous scanning"
-				text: qsTrId("settings_continuous_scan")
-				dataItem.uid: root.bleServiceUid + "/ContinuousScan"
-				preferredVisible: enable.checked
-			}
-
-			PrimaryListLabel {
-				//% "Continuous scanning may interfere with Wi-Fi operation."
-				text: qsTrId("settings_continuous_scan_may_interfere")
-				preferredVisible: contScan.checked
-			}
-
 			ListNavigation {
-				//% "Bluetooth adapters"
-				text: qsTrId("settings_io_bluetooth_adapters")
+				//% "Advanced"
+				text: qsTrId("settings_ble_advanced")
 				preferredVisible: enable.checked
-				onClicked: Global.pageManager.pushPage(bluetoothAdaptersComponent, {"title": text})
-
-				Component {
-					id: bluetoothAdaptersComponent
-
-					Page {
-						GradientListView {
-							model: VeQItemSortTableModel {
-								model: VeQItemChildModel {
-									model: interfaces
-									childId: "Address"
-								}
-								dynamicSortFilter: true
-								filterFlags: VeQItemSortTableModel.FilterInvalid
-							}
-							delegate: ListText {
-								text: model.item.itemParent().id
-								dataItem.uid: model.item.uid
-							}
-						}
-					}
-				}
+				onClicked: Global.pageManager.pushPage(advancedPageComponent, {"title": text})
 			}
 
-			ListRadioButtonGroup {
-				id: gatewayAccess
-				//% "BLE gateway access"
-				text: qsTrId("settings_ble_gateway_access")
-				dataItem.uid: root.bleServiceUid + "/Socket/BindAddress"
-				preferredVisible: enable.checked && dataItem.valid
-				optionModel: [
-					{ display: CommonWords.disabled, value: "" },
-					//% "Proxy"
-					{ display: qsTrId("settings_ble_gateway_access_proxy"), value: "127.0.0.1" },
-					//% "Proxy and direct"
-					{ display: qsTrId("settings_ble_gateway_access_proxy_and_direct"), value: "0.0.0.0" },
-				]
+			SectionHeader {
+				//% "Sensors"
+				text: qsTrId("settings_ble_sensors")
+				preferredVisible: enable.checked && sensorRepeater.count > 0
 			}
 
 			SettingsColumn {
 				width: parent ? parent.width : 0
-				preferredVisible: sensorRepeater.count > 0
+				preferredVisible: enable.checked && sensorRepeater.count > 0
 
 				Repeater {
 					id: sensorRepeater
@@ -117,6 +73,186 @@ Page {
 
 						devicePrefix: item.itemParent().uid
 						deviceName: item.value || ""
+					}
+				}
+			}
+		}
+	}
+
+	Component {
+		id: advancedPageComponent
+
+		Page {
+			VeQuickItem {
+				id: bleTokenUsers
+				uid: Global.venusPlatform.serviceUid + "/BleTokens/Users"
+				onValueChanged: {
+					if (!valid) {
+						bleTokensView.model = []
+						return
+					}
+					let model = []
+					try {
+						model = JSON.parse(value)
+					} catch (e) {
+						console.warn(uid, ": unable to parse JSON:", value, "exception:", e)
+						model = []
+					}
+					bleTokensView.model = model
+				}
+			}
+
+			GradientListView {
+				id: bleTokensView
+
+				header: SettingsColumn {
+					width: parent?.width ?? 0
+
+					ListNavigation {
+						//% "Bluetooth adapters"
+						text: qsTrId("settings_io_bluetooth_adapters")
+						onClicked: Global.pageManager.pushPage(bluetoothAdaptersComponent, {"title": text})
+
+						Component {
+							id: bluetoothAdaptersComponent
+
+							Page {
+								GradientListView {
+									model: VeQItemSortTableModel {
+										model: VeQItemChildModel {
+											model: interfaces
+											childId: "Address"
+										}
+										dynamicSortFilter: true
+										filterFlags: VeQItemSortTableModel.FilterInvalid
+									}
+									delegate: ListText {
+										text: model.item.itemParent().id
+										dataItem.uid: model.item.uid
+									}
+								}
+							}
+						}
+					}
+
+					ListSwitch {
+						id: contScan
+						//% "Continuous scanning"
+						text: qsTrId("settings_continuous_scan")
+						dataItem.uid: root.bleServiceUid + "/ContinuousScan"
+					}
+
+					PrimaryListLabel {
+						//% "Continuous scanning may interfere with Wi-Fi operation."
+						text: qsTrId("settings_continuous_scan_may_interfere")
+						preferredVisible: contScan.checked
+					}
+
+					ListRadioButtonGroup {
+						id: gatewayAccess
+						topInset: Theme.geometry_listItem_itemSeparator_height
+						//% "BLE bridge access"
+						text: qsTrId("settings_ble_bridge_access")
+						dataItem.uid: root.bleServiceUid + "/Socket/BindAddress"
+						preferredVisible: dataItem.valid
+
+						readonly property bool _isCustom: dataItem.valid && dataItem.value !== "" && dataItem.value !== "127.0.0.1"
+
+						optionModel: [
+							{ display: CommonWords.disabled, value: "" },
+							//% "Paired devices only"
+							{ display: qsTrId("settings_ble_bridge_access_paired_only"), value: "127.0.0.1" },
+						].concat(_isCustom ? [
+							//% "Custom"
+							{ display: qsTrId("settings_ble_bridge_access_custom"), value: dataItem.value, readOnly: _isCustom },
+						] : [])
+					}
+
+					ListButton {
+						//% "Pairing mode"
+						text: qsTrId("mqtt_devices_pairing_mode")
+						secondaryText: readOnly
+								  //: %1 = number of seconds remaining
+								  //% "Active \u2022 %1s remaining"
+								? qsTrId("mqtt_devices_pairing_active").arg(blePairingCountDown.secondsRemaining)
+								  //% "Activate"
+								: qsTrId("mqtt_devices_pairing_activate")
+						readOnly: blePairingCountDown.secondsRemaining > 0
+						preferredVisible: blePairingEnable.valid && !!gatewayAccess.currentValue
+						writeAccessLevel: VenusOS.User_AccessType_User
+
+						onClicked: blePairingEnable.setValue("")
+
+						VeQuickItem {
+							id: blePairingEnable
+							uid: Global.venusPlatform.serviceUid + "/Tokens/Pairing/Enable"
+						}
+
+						VeQuickItem {
+							id: blePairingCountDown
+
+							property bool notificationShown
+							readonly property int secondsRemaining: value || 0
+
+							uid: Global.venusPlatform.serviceUid + "/Tokens/Pairing/CountDown"
+							onSecondsRemainingChanged: {
+								if (secondsRemaining > 0) {
+									if (!notificationShown) {
+										Global.showToastNotification(VenusOS.Notification_Info,
+												//% "Pairing mode enabled for %1 seconds"
+												qsTrId("mqtt_devices_pairing_enabled").arg(secondsRemaining), 5000)
+									}
+									notificationShown = true
+								} else {
+									notificationShown = false
+								}
+							}
+						}
+					}
+
+					SectionHeader {
+						//% "Paired BLE bridges"
+						text: qsTrId("pairing_ble_paired_bridges")
+						visible: bleTokensView.count > 0
+					}
+				}
+
+				delegate: ListButton {
+					required property var modelData
+					readonly property string tokenName: modelData["token_name"] ?? ""
+					readonly property var tokenNameParts: tokenName.split("/")
+
+					text: tokenNameParts[tokenNameParts.length - 1] ?? ""
+					//% "Unpair"
+					secondaryText: qsTrId("mqtt_devices_pairing_unpair")
+					writeAccessLevel: VenusOS.User_AccessType_User
+					buttonBorderColor: Theme.color_red
+					buttonBackgroundColor: Theme.color_darkRed
+					onClicked: {
+						Global.dialogLayer.open(bleUnpairDialogComponent, { tokenName: tokenName })
+					}
+				}
+			}
+
+			Component {
+				id: bleUnpairDialogComponent
+
+				ModalWarningDialog {
+					required property string tokenName
+
+					//% "Unpairing %1"
+					title: qsTrId("mqtt_devices_unpairing_confirm_title").arg(tokenName.split("/").pop())
+
+					//% "This will disconnect the device and it will need to be paired again to reconnect."
+					description: qsTrId("mqtt_devices_unpairing_confirm_description")
+					dialogDoneOptions: VenusOS.ModalDialog_DoneOptions_OkAndCancel
+					onAccepted: {
+						bleTokenRemove.setValue(tokenName)
+					}
+
+					VeQuickItem {
+						id: bleTokenRemove
+						uid: Global.venusPlatform.serviceUid + "/BleTokens/Remove"
 					}
 				}
 			}

--- a/pages/settings/PageSettingsBleSensors.qml
+++ b/pages/settings/PageSettingsBleSensors.qml
@@ -168,45 +168,14 @@ Page {
 						] : [])
 					}
 
-					ListButton {
-						//% "Pairing mode"
-						text: qsTrId("mqtt_devices_pairing_mode")
-						secondaryText: readOnly
-								  //: %1 = number of seconds remaining
-								  //% "Active \u2022 %1s remaining"
-								? qsTrId("mqtt_devices_pairing_active").arg(blePairingCountDown.secondsRemaining)
-								  //% "Activate"
-								: qsTrId("mqtt_devices_pairing_activate")
-						readOnly: blePairingCountDown.secondsRemaining > 0
+					ListPairingModeButton {
+						countDownUid: Global.venusPlatform.serviceUid + "/Tokens/Pairing/CountDown"
 						preferredVisible: blePairingEnable.valid && !!gatewayAccess.currentValue
-						writeAccessLevel: VenusOS.User_AccessType_User
-
 						onClicked: blePairingEnable.setValue("")
 
 						VeQuickItem {
 							id: blePairingEnable
 							uid: Global.venusPlatform.serviceUid + "/Tokens/Pairing/Enable"
-						}
-
-						VeQuickItem {
-							id: blePairingCountDown
-
-							property bool notificationShown
-							readonly property int secondsRemaining: value || 0
-
-							uid: Global.venusPlatform.serviceUid + "/Tokens/Pairing/CountDown"
-							onSecondsRemainingChanged: {
-								if (secondsRemaining > 0) {
-									if (!notificationShown) {
-										Global.showToastNotification(VenusOS.Notification_Info,
-												//% "Pairing mode enabled for %1 seconds"
-												qsTrId("mqtt_devices_pairing_enabled").arg(secondsRemaining), 5000)
-									}
-									notificationShown = true
-								} else {
-									notificationShown = false
-								}
-							}
 						}
 					}
 
@@ -217,17 +186,12 @@ Page {
 					}
 				}
 
-				delegate: ListButton {
+				delegate: ListUnpairButton {
 					required property var modelData
 					readonly property string tokenName: modelData["token_name"] ?? ""
 					readonly property var tokenNameParts: tokenName.split("/")
 
 					text: tokenNameParts[tokenNameParts.length - 1] ?? ""
-					//% "Unpair"
-					secondaryText: qsTrId("mqtt_devices_pairing_unpair")
-					writeAccessLevel: VenusOS.User_AccessType_User
-					buttonBorderColor: Theme.color_red
-					buttonBackgroundColor: Theme.color_darkRed
 					onClicked: {
 						Global.dialogLayer.open(bleUnpairDialogComponent, { tokenName: tokenName })
 					}
@@ -237,15 +201,10 @@ Page {
 			Component {
 				id: bleUnpairDialogComponent
 
-				ModalWarningDialog {
+				UnpairDialog {
 					required property string tokenName
 
-					//% "Unpairing %1"
-					title: qsTrId("mqtt_devices_unpairing_confirm_title").arg(tokenName.split("/").pop())
-
-					//% "This will disconnect the device and it will need to be paired again to reconnect."
-					description: qsTrId("mqtt_devices_unpairing_confirm_description")
-					dialogDoneOptions: VenusOS.ModalDialog_DoneOptions_OkAndCancel
+					name: tokenName.split("/").pop() ?? ""
 					onAccepted: {
 						bleTokenRemove.setValue(tokenName)
 					}

--- a/pages/settings/PageSettingsMqttDevices.qml
+++ b/pages/settings/PageSettingsMqttDevices.qml
@@ -50,45 +50,14 @@ Page {
 		header: SettingsColumn {
 			width: parent?.width ?? 0
 
-			ListButton {
-				//% "Pairing mode"
-				text: qsTrId("mqtt_devices_pairing_mode")
-				secondaryText: readOnly
-						  //: %1 = number of seconds remaining
-						  //% "Active \u2022 %1s remaining"
-						? qsTrId("mqtt_devices_pairing_active").arg(pairingCountDown.secondsRemaining)
-						  //% "Activate"
-						: qsTrId("mqtt_devices_pairing_activate")
-				readOnly: pairingCountDown.secondsRemaining > 0
+			ListPairingModeButton {
+				countDownUid: Global.venusPlatform.serviceUid + "/Tokens/Pairing/CountDown"
 				preferredVisible: pairingEnable.valid
-				writeAccessLevel: VenusOS.User_AccessType_User
-
 				onClicked: pairingEnable.setValue("")
 
 				VeQuickItem {
 					id: pairingEnable
 					uid: Global.venusPlatform.serviceUid + "/Tokens/Pairing/Enable"
-				}
-
-				VeQuickItem {
-					id: pairingCountDown
-
-					property bool notificationShown
-					readonly property int secondsRemaining: value || 0
-
-					uid: Global.venusPlatform.serviceUid + "/Tokens/Pairing/CountDown"
-					onSecondsRemainingChanged: {
-						if (secondsRemaining > 0) {
-							if (!notificationShown) {
-								Global.showToastNotification(VenusOS.Notification_Info,
-										//% "Pairing mode enabled for %1 seconds"
-										qsTrId("mqtt_devices_pairing_enabled").arg(secondsRemaining), 5000)
-							}
-							notificationShown = true
-						} else {
-							notificationShown = false
-						}
-					}
 				}
 			}
 
@@ -106,17 +75,12 @@ Page {
 			}
 		}
 
-		delegate: ListButton {
+		delegate: ListUnpairButton {
 			required property var modelData
 			readonly property string tokenName: modelData["token_name"] ?? ""
 			readonly property var tokenNameParts: tokenName.split("/")
 
 			text: "%1 (%2)".arg(root._findProductName(tokenNameParts[1])).arg(tokenNameParts[2] ?? "")
-			//% "Unpair"
-			secondaryText: qsTrId("mqtt_devices_pairing_unpair")
-			writeAccessLevel: VenusOS.User_AccessType_User
-			buttonBorderColor: Theme.color_red
-			buttonBackgroundColor: Theme.color_darkRed
 			onClicked: {
 				Global.dialogLayer.open(unpairDialogComponent, { tokenName: tokenName })
 			}
@@ -126,15 +90,10 @@ Page {
 	Component {
 		id: unpairDialogComponent
 
-		ModalWarningDialog {
+		UnpairDialog {
 			required property string tokenName
 
-			//% "Unpairing %1"
-			title: qsTrId("mqtt_devices_unpairing_confirm_title").arg(tokenName.split("/")[2] ?? "")
-
-			//% "This will disconnect the device and it will need to be paired again to reconnect."
-			description: qsTrId("mqtt_devices_unpairing_confirm_description")
-			dialogDoneOptions: VenusOS.ModalDialog_DoneOptions_OkAndCancel
+			name: tokenName.split("/").pop() ?? ""
 			onAccepted: {
 				pairingRemove.setValue(tokenName)
 			}

--- a/pages/settings/PageSettingsMqttDevices.qml
+++ b/pages/settings/PageSettingsMqttDevices.qml
@@ -100,8 +100,8 @@ Page {
 			}
 
 			SectionHeader {
-				//% "Access tokens for paired devices"
-				text: qsTrId("mqtt_devices_pairing_access_tokens")
+				//% "Paired devices"
+				text: qsTrId("pairing_mqtt_paired_devices")
 				visible: mqttDevicesView.count > 0
 			}
 		}


### PR DESCRIPTION
Add pairing mode for BLE bridges with configurable access levels (disabled, paired only, custom) and paired bridge management with unpair support. Move advanced settings (Bluetooth adapters, continuous scanning, bridge access, pairing) to a dedicated sub-page so the sensor list stays prominent. Only show the Custom access option (readonly) when a non-standard address is set.