### PR TITLE
Mock: do not override the mock timer setting requested by a UI test

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -359,8 +359,12 @@ void initBackend(bool *enableFpsCounter, bool *skipSplashScreen)
 		Victron::VenusOS::MockManager *mockManager = Victron::VenusOS::MockManager::create();
 		if (parser.isSet(noMockTimers)) {
 			mockTimersEnabled = false;
+			mockManager->setTimersActive(mockTimersEnabled);
+		} else if (!uiTestConf.hasMockTimersActive()) {
+			// A UI test configuration that sets Mock/TimersActive has already applied it above.
+			// Do not overwrite it here, or the test runs with mock timers it asked to have off.
+			mockManager->setTimersActive(mockTimersEnabled);
 		}
-		mockManager->setTimersActive(mockTimersEnabled);
 
 		// Some UI tests specify a mock configuration, if the test is only designed to be run
 		// against that configuration. In that case, exit with an error if --mock-conf is also set,

--- a/src/uitest.cpp
+++ b/src/uitest.cpp
@@ -74,6 +74,11 @@ bool UiTestConfiguration::hasMockConfiguration() const
 	return m_settings.contains("Mock");
 }
 
+bool UiTestConfiguration::hasMockTimersActive() const
+{
+	return m_settings.value("Mock").toMap().value("TimersActive").isValid();
+}
+
 
 UiTest* UiTest::create(QQmlEngine *, QJSEngine *)
 {

--- a/src/uitest.h
+++ b/src/uitest.h
@@ -29,6 +29,10 @@ public:
 	const QVariantMap &settingsMap() const;
 	bool hasMockConfiguration() const;
 
+	// Returns true if the configuration sets Mock/TimersActive, i.e. the test requires the mock
+	// timers to be in a particular state.
+	bool hasMockTimersActive() const;
+
 private:
 	QVariantMap m_settings;
 	QString m_dirName;


### PR DESCRIPTION
UiTest::loadConfiguration() applies the "Mock": {"TimersActive": false} of a test configuration, and the mock backend setup immediately below it then called setTimersActive() again with the command-line default, which is true unless --no-mock-timers was given. A UI test therefore always ran with mock timers on, however its configuration was written.

The visible effect is that image captures are not reproducible: MockDataRandomizer keeps shifting mock values by +/-10% for the whole sweep, so screens showing live values differ between two runs of the very same build. Measured over smoke/mock-maximal, two sweeps of one build differed on 182 of 1171 screens (worst MSE 256) before this change and on 3 of 1171 (worst MSE 17.8) after it, with 1153 screens pixel-identical.

Only apply the command-line default when the test configuration did not ask for a particular setting. An explicit --no-mock-timers still wins.

The 3 screens that still differ are not a rendering problem: the "Start page" setting resolves to a different value between runs.