### PR TITLE
Update alarms and error codes for Lynx Smart BMS

### DIFF
--- a/pages/settings/devicelist/battery/PageBatteryAlarms.qml
+++ b/pages/settings/devicelist/battery/PageBatteryAlarms.qml
@@ -165,7 +165,7 @@ Page {
 			}
 
 			ListAlarm {
-				//% "BMS cable fault"
+				//% "Battery communication lost"
 				text: qsTrId("batteryalarms_bms_cable")
 				dataItem.uid: root.bindPrefix + "/Alarms/BmsCable"
 				preferredVisible: dataItem.valid

--- a/pages/settings/devicelist/battery/PageBatteryAlarms.qml
+++ b/pages/settings/devicelist/battery/PageBatteryAlarms.qml
@@ -177,6 +177,13 @@ Page {
 				dataItem.uid: root.bindPrefix + "/Alarms/Contactor"
 				preferredVisible: dataItem.valid
 			}
+
+			ListAlarm {
+				//% "Cell measurements fault"
+				text: qsTrId("batteryalarms_cell_measurements_fault")
+				dataItem.uid: root.bindPrefix + "/Alarms/CellMeasurementsFault"
+				preferredVisible: dataItem.valid
+			}
 		}
 	}
 }


### PR DESCRIPTION
This 
- Changes `BMS cable fault` to `Battery communication lost``
- Adds `Cell measurements fault` through `/Alarms/CellMeasurementsFault`
- Adds descriptions for `/ErrorCode` 44, and others (veutil update)

See https://github.com/victronenergy/venus/issues/1650