### PR TITLE
Settings: show write permission error notification for list items

### DIFF
--- a/components/listitems/ListSpinBoxRange.qml
+++ b/components/listitems/ListSpinBoxRange.qml
@@ -137,6 +137,19 @@ ListSetting {
 		}
 	}
 
+	background: ListSettingBackground {
+		color: root.flat ? "transparent" : Theme.color_listItem_background
+		indicatorColor: root.backgroundIndicatorColor
+
+		// If button item is disabled due to write permissions, allow click to fall through to here
+		// and show an error.
+		MouseArea {
+			anchors.fill: parent
+			enabled: !root.clickable && !root.readOnly
+			onClicked: root.checkWriteAccessLevel()
+		}
+	}
+
 	Keys.onSpacePressed: {
 		if (readOnly || !root.checkWriteAccessLevel() || !root.clickable) {
 			return

--- a/components/listitems/core/ListButton.qml
+++ b/components/listitems/core/ListButton.qml
@@ -73,5 +73,18 @@ ListSetting {
 		}
 	}
 
+	background: ListSettingBackground {
+		color: root.flat ? "transparent" : Theme.color_listItem_background
+		indicatorColor: root.backgroundIndicatorColor
+
+		// If button item is disabled due to write permissions, allow click to fall through to here
+		// and show an error.
+		MouseArea {
+			anchors.fill: parent
+			enabled: !root.clickable && !root.readOnly
+			onClicked: root.checkWriteAccessLevel()
+		}
+	}
+
 	Keys.onSpacePressed: click()
 }

--- a/components/listitems/core/ListSwitch.qml
+++ b/components/listitems/core/ListSwitch.qml
@@ -127,6 +127,19 @@ ListSetting {
 		}
 	}
 
+	background: ListSettingBackground {
+		color: root.flat ? "transparent" : Theme.color_listItem_background
+		indicatorColor: root.backgroundIndicatorColor
+
+		// If button item is disabled due to write permissions, allow click to fall through to here
+		// and show an error.
+		MouseArea {
+			anchors.fill: parent
+			enabled: !root.clickable
+			onClicked: root.checkWriteAccessLevel()
+		}
+	}
+
 	Keys.onSpacePressed: root.click()
 
 	VeQuickItem {


### PR DESCRIPTION
When a button or switch list item is disabled due to the write permissions, instead of just appearing disabled, also show a notification when the user tries to activate it via a click.

To do this, provide a background with a mouse area, which will show a toast notification when clicked if the user is lacking sufficient write permissions. If the user clicks the button/switch in the contentItem but it is disabled (due to clickable=false for the write permissions) then the click falls through to the background.