### PR TITLE
Levels: do not clip view unnecessarily

### DIFF
--- a/pages/LevelsPage.qml
+++ b/pages/LevelsPage.qml
@@ -22,10 +22,6 @@ SwipeViewPage {
 	iconSource: "qrc:/images/levels.svg"
 	url: "qrc:/qt/qml/Victron/VenusOS/pages/LevelsPage.qml"
 
-	// Gauges may overflow into previous/next pages in the SwipeView, so clip the gauge ListView
-	// to the page bounds.
-	clip: tanksTab.contentWidth > tanksTab.width || environmentTab.contentWidth > environmentTab.width
-
 	onActiveFocusChanged: {
 		if (root.view.focusEdgeHint === Qt.TopEdge) {
 			tabBar.focus = true

--- a/pages/LevelsTab.qml
+++ b/pages/LevelsTab.qml
@@ -25,4 +25,9 @@ BaseListView {
 	orientation: Theme.screenSize === Theme.Portrait ? ListView.Vertical : ListView.Horizontal
 	spacing: Theme.screenSize === Theme.Portrait ? Theme.geometry_levelsPage_gauge_spacing_tiny : Gauges.spacing(count)
 	currentIndex: 0
+
+	// If the gauges overflow beyond the view bounds, clip when the user may swipe into previous/
+	// next pages in the SwipeView, else the gauges are overlaid onto neighbouring pages.
+	clip: Global.pageManager?.interactivity === VenusOS.PageManager_InteractionMode_Interactive
+			&& contentWidth > width
 }

--- a/pages/MainView.qml
+++ b/pages/MainView.qml
@@ -170,15 +170,11 @@ FocusScope {
 			readonly property bool readyToLoad: swipePageModel.completed
 					&& Global.notifications && Global.notificationLayer // checked by onLoaded handler
 
-			// For the vertical anchors, use hardcoded margins instead of referring to the height
-			// of the StatusBar and NavBar, so that the SwipeView position does not jump when the
-			// StatusBar sizes to its internal content geometry or when the NavBar y position
-			// animates into view.
 			anchors {
 				top: parent.top
-				topMargin: Theme.geometry_statusBar_height
+				topMargin: Theme.geometry_statusBar_height // hardcoded, to avoid SwipeView jump when StatusBar sizes to internal content
 				bottom: parent.bottom
-				bottomMargin: Theme.geometry_navigationBar_height
+				bottomMargin: Math.max(0, root.height - navBar.y)
 				left: parent.left
 				right: parent.right
 			}

--- a/pages/PageManager.qml
+++ b/pages/PageManager.qml
@@ -27,6 +27,7 @@ QtObject {
 			&& (currentMainPage?.fullScreenWhenIdle || Global.keyNavigationEnabled)
 			&& root.interactivity === VenusOS.PageManager_InteractionMode_Interactive
 			&& UiConfig.applicationVisible
+			&& !Global.mainView?.swipeView?.moving // don't enter idle mode while user is swiping between pages
 		interval: Theme.animation_page_idleResize_timeout
 		onTriggered: {
 			Global.main.keyNavigationTimeout()


### PR DESCRIPTION
Fix a bug where the Levels view would clip at the top edge of the navigation bar area.

Expand the SwipeView to the full available height of the UI when the bottom navigation bar moves out of view, so that the SwipeView's pages also extend to the bottom of the SwipeView.

Also, only clip the Levels view when the app is in interactive mode and the user may swipe to other pages, because:

- It does not need to be clipped in idle mode or when animating to/from idle mode; the purpose of clipping is to avoid overlapping with the prev/next page in the SwipeView when swiping between pages.

- If it clips while animating to/from idle mode, it will be clipped at the start of the animation, then suddenly jump to the full expanded height. This is because the SwipeView's bottom is effectively anchored to the NavBar y, and since the NavBar y position is animated with an Animator rather than an Animation type (in MainView.qml), the y value jumps to the end position when the animation is complete, instead of changing gradually while the animation is running.

Additionally:

- Move the 'clip' binding into LevelsTab so that the overall page does not clip when the non-visible view extends beyond its bounds.
- Update the idleModeTimer in PageManager so that the UI does not enter idle mode while the user is swiping between pages in the SwipeView. Otherwise, the Levels view will un-clip itself during a swipe.


Fixes #3190