### PR TITLE
Tests: improve unit testing for parallel and shadow builds

### DIFF
--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -4,6 +4,21 @@ if ("${RUN_UNIT_TESTS}" STREQUAL "ON")
          COMMENT "Run tests"
          POST_BUILD
          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-         COMMAND ${CMAKE_CTEST_COMMAND} -V -C $<CONFIGURATION> --output-on-failures
+         COMMAND ${CMAKE_CTEST_COMMAND} -V
+                "$<$<BOOL:$<CONFIG>>:-C;$<CONFIG>>" # only pass -C when a config is set by the build tool
+                --output-on-failure
     )
+
+    if (VENUS_GUI_V2_TESTS_ENABLED)
+        # Add dependency to each unit test, so that tests are not run
+        # before all test targets are built.
+        get_property(subdirs DIRECTORY "${CMAKE_SOURCE_DIR}/tests" PROPERTY SUBDIRECTORIES)
+        foreach(subdir ${subdirs})
+            if (EXISTS "${subdir}/CMakeLists.txt")
+                cmake_path(GET subdir FILENAME dirName)
+                add_dependencies(${PROJECT_NAME} "tst_${dirName}")
+            endif()
+        endforeach()
+    endif()
+
 endif()

--- a/cmake/UnitTests.cmake
+++ b/cmake/UnitTests.cmake
@@ -70,7 +70,8 @@ endif()
 
 qt_import_qml_plugins(${TEST_NAME})
 
-add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+# Add source dir using -input so that tests can be run from shadow builds.
+add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME} -input ${CMAKE_CURRENT_SOURCE_DIR} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
 endmacro()
 


### PR DESCRIPTION
cmake/RunTests.cmake:
- Add a dependency on each unit test to the project, so that tests do not run before the build is complete. Otherwise, the tests fail in parallel builds as the binaries are not yet available.
- Remove the "-C $<CONFIGURATION>" from the ctest command, otherwise the configure step fails if CMAKE_BUILD_TYPE has not been set.
- Fix typo "--output-on-failures" -> "--output-on-failure".

cmake/UnitTests.cmake:
- Pass -input when adding a test, so that the tests can be run from shadow builds.