### PR TITLE
VisibleItemModel: declare effectiveVisibleChanged() as a slot

### DIFF
--- a/src/visibleitemmodel.h
+++ b/src/visibleitemmodel.h
@@ -69,10 +69,11 @@ public:
 Q_SIGNALS:
 	void sourceModelChanged();
 
+private Q_SLOTS:
+	void effectiveVisibleChanged();
+
 private:
 	Q_DISABLE_COPY(VisibleItemModel)
-
-	Q_INVOKABLE void effectiveVisibleChanged();
 };
 
 } /* VenusOS */


### PR DESCRIPTION
`VisibleItemModelPrivate::append()` connects each source item's `effectiveVisibleChanged()` signal using the string-based `SIGNAL()`/`SLOT()` overload, but the target method was declared `Q_INVOKABLE` rather than as a slot. Qt 6.11 started warning about this on every such connect:

```
QObject::connect: the SLOT() macro is used with a non-slot function: Victron::VenusOS::VisibleItemModel::effectiveVisibleChanged(). This currently works due to backwards-compatibility reasons. In Qt7 the SLOT() macro will work only for methods marked as slots.
```

Because the connect runs once per list item, an experimental Qt 6.11.2 wasm build printed the warning hundreds of times during startup. Console output from wasm is expensive on embedded MFD browsers, and on a Raymarine MFD that build loaded noticeably slower than the same build after this fix.

The method is private and only reached through that connect, so it is now declared under `private Q_SLOTS`. No behaviour change on Qt 6.8.3; the warnings disappear on 6.11+, and the code stays valid for Qt 7, where `SLOT()` will only accept real slots.

### Verification

- Headless (Playwright, `?mock`) against a Qt 6.11.2 wasm build: the warning count went from one per list item to zero, with the UI still reaching "UI loaded and visible" in the same time.
- On-device: the fixed Qt 6.11.2 build installed on a Cerbo GX (v3.80~49) driven from a Raymarine MFD loads better and works normally.

Found while preparing Qt 6.11/6.12 test builds for #3154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
