### PR TITLE
BLE: add VictronConnect hint for BLE sensor encryption keys

### DIFF
--- a/pages/settings/PageSettingsBleSensors.qml
+++ b/pages/settings/PageSettingsBleSensors.qml
@@ -32,6 +32,43 @@ Page {
 		filterFlags: VeQItemSortTableModel.FilterOffline
 	}
 
+	// Counts the number of devices that require an encryption key to be entered.
+	Instantiator {
+		id: devicesNeedingKeys
+
+		property int matchingDeviceCount
+
+		function _updatedevicesNeedingKeysCount() {
+			let total = 0
+			for (let i = 0; i < devicesNeedingKeys.count; ++i) {
+				const delegate = devicesNeedingKeys.objectAt(i)
+				if (delegate.needsKeyInput) {
+					total++
+				}
+			}
+			matchingDeviceCount = total
+		}
+
+		model: sensors
+		delegate: QtObject {
+			id: sensorDeviceDelegate
+
+			required property string uid
+
+			readonly property bool needsKeyInput: enabledItem.value !== 1 && keyItem.seen
+			onNeedsKeyInputChanged: Qt.callLater(devicesNeedingKeys._updatedevicesNeedingKeysCount)
+
+			readonly property VeQuickItem enabledItem: VeQuickItem {
+				uid: sensorDeviceDelegate.uid + "/Enabled"
+			}
+			readonly property VeQuickItem keyItem: VeQuickItem {
+				uid: sensorDeviceDelegate.uid + "/Key"
+			}
+		}
+		onObjectAdded: Qt.callLater(devicesNeedingKeys._updatedevicesNeedingKeysCount)
+		onObjectRemoved: Qt.callLater(devicesNeedingKeys._updatedevicesNeedingKeysCount)
+	}
+
 	GradientListView {
 		model: VisibleItemModel {
 			ListSwitch {
@@ -75,6 +112,12 @@ Page {
 						deviceName: item.value || ""
 					}
 				}
+			}
+
+			ListInfoLabel {
+				//% "Use VictronConnect over Bluetooth to add encryption keys automatically."
+				text: qsTrId("settings_ble_sensors_add_encryption_keys_via_victronconnect")
+				preferredVisible: enable.checked && devicesNeedingKeys.matchingDeviceCount > 0
 			}
 		}
 	}


### PR DESCRIPTION
When at least one sensor is shown which requires entering an Encryption key, show a hint at the bottom of the list of found sensors.

Contributes to victronenergy/venus-private#691
Fixes #3202

<img width="793" height="424" alt="image" src="https://github.com/user-attachments/assets/3864dde1-ca04-46e9-96b3-5524c2644885" />