### PR TITLE
Switches: ensure name is correct when device is not yet available

### DIFF
--- a/src/iochannel.cpp
+++ b/src/iochannel.cpp
@@ -28,6 +28,15 @@ void IOChannel::initialize(VeQItem *item)
 	}
 	m_item = item;
 
+	if (m_deviceAddedConn) {
+		disconnect(m_deviceAddedConn);
+		m_deviceAddedConn = QMetaObject::Connection();
+	}
+	if (m_device) {
+		m_device->disconnect(this);
+		m_device.clear();
+	}
+
 	if (m_item) {
 		m_serviceUid = m_item->itemParent() // the /GenericInput or /SwitchableOutput parent
 				&& m_item->itemParent()->itemParent() // the root service item
@@ -37,11 +46,11 @@ void IOChannel::initialize(VeQItem *item)
 		// Set up BaseDevice member pointer, in order to update the formatted name when the device's
 		// product/custom name or device instance changes.
 		if (BaseDevice::serviceTypeFromUid(m_serviceUid) != QStringLiteral("system")) {
-			m_device = AllDevicesModel::create()->findDevice(m_serviceUid);
-			if (m_device) {
-				connect(m_device, &BaseDevice::productNameChanged, this, &IOChannel::updateFormattedName);
-				connect(m_device, &BaseDevice::customNameChanged, this, &IOChannel::updateFormattedName);
-				connect(m_device, &BaseDevice::deviceInstanceChanged, this, &IOChannel::updateFormattedName);
+			if (BaseDevice *device = AllDevicesModel::create()->findDevice(m_serviceUid)) {
+				setDevice(device);
+			} else {
+				m_deviceAddedConn = connect(AllDevicesModel::create(), &AllDevicesModel::deviceAdded,
+						this, &IOChannel::setDevice);
 			}
 		}
 
@@ -93,12 +102,6 @@ void IOChannel::initialize(VeQItem *item)
 	} else {
 		m_serviceUid.clear();
 
-		// Clear member pointers.
-		if (m_device) {
-			m_device->disconnect();
-			m_device.clear();
-		}
-
 		// Clear formatted name.
 		m_name.clear();
 		m_customName.clear();
@@ -116,6 +119,22 @@ void IOChannel::initialize(VeQItem *item)
 	emit channelIdChanged();
 	emit serviceUidChanged();
 	emit uidChanged();
+}
+
+void IOChannel::setDevice(BaseDevice *device)
+{
+	if (device && device->serviceUid() == m_serviceUid) {
+		if (m_deviceAddedConn) {
+			disconnect(m_deviceAddedConn);
+			m_deviceAddedConn = QMetaObject::Connection();
+		}
+		m_device = device;
+		connect(m_device, &BaseDevice::productNameChanged, this, &IOChannel::updateFormattedName);
+		connect(m_device, &BaseDevice::customNameChanged, this, &IOChannel::updateFormattedName);
+		connect(m_device, &BaseDevice::deviceInstanceChanged, this, &IOChannel::updateFormattedName);
+	}
+
+	updateFormattedName();
 }
 
 QString IOChannel::uid() const
@@ -329,6 +348,7 @@ bool IOChannel::canShowUI(const QVariant &showUIValue) const
 	// The VRM connection status doesn't match the local/remote visibility preference.
 	return false;
 }
+
 void IOChannel::updateFormattedName()
 {
 	QString newFormattedName;
@@ -348,7 +368,11 @@ void IOChannel::updateFormattedName()
 					? m_device->customName()
 					: QStringLiteral("%1 (%2)").arg(m_device->productName()).arg(m_device->deviceInstance());
 		}
-		newFormattedName = QStringLiteral("%1 | %2").arg(prefix).arg(m_name);
+		if (prefix.isEmpty()) {
+			newFormattedName = m_name;
+		} else {
+			newFormattedName = QStringLiteral("%1 | %2").arg(prefix).arg(m_name);
+		}
 	} else {
 		// When the channel is in the default group for the device, instead of in a named group,
 		// then the /Name can be used directly.

--- a/src/iochannel.h
+++ b/src/iochannel.h
@@ -149,6 +149,7 @@ protected:
 	void updateDecimals();
 
 private:
+	void setDevice(BaseDevice *device);
 	void setStatus(const QVariant &variant);
 	void setType(const QVariant &variant);
 	void setValidTypes(const QVariant &variant);
@@ -173,6 +174,7 @@ protected:
 	QString m_group;
 	QString m_unitText;
 	Direction m_direction = Input;
+	QMetaObject::Connection m_deviceAddedConn;
 	int m_status = -1; // Default status is -1 (invalid)
 	int m_type = -1;
 	int m_unitType = Enums::Units_None;

--- a/tests/genericinput/tst_genericinput.qml
+++ b/tests/genericinput/tst_genericinput.qml
@@ -474,10 +474,10 @@ TestCase {
 				inputProperties: { "Settings/Type": 0, "Name": "A", "Settings/Group": "test" },
 				deviceValues: {
 					"mock/com.victronenergy.test.a/ProductName": "Test product",
-					"mock/com.victronenergy.test.a/ProductName": "Test custom",
+					"mock/com.victronenergy.test.a/CustomName": "Test custom",
 					"mock/com.victronenergy.test.a/DeviceInstance": 1,
 				},
-				formattedName: "Test custom (1) | A",
+				formattedName: "Test custom | A",
 			},
 		]
 	}
@@ -496,6 +496,63 @@ TestCase {
 		input.uid = data.uid
 		compare(input.uid, data.uid)
 		compare(input.formattedName, data.formattedName)
+
+		// Clean up
+		input.uid = ""
+		MockManager.removeValue(data.uid)
+		if (data.deviceValues) {
+			for (propertyName in data.deviceValues) {
+				MockManager.removeValue(propertyName)
+			}
+		}
+	}
+
+	function test_formattedName_without_device_data() {
+		return [
+			{
+				tag: "no custom name, in group: use device product name",
+				uid: "mock/com.victronenergy.test.x/GenericInput/0",
+				inputProperties: { "Settings/Type": 0, "Name": "X", "Settings/Group": "test" },
+				deviceValues: {
+					"mock/com.victronenergy.test.x/ProductName": "Test product",
+					"mock/com.victronenergy.test.x/DeviceInstance": 1,
+				},
+				formattedNameWithoutDevice: "X",
+				formattedNameWithDevice: "Test product (1) | X",
+			},
+
+			{
+				tag: "no custom name, in group: use device custom name",
+				uid: "mock/com.victronenergy.test.y/GenericInput/0",
+				inputProperties: { "Settings/Type": 0, "Name": "Y", "Settings/Group": "test" },
+				deviceValues: {
+					"mock/com.victronenergy.test.y/ProductName": "Test product",
+					"mock/com.victronenergy.test.y/CustomName": "Test custom",
+					"mock/com.victronenergy.test.y/DeviceInstance": 1,
+				},
+				formattedNameWithoutDevice: "Y",
+				formattedNameWithDevice: "Test custom | Y",
+			},
+		]
+	}
+
+	function test_formattedName_without_device(data) {
+		let propertyName
+		compare(input.formattedName, "")
+
+		// Set the input properties first, and initialise the input, before the device is available.
+		setInputProperties(data.uid, data.inputProperties)
+		input.uid = data.uid
+		compare(input.uid, data.uid)
+		compare(input.formattedName, data.formattedNameWithoutDevice)
+
+		// Now set the device properties and check the formatted name again.
+		if (data.deviceValues) {
+			for (propertyName in data.deviceValues) {
+				MockManager.setValue(propertyName, data.deviceValues[propertyName])
+			}
+		}
+		compare(input.formattedName, data.formattedNameWithDevice)
 
 		// Clean up
 		input.uid = ""

--- a/tests/switchableoutput/tst_switchableoutput.qml
+++ b/tests/switchableoutput/tst_switchableoutput.qml
@@ -470,10 +470,10 @@ TestCase {
 				outputProperties: { "Settings/Type": 0, "Name": "A", "Settings/Group": "test" },
 				deviceValues: {
 					"mock/com.victronenergy.test.a/ProductName": "Test product",
-					"mock/com.victronenergy.test.a/ProductName": "Test custom",
+					"mock/com.victronenergy.test.a/CustomName": "Test custom",
 					"mock/com.victronenergy.test.a/DeviceInstance": 1,
 				},
-				formattedName: "Test custom (1) | A",
+				formattedName: "Test custom | A",
 			},
 		]
 	}
@@ -492,6 +492,63 @@ TestCase {
 		output.uid = data.uid
 		compare(output.uid, data.uid)
 		compare(output.formattedName, data.formattedName)
+
+		// Clean up
+		output.uid = ""
+		MockManager.removeValue(data.uid)
+		if (data.deviceValues) {
+			for (propertyName in data.deviceValues) {
+				MockManager.removeValue(propertyName)
+			}
+		}
+	}
+
+	function test_formattedName_without_device_data() {
+		return [
+			{
+				tag: "no custom name, in group: use device product name",
+				uid: "mock/com.victronenergy.test.x/SwitchableOutput/0",
+				outputProperties: { "Settings/Type": 0, "Name": "X", "Settings/Group": "test" },
+				deviceValues: {
+					"mock/com.victronenergy.test.x/ProductName": "Test product",
+					"mock/com.victronenergy.test.x/DeviceInstance": 1,
+				},
+				formattedNameWithoutDevice: "X",
+				formattedNameWithDevice: "Test product (1) | X",
+			},
+
+			{
+				tag: "no custom name, in group: use device custom name",
+				uid: "mock/com.victronenergy.test.y/SwitchableOutput/0",
+				outputProperties: { "Settings/Type": 0, "Name": "Y", "Settings/Group": "test" },
+				deviceValues: {
+					"mock/com.victronenergy.test.y/ProductName": "Test product",
+					"mock/com.victronenergy.test.y/CustomName": "Test custom",
+					"mock/com.victronenergy.test.y/DeviceInstance": 1,
+				},
+				formattedNameWithoutDevice: "Y",
+				formattedNameWithDevice: "Test custom | Y",
+			},
+		]
+	}
+
+	function test_formattedName_without_device(data) {
+		let propertyName
+		compare(output.formattedName, "")
+
+		// Set the output properties first, and initialise the output, before the device is available.
+		setOutputProperties(data.uid, data.outputProperties)
+		output.uid = data.uid
+		compare(output.uid, data.uid)
+		compare(output.formattedName, data.formattedNameWithoutDevice)
+
+		// Now set the device properties and check the formatted name again.
+		if (data.deviceValues) {
+			for (propertyName in data.deviceValues) {
+				MockManager.setValue(propertyName, data.deviceValues[propertyName])
+			}
+		}
+		compare(output.formattedName, data.formattedNameWithDevice)
 
 		// Clean up
 		output.uid = ""


### PR DESCRIPTION
If the device details for an input/output control are not available on initialisation, ensure the displayed name is simply "<control name>", instead of " | <control name>" (i.e. starting with an empty string where the device name should be). Later when the device details become available via AllDevicesModel, update the displayed name to be "<device name> | <control name>".

Fixes #3198