### PR TITLE
[ feat] Air quality: show Ruuvi Air IAQS score in device list and detail page

### DIFF
--- a/cmake/ModuleMock_Sources.cmake
+++ b/cmake/ModuleMock_Sources.cmake
@@ -77,6 +77,7 @@ SET(VictronMock_QML_MODULE_RESOURCES
     data/mock/conf/services/pylontech.json
     data/mock/conf/services/quattro-3phase-grid-genset.json
     data/mock/conf/services/relays-temperature-and-manual.json
+    data/mock/conf/services/ruuvi-air.json
     data/mock/conf/services/ruuvi-fridge.json
     data/mock/conf/services/ruuvi-salon.json
     data/mock/conf/services/shelly.json

--- a/data/mock/conf/README.md
+++ b/data/mock/conf/README.md
@@ -49,7 +49,7 @@ Also, if --mock-conf is set, the --mock option is implied. For example, the abov
         - Networking: wifi, modem
         - ESS
         - Digital input, relays
-    - Temperature sensors: Ruuvi, generic
+    - Temperature sensors: Ruuvi (incl. Ruuvi Air quality), generic
     - Tanks: generic
     - Switches: GIO Extender and ES SmartSwitch
     - Pulsemeter, pump, meteo (SolarSense)

--- a/data/mock/conf/maximal.json
+++ b/data/mock/conf/maximal.json
@@ -41,6 +41,7 @@
         ":/data/mock/conf/services/pylontech.json",
         ":/data/mock/conf/services/quattro-3phase-grid-genset.json",
         ":/data/mock/conf/services/relays-temperature-and-manual.json",
+        ":/data/mock/conf/services/ruuvi-air.json",
         ":/data/mock/conf/services/ruuvi-fridge.json",
         ":/data/mock/conf/services/ruuvi-salon.json",
         ":/data/mock/conf/services/skylla-charger.json",

--- a/data/mock/conf/services/ruuvi-air.json
+++ b/data/mock/conf/services/ruuvi-air.json
@@ -1,0 +1,24 @@
+{
+    "com.victronenergy.temperature.ruuvi_f00f00d00003": {
+        "/CO2": 683,
+        "/Connected": 1,
+        "/CustomName": "Ruuvi Air",
+        "/DeviceInstance": 30,
+        "/DeviceName": "Ruuvi Air 9F3A",
+        "/Humidity": 52.0,
+        "/IAQS": 86,
+        "/Luminosity": 120,
+        "/Mgmt/Connection": "Bluetooth LE",
+        "/Mgmt/ProcessName": "dbus-ble-sensors",
+        "/Mgmt/ProcessVersion": "0.3",
+        "/NOX": 1,
+        "/PM25": 1.9,
+        "/Pressure": 1018.7,
+        "/ProductId": 49296,
+        "/ProductName": "Ruuvi Air",
+        "/SeqNo": 87,
+        "/Temperature": 24.0,
+        "/TemperatureType": 3,
+        "/VOC": 169
+    }
+}

--- a/pages/settings/devicelist/delegates/DeviceListDelegate_temperature.qml
+++ b/pages/settings/devicelist/delegates/DeviceListDelegate_temperature.qml
@@ -12,14 +12,21 @@ DeviceListDelegate {
 	quantityModel: QuantityObjectModel {
 		filterType: QuantityObjectModel.HasValue
 
-		// Show air quality data if CO2 is available, otherwise show temperature/humidity
+		// Show the overall air quality score if available, otherwise raw CO2/PM2.5,
+		// otherwise show temperature/humidity
 		QuantityObject {
-			object: co2.value !== undefined ? co2 : temperature
-			unit: co2.value !== undefined ? VenusOS.Units_PartsPerMillion : Global.systemSettings.temperatureUnit
+			object: iaqs.valid ? iaqs : co2.value !== undefined ? co2 : temperature
+			key: iaqs.valid ? "textValue" : "value"
+			unit: iaqs.valid ? VenusOS.Units_None
+					: co2.value !== undefined ? VenusOS.Units_PartsPerMillion
+					: Global.systemSettings.temperatureUnit
+			valueColor: iaqs.valid ? iaqs.qualityColor : Theme.color_font_primary
 		}
 		QuantityObject {
-			object: co2.value !== undefined ? pm25 : humidity
-			unit: co2.value !== undefined ? VenusOS.Units_MicrogramPerCubicMeter : VenusOS.Units_Percentage
+			object: co2.value !== undefined ? (iaqs.valid ? co2 : pm25) : humidity
+			unit: co2.value === undefined ? VenusOS.Units_Percentage
+					: iaqs.valid ? VenusOS.Units_PartsPerMillion
+					: VenusOS.Units_MicrogramPerCubicMeter
 		}
 	}
 
@@ -48,5 +55,50 @@ DeviceListDelegate {
 	VeQuickItem {
 		id: pm25
 		uid: root.device.serviceUid + "/PM25"
+	}
+
+	VeQuickItem {
+		id: iaqs
+		uid: root.device.serviceUid + "/IAQS"
+
+		readonly property string textValue: valid
+				//% "%1 (%2)"
+				? qsTrId("temperature_air_quality_score_short").arg(value).arg(qualityLabel)
+				: ""
+		readonly property string qualityLabel: {
+			if (!valid) {
+				return ""
+			}
+			if (value > 90) {
+				//% "Excellent"
+				return qsTrId("temperature_air_quality_excellent")
+			}
+			if (value > 80) {
+				//% "Good"
+				return qsTrId("temperature_air_quality_good")
+			}
+			if (value > 50) {
+				//% "Fair"
+				return qsTrId("temperature_air_quality_fair")
+			}
+			if (value >= 10) {
+				//% "Poor"
+				return qsTrId("temperature_air_quality_poor")
+			}
+			//% "Very poor"
+			return qsTrId("temperature_air_quality_very_poor")
+		}
+		readonly property color qualityColor: {
+			if (!valid) {
+				return Theme.color_font_primary
+			}
+			if (value > 80) {
+				return Theme.color_green
+			}
+			if (value > 50) {
+				return Theme.color_orange
+			}
+			return Theme.color_red
+		}
 	}
 }

--- a/pages/settings/devicelist/temperature/PageTemperatureSensor.qml
+++ b/pages/settings/devicelist/temperature/PageTemperatureSensor.qml
@@ -43,6 +43,54 @@ DevicePage {
 			}
 		}
 
+		ListText {
+			//% "Air quality"
+			text: qsTrId("temperature_air_quality")
+			dataItem.uid: root.bindPrefix + "/IAQS"
+			preferredVisible: dataItem.valid
+			secondaryText: dataItem.valid
+					//% "%1/100 (%2)"
+					? qsTrId("temperature_air_quality_score").arg(dataItem.value).arg(qualityLabel)
+					: ""
+			secondaryTextColor: qualityColor
+
+			readonly property string qualityLabel: {
+				if (!dataItem.valid) {
+					return ""
+				}
+				if (dataItem.value > 90) {
+					//% "Excellent"
+					return qsTrId("temperature_air_quality_excellent")
+				}
+				if (dataItem.value > 80) {
+					//% "Good"
+					return qsTrId("temperature_air_quality_good")
+				}
+				if (dataItem.value > 50) {
+					//% "Fair"
+					return qsTrId("temperature_air_quality_fair")
+				}
+				if (dataItem.value >= 10) {
+					//% "Poor"
+					return qsTrId("temperature_air_quality_poor")
+				}
+				//% "Very poor"
+				return qsTrId("temperature_air_quality_very_poor")
+			}
+			readonly property color qualityColor: {
+				if (!dataItem.valid) {
+					return Theme.color_listItem_secondaryText
+				}
+				if (dataItem.value > 80) {
+					return Theme.color_green
+				}
+				if (dataItem.value > 50) {
+					return Theme.color_orange
+				}
+				return Theme.color_red
+			}
+		}
+
 		ListTemperature {
 			text: CommonWords.temperature
 			dataItem.uid: bindPrefix + "/Temperature"


### PR DESCRIPTION
Surface the derived Indoor Air Quality Score (0-100, with an Excellent/Good/Fair/Poor/Very poor label) now published on `/IAQS` by dbus-ble-sensors, colored by quality band. Falls back to the existing CO2/PM2.5 display for devices without a score.

<img width="912" height="624" alt="image" src="https://github.com/user-attachments/assets/b071aaab-354c-48ab-9102-7577894a9b52" /> and 
<img width="912" height="624" alt="image" src="https://github.com/user-attachments/assets/75e2f61e-fc76-4141-87c6-b0c38b6febcc" />

Note that I am not sure about the coloring. Probably something to check with Serj. 

The /IAQS field got added to dbus-ble-sensors via [this commit](https://github.com/victronenergy/dbus-ble-sensors/commit/f1fdb976550a3e0ba52c749ff0710f6550354de4) and is already in Venus. I added a mock, but if you need a system to test on, you can use my system (102195)

Note that the Ruuvi app shows something like this:
<img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/2b61de09-46e6-45d2-9602-deb3b4efe232" />
