### PR TITLE
Switches: add capabilities to IOChannels

### DIFF
--- a/components/listitems/ListIOChannelShowRadioButtonGroup.qml
+++ b/components/listitems/ListIOChannelShowRadioButtonGroup.qml
@@ -6,19 +6,154 @@
 import QtQuick
 import Victron.VenusOS
 
-ListRadioButtonGroup {
+ListNavigation {
+	id: root
+	required property string capabilitiesUid
+	required property string showUiUid
+	readonly property bool watchCapability: root._capabilities.valid && (root._capabilities.value & VenusOS.IOChannel_Capability_Watch)
+
+	readonly property VeQuickItem _capabilities: VeQuickItem {
+		uid: root.capabilitiesUid
+	}
+
+	function _generateSecondaryText () {
+		if (showUiControl.value == VenusOS.IOChannel_ShowUI_Off) {
+			return CommonWords.off
+		}
+		if (showUiControl.value == VenusOS.IOChannel_ShowUI_Always) {
+			return qsTrId("iochannel_showui_always")
+		}
+		if (showUiControl.value == VenusOS.IOChannel_ShowUI_Local) {
+			return qsTrId("iochannel_showui_local")
+		}
+		if (showUiControl.value == VenusOS.IOChannel_ShowUI_Remote) {
+			return qsTrId("iochannel_showui_remote")
+		}
+
+		return (showUiControl.value & VenusOS.IOChannel_ShowUI_Local ? qsTrId("iochannel_showui_custom_local") + " " : "" ) +
+				(showUiControl.value & VenusOS.IOChannel_ShowUI_Remote ? qsTrId("iochannel_showui_custom_vrm") + " " : "" ) +
+				(showUiControl.value & VenusOS.IOChannel_ShowUI_Watch ? qsTrId("iochannel_showui_custom_watch") : "" )
+	}
+
 	//: Whether UI controls should be shown for this input/output
 	//% "Show controls"
 	text: qsTrId("iochannel_showui_controls")
+	secondaryText: _generateSecondaryText()
 	writeAccessLevel: VenusOS.User_AccessType_User
-	preferredVisible: dataItem.valid
-	optionModel: [
-		{ display: CommonWords.off, value: VenusOS.IOChannel_ShowUI_Off },
-		//% "Always"
-		{ display: qsTrId("iochannel_showui_always"), value: VenusOS.IOChannel_ShowUI_Always },
-		//% "Only local"
-		{ display: qsTrId("iochannel_showui_local"), value: VenusOS.IOChannel_ShowUI_Local },
-		//% "Only on VRM"
-		{ display: qsTrId("iochannel_showui_vrm"), value: VenusOS.IOChannel_ShowUI_Remote }
-	]
+
+	onClicked: Global.pageManager.pushPage(showUiControlComponent, { title: text })
+
+	VeQuickItem {
+		id: showUiControl
+		uid: root.showUiUid
+	}
+
+	ButtonGroup {
+		id: stateRadioButtonGroup
+	}
+
+	Component {
+		id: showUiControlComponent
+
+		Page {
+			GradientListView {
+				model: VisibleItemModel {
+
+					ListRadioButton {
+						text: CommonWords.off
+						checked: showUiControl.value == VenusOS.IOChannel_ShowUI_Off
+						ButtonGroup.group: stateRadioButtonGroup
+						onClicked: {
+							showUiControl.setValue(VenusOS.IOChannel_ShowUI_Off)
+							Global.pageManager.popPage()
+						}
+					}
+					ListRadioButton {
+						//% "Always"
+						text: qsTrId("iochannel_showui_always")
+						checked: showUiControl.value == VenusOS.IOChannel_ShowUI_Always
+						ButtonGroup.group: stateRadioButtonGroup
+						onClicked: {
+							showUiControl.setValue(VenusOS.IOChannel_ShowUI_Always)
+							Global.pageManager.popPage()
+						}
+					}
+					ListRadioButton {
+						//% "Only local"
+						text: qsTrId("iochannel_showui_local")
+						checked: showUiControl.value == VenusOS.IOChannel_ShowUI_Local
+						ButtonGroup.group: stateRadioButtonGroup
+						onClicked: {
+							showUiControl.setValue(VenusOS.IOChannel_ShowUI_Local)
+							Global.pageManager.popPage()
+						}
+						preferredVisible: !watchCapability
+					}
+					ListRadioButton {
+						//% "Only on VRM"
+						text: qsTrId("iochannel_showui_vrm")
+						checked: showUiControl.value == VenusOS.IOChannel_ShowUI_Remote
+						ButtonGroup.group: stateRadioButtonGroup
+						onClicked: {
+							showUiControl.setValue(VenusOS.IOChannel_ShowUI_Remote)
+							Global.pageManager.popPage()
+						}
+						preferredVisible: !watchCapability
+					}
+					ListNavigation {
+						id: customList
+
+						function _generateCustomSecondaryText () {
+							if (showUiControl.value == VenusOS.IOChannel_ShowUI_Off
+									|| showUiControl.value == VenusOS.IOChannel_ShowUI_Always) {
+								return "" // Do not display more information than is required
+							}
+
+							return (showUiControl.value & VenusOS.IOChannel_ShowUI_Local ? qsTrId("iochannel_showui_custom_local") + " " : "" ) +
+									(showUiControl.value & VenusOS.IOChannel_ShowUI_Remote ? qsTrId("iochannel_showui_custom_vrm") + " " : "" ) +
+									(showUiControl.value & VenusOS.IOChannel_ShowUI_Watch ? qsTrId("iochannel_showui_custom_watch") : "" )
+						}
+
+						//: Whether UI controls should be shown for this input/output
+						//% "Custom"
+						text: qsTrId("iochannel_showui_controls_custom")
+						secondaryText: _generateCustomSecondaryText()
+						writeAccessLevel: VenusOS.User_AccessType_User
+
+						onClicked: Global.pageManager.pushPage(showCustomUiControlComponent, { title: text })
+						preferredVisible: watchCapability
+
+						Component {
+							id: showCustomUiControlComponent
+
+							Page {
+								GradientListView {
+									model: VisibleItemModel {
+										ListRadioButton {
+											//% "Local"
+											text: qsTrId("iochannel_showui_custom_local")
+											checked: showUiControl.value & VenusOS.IOChannel_ShowUI_Local
+											onClicked: showUiControl.setValue(showUiControl.value ^ VenusOS.IOChannel_ShowUI_Local)
+										}
+										ListRadioButton {
+											//% "VRM"
+											text: qsTrId("iochannel_showui_custom_vrm")
+											checked: showUiControl.value & VenusOS.IOChannel_ShowUI_Remote
+											onClicked: showUiControl.setValue(showUiControl.value ^ VenusOS.IOChannel_ShowUI_Remote)
+										}
+										ListRadioButton {
+											//% "Watch"
+											text: qsTrId("iochannel_showui_custom_watch")
+											checked: showUiControl.value & VenusOS.IOChannel_ShowUI_Watch
+											onClicked: showUiControl.setValue(showUiControl.value ^ VenusOS.IOChannel_ShowUI_Watch)
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
 }

--- a/data/mock/conf/services/smartswitch.json
+++ b/data/mock/conf/services/smartswitch.json
@@ -91,7 +91,8 @@
         "/SwitchableOutput/3/State": 0,
         "/SwitchableOutput/3/Status": 9,
         "/SwitchableOutput/3/Temperature": 29.693782806396484,
-        "/SwitchableOutput/3/Voltage": 24.200000762939453
+        "/SwitchableOutput/3/Voltage": 24.200000762939453,
+        "/SwitchableOutput/Capabilities": 1
     },
     "com.victronenergy.vecan.vecan1": {
         "/Alarms/SameUniqueNameUsed": 0,

--- a/pages/settings/devicelist/iochannel/PageGenericInput.qml
+++ b/pages/settings/devicelist/iochannel/PageGenericInput.qml
@@ -42,7 +42,8 @@ Page {
 			}
 
 			ListIOChannelShowRadioButtonGroup {
-				dataItem.uid: genericInput.uid + "/Settings/ShowUIInput"
+				capabilitiesUid: "" // GenericInputs do not have a "/Capabilities" setting
+				showUiUid: genericInput.uid + "/Settings/ShowUIInput"
 			}
 
 			ListRadioButtonGroup {

--- a/pages/settings/devicelist/iochannel/PageSwitchableOutput.qml
+++ b/pages/settings/devicelist/iochannel/PageSwitchableOutput.qml
@@ -134,7 +134,8 @@ Page {
 			}
 
 			ListIOChannelShowRadioButtonGroup {
-				dataItem.uid: switchableOutput.uid + "/Settings/ShowUIControl"
+				capabilitiesUid: switchableOutput.serviceUid + "/SwitchableOutput/Capabilities"
+				showUiUid: switchableOutput.uid + "/Settings/ShowUIControl"
 				interactive: _writeable
 			}
 

--- a/src/enums.h
+++ b/src/enums.h
@@ -631,8 +631,14 @@ public:
 		IOChannel_ShowUI_Always = 0x1,
 		IOChannel_ShowUI_Local = 0x2,
 		IOChannel_ShowUI_Remote = 0x4,
+		IOChannel_ShowUI_Watch = 0x8,
 	};
 	Q_ENUM(IOChannel_ShowUI)
+
+	enum IOChannel_Capability {
+		IOChannel_Capability_Watch = 0x1,
+	};
+	Q_ENUM(IOChannel_Capability)
 
 	enum Notification_Type {
 		Notification_Warning,

--- a/tests/switchableoutput/tst_switchableoutput.qml
+++ b/tests/switchableoutput/tst_switchableoutput.qml
@@ -391,6 +391,15 @@ TestCase {
 				allowedInGroupModel: true,
 			},
 			{
+				tag: "ShowUIControl=Always, with Remote set",
+				uid: "mock/com.victronenergy.test.a/SwitchableOutput/1",
+				outputProperties: {
+					"Settings/ShowUIControl": 5, // All+Remote = 0x1 | 0x4
+					"State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0, "Name": "A"
+				},
+				allowedInGroupModel: true,
+			},
+			{
 				tag: "ShowUIControl=Local+Remote, local connection",
 				uid: "mock/com.victronenergy.test.a/SwitchableOutput/1",
 				outputProperties: {
@@ -408,16 +417,6 @@ TestCase {
 					"State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0, "Name": "A"
 				},
 				vrm: true,
-				allowedInGroupModel: true,
-			},
-			{
-				// If value is invalid, then show the control (just like if ShowUIControl is not set)
-				tag: "ShowUIControl=0x5 (invalid)",
-				uid: "mock/com.victronenergy.test.a/SwitchableOutput/1",
-				outputProperties: {
-					"Settings/ShowUIControl": 5,
-					"State": 0, "Settings/Type": 0, "Settings/ValidTypes": 1 << 0, "Name": "A"
-				},
 				allowedInGroupModel: true,
 			},
 		]


### PR DESCRIPTION
There is a new capability in the iochannels possibly display flag. This allows setting visibility on different services (local/device, remote/vrm, and watch).

The user is now able to select a display combination of these three platforms.

Contributes to issue #3201